### PR TITLE
Rewrite InteractiveImage component in a more vue-style way.

### DIFF
--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -1,11 +1,7 @@
 export default {
   template: `
     <div style="position:relative">
-      <img 
-        :src="src"
-        style="width:100%; height:100%;" 
-        v-on="onEvents"
-      />
+      <img :src="src" style="width:100%; height:100%;"  v-on="onEvents" draggable="false" />
       <svg v-if="cross" style="position:absolute;top:0;left:0;pointer-events:none" :viewBox="viewBox">
         <g :style="{ display: cssDisplay } ">
           <line :x1="x" y1="0" :x2="x" y2="100%" stroke="black" />

--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -1,9 +1,9 @@
 export default {
   template: `
     <div style="position:relative">
-      <img :src="src" style="width:100%; height:100%;"  v-on="onEvents" draggable="false" />
+      <img :src="src" style="width:100%; height:100%;" v-on="onEvents" draggable="false" />
       <svg v-if="cross" style="position:absolute;top:0;left:0;pointer-events:none" :viewBox="viewBox">
-        <g :style="{ display: cssDisplay } ">
+        <g :style="{ display: cssDisplay }">
           <line :x1="x" y1="0" :x2="x" y2="100%" stroke="black" />
           <line x1="0" :y1="y" x2="100%" :y2="y" stroke="black" />
         </g>
@@ -13,11 +13,11 @@ export default {
   `,
   data() {
     return {
-      viewBox: '0 0 0 0',
+      viewBox: "0 0 0 0",
       x: 100,
       y: 100,
-      cssDisplay: 'none'
-    }
+      cssDisplay: "none",
+    };
   },
   methods: {
     updateCrossHair(e) {
@@ -39,7 +39,7 @@ export default {
         metaKey: e.metaKey,
         shiftKey: e.shiftKey,
       });
-    }
+    },
   },
   computed: {
     onEvents() {
@@ -48,13 +48,13 @@ export default {
         allEvents[type] = (event) => this.onMouseEvent(type, event);
       }
       if (this.cross) {
-        allEvents['mouseenter'] = () => this.cssDisplay = 'block';
-        allEvents['mouseleave'] = () => this.cssDisplay = 'none';
-        allEvents['mousemove'] = (event) => this.updateCrossHair(event);
-        allEvents['load'] = (event) => this.onImageLoaded(event)
+        allEvents["mouseenter"] = () => (this.cssDisplay = "block");
+        allEvents["mouseleave"] = () => (this.cssDisplay = "none");
+        allEvents["mousemove"] = (event) => this.updateCrossHair(event);
+        allEvents["load"] = (event) => this.onImageLoaded(event);
       }
-      return allEvents
-    }
+      return allEvents;
+    },
   },
   props: {
     src: String,

--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -1,79 +1,64 @@
 export default {
   template: `
     <div style="position:relative">
-      <img style="width:100%; height:100%" />
-      <svg style="position:absolute;top:0;left:0;pointer-events:none">
-        <g style="display:none">
-          <line x1="100" y1="0" x2="100" y2="100%" stroke="black" />
-          <line x1="0" y1="100" x2="100%" y2="100" stroke="black" />
+      <img 
+        :src="src"
+        style="width:100%; height:100%;" 
+        v-on="onEvents"
+      />
+      <svg v-if="cross" style="position:absolute;top:0;left:0;pointer-events:none" :viewBox="viewBox">
+        <g :style="{ display: cssDisplay } ">
+          <line :x1="x" y1="0" :x2="x" y2="100%" stroke="black" />
+          <line x1="0" :y1="y" x2="100%" :y2="y" stroke="black" />
         </g>
-        <g v-html="content" style="display:none"></g>
+        <g v-html="content"></g>
       </svg>
     </div>
   `,
-  mounted() {
-    this.image = this.$el.firstChild;
-    const handle_completion = () => {
-      if (this.waiting_source) {
-        this.image.src = this.waiting_source;
-        this.waiting_source = undefined;
-      } else {
-        this.loading = false;
-      }
-    };
-    this.image.addEventListener("load", handle_completion);
-    this.image.addEventListener("error", handle_completion);
-    this.svg = this.$el.lastChild;
-    const cross = this.svg.firstChild;
-    this.image.ondragstart = () => false;
-    if (this.cross) {
-      this.image.style.cursor = "none";
-      this.image.addEventListener("mouseenter", (e) => {
-        cross.style.display = "block";
-      });
-      this.image.addEventListener("mouseleave", (e) => {
-        cross.style.display = "none";
-      });
-      this.image.addEventListener("mousemove", (e) => {
-        const x = (e.offsetX * e.target.naturalWidth) / e.target.clientWidth;
-        const y = (e.offsetY * e.target.naturalHeight) / e.target.clientHeight;
-        cross.firstChild.setAttribute("x1", x);
-        cross.firstChild.setAttribute("x2", x);
-        cross.lastChild.setAttribute("y1", y);
-        cross.lastChild.setAttribute("y2", y);
-      });
-    }
-    this.image.onload = (e) => {
-      const viewBox = `0 0 ${this.image.naturalWidth} ${this.image.naturalHeight}`;
-      this.svg.setAttribute("viewBox", viewBox);
-      this.svg.lastChild.setAttribute("style", "");
-    };
-    this.image.src = this.src;
-    for (const type of this.events) {
-      this.image.addEventListener(type, (e) => {
-        this.$emit("mouse", {
-          mouse_event_type: type,
-          image_x: (e.offsetX * e.target.naturalWidth) / e.target.clientWidth,
-          image_y: (e.offsetY * e.target.naturalHeight) / e.target.clientHeight,
-          button: e.button,
-          buttons: e.buttons,
-          altKey: e.altKey,
-          ctrlKey: e.ctrlKey,
-          metaKey: e.metaKey,
-          shiftKey: e.shiftKey,
-        });
-      });
+  data() {
+    return {
+      viewBox: '0 0 0 0',
+      x: 100,
+      y: 100,
+      cssDisplay: 'none'
     }
   },
   methods: {
-    set_source(source) {
-      if (this.loading) {
-        this.waiting_source = source;
-        return;
-      }
-      this.loading = true;
-      this.image.src = source;
+    updateCrossHair(e) {
+      this.x = (e.offsetX * e.target.naturalWidth) / e.target.clientWidth;
+      this.y = (e.offsetY * e.target.naturalHeight) / e.target.clientHeight;
     },
+    onImageLoaded(e) {
+      this.viewBox = `0 0 ${e.target.naturalWidth} ${e.target.naturalHeight}`;
+    },
+    onMouseEvent(type, e) {
+      this.$emit("mouse", {
+        mouse_event_type: type,
+        image_x: (e.offsetX * e.target.naturalWidth) / e.target.clientWidth,
+        image_y: (e.offsetY * e.target.naturalHeight) / e.target.clientHeight,
+        button: e.button,
+        buttons: e.buttons,
+        altKey: e.altKey,
+        ctrlKey: e.ctrlKey,
+        metaKey: e.metaKey,
+        shiftKey: e.shiftKey,
+      });
+    }
+  },
+  computed: {
+    onEvents() {
+      const allEvents = {};
+      for (const type of this.events) {
+        allEvents[type] = (event) => this.onMouseEvent(type, event);
+      }
+      if (this.cross) {
+        allEvents['mouseenter'] = () => this.cssDisplay = 'block';
+        allEvents['mouseleave'] = () => this.cssDisplay = 'none';
+        allEvents['mousemove'] = (event) => this.updateCrossHair(event);
+        allEvents['load'] = (event) => this.onImageLoaded(event)
+      }
+      return allEvents
+    }
   },
   props: {
     src: String,

--- a/nicegui/elements/interactive_image.py
+++ b/nicegui/elements/interactive_image.py
@@ -52,7 +52,3 @@ class InteractiveImage(SourceElement, ContentElement):
             )
             return handle_event(on_mouse, arguments)
         self.on('mouse', handle_mouse)
-
-    def on_source_change(self, source: str) -> None:
-        super().on_source_change(source)
-        self.run_method('set_source', source)


### PR DESCRIPTION
PR to demonstrate solution 2 evocated at #600 .

The following code prove this PR to not introduce regression: it shows the bubble on click, the crosshair and the bind_source.
```py
import uuid
from nicegui import ui
from nicegui.events import MouseEventArguments

class Demo:
    source = f"https://picsum.photos/200/300"

def reload():
    Demo.source = f"https://picsum.photos/200/300?dummy={uuid.uuid4()}"

def mouse_handler(e: MouseEventArguments):
    color = 'SkyBlue' if e.type == 'mousedown' else 'SteelBlue'
    ii.content += f'<circle cx="{e.image_x}" cy="{e.image_y}" r="15" fill="none" stroke="{color}" stroke-width="4" />'
    ui.notify(f'{e.type} at ({e.image_x:.1f}, {e.image_y:.1f})')

source = f"https://picsum.photos/200/300"
ui.button("click me", on_click=reload).style("height: 100%; width: 100%;")
ii = ui.interactive_image(on_mouse=mouse_handler, events=['mousedown', 'mouseup'], cross=True).style("width: 22em;").bind_source(Demo, 'source')
ui.run(dark=True)
```

Also this code below, demonstrate it to solve the issue at #600 : 
```py
import uuid
from nicegui import ui

def reload():
    rowItem.clear()
    words = uuid.uuid4()
    with rowItem:
        ui.button(words, on_click=reload).style("height: 100%; width: 100%;")
        ui.label(words.__str__()).style("height: 100%; width: 100%; font-size: 2em; text-align: center;")
        ui.interactive_image(f"https://picsum.photos/200/300?dummy={uuid.uuid4()}").style("width: 22em;")
    ui.update(rowItem)

rowItem = ui.row()
reload()
ui.run(dark=True)
```