### PR TITLE
Fix: Exception when closing native mode window on Windows

### DIFF
--- a/nicegui/native_mode.py
+++ b/nicegui/native_mode.py
@@ -25,10 +25,8 @@ def activate(url: str, title: str, width: int, height: int, fullscreen: bool) ->
     shutdown = multiprocessing.Event()
 
     def check_shutdown() -> None:
-        while True:
-            if shutdown.wait():
-                _thread.interrupt_main()
-            time.sleep(0.1)
+        if shutdown.wait() and shutdown.is_set():
+            _thread.interrupt_main()
 
     args = url, title, width, height, fullscreen, shutdown
     multiprocessing.Process(target=open_window, args=args, daemon=False).start()

--- a/nicegui/native_mode.py
+++ b/nicegui/native_mode.py
@@ -1,3 +1,4 @@
+import _thread
 import multiprocessing
 import os
 import signal
@@ -25,8 +26,8 @@ def activate(url: str, title: str, width: int, height: int, fullscreen: bool) ->
 
     def check_shutdown() -> None:
         while True:
-            if shutdown.is_set():
-                os.kill(os.getpgid(os.getpid()), signal.SIGTERM)
+            if shutdown.wait():
+                _thread.interrupt_main()
             time.sleep(0.1)
 
     args = url, title, width, height, fullscreen, shutdown


### PR DESCRIPTION
As described in #584 closing the webview window throws an `AttributeError` exception on Windows OS. This is caused by `os.getpgid()` which only exists on unix systems.

I replace the `os.kill(os.getpgid(os.getpid()), signal.SIGTERM)`  method by `_thread.interrupt_main()`.

To avoid polling `is_set`, the blocking method `wait` is used to wait until the `shutdown` event is triggered.