### PR TITLE
Fix highchart error on update before mounted.

### DIFF
--- a/nicegui/elements/chart.js
+++ b/nicegui/elements/chart.js
@@ -9,12 +9,25 @@ export default {
       });
     }, 0); // NOTE: wait for window.path_prefix to be set in app.mounted()
   },
+  beforeDestroy() {
+    this.destroyChart();
+  },
+  beforeUnmount() {
+    this.destroyChart();
+  },
   methods: {
     update_chart() {
-      while (this.chart.series.length > this.options.series.length) this.chart.series[0].remove();
-      while (this.chart.series.length < this.options.series.length) this.chart.addSeries({}, false);
-      this.chart.update(this.options);
+      if (this.chart) {
+        while (this.chart.series.length > this.options.series.length) this.chart.series[0].remove();
+        while (this.chart.series.length < this.options.series.length) this.chart.addSeries({}, false);
+        this.chart.update(this.options);
+      }
     },
+    destroyChart () {
+      if (this.chart) {
+        this.chart.destroy()
+      }
+    }
   },
   props: {
     type: String,


### PR DESCRIPTION
Open the page: [https://nicegui.io/reference#chart](https://nicegui.io/reference#chart) with your console opened.

You will see an error :
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'series')

This is because the chart.py component is updated without the vue component actually mounted yet, hence the chart does not exists and can be updated.
Plus, if the component unmount/remount on the life of a single page, the chart is therefore leaking. Added a destroy method to handle that.