### PR TITLE
Fix object duplication in ui.scene when using without page decorator

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -53,6 +53,10 @@ class Client:
         return self.environ.get('REMOTE_ADDR') if self.environ else None
 
     @property
+    def room(self) -> str:
+        return globals._current_socket_ids[-1] if globals._use_current_socket[-1] else self.id
+
+    @property
     def has_socket_connection(self) -> bool:
         return self.environ is not None
 
@@ -98,7 +102,7 @@ class Client:
             'code': code,
             'request_id': request_id if respond else None,
         }
-        create_task(globals.sio.emit('run_javascript', command, room=self.id))
+        create_task(globals.sio.emit('run_javascript', command, room=self.room))
         if not respond:
             return None
         deadline = time.time() + timeout
@@ -110,4 +114,4 @@ class Client:
 
     def open(self, target: Union[Callable, str]) -> None:
         path = target if isinstance(target, str) else globals.page_routes[target]
-        create_task(globals.sio.emit('open', path, room=self.id))
+        create_task(globals.sio.emit('open', path, room=self.room))

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -174,7 +174,7 @@ class Element(ABC, Visibility):
         if not globals.loop:
             return
         data = {'id': self.id, 'name': name, 'args': args}
-        create_task(globals.sio.emit('run_method', data, room=self.client.id))
+        create_task(globals.sio.emit('run_method', data, room=globals._socketio_id or self.client.id))
 
     def clear(self) -> None:
         descendants = [self.client.elements[id] for id in self.collect_descendant_ids()[1:]]

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -168,13 +168,13 @@ class Element(ABC, Visibility):
             return
         ids = self.collect_descendant_ids()
         elements = {id: self.client.elements[id].to_dict() for id in ids}
-        create_task(globals.sio.emit('update', {'elements': elements}, room=self.client.id))
+        create_task(globals.sio.emit('update', {'elements': elements}, room=self.client.room))
 
     def run_method(self, name: str, *args: Any) -> None:
         if not globals.loop:
             return
         data = {'id': self.id, 'name': name, 'args': args}
-        create_task(globals.sio.emit('run_method', data, room=globals._socketio_id or self.client.id))
+        create_task(globals.sio.emit('run_method', data, room=self.client.room))
 
     def clear(self) -> None:
         descendants = [self.client.elements[id] for id in self.collect_descendant_ids()[1:]]

--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -134,21 +134,9 @@ export default {
 
     this.texture_loader = new THREE.TextureLoader();
     this.stl_loader = new THREE.STLLoader();
-
-    this.is_initialized = false;
-    const sendConnectEvent = async () => {
-      if (window.socket.id === undefined) return;
-      if (!this.is_initialized) {
-        this.$emit("connect", window.socket.id);
-      } else clearInterval(connectInterval);
-    };
-    const connectInterval = setInterval(sendConnectEvent, 100);
   },
 
   methods: {
-    init() {
-      this.is_initialized = true;
-    },
     create(type, id, parent_id, ...args) {
       let mesh;
       if (type == "group") {

--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -136,9 +136,11 @@ export default {
     this.stl_loader = new THREE.STLLoader();
 
     this.is_initialized = false;
-    const sendConnectEvent = () => {
-      if (!this.is_initialized) this.$emit("connect");
-      else clearInterval(connectInterval);
+    const sendConnectEvent = async () => {
+      if (window.socket.id === undefined) return;
+      if (!this.is_initialized) {
+        this.$emit("connect", window.socket.id);
+      } else clearInterval(connectInterval);
     };
     const connectInterval = setInterval(sendConnectEvent, 100);
   },

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict, List, Optional, Union
 from ..dependencies import register_component
 from ..element import Element
 from ..events import SceneClickEventArguments, SceneClickHit, handle_event
+from ..globals import socketio_id
 from .scene_object3d import Object3D
 from .scene_objects import Scene as SceneObject
 
@@ -73,11 +74,15 @@ class Scene(Element):
         self.on('connect', self.handle_connect)
         self.on('click3d', self.handle_click)
 
-    def handle_connect(self, _) -> None:
-        self.run_method('init')
-        self.move_camera(duration=0)
-        for object in self.objects.values():
-            object.send()
+    def handle_connect(self, x) -> None:
+        if not 'args' in x:
+            raise Exception('no args')
+        with socketio_id(x['args']):
+            self.run_method('init')
+            self.move_camera(duration=0)
+            for object in self.objects.values():
+                object.send()
+        return 'bam2'
 
     def handle_click(self, msg: Dict) -> None:
         arguments = SceneClickEventArguments(

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Union
 
+from .. import globals
 from ..dependencies import register_component
 from ..element import Element
 from ..events import SceneClickEventArguments, SceneClickHit, handle_event
-from ..globals import socketio_id
+from ..functions.lifecycle import on_connect
 from .scene_object3d import Object3D
 from .scene_objects import Scene as SceneObject
 
@@ -71,18 +72,14 @@ class Scene(Element):
         self.stack: List[Union[Object3D, SceneObject]] = [SceneObject()]
         self.camera: SceneCamera = SceneCamera()
         self.on_click = on_click
-        self.on('connect', self.handle_connect)
         self.on('click3d', self.handle_click)
+        on_connect(self.handle_connect)
 
-    def handle_connect(self, x) -> None:
-        if not 'args' in x:
-            raise Exception('no args')
-        with socketio_id(x['args']):
-            self.run_method('init')
+    def handle_connect(self) -> None:
+        with globals.current_socket():
             self.move_camera(duration=0)
             for object in self.objects.values():
                 object.send()
-        return 'bam2'
 
     def handle_click(self, msg: Dict) -> None:
         arguments = SceneClickEventArguments(

--- a/nicegui/functions/notify.py
+++ b/nicegui/functions/notify.py
@@ -24,4 +24,4 @@ def notify(message: str, *,
     Note: You can pass additional keyword arguments according to `Quasar's Notify API <https://quasar.dev/quasar-plugins/notify#notify-api>`_.
     """
     options = {key: value for key, value in locals().items() if not key.startswith('_') and value is not None}
-    create_task(globals.sio.emit('notify', options, room=globals.get_client().id))
+    create_task(globals.sio.emit('notify', options, room=globals.get_client().room))

--- a/nicegui/globals.py
+++ b/nicegui/globals.py
@@ -36,11 +36,12 @@ dark: Optional[bool]
 binding_refresh_interval: float
 excludes: List[str]
 socket_io_js_extra_headers: Dict = {}
-_socketio_id: Optional[str] = None
 
 slot_stacks: Dict[int, List['Slot']] = {}
 clients: Dict[str, 'Client'] = {}
 index_client: 'Client'
+_current_socket_ids: List[str] = []
+_use_current_socket: List[bool] = [False]
 
 page_routes: Dict[Callable, str] = {}
 favicons: Dict[str, Optional[str]] = {}
@@ -80,7 +81,13 @@ def get_client() -> 'Client':
 
 @contextmanager
 def socketio_id(id: str) -> None:
-    global _socketio_id
-    _socketio_id = id
+    _current_socket_ids.append(id)
     yield
-    _socketio_id = None
+    _current_socket_ids.pop()
+
+
+@contextmanager
+def current_socket() -> None:
+    _use_current_socket.append(True)
+    yield
+    _use_current_socket.pop()

--- a/nicegui/globals.py
+++ b/nicegui/globals.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from contextlib import contextmanager
 from enum import Enum
 from typing import TYPE_CHECKING, Awaitable, Callable, Dict, List, Optional, Union
 
@@ -35,6 +36,7 @@ dark: Optional[bool]
 binding_refresh_interval: float
 excludes: List[str]
 socket_io_js_extra_headers: Dict = {}
+_socketio_id: Optional[str] = None
 
 slot_stacks: Dict[int, List['Slot']] = {}
 clients: Dict[str, 'Client'] = {}
@@ -74,3 +76,11 @@ def get_slot() -> 'Slot':
 
 def get_client() -> 'Client':
     return get_slot().parent.client
+
+
+@contextmanager
+def socketio_id(id: str) -> None:
+    global _socketio_id
+    _socketio_id = id
+    yield
+    _socketio_id = None

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -94,7 +94,7 @@ async def handle_handshake(sid: str) -> bool:
         return False
     client.environ = sio.get_environ(sid)
     sio.enter_room(sid, client.id)
-    with client:
+    with client, globals.socketio_id(sid):
         for t in client.connect_handlers:
             safe_invoke(t)
     return True

--- a/tests/screen.py
+++ b/tests/screen.py
@@ -70,6 +70,15 @@ class Screen:
         if self.is_open:
             self.selenium.close()
 
+    def switch_to(self, tab_id: int) -> None:
+        window_count = len(self.selenium.window_handles)
+        if tab_id > window_count:
+            raise IndexError(f'Could not go to or create tab {tab_id}, there are only {window_count} tabs')
+        elif tab_id == window_count:
+            self.selenium.switch_to.new_window('tab')
+        else:
+            self.selenium.switch_to.window(self.selenium.window_handles[tab_id])
+
     def should_contain(self, text: str) -> None:
         assert self.selenium.title == text or self.find(text), f'could not find "{text}"'
 

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -1,3 +1,4 @@
+from selenium import webdriver
 from selenium.common.exceptions import JavascriptException
 
 from nicegui import ui
@@ -25,3 +26,16 @@ def test_moving_sphere_with_timer(screen: Screen):
 
     screen.wait(0.2)
     assert position() > 0
+
+
+def test_no_object_duplication_on_index_client(screen: Screen, selenium: webdriver.Chrome):
+    with ui.scene() as scene:
+        scene.sphere()
+
+    screen.open('/')
+    screen.switch_to(1)
+    screen.open('/')
+    screen.switch_to(0)
+
+    screen.wait(0.2)
+    assert screen.selenium.execute_script('return scene_3.children.length') == 5

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -15,7 +15,7 @@ def test_moving_sphere_with_timer(screen: Screen):
     def position() -> None:
         for _ in range(3):
             try:
-                pos = screen.selenium.execute_script('return scene_3.getObjectByName("sphere").position.z')
+                pos = screen.selenium.execute_script(f'return scene_{scene.id}.getObjectByName("sphere").position.z')
                 if pos is not None:
                     return pos
             except JavascriptException as e:
@@ -38,4 +38,4 @@ def test_no_object_duplication_on_index_client(screen: Screen):
     screen.open('/')
     screen.switch_to(0)
     screen.wait(0.2)
-    assert screen.selenium.execute_script('return scene_3.children.length') == 5
+    assert screen.selenium.execute_script(f'return scene_{scene.id}.children.length') == 5

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -1,4 +1,3 @@
-from selenium import webdriver
 from selenium.common.exceptions import JavascriptException
 
 from nicegui import ui
@@ -28,14 +27,15 @@ def test_moving_sphere_with_timer(screen: Screen):
     assert position() > 0
 
 
-def test_no_object_duplication_on_index_client(screen: Screen, selenium: webdriver.Chrome):
+def test_no_object_duplication_on_index_client(screen: Screen):
     with ui.scene() as scene:
-        scene.sphere()
+        sphere = scene.sphere().move(0, -4, 0)
+        ui.timer(0.1, lambda: sphere.move(0, sphere.y + 0.5, 0))
 
     screen.open('/')
+    screen.wait(0.4)
     screen.switch_to(1)
     screen.open('/')
     screen.switch_to(0)
-
     screen.wait(0.2)
     assert screen.selenium.execute_script('return scene_3.children.length') == 5


### PR DESCRIPTION
If the following code is run and accessed from multiple tabs the sphere is duplicated.

```python
from nicegui import ui

with ui.scene() as scene:
    sphere = scene.sphere().move(0, -4, 0)
    ui.timer(0.1, lambda: sphere.move(0, sphere.y + 0.5, 0))

ui.run()
```

This is caused by the `connect` event send by each tab. It was meant to initialize the scene. But this does not work with our `index_client`. This special client is used when elements are not enclosed in an `@ui.page` decorator. So the tab which connects first will receives the init-commands also from the second tab.

- [x] create pytest reproduction
- [x] ensure `connect` event from `ui.scene` is only send to the client which connects
- [x] code review
- [x] revisit reconnect behaviour (it looks like there may be send multiple connect commands from a single tab)