### PR TITLE
fix favicon routes for pages that are created during or after startup

### DIFF
--- a/nicegui/favicon.py
+++ b/nicegui/favicon.py
@@ -9,13 +9,12 @@ if TYPE_CHECKING:
     from .page import page
 
 
-def create_favicon_routes() -> None:
+def create_favicon_route(path: str, favicon: Optional[str]) -> None:
+    if favicon and is_remote_url(favicon):
+        return
     fallback = Path(__file__).parent / 'static' / 'favicon.ico'
-    for path, favicon in globals.favicons.items():
-        if favicon and is_remote_url(favicon):
-            continue
-        globals.app.add_route(f'{"" if path == "/" else path}/favicon.ico',
-                              lambda _, favicon=favicon or globals.favicon or fallback: FileResponse(favicon))
+    globals.app.add_route(f'{"" if path == "/" else path}/favicon.ico',
+                          lambda _: FileResponse(favicon or globals.favicon or fallback))
 
 
 def get_favicon_url(page: 'page', prefix: str) -> str:

--- a/nicegui/globals.py
+++ b/nicegui/globals.py
@@ -41,7 +41,6 @@ clients: Dict[str, 'Client'] = {}
 index_client: 'Client'
 
 page_routes: Dict[Callable, str] = {}
-favicons: Dict[str, Optional[str]] = {}
 tasks: List[asyncio.tasks.Task] = []
 
 startup_handlers: List[Union[Callable, Awaitable]] = []

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -15,7 +15,6 @@ from .client import Client
 from .dependencies import js_components, js_dependencies
 from .element import Element
 from .error import error_content
-from .favicon import create_favicon_routes
 from .helpers import safe_invoke
 from .page import page
 from .task_logger import create_task
@@ -50,7 +49,6 @@ def get_components(name: str):
 def handle_startup(with_welcome_message: bool = True) -> None:
     globals.state = globals.State.STARTING
     globals.loop = asyncio.get_running_loop()
-    create_favicon_routes()
     for t in globals.startup_handlers:
         safe_invoke(t)
     create_task(binding.loop())

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -8,6 +8,7 @@ from fastapi import Request, Response
 from . import globals
 from .async_updater import AsyncUpdater
 from .client import Client
+from .favicon import create_favicon_route
 from .task_logger import create_task
 
 
@@ -36,7 +37,7 @@ class page:
         self.dark = dark
         self.response_timeout = response_timeout
 
-        globals.favicons[self.path] = favicon
+        create_favicon_route(self.path, favicon)
 
     def resolve_title(self) -> str:
         return self.title if self.title is not None else globals.title


### PR DESCRIPTION
Until now favicons are collected in a global dictionary. During startup a function `create_favicon_routes()` is called to create routes for all favicons in this dictionary. This is because we need wait until `ui.run(..., favicon=...)` has been called because it might define a default favicon.

But this does not work for pages that are also created during startup (but a bit later) or even dynamically caused by a user event.

```python
from nicegui import ui

ui.label('The favicon is correct on the index page.')

def startup():
    @ui.page('/sub')
    def page():
        ui.label('There is no favicon route for this page because it was only created during startup.')

ui.on_startup(startup)

ui.run(favicon='favicon.ico')
```

This PR proposes to create routes directly when initializing pages. Even though we need to wait for the `favicon` argument in `ui.run`, we can already create routes and let the callback access the fallback favicon _when called_. This simplifies things (no need for the global dictionary anymore) and works more robustly, since pages can be created at any time and favicons will be routed.