### PR TITLE
`Password Input`: dedicated element for passwords, like `textarea element`

### DIFF
--- a/nicegui/elements/password.py
+++ b/nicegui/elements/password.py
@@ -1,0 +1,59 @@
+from typing import Any, Callable, Dict, Optional
+
+from .icon import Icon
+from .mixins.value_element import ValueElement
+
+
+class Password(ValueElement):
+    LOOPBACK = False
+
+    def __init__(self,
+                 label: Optional[str] = None, *,
+                 placeholder: Optional[str] = None,
+                 value: str = '',
+                 toggle_button: bool = False,
+                 on_change: Optional[Callable] = None,
+                 validation: Dict[str, Callable] = {}) -> None:
+        """Password Input
+
+        This element is based on Quasar's `QInput <https://quasar.dev/vue-components/input>`_ component.
+
+        The `on_change` event is called on every keystroke and the value updates accordingly.
+        If you want to wait until the user confirms the input, you can register a custom event callback, e.g.
+        `ui.input(...).on('keydown.enter', ...)` or `ui.input(...).on('blur', ...)`.
+
+        You can use the `validation` parameter to define a dictionary of validation rules.
+        The key of the first rule that fails will be displayed as an error message.
+
+        :param label: displayed label for the text input
+        :param placeholder: text to show if no value is entered
+        :param value: the current value of the text input
+        :param toggle_button: whether to show a button to toggle the password visibility (default: False)
+        :param on_change: callback to execute when the input is confirmed by leaving the focus
+        :param validation: dictionary of validation rules, e.g. ``{'Too short!': lambda value: len(value) < 3}``
+        """
+        super().__init__(tag='q-input', value=value, on_value_change=on_change)
+        if label is not None:
+            self._props['label'] = label
+        if placeholder is not None:
+            self._props['placeholder'] = placeholder
+        self._props['type'] = 'password'
+
+        if toggle_button:
+            with self.add_slot('append'):
+                def toggle_type(_):
+                    is_hidden = self._props.get('type') == 'password'
+                    icon.props(f'name={"visibility" if is_hidden else "visibility_off"}')
+                    self.props(f'type={"text" if is_hidden else "password"}')
+                icon = Icon('visibility_off').classes('cursor-pointer').on('click', toggle_type)
+
+        self.validation = validation
+
+    def on_value_change(self, value: Any) -> None:
+        super().on_value_change(value)
+        for message, check in self.validation.items():
+            if not check(value):
+                self.props(f'error error-message="{message}"')
+                break
+        else:
+            self.props(remove='error')

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -32,6 +32,7 @@ from .elements.menu import Menu as menu
 from .elements.menu import MenuItem as menu_item
 from .elements.mermaid import Mermaid as mermaid
 from .elements.number import Number as number
+from .elements.password import Password as password
 from .elements.plotly import Plotly as plotly
 from .elements.progress import CircularProgress as circular_progress
 from .elements.progress import LinearProgress as linear_progress

--- a/website/reference.py
+++ b/website/reference.py
@@ -134,6 +134,12 @@ def create_full(menu: ui.element) -> None:
                  validation={'Input too long': lambda value: len(value) < 20})
         result = ui.label()
 
+    @example(ui.password, menu)
+    def password_example():
+        ui.password(label='Password', placeholder='start typing', validation={
+                    'Input too long': lambda value: len(value) < 20,
+                    'Input too short': lambda value: len(value) > 8, })
+
     @example(ui.textarea, menu)
     def textarea_example():
         ui.textarea(label='Text', placeholder='start typing',


### PR DESCRIPTION
I believe that a `password` element is interesting, for the clarity of the built code.

It's preferable:

```python
from nicegui import ui

with ui.card():
    ui.input('Email')
    ui.password('Password')
    ui.button('Login')
```

To a `ui.input('Password', password=true)`