### PR TITLE
Expansion value

### DIFF
--- a/nicegui/elements/expansion.py
+++ b/nicegui/elements/expansion.py
@@ -1,18 +1,25 @@
 from typing import Optional
 
-from ..element import Element
+from .mixins.value_element import ValueElement
 
 
-class Expansion(Element):
+class Expansion(ValueElement):
 
-    def __init__(self, text: str, *, icon: Optional[str] = None) -> None:
+    def __init__(self, text: str, *, icon: Optional[str] = None, value: bool = False) -> None:
         '''Expansion Element
 
         Provides an expandable container.
 
         :param text: title text
         :param icon: optional icon (default: None)
+        :param value: whether the expansion should be opened on creation (default: `False`)
         '''
-        super().__init__('q-expansion-item')
+        super().__init__(tag='q-expansion-item', value=value, on_value_change=None)
         self._props['label'] = text
         self._props['icon'] = icon
+
+    def open(self) -> None:
+        self.value = True
+
+    def close(self) -> None:
+        self.value = False

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -1,0 +1,47 @@
+from typing import List
+
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
+
+from nicegui import ui
+
+from .screen import Screen
+
+
+def test_open_close_dialog(screen: Screen):
+    with ui.dialog() as d, ui.card():
+        ui.label('Content')
+        ui.button('Close', on_click=d.close)
+    ui.button('Open', on_click=d.open)
+
+    screen.open('/')
+    screen.should_not_contain('Content')
+    screen.click('Open')
+    screen.wait(0.5)
+    screen.should_contain('Content')
+    screen.click('Close')
+    screen.wait(0.5)
+    screen.should_not_contain('Content')
+
+
+def test_await_dialog(screen: Screen):
+    with ui.dialog() as dialog, ui.card():
+        ui.label('Are you sure?')
+        with ui.row():
+            ui.button('Yes', on_click=lambda: dialog.submit('Yes'))
+            ui.button('No', on_click=lambda: dialog.submit('No'))
+
+    async def show() -> None:
+        results.append(await dialog)
+    results: List[str] = []
+    ui.button('Open', on_click=show)
+
+    screen.open('/')
+    screen.click('Open')
+    screen.click('Yes')
+    screen.click('Open')
+    screen.click('No')
+    screen.click('Open')
+    ActionChains(screen.selenium).send_keys(Keys.ESCAPE).perform()
+    screen.wait(0.5)
+    assert results == ['Yes', 'No', None]

--- a/tests/test_expansion.py
+++ b/tests/test_expansion.py
@@ -1,0 +1,20 @@
+from nicegui import ui
+
+from .screen import Screen
+
+
+def test_open_close_expansion(screen: Screen):
+    with ui.expansion('Expansion') as e:
+        ui.label('Content')
+    ui.button('Open', on_click=e.open)
+    ui.button('Close', on_click=e.close)
+
+    screen.open('/')
+    screen.should_contain('Expansion')
+    screen.should_not_contain('Content')
+    screen.click('Open')
+    screen.wait(0.5)
+    screen.should_contain('Content')
+    screen.click('Close')
+    screen.wait(0.5)
+    screen.should_not_contain('Content')


### PR DESCRIPTION
In discussion #329 we came up with the idea of deriving the `ui.expansion` from `ValueElement`. This way it behaves just like `ui.dialog`: There is a bindable `value` property representing its current state, a `value` initializer parameter, and `open()`/`close()` methods.

I also took the opportunity to add tests not only for `ui.expansion` but for `ui.dialog` as well.