### PR TITLE
delay opening the browser until uvicorn is ready (fixes #412)

### DIFF
--- a/nicegui/globals.py
+++ b/nicegui/globals.py
@@ -31,6 +31,7 @@ ui_run_has_been_called: bool = False
 
 host: str
 port: int
+show: bool
 reload: bool
 title: str
 viewport: str

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 import urllib.parse
+import webbrowser
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -67,6 +68,8 @@ def handle_startup(with_welcome_message: bool = True) -> None:
     globals.state = globals.State.STARTED
     if with_welcome_message:
         print(f'NiceGUI ready to go on http://{globals.host}:{globals.port}')
+    if globals.show:
+        webbrowser.open(f'http://{globals.host if globals.host != "0.0.0.0" else "127.0.0.1"}:{globals.port}/')
 
 
 @app.on_event('shutdown')

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -2,7 +2,6 @@ import logging
 import multiprocessing
 import os
 import sys
-import webbrowser
 from typing import List, Optional
 
 import uvicorn
@@ -53,6 +52,7 @@ def run(*,
     globals.ui_run_has_been_called = True
     globals.host = host
     globals.port = port
+    globals.show = show
     globals.reload = reload
     globals.title = title
     globals.viewport = viewport
@@ -64,9 +64,6 @@ def run(*,
 
     if multiprocessing.current_process().name != 'MainProcess':
         return
-
-    if show:
-        webbrowser.open(f'http://{host if host != "0.0.0.0" else "127.0.0.1"}:{port}/')
 
     def split_args(args: str) -> List[str]:
         return [a.strip() for a in args.split(',')]

--- a/nicegui/run_with.py
+++ b/nicegui/run_with.py
@@ -20,6 +20,7 @@ def run_with(
     globals.viewport = viewport
     globals.favicon = favicon
     globals.dark = dark
+    globals.show = False
     globals.binding_refresh_interval = binding_refresh_interval
     globals.excludes = [e.strip() for e in exclude.split(',')]
     globals.tailwind = True


### PR DESCRIPTION
As described in #412 the browser opening command was executed way too early. This PR fixes this by moving the open until Uvicorn is ready.