### PR TITLE
Audio reference: align mute and unmute buttons with their intended function

### DIFF
--- a/website/reference.py
+++ b/website/reference.py
@@ -260,8 +260,8 @@ To overlay an SVG, make the `viewBox` exactly the size of the image and provide 
         a = ui.audio('https://cdn.pixabay.com/download/audio/2022/02/22/audio_d1718ab41b.mp3')
         a.on('ended', lambda _: ui.notify('Audio playback completed'))
 
-        ui.button(on_click=lambda: a.props('muted')).props('outline icon=volume_up')
-        ui.button(on_click=lambda: a.props(remove='muted')).props('outline icon=volume_off')
+        ui.button(on_click=lambda: a.props('muted')).props('outline icon=volume_off')
+        ui.button(on_click=lambda: a.props(remove='muted')).props('outline icon=volume_up')
 
     @example(ui.video, menu)
     def image_example():


### PR DESCRIPTION
## Description
I noticed that in the **audio example**, the buttons were mislabeled; the mute button was unmuting and the unmute button was muting.
After swapping the icons, the buttons now correspond to their function.

