### PR TITLE
Adds scoped slots feature.

### DIFF
--- a/examples/slots/main.py
+++ b/examples/slots/main.py
@@ -5,7 +5,7 @@ with ui.tree([
     {'id': 'numbers', 'icon': 'tag', 'children': [{'id': '1'}, {'id': '2'}]},
     {'id': 'letters', 'icon': 'text_fields', 'children': [{'id': 'A'}, {'id': 'B'}]},
 ], label_key='id', on_select=lambda e: ui.notify(e.value)) as tree:
-    tree.add_slot('default-header', '''
+    tree.add_slot('default-header', r'''
         <div class="row items-center">
             <q-icon :name="props.node.icon || 'share'" color="orange" size="28px" class="q-mr-sm" />
             <div class="text-weight-bold text-primary">{{ props.node.id }}</div>

--- a/examples/slots/main.py
+++ b/examples/slots/main.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from nicegui import ui
+
+with ui.tree([
+    {'id': 'numbers', 'icon': 'tag', 'children': [{'id': '1'}, {'id': '2'}]},
+    {'id': 'letters', 'icon': 'text_fields', 'children': [{'id': 'A'}, {'id': 'B'}]},
+], label_key='id', on_select=lambda e: ui.notify(e.value)) as tree:
+    tree.add_slot('default-header', '''
+        <div class="row items-center">
+            <q-icon :name="props.node.icon || 'share'" color="orange" size="28px" class="q-mr-sm" />
+            <div class="text-weight-bold text-primary">{{ props.node.id }}</div>
+        </div>
+    ''')
+    with tree.add_slot('default-body'):
+        ui.label('This is some default content.').classes('ml-8 text-weight-light text-black')
+
+ui.run()

--- a/main.py
+++ b/main.py
@@ -244,6 +244,7 @@ The command searches for `main.py` in in your current directory and makes the ap
             example_link('Search as you type', 'using public API of thecocktaildb.com to search for cocktails')
             example_link('Menu and Tabs', 'uses Quasar to create foldable menu and tabs inside a header bar')
             example_link('Trello Cards', 'shows Trello-like cards that can be dragged and dropped into columns')
+            example_link('Slots', 'shows how to use scoped slots to customize Quasar elements')
 
     with ui.row().classes('bg-primary w-full min-h-screen mt-16'):
         link_target('why')

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -58,7 +58,7 @@ class Element(ABC, Visibility):
         """Add a slot to the element.
 
         :param name: name of the slot
-        :param template: vueJS template of the slot
+        :param template: Vue template of the slot
         :return: the slot
         """
         self.slots[name] = Slot(self, name, template)
@@ -91,7 +91,10 @@ class Element(ABC, Visibility):
         return events
 
     def _collect_slot_dict(self) -> Dict[str, List[int]]:
-        return {name: {'template': slot.template, 'ids': [child.id for child in slot.children]} for name, slot in self.slots.items()}
+        return {
+            name: {'template': slot.template, 'ids': [child.id for child in slot.children]}
+            for name, slot in self.slots.items()
+        }
 
     def _to_dict(self, *keys: str) -> Dict:
         if not keys:

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -54,13 +54,14 @@ class Element(ABC, Visibility):
         if self.parent_slot:
             outbox.enqueue_update(self.parent_slot.parent)
 
-    def add_slot(self, name: str) -> Slot:
+    def add_slot(self, name: str, template: Optional[str] = None) -> Slot:
         """Add a slot to the element.
 
         :param name: name of the slot
+        :param template: vueJS template of the slot
         :return: the slot
         """
-        self.slots[name] = Slot(self, name)
+        self.slots[name] = Slot(self, name, template)
         return self.slots[name]
 
     def __enter__(self) -> Self:
@@ -90,7 +91,7 @@ class Element(ABC, Visibility):
         return events
 
     def _collect_slot_dict(self) -> Dict[str, List[int]]:
-        return {name: [child.id for child in slot.children] for name, slot in self.slots.items()}
+        return {name: {'template': slot.template, 'ids': [child.id for child in slot.children]} for name, slot in self.slots.items()}
 
     def _to_dict(self, *keys: str) -> Dict:
         if not keys:

--- a/nicegui/slot.py
+++ b/nicegui/slot.py
@@ -1,4 +1,6 @@
-from typing import Optional, TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
+
+from typing_extensions import Self
 
 from . import globals
 
@@ -11,13 +13,13 @@ class Slot:
     def __init__(self, parent: 'Element', name: str, template: Optional[str] = None) -> None:
         self.name = name
         self.parent = parent
+        self.template = template
         self.children: List['Element'] = []
-        self.template: str = template
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         globals.get_slot_stack().append(self)
         return self
 
-    def __exit__(self, *_):
+    def __exit__(self, *_) -> None:
         globals.get_slot_stack().pop()
         globals.prune_slot_stack()

--- a/nicegui/slot.py
+++ b/nicegui/slot.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List
+from typing import Optional, TYPE_CHECKING, List
 
 from . import globals
 
@@ -8,10 +8,11 @@ if TYPE_CHECKING:
 
 class Slot:
 
-    def __init__(self, parent: 'Element', name: str) -> None:
+    def __init__(self, parent: 'Element', name: str, template: Optional[str] = None) -> None:
         self.name = name
         self.parent = parent
         self.children: List['Element'] = []
+        self.template: str = template
 
     def __enter__(self):
         globals.get_slot_stack().append(self)

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -81,8 +81,7 @@
                 props: props
               }));
             }
-            const ids = ('ids' in data) ? data.ids : data;
-            const children = ids.map(id => renderRecursively(elements, id));
+            const children = data.ids.map(id => renderRecursively(elements, id));
             if (name === 'default' && element.text) {
               children.unshift(element.text);
             }

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -75,11 +75,11 @@
             const rendered = [];
             if (data.template) {
               rendered.push(Vue.h({
-                props: { props: { type: Object, default: {}} },
+                props: { props: { type: Object, default: {} } },
                 template: data.template,
               }, {
                 props: props
-              }))
+              }));
             }
             const ids = ('ids' in data) ? data.ids : data;
             const children = ids.map(id => renderRecursively(elements, id));

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -70,12 +70,24 @@
           props[event_name] = handler;
         });
         const slots = {};
-        Object.entries(element.slots).forEach(([name, ids]) => {
-          const children = ids.map(id => renderRecursively(elements, id));
-          if (name == 'default' && element.text) {
-            children.unshift(element.text);
+        Object.entries(element.slots).forEach(([name, data]) => {
+          slots[name] = (props) => {
+            const rendered = [];
+            if (data.template) {
+              rendered.push(Vue.h({
+                props: { props: { type: Object, default: {}} },
+                template: data.template,
+              }, {
+                props: props
+              }))
+            }
+            const ids = ('ids' in data) ? data.ids : data;
+            const children = ids.map(id => renderRecursively(elements, id));
+            if (name === 'default' && element.text) {
+              children.unshift(element.text);
+            }
+            return [ ...rendered, ...children]
           }
-          slots[name] = () => children;
         });
         return Vue.h(Vue.resolveComponent(element.tag), props, slots);
       }


### PR DESCRIPTION
I wish to suggest this PR.

It allows to customize component using there scoped slots. Somehow using the current API, you can customize a component via their named slots. Some components thought, let's you create complex and interesting features such as QTree or QTable. But to do so, you need to use the props injected into their scoped slots. For instance : 
- https://quasar.dev/vue-components/tree#customize-content
- https://quasar.dev/vue-components/table#body-slots

Here are some examples created using Nicegui and this PR: 
<img src="https://user-images.githubusercontent.com/812055/224907699-9b949031-d709-4e39-861b-41bfcdd4a0d7.png" width=300px>

![image](https://user-images.githubusercontent.com/812055/224911436-fb6c4d61-68da-4418-9430-f6c144acd179.png)


Some notes about the API: 
- Slot class has been extended to receive an optional template. A Slot with a template will be rendered as a scoped slot.
- The rest of the API has not changed, so it is transparent to anything else.
- Scoped slots uses props injected into the slot. The injected data is always named **props** and can be accessed from the vue template.
- There is no way to make that pure python that I could think of for technical reasons (I guess its kinda obvious but I can expand on this). I would argue that:
  - scoped slots can only be discovered using the Quasar documentation, hence it is an advanced use case
  - once discovered in the documentation, you have a vue example that you simply have to past in your own code. The only change will be to rename the injected props to props on some cases. 

I am looking forward to have your feedback on this :) I strongly believe this is a nice addition to the API because that is the only way to avoid creating custom components and custom js files in our projects to create stuffs like the table above.
