### PR TITLE
Let ui.log hold a server-side copy of recent lines

### DIFF
--- a/nicegui/elements/log.js
+++ b/nicegui/elements/log.js
@@ -5,6 +5,11 @@ export default {
       num_lines: 0,
     };
   },
+  mounted() {
+    const text = decodeURIComponent(this.lines);
+    this.$el.innerHTML = text;
+    this.num_lines = text ? text.split("\n").length : 0;
+  },
   methods: {
     push(line) {
       const decoded = decodeURIComponent(line);
@@ -22,5 +27,6 @@ export default {
   },
   props: {
     max_lines: Number,
+    lines: String,
   },
 };

--- a/nicegui/elements/log.py
+++ b/nicegui/elements/log.py
@@ -24,6 +24,6 @@ class Log(Element):
         self.lines: deque[str] = deque(maxlen=max_lines)
 
     def push(self, line: str) -> None:
-        self.lines.append(line)
+        self.lines.extend(line.splitlines())
         self._props['lines'] = '\n'.join(self.lines)
         self.run_method('push', line)

--- a/nicegui/elements/log.py
+++ b/nicegui/elements/log.py
@@ -1,3 +1,4 @@
+from collections import deque
 from typing import Optional
 
 from ..dependencies import register_component
@@ -17,8 +18,12 @@ class Log(Element):
         """
         super().__init__('log')
         self._props['max_lines'] = max_lines
+        self._props['lines'] = ''
         self.classes('border whitespace-pre font-mono')
         self.style('opacity: 1 !important; cursor: text !important')
+        self.lines: deque[str] = deque(maxlen=max_lines)
 
     def push(self, line: str) -> None:
+        self.lines.append(line)
+        self._props['lines'] = '\n'.join(self.lines)
         self.run_method('push', line)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.by import By
+
 from nicegui import ui
 
 from .screen import Screen
@@ -11,7 +13,14 @@ def test_log(screen: Screen):
     log.push('D')
 
     screen.open('/')
-    screen.should_not_contain('A')
-    screen.should_contain('B')
-    screen.should_contain('C')
-    screen.should_contain('D')
+    assert screen.selenium.find_element(By.ID, log.id).text == 'B\nC\nD'
+
+
+def test_log_with_newlines(screen: Screen):
+    log = ui.log(max_lines=3)
+    log.push('A')
+    log.push('B')
+    log.push('C\nD')
+
+    screen.open('/')
+    assert screen.selenium.find_element(By.ID, log.id).text == 'B\nC\nD'

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,17 @@
+from nicegui import ui
+
+from .screen import Screen
+
+
+def test_log(screen: Screen):
+    log = ui.log(max_lines=3)
+    log.push('A')
+    log.push('B')
+    log.push('C')
+    log.push('D')
+
+    screen.open('/')
+    screen.should_not_contain('A')
+    screen.should_contain('B')
+    screen.should_contain('C')
+    screen.should_contain('D')


### PR DESCRIPTION
I updated `ui.log` in https://github.com/zauberzeug/nicegui/commit/febe05d368c2f19e921207175c5c4d29350736f9 as follows:

log.py keeps two copies of all pushed lines, one in the deque `lines` and one as concatenated string in `_props['lines']`:

- `lines` is used to automatically drop lines exceeding the number `max_lines`.
- `_props['lines']` are kept up to date for initializing newly connected clients.

Now new clients see previously pushed lines. And reloading the browser does not clear the log.