### PR TITLE
Add viewport meta element

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -77,6 +77,7 @@ class Client:
             'vue_scripts': vue_scripts,
             'js_imports': generate_js_imports(prefix),
             'title': self.page.resolve_title(),
+            'viewport': self.page.resolve_viewport(),
             'favicon_url': get_favicon_url(self.page, prefix),
             'dark': str(self.page.resolve_dark()),
             'prefix': prefix,

--- a/nicegui/globals.py
+++ b/nicegui/globals.py
@@ -33,6 +33,7 @@ host: str
 port: int
 reload: bool
 title: str
+viewport: str
 favicon: Optional[str]
 dark: Optional[bool]
 binding_refresh_interval: float

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -16,6 +16,7 @@ class page:
     def __init__(self,
                  path: str, *,
                  title: Optional[str] = None,
+                 viewport: Optional[str] = None,
                  favicon: Optional[str] = None,
                  dark: Optional[bool] = ...,
                  response_timeout: float = 3.0,
@@ -26,12 +27,14 @@ class page:
 
         :param path: route of the new page (path must start with '/')
         :param title: optional page title
+        :param viewport: optional viewport meta tag content
         :param favicon: optional relative filepath or absolute URL to a favicon (default: `None`, NiceGUI icon will be used)
         :param dark: whether to use Quasar's dark mode (defaults to `dark` argument of `run` command)
         :param response_timeout: maximum time for the decorated function to build the page (default: 3.0)
         """
         self.path = path
         self.title = title
+        self.viewport = viewport
         self.favicon = favicon
         self.dark = dark
         self.response_timeout = response_timeout
@@ -40,6 +43,9 @@ class page:
 
     def resolve_title(self) -> str:
         return self.title if self.title is not None else globals.title
+
+    def resolve_viewport(self) -> str:
+        return self.viewport if self.viewport is not None else globals.viewport
 
     def resolve_dark(self) -> Optional[bool]:
         return self.dark if self.dark is not ... else globals.dark

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -16,6 +16,7 @@ def run(*,
         host: str = '0.0.0.0',
         port: int = 8080,
         title: str = 'NiceGUI',
+        viewport: str = 'width=device-width, initial-scale=1',
         favicon: Optional[str] = None,
         dark: Optional[bool] = False,
         binding_refresh_interval: float = 0.1,
@@ -35,6 +36,7 @@ def run(*,
     :param host: start server with this host (default: `'0.0.0.0'`)
     :param port: use this port (default: `8080`)
     :param title: page title (default: `'NiceGUI'`, can be overwritten per page)
+    :param viewport: page meta viewport content (default: `'width=device-width, initial-scale=1'`, can be overwritten per page)
     :param favicon: relative filepath or absolute URL to a favicon (default: `None`, NiceGUI icon will be used)
     :param dark: whether to use Quasar's dark mode (default: `False`, use `None` for "auto" mode)
     :param binding_refresh_interval: time between binding updates (default: `0.1` seconds, bigger is more CPU friendly)
@@ -53,6 +55,7 @@ def run(*,
     globals.port = port
     globals.reload = reload
     globals.title = title
+    globals.viewport = viewport
     globals.favicon = favicon
     globals.dark = dark
     globals.binding_refresh_interval = binding_refresh_interval

--- a/nicegui/run_with.py
+++ b/nicegui/run_with.py
@@ -9,6 +9,7 @@ from nicegui.nicegui import handle_shutdown, handle_startup
 def run_with(
     app: FastAPI, *,
     title: str = 'NiceGUI',
+    viewport: str = 'width=device-width, initial-scale=1',
     favicon: Optional[str] = None,
     dark: Optional[bool] = False,
     binding_refresh_interval: float = 0.1,
@@ -16,6 +17,7 @@ def run_with(
 ) -> None:
     globals.ui_run_has_been_called = True
     globals.title = title
+    globals.viewport = viewport
     globals.favicon = favicon
     globals.dark = dark
     globals.binding_refresh_interval = binding_refresh_interval

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>{{ title }}</title>
+    <meta name="viewport" content="{{ viewport }}">
     <script src="{{ prefix | safe }}/_nicegui/static/socket.io.min.js"></script>
     <link href="{{ favicon_url }}" rel="shortcut icon" />
     <link href="{{ prefix | safe }}/_nicegui/static/fonts.css" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Add viewport <meta> element to the head of the rendered page. It could be changed setting 'viewport' global variable or at page level.

Ref: Issue #274 