### PR TITLE
Generic events

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import shlex
 from abc import ABC
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 from . import background_tasks, binding, globals
 from .elements.mixins.visibility import Visibility
 from .event_listener import EventListener
+from .events import handle_event
 from .slot import Slot
 
 if TYPE_CHECKING:
@@ -158,9 +159,7 @@ class Element(ABC, Visibility):
     def handle_event(self, msg: Dict) -> None:
         for listener in self._event_listeners:
             if listener.type == msg['type']:
-                result = listener.handler(msg)
-                if isinstance(result, Awaitable):
-                    background_tasks.create(result)
+                handle_event(listener.handler, msg, sender=self)
 
     def collect_descendant_ids(self) -> List[int]:
         '''includes own ID as first element'''

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -2,10 +2,12 @@ import asyncio
 import functools
 import inspect
 from contextlib import nullcontext
-from typing import Any, Awaitable, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, Union
 
 from . import background_tasks, globals
-from .client import Client
+
+if TYPE_CHECKING:
+    from .client import Client
 
 
 def is_coroutine(object: Any) -> bool:
@@ -14,7 +16,7 @@ def is_coroutine(object: Any) -> bool:
     return asyncio.iscoroutinefunction(object)
 
 
-def safe_invoke(func: Union[Callable, Awaitable], client: Optional[Client] = None) -> None:
+def safe_invoke(func: Union[Callable, Awaitable], client: Optional['Client'] = None) -> None:
     try:
         if isinstance(func, Awaitable):
             async def func_with_client():

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -1,5 +1,6 @@
 import os
 
+from .element import Element as element
 from .elements.audio import Audio as audio
 from .elements.badge import Badge as badge
 from .elements.button import Button as button

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,8 +3,63 @@ import asyncio
 from selenium.webdriver.common.by import By
 
 from nicegui import ui
+from nicegui.events import ClickEventArguments
 
 from .screen import Screen
+
+
+def click_sync_no_args():
+    ui.label('click_sync_no_args')
+
+
+def click_sync_with_args(_: ClickEventArguments):
+    ui.label('click_sync_with_args')
+
+
+async def click_async_no_args():
+    await asyncio.sleep(0.1)
+    ui.label('click_async_no_args')
+
+
+async def click_async_with_args(_: ClickEventArguments):
+    await asyncio.sleep(0.1)
+    ui.label('click_async_with_args')
+
+
+def test_click_events(screen: Screen):
+    ui.button('click_sync_no_args', on_click=click_sync_no_args)
+    ui.button('click_sync_with_args', on_click=click_sync_with_args)
+    ui.button('click_async_no_args', on_click=click_async_no_args)
+    ui.button('click_async_with_args', on_click=click_async_with_args)
+
+    screen.open('/')
+    screen.click('click_sync_no_args')
+    screen.click('click_sync_with_args')
+    screen.click('click_async_no_args')
+    screen.click('click_async_with_args')
+    screen.wait(0.5)
+    screen.should_contain('click_sync_no_args')
+    screen.should_contain('click_sync_with_args')
+    screen.should_contain('click_async_no_args')
+    screen.should_contain('click_async_with_args')
+
+
+def test_generic_events(screen: Screen):
+    ui.label('click_sync_no_args').on('click', click_sync_no_args)
+    ui.label('click_sync_with_args').on('click', click_sync_with_args)
+    ui.label('click_async_no_args').on('click', click_async_no_args)
+    ui.label('click_async_with_args').on('click', click_async_with_args)
+
+    screen.open('/')
+    screen.click('click_sync_no_args')
+    screen.click('click_sync_with_args')
+    screen.click('click_async_no_args')
+    screen.click('click_async_with_args')
+    screen.wait(0.5)
+    screen.should_contain('click_sync_no_args')
+    screen.should_contain('click_sync_with_args')
+    screen.should_contain('click_async_no_args')
+    screen.should_contain('click_async_with_args')
 
 
 def test_event_with_update_before_await(screen: Screen):


### PR DESCRIPTION
This PR

- adds tests for all supported types of event handlers
- allows `event.handle_event` being called with a dictionary and an additional `sender` argument
- lets `element.handle_event` use `event.handle_event`

This way every event handler is executed in the correct scope and awaited (if necessary).

Weirdly, though, an `on_click` event of, e.g., a button will enter `event.handle_event` twice: Once from `element.handle_event` and once from within the lambda statement:

```py
self.on('click', lambda _: handle_event(on_click, ClickEventArguments(sender=self, client=self.client)))
```

But this should be ok. The element is pushed to the slot stack twice, which doesn't matter. Apart from this the second call doesn't do much. So I'd leave it like this.