### PR TITLE
Change Python version required for cryptography package to avoid a conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ matplotlib = [
     { version = "^3.6.0", markers = "python_version ~= '3.11.0'"},
 ]
 cryptography = [
-    { version = "^37.0.4", markers = "python_version ~= '3.7'"},
+    { version = "^37.0.4", markers = "python_version < '3.11.0'"},
     { version = "^38.0.3", markers = "python_version ~= '3.11.0'"},
 ]
 pillow = ">=9.3.0"


### PR DESCRIPTION
This should avoid requirements conflict.