### PR TITLE
#315 catch webgl exception and show error message

### DIFF
--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -67,7 +67,7 @@ export default {
     light.position.set(5, 10, 40);
     this.scene.add(light);
 
-    const renderer = undefined;
+    let renderer = undefined;
     try {
       renderer = new THREE.WebGLRenderer({
         antialias: true,

--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -67,11 +67,21 @@ export default {
     light.position.set(5, 10, 40);
     this.scene.add(light);
 
-    const renderer = new THREE.WebGLRenderer({
-      antialias: true,
-      alpha: true,
-      canvas: this.$el.children[0],
-    });
+    const renderer = undefined;
+    try {
+      renderer = new THREE.WebGLRenderer({
+        antialias: true,
+        alpha: true,
+        canvas: this.$el.children[0],
+      });
+    } catch {
+      this.$el.innerHTML = "Could not create WebGL renderer.";
+      this.$el.style.width = this.width + "px";
+      this.$el.style.height = this.height + "px";
+      this.$el.style.padding = "10px";
+      this.$el.style.border = "1px solid silver";
+      return;
+    }
     renderer.setClearColor("#eee");
     renderer.setSize(this.width, this.height);
 


### PR DESCRIPTION
This PR proposes a solution to #315: If the `THREE.WebGLRenderer` cannot be instantiated, an error message is shown instead of the 3D scene.