### PR TITLE
(feature) Exposing the AG Grid table's getSelectedRows function.

### DIFF
--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -1,5 +1,6 @@
 from typing import Dict, List
 
+from .. import globals
 from ..dependencies import register_component
 from ..element import Element
 
@@ -41,3 +42,23 @@ class Table(Element):
         :param args: arguments to pass to the method
         """
         self.run_method('call_api_method', name, *args)
+
+    async def get_selected_rows(self, single: bool = False) -> list[dict[str, any]] | None:
+        """Returns an unsorted list of selected rows (i.e. row data that you provided).
+
+        See `AG Grid API <https://www.ag-grid.com/javascript-data-grid/row-selection/#reference-selection-getSelectedRows>`_ for a doc of method.
+
+        :param single: return a single row (default: `False`)
+        """
+
+        selected_rows: list[dict] = await globals.get_client().run_javascript(
+            f'return getElement({self.id}).gridOptions.api.getSelectedRows();'
+        )
+
+        if len(selected_rows) == 0:
+            return None
+
+        if single:
+            return selected_rows[0]
+
+        return selected_rows

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,3 +1,6 @@
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
+
 from nicegui import ui
 
 from .screen import Screen
@@ -82,3 +85,29 @@ def test_call_api_method_with_argument(screen: Screen):
     screen.should_contain('Alice')
     screen.should_not_contain('Bob')
     screen.should_not_contain('Carol')
+
+
+def test_get_selected_rows(screen: Screen):
+    table = ui.table({
+        'columnDefs': [{'field': 'name'}],
+        'rowData': [{'name': 'Alice'}, {'name': 'Bob'}, {'name': 'Carol'}],
+        'rowSelection': 'multiple',
+    })
+
+    async def get_selected_rows():
+        ui.label(str(await table.get_selected_rows()))
+    ui.button('Get selected rows', on_click=get_selected_rows)
+
+    async def get_selected_row():
+        ui.label(str(await table.get_selected_row()))
+    ui.button('Get selected row', on_click=get_selected_row)
+
+    screen.open('/')
+    screen.click('Alice')
+    screen.find('Bob')
+    ActionChains(screen.selenium).key_down(Keys.SHIFT).click(screen.find('Bob')).key_up(Keys.SHIFT).perform()
+    screen.click('Get selected rows')
+    screen.should_contain("[{'name': 'Alice'}, {'name': 'Bob'}]")
+
+    screen.click('Get selected row')
+    screen.should_contain("{'name': 'Alice'}")


### PR DESCRIPTION
It is very complicated to have to search to find out how to get the data of the rows selected by the user.

For this reason, I decided to implement a method that internally calls the getSelectedRows function of the Ag Grid API, returning the list of data, or, if the value "single" is passed, the first result, and None, if nothing is selected.