### PR TITLE
Using quasar uploader for ui.upload

### DIFF
--- a/nicegui/elements/upload.vue
+++ b/nicegui/elements/upload.vue
@@ -1,8 +1,5 @@
 <template>
-  <div>
-    <q-file :label="file_picker_label" v-model="file" :multiple="multiple" />
-    <q-btn :icon="upload_button_icon" @click="upload" size="sm" round color="primary" />
-  </div>
+  <q-uploader url="_nicegui/upload" :label="file_picker_label" :multiple="multiple" />
 </template>
 
 <script>

--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -1,7 +1,7 @@
 import traceback
 from dataclasses import dataclass
 from inspect import signature
-from typing import TYPE_CHECKING, Any, Callable, List, Optional
+from typing import TYPE_CHECKING, Any, BinaryIO, Callable, List, Optional
 
 from . import globals
 from .async_updater import AsyncUpdater
@@ -65,17 +65,10 @@ class JoystickEventArguments(EventArguments):
 
 
 @dataclass
-class UploadFile:
-    content: bytes
-    name: str
-    lastModified: float
-    size: int
-    type: str
-
-
-@dataclass
 class UploadEventArguments(EventArguments):
-    files: List[UploadFile]
+    content: BinaryIO
+    name: str
+    type: str
 
 
 @dataclass


### PR DESCRIPTION
This pull-request aims to fix #220 by modifying `ui.upload` to use The Quasar Uploader `q-uploader` internally.

It will likely be a breaking change because the `UploadEventArguments` used by `on_upload` callback can be simplified.