### PR TITLE
Add attribution to map example

### DIFF
--- a/examples/map/leaflet.js
+++ b/examples/map/leaflet.js
@@ -2,7 +2,9 @@ export default {
   template: "<div></div>",
   mounted() {
     this.map = L.map(this.$el);
-    L.tileLayer("http://{s}.tile.osm.org/{z}/{x}/{y}.png").addTo(this.map);
+    L.tileLayer("http://{s}.tile.osm.org/{z}/{x}/{y}.png", {
+        attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+      }).addTo(this.map);
   },
   methods: {
     set_location(latitude, longitude) {


### PR DESCRIPTION
Fixes one of the problems with the example files mentioned in #454 