### PR TITLE
Fix issue when path to '.js'-files were incorrect

### DIFF
--- a/nicegui/elements/custom_view.py
+++ b/nicegui/elements/custom_view.py
@@ -34,7 +34,7 @@ class CustomView(jp.JustpyBaseComponent):
 
     @staticmethod
     def use(py_filepath: str, dependencies: List[str] = []):
-        vue_filepath = os.path.realpath(py_filepath).replace('.py', '.js')
+        vue_filepath = os.path.splitext(os.path.realpath(py_filepath))[0] + '.js'
 
         for dependency in dependencies:
             is_remote = dependency.startswith('http://') or dependency.startswith('https://')


### PR DESCRIPTION
When running nicegui under pyenv environment `vue_filepath` is constructed incorrectly - it replaces default pyenv root `.pyenv` to `.jsenv`.
The fix is just replace extension, not whole path.