### PR TITLE
Add point-cloud support to 3D scene

### DIFF
--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -200,9 +200,9 @@ export default {
         mesh.add(light.target);
       } else if (type == "point_cloud") {
         const geometry = new THREE.BufferGeometry();
-        geometry.setAttribute('position', new THREE.Float32BufferAttribute(args[0].flat(), 3));
-        geometry.setAttribute('color', new THREE.Float32BufferAttribute(args[1].flat(), 3));
-        const material = new THREE.PointsMaterial( { size: args[2], vertexColors: true } );
+        geometry.setAttribute("position", new THREE.Float32BufferAttribute(args[0].flat(), 3));
+        geometry.setAttribute("color", new THREE.Float32BufferAttribute(args[1].flat(), 3));
+        const material = new THREE.PointsMaterial({ size: args[2], vertexColors: true });
         mesh = new THREE.Points(geometry, material);
       } else {
         let geometry;

--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -198,6 +198,12 @@ export default {
         light.target.position.set(1, 0, 0);
         mesh.add(light);
         mesh.add(light.target);
+      } else if (type == "point_cloud") {
+        const geometry = new THREE.BufferGeometry();
+        geometry.setAttribute('position', new THREE.Float32BufferAttribute(args[0].flat(), 3));
+        geometry.setAttribute('color', new THREE.Float32BufferAttribute(args[1].flat(), 3));
+        const material = new THREE.PointsMaterial( { size: args[2], vertexColors: true } );
+        mesh = new THREE.Points(geometry, material);
       } else {
         let geometry;
         const wireframe = args.pop();

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -44,6 +44,7 @@ class Scene(Element):
     from .scene_objects import Extrusion as extrusion
     from .scene_objects import Group as group
     from .scene_objects import Line as line
+    from .scene_objects import PointCloud as point_cloud
     from .scene_objects import QuadraticBezierTube as quadratic_bezier_tube
     from .scene_objects import Ring as ring
     from .scene_objects import Sphere as sphere
@@ -52,7 +53,6 @@ class Scene(Element):
     from .scene_objects import Text as text
     from .scene_objects import Text3d as text3d
     from .scene_objects import Texture as texture
-    from .scene_objects import PointCloud as pointcloud
 
     def __init__(self, width: int = 400, height: int = 300, on_click: Optional[Callable] = None) -> None:
         """3D Scene

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -52,6 +52,7 @@ class Scene(Element):
     from .scene_objects import Text as text
     from .scene_objects import Text3d as text3d
     from .scene_objects import Texture as texture
+    from .scene_objects import PointCloud as pointcloud
 
     def __init__(self, width: int = 400, height: int = 300, on_click: Optional[Callable] = None) -> None:
         """3D Scene

--- a/nicegui/elements/scene_objects.py
+++ b/nicegui/elements/scene_objects.py
@@ -169,3 +169,13 @@ class SpotLight(Object3D):
                  decay: float = 1.0,
                  ) -> None:
         super().__init__('spot_light', color, intensity, distance, angle, penumbra, decay)
+
+
+class PointCloud(Object3D):
+
+    def __init__(self,
+                points: List[List[float]],
+                color: List[List[float]],
+                point_size: float = 1.0,
+                ) -> None:
+        super().__init__('point_cloud', points, color, point_size)

--- a/nicegui/elements/scene_objects.py
+++ b/nicegui/elements/scene_objects.py
@@ -174,8 +174,8 @@ class SpotLight(Object3D):
 class PointCloud(Object3D):
 
     def __init__(self,
-                points: List[List[float]],
-                color: List[List[float]],
-                point_size: float = 1.0,
-                ) -> None:
-        super().__init__('point_cloud', points, color, point_size)
+                 points: List[List[float]],
+                 colors: List[List[float]],
+                 point_size: float = 1.0,
+                 ) -> None:
+        super().__init__('point_cloud', points, colors, point_size)


### PR DESCRIPTION
In my project I need to render pointclouds. As I would like to use nicegui, I added the support for rendering pointclouds.

Example usage:
```python
from nicegui import ui
import numpy as np

with ui.scene(width=1000, height=1000) as scene:
    x = np.linspace(0, 1, 10)
    cube = [[i, j, k] for i in x 
                    for j in x
                    for k in x]
    cube = np.array(cube).reshape(-1, 3)

    scene.pointcloud(points=cube.tolist(), color=cube.tolist(), point_size=0.1)

ui.run()
```

I'm a bit unsure how to best implement the colors, because with point clouds, each point can get its own color. This is not possible with materials. Therefore I use the `color` attribute of the `BufferGeometry`, as it is [intended](https://github.com/mrdoob/three.js/blob/master/examples/webgl_buffergeometry_points.html#L91) in ThreeJS.