### PR TITLE
Enable async execution of Javascript.

### DIFF
--- a/nicegui/static/templates/main.html
+++ b/nicegui/static/templates/main.html
@@ -156,27 +156,24 @@
                     comp_replace(msg.data, app1.justpyComponents);
                     break;
                 case 'run_javascript':
-                    // let js_result = eval(msg.data);
-                    let js_result;
 
-                function eval_success() {
-                    e = {
-                        'event_type': 'result_ready',
-                        'visibility': document.visibilityState,
-                        'page_id': page_id,
-                        'websocket_id': websocket_id,
-                        'request_id': msg.request_id,
-                        'result': js_result //JSON.stringify(js_result)
-                    };
-                    {% if 'result_ready' in page_options.events %}
-                        if (msg.send) send_to_server(e, 'page_event', false);
-                    {% endif %}
-                }
+                    function eval_success(js_result) {
+                        e = {
+                            'event_type': 'result_ready',
+                            'visibility': document.visibilityState,
+                            'page_id': page_id,
+                            'websocket_id': websocket_id,
+                            'request_id': msg.request_id,
+                            'result': js_result //JSON.stringify(js_result)
+                        };
+                        {% if 'result_ready' in page_options.events %}
+                            if (msg.send) send_to_server(e, 'page_event', false);
+                        {% endif %}
+                    }
 
-                    const jsPromise = (new Promise(function () {
-                        js_result = eval(msg.data);
-                    })).then(eval_success());
-
+                    const jsPromise = (new Promise((resolve) => {
+                        resolve(eval(msg.data));
+                    })).catch(() => {return eval(`(async() => {${msg.data}})()`);}).then(eval_success);
                     break;
                 case 'run_method':
                     // await websocket.send_json({'type': 'run_method', 'data': command, 'id': self.id})

--- a/nicegui/static/templates/main.html
+++ b/nicegui/static/templates/main.html
@@ -161,7 +161,7 @@
                     // causing its result to be returned as the result of the second call.
                     // This is impossible with synchronous eval execution, but can happen with asynchronous one.
                     ((msg) => {
-                        function eval_success(js_result) {
+                            eval_success = (msg) => (js_result) => {
                             e = {
                                 'event_type': 'result_ready',
                                 'visibility': document.visibilityState,
@@ -177,7 +177,7 @@
 
                         const jsPromise = (new Promise((resolve) => {
                             resolve(eval(msg.data));
-                        })).catch((reason) => {if(reason instanceof SyntaxError) return eval(`(async() => {${msg.data}})()`); else throw reason;}).then(eval_success);
+                        })).catch((reason) => {if(reason instanceof SyntaxError) return eval(`(async() => {${msg.data}})()`); else throw reason;}).then(eval_success(msg));
                     })(msg);
                     break;
                 case 'run_method':

--- a/nicegui/static/templates/main.html
+++ b/nicegui/static/templates/main.html
@@ -156,24 +156,29 @@
                     comp_replace(msg.data, app1.justpyComponents);
                     break;
                 case 'run_javascript':
+                    // put msg into a closure to avoid a situation when the first call times out on Python side, 
+                    // then the second call with different msg.request_id is made, then the first call succeeds, 
+                    // causing its result to be returned as the result of the second call.
+                    // This is impossible with synchronous eval execution, but can happen with asynchronous one.
+                    ((msg) => {
+                        function eval_success(js_result) {
+                            e = {
+                                'event_type': 'result_ready',
+                                'visibility': document.visibilityState,
+                                'page_id': page_id,
+                                'websocket_id': websocket_id,
+                                'request_id': msg.request_id,
+                                'result': js_result //JSON.stringify(js_result)
+                            };
+                            {% if 'result_ready' in page_options.events %}
+                                if (msg.send) send_to_server(e, 'page_event', false);
+                            {% endif %}
+                        }
 
-                    function eval_success(js_result) {
-                        e = {
-                            'event_type': 'result_ready',
-                            'visibility': document.visibilityState,
-                            'page_id': page_id,
-                            'websocket_id': websocket_id,
-                            'request_id': msg.request_id,
-                            'result': js_result //JSON.stringify(js_result)
-                        };
-                        {% if 'result_ready' in page_options.events %}
-                            if (msg.send) send_to_server(e, 'page_event', false);
-                        {% endif %}
-                    }
-
-                    const jsPromise = (new Promise((resolve) => {
-                        resolve(eval(msg.data));
-                    })).catch(() => {return eval(`(async() => {${msg.data}})()`);}).then(eval_success);
+                        const jsPromise = (new Promise((resolve) => {
+                            resolve(eval(msg.data));
+                        })).catch((reason) => {if(reason instanceof SyntaxError) return eval(`(async() => {${msg.data}})()`); else throw reason;}).then(eval_success);
+                    })(msg);
                     break;
                 case 'run_method':
                     // await websocket.send_json({'type': 'run_method', 'data': command, 'id': self.id})


### PR DESCRIPTION
Please consider the following code snippets in NiceGUI:

```python
r1 = await ui.run_javascript("""
    window.exampleSocket = new WebSocket('ws://echo.websocket.events/');
    exampleSocket.onmessage = (event) => {
        console.log('Got back: ' + event.data);
    }
""")
r2 = await ui.run_javascript("""
    console.log("Waiting for the websocket to connect...");
    while(exampleSocket.readyState !== exampleSocket.OPEN) {
        console.log('Waiting 1 second...');
        await new Promise(r => setTimeout(r, 1000));
    }
    console.log(exampleSocket.readyState);
    exampleSocket.send('Hello world!');
""")
r3 = await ui.run_javascript('42')
r4 = await ui.run_javascript("""
    console.log('Executing throw...');
    throw 'Example exception';
""")
r5 = await ui.run_javascript("""
    await new Promise(r => setTimeout(r, 1500));
    return 1;
""")
r6 = await ui.run_javascript("""
    await new Promise(r => setTimeout(r, 750));
    return 2;
""")
```

`r1` and `r3` will currently execute normally, but `r2` will throw exception about `await` not being allowed inside `eval`. I added `catch` block in this pull request which will attempt to execute the code again in this case, this time inside anonymous immediately invoked async function.

More improvements can be done, e.g. making sure the exception is `"SyntaxError: await is only valid in async functions, async generators and modules"`, but I'm not sure whether the message could differ between browsers, so I currently leave it as it is. Worst case, it will attempt to execute the code twice, throwing SyntaxError not related to async execution twice too.

**Please note**: since the code blocks with `await` keyword will be executed inside async function, you'll have to use `return` statement to return values from such code snippets. If the code does not contain `await` keyword, it will be executed synchronously outside of a function, making use of `return` statement optional (i.e. as it is now, before the pull request).

`r4` demonstrates what would happen if the code throws exception not related to SyntaxError (it will be logged in the browser console). `r5` and `r6` show that even if the first code times out on Python side and completes (much) later, its request_id would not be overwritten with Javascript snippets which are executed after it.