### PR TITLE
making refresh interval for bindings configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ You can call `ui.run()` with optional arguments for some high-level configuratio
 - `on_connect`: default function or coroutine which is called for each new client connection; the optional `request` argument provides session infos
 - `uvicorn_logging_level`: logging level for uvicorn server (default: `'warning'`)
 - `main_page_classes`: configure Quasar classes of main page (default: `q-ma-md column items-start`)
-- `interactive`: used internally when run in interactive Python shell (default: `False`)
 - `binding_refresh_interval`: time between binding updates (default: `0.1` seconds, bigger is more cpu friendly)
+- `interactive`: used internally when run in interactive Python shell (default: `False`)
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ You can call `ui.run()` with optional arguments for some high-level configuratio
 - `uvicorn_logging_level`: logging level for uvicorn server (default: `'warning'`)
 - `main_page_classes`: configure Quasar classes of main page (default: `q-ma-md column items-start`)
 - `interactive`: used internally when run in interactive Python shell (default: `False`)
+- `binding_refresh_interval`: time between binding updates (default: `0.1` seconds, bigger is more cpu friendly)
 
 ## Docker
 

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from justpy.htmlcomponents import HTMLBaseComponent
 from typing import Any, Callable, Optional, Set, Tuple
 from .task_logger import create_task
-from . import globals
+from .globals import config
 
 bindings = defaultdict(list)
 bindable_properties = dict()
@@ -21,7 +21,7 @@ async def loop():
                 setattr(target_obj, target_name, value)
                 propagate(target_obj, target_name, visited, visited_views)
         update_views(visited_views)
-        await asyncio.sleep(globals.config.binding_refresh_interval)
+        await asyncio.sleep(config.binding_refresh_interval)
 
 async def update_views_async(views: Set[HTMLBaseComponent]):
     for view in views:

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from justpy.htmlcomponents import HTMLBaseComponent
 from typing import Any, Callable, Optional, Set, Tuple
 from .task_logger import create_task
+from . import globals
 
 bindings = defaultdict(list)
 bindable_properties = dict()
@@ -20,7 +21,7 @@ async def loop():
                 setattr(target_obj, target_name, value)
                 propagate(target_obj, target_name, visited, visited_views)
         update_views(visited_views)
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(globals.config.binding_refresh_interval)
 
 async def update_views_async(views: Set[HTMLBaseComponent]):
     for view in views:

--- a/nicegui/config.py
+++ b/nicegui/config.py
@@ -18,8 +18,8 @@ class Config():
     on_connect: Optional[Union[Callable, Awaitable]] = None
     uvicorn_logging_level: str = 'warning'
     main_page_classes: str = 'q-ma-md column items-start'
-    interactive: bool = False
     binding_refresh_interval: float = 0.1
+    interactive: bool = False
 
 
 excluded_endings = (

--- a/nicegui/config.py
+++ b/nicegui/config.py
@@ -19,6 +19,7 @@ class Config():
     uvicorn_logging_level: str = 'warning'
     main_page_classes: str = 'q-ma-md column items-start'
     interactive: bool = False
+    binding_refresh_interval: float = 0.1
 
 
 excluded_endings = (

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -24,6 +24,7 @@ def run(self, *,
         on_connect: Optional[Union[Callable, Awaitable]] = None,
         uvicorn_logging_level: str = 'warning',
         main_page_classes: str = 'q-ma-md column items-start',
+        binding_refresh_interval=0.1,
         ):
 
     if globals.config.interactive or reload == False:  # NOTE: if reload == True we already started uvicorn above

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -24,7 +24,7 @@ def run(self, *,
         on_connect: Optional[Union[Callable, Awaitable]] = None,
         uvicorn_logging_level: str = 'warning',
         main_page_classes: str = 'q-ma-md column items-start',
-        binding_refresh_interval=0.1,
+        binding_refresh_interval: float = 0.1,
         ):
 
     if globals.config.interactive or reload == False:  # NOTE: if reload == True we already started uvicorn above


### PR DESCRIPTION
Increasing the interval to 0.3 s or more can save significant CPU on slow systems or when using a lot of bindings.