### PR TITLE
Fix pyinstaller packaging after introduction of "native" mode

### DIFF
--- a/nicegui/native_mode.py
+++ b/nicegui/native_mode.py
@@ -12,6 +12,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings('ignore', category=DeprecationWarning)
     import webview
 
+multiprocessing.freeze_support()
 shutdown = multiprocessing.Event()
 
 


### PR DESCRIPTION
After the introduction of native mode, frozen packages created with pyinstaller as described in https://nicegui.io/reference#package_for_installation produced an executable which hung in an endless restarting loop. After much analysis it seems to be caused by

https://github.com/zauberzeug/nicegui/blob/main/nicegui/native_mode.py#L15

After applying this PR, which enables freeze-support for multiprocessing the error is gone.