### PR TITLE
Caching markdown to speed up repeated requests

### DIFF
--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -45,7 +45,7 @@ class Markdown(ContentElement):
             self.update()
 
 
-@lru_cache(maxsize=int(os.environ.get('MARKDOWN_CONTENT_CACHE_SIZE', ('1000'))))
+@lru_cache(maxsize=int(os.environ.get('MARKDOWN_CONTENT_CACHE_SIZE', '1000')))
 def prepare_content(content: str, extras: str) -> str:
     html = markdown2.markdown(content, extras=extras.split())
     return apply_tailwind(html)  # we need explicit markdown styling because tailwind CSS removes all default styles

--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -1,3 +1,4 @@
+import os
 import re
 from functools import lru_cache
 from typing import List
@@ -44,7 +45,7 @@ class Markdown(ContentElement):
             self.update()
 
 
-@lru_cache(maxsize=1000)
+@lru_cache(maxsize=int(os.environ.get('MARKDOWN_CONTENT_CACHE_SIZE', ('1000'))))
 def prepare_content(content: str, extras: str) -> str:
     html = markdown2.markdown(content, extras=extras.split())
     return apply_tailwind(html)  # we need explicit markdown styling because tailwind CSS removes all default styles

--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -1,4 +1,5 @@
 import re
+from functools import lru_cache
 from typing import List
 
 import markdown2
@@ -37,8 +38,13 @@ class Markdown(ContentElement):
         super().__init__(tag='div', content=content)
 
     def on_content_change(self, content: str) -> None:
-        html = markdown2.markdown(content, extras=self.extras)
-        html = apply_tailwind(html)  # we need explicit markdown styling because tailwind CSS removes all default styles
+        html = prepare_content(content, extras=' '.join(self.extras))
         if self._props.get('innerHTML') != html:
             self._props['innerHTML'] = html
             self.update()
+
+
+@lru_cache(maxsize=1000)
+def prepare_content(content: str, extras: str) -> str:
+    html = markdown2.markdown(content, extras=extras.split())
+    return apply_tailwind(html)  # we need explicit markdown styling because tailwind CSS removes all default styles

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -45,11 +45,6 @@ def run(*,
     :param uvicorn_reload_excludes: string with comma-separated list of glob-patterns which should be ignored for reload (default: `'.*, .py[cod], .sw.*, ~*'`)
     :param exclude: comma-separated string to exclude elements (with corresponding JavaScript libraries) to save bandwidth
       (possible entries: chart, colors, interactive_image, joystick, keyboard, log, scene, upload, table)
-
-    The environment variables `HOST` and `PORT` can also be used to configure NiceGUI.
-
-    To avoid the potentially costly import of Matplotlib, you set the environment variable `MATPLOTLIB=false`.
-    This will make `ui.plot` and `ui.line_plot` unavailable.
     '''
     globals.host = host
     globals.port = port

--- a/website/reference.py
+++ b/website/reference.py
@@ -810,8 +810,6 @@ This is used in our [authentication demo](https://github.com/zauberzeug/nicegui/
 
 You can set the following environment variables to configure NiceGUI:
 
-- `HOST`: Alternative to specify the host address (normally via `ui.run(host=...)`).
-- `PORT`: Alternative to specify the port (normally via `ui.run(port=...)`).
 - `MATPLOTLIB` (default: true) can be set to `false` to avoid the potentially costly import of Matplotlib. This will make `ui.plot` and `ui.line_plot` unavailable.
 - `MARKDOWN_CONTENT_CACHE_SIZE` (default: 1000): The maximum number of Markdown content snippets that are cached in memory.
 ''')

--- a/website/reference.py
+++ b/website/reference.py
@@ -805,3 +805,17 @@ This is used in our [authentication demo](https://github.com/zauberzeug/nicegui/
         ui.label('page with custom title')
 
         # ui.run(title='My App')
+
+    @example('''#### Environment Variables
+
+You can set the following environment variables to configure NiceGUI:
+
+- `HOST`: Alternative to specify the host address (normally via `ui.run(host=...)`).
+- `PORT`: Alternative to specify the port (normally via `ui.run(port=...)`).
+- `MATPLOTLIB` (default: true) can be set to `false` to avoid the potentially costly import of Matplotlib. This will make `ui.plot` and `ui.line_plot` unavailable.
+- `MARKDOWN_CONTENT_CACHE_SIZE` (default: 1000): The maximum number of Markdown content snippets that are cached in memory.
+''')
+    def env_var_example():
+        from nicegui.elements import markdown
+
+        ui.label(f'markdown content cache size is {markdown.prepare_content.cache_info().maxsize}')


### PR DESCRIPTION
Our reference at https://nicegui.io/reference uses a lot of markdown elements. These take quite some time to transform into html. By introducing an `lru_cache` the response speed can be nearly be doubled.