### PR TITLE
Wait for the port to be open before opening the web browser.

### DIFF
--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -44,7 +44,7 @@ def is_port_open(host: str, port: int) -> bool:
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         sock.connect((host, port))
-    except ConnectionRefusedError, TimeoutError:
+    except (ConnectionRefusedError, TimeoutError):
         return False
     else:
         return True

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -39,8 +39,8 @@ def safe_invoke(func: Union[Callable, Awaitable], client: Optional['Client'] = N
         globals.handle_exception(e)
 
 
-def port_open_tcp(host: str, port: int) -> bool:
-    # Check if the port is open by checking if a TCP connection can be established.
+def is_port_open(host: str, port: int) -> bool:
+    """Check if the port is open by checking if a TCP connection can be established."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         sock.connect((host, port))
@@ -53,11 +53,16 @@ def port_open_tcp(host: str, port: int) -> bool:
 
 
 def schedule_browser(host: str, port: int) -> None:
-    # This function has to be non blocking. Therefore, we'll launch a thread, s.th.
-    # the main thread can proceed with the actual startup.
-    # The thread will be launched as a daemon, s.th. it doesn't interfere with Ctrl+C.
+    """Wait non-blockingly for the port to be open, then start a webbrowser.
+
+    This function launches a thread in order to be non-blocking. This thread then uses
+    `is_port_open` to check when the port opens. When connectivity is confirmed, the
+    webbrowser is launched using `webbrowser.open`
+
+    The thread is created as a daemon thread, in order to not interfere with Ctrl+C.
+    """
     def thread(host: str, port: int) -> None:
-        while not port_open_tcp(host, port):
+        while not is_port_open(host, port):
             time.sleep(0.1)
         webbrowser.open(f'http://{host}:{port}/')
 

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -44,7 +44,7 @@ def is_port_open(host: str, port: int) -> bool:
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         sock.connect((host, port))
-    except ConnectionRefusedError:
+    except ConnectionRefusedError, TimeoutError:
         return False
     else:
         return True

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -70,10 +70,10 @@ def schedule_browser(host: str, port: int) -> Tuple[threading.Thread, threading.
     cancel = threading.Event()
 
     def in_thread(host: str, port: int) -> None:
-        while not is_port_open(host, port) and not cancel.is_set():
+        while not is_port_open(host, port):
+            if cancel.is_set():
+                return
             time.sleep(0.1)
-        if cancel.is_set():
-            return
         webbrowser.open(f'http://{host}:{port}/')
 
     host = host if host != "0.0.0.0" else "127.0.0.1"

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -2,14 +2,13 @@ import logging
 import multiprocessing
 import os
 import sys
-import webbrowser
 from typing import List, Optional, Tuple
 
 import uvicorn
 from uvicorn.main import STARTUP_FAILURE
 from uvicorn.supervisors import ChangeReload, Multiprocess
 
-from . import globals, native_mode
+from . import globals, helpers, native_mode
 
 
 def run(*,
@@ -88,7 +87,7 @@ def run(*,
     os.environ['NICEGUI_URL'] = f'http://{host}:{port}'
 
     if show:
-        webbrowser.open(f'http://{host if host != "0.0.0.0" else "127.0.0.1"}:{port}/')
+        helpers.schedule_browser(host, port)
 
     def split_args(args: str) -> List[str]:
         return [a.strip() for a in args.split(',')]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -43,7 +43,7 @@ def test_schedule_browser(monkeypatch):
 
             sock.listen()
             # port opened
-            time.sleep(0.2)
+            time.sleep(1)
             assert called_with_url == f"http://{host}:{port}/"
         finally:
             cancel_event.set()
@@ -70,7 +70,7 @@ def test_schedule_browser_cancel(monkeypatch):
 
     cancel_event.set()
 
-    time.sleep(0.2)
+    time.sleep(1)
 
     assert not thread.is_alive()
     assert called_with_url is None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,13 +6,15 @@ import webbrowser
 from nicegui import helpers
 
 
-def test_is_port_open():
+def test_is_port_open_when_open():
     with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
         sock.bind(('127.0.0.1', 0))  # port = 0 => the OS chooses a port for us
         sock.listen(1)
         host, port = sock.getsockname()
     assert not helpers.is_port_open(host, port), 'after closing the socket, the port should be free'
 
+
+def test_is_port_open_when_closed():
     with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
         sock.bind(('127.0.0.1', port))
         sock.listen(1)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,76 @@
+import contextlib
+import socket
+import time
+import webbrowser
+
+from nicegui import helpers
+
+
+def test_is_port_open():
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+
+        sock.bind(('127.0.0.1', 0))  # port = 0 => the OS chooses a port for us
+        host, port = sock.getsockname()
+
+        # port bound, but not opened yet
+        assert not helpers.is_port_open(host, port)
+
+        sock.listen()
+        # port opened
+        assert helpers.is_port_open(host, port)
+
+
+def test_schedule_browser(monkeypatch):
+
+    called_with_url = None
+
+    def mock_webbrowser_open(url):
+        nonlocal called_with_url
+        called_with_url = url
+
+    monkeypatch.setattr(webbrowser, "open", mock_webbrowser_open)
+
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+
+        sock.bind(('127.0.0.1', 0))
+        host, port = sock.getsockname()
+
+        thread, cancel_event = helpers.schedule_browser(host, port)
+
+        try:
+            # port bound, but not opened yet
+            assert called_with_url is None
+
+            sock.listen()
+            # port opened
+            time.sleep(0.2)
+            assert called_with_url == f"http://{host}:{port}/"
+        finally:
+            cancel_event.set()
+
+
+def test_schedule_browser_cancel(monkeypatch):
+
+    called_with_url = None
+
+    def mock_webbrowser_open(url):
+        nonlocal called_with_url
+        called_with_url = url
+
+    monkeypatch.setattr(webbrowser, "open", mock_webbrowser_open)
+
+    # This test doesn't need to open a port, but it binds a socket, s.th. we can be sure
+    # it is NOT open.
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(('127.0.0.1', 0))
+    host, port = sock.getsockname()
+
+    thread, cancel_event = helpers.schedule_browser(host, port)
+
+    cancel_event.set()
+
+    time.sleep(0.2)
+
+    assert not thread.is_alive()
+    assert called_with_url is None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,16 +8,15 @@ from nicegui import helpers
 
 def test_is_port_open():
     with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
-
         sock.bind(('127.0.0.1', 0))  # port = 0 => the OS chooses a port for us
+        sock.listen(1)
         host, port = sock.getsockname()
+    assert not helpers.is_port_open(host, port), 'after closing the socket, the port should be free'
 
-        # port bound, but not opened yet
-        assert not helpers.is_port_open(host, port)
-
-        sock.listen()
-        # port opened
-        assert helpers.is_port_open(host, port)
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(('127.0.0.1', port))
+        sock.listen(1)
+        assert helpers.is_port_open(host, port), 'after opening the socket, the port should be detected'
 
 
 def test_schedule_browser(monkeypatch):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -49,7 +49,7 @@ def test_schedule_browser(monkeypatch):
             cancel_event.set()
 
 
-def test_schedule_browser_cancel(monkeypatch):
+def test_canceling_schedule_browser(monkeypatch):
 
     called_with_url = None
 
@@ -59,18 +59,17 @@ def test_schedule_browser_cancel(monkeypatch):
 
     monkeypatch.setattr(webbrowser, "open", mock_webbrowser_open)
 
-    # This test doesn't need to open a port, but it binds a socket, s.th. we can be sure
-    # it is NOT open.
-
+    # find a free port ...
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.bind(('127.0.0.1', 0))
+    sock.listen(1)
     host, port = sock.getsockname()
+    # ... and close it so schedule_browser does not launch the browser
+    sock.close()
 
     thread, cancel_event = helpers.schedule_browser(host, port)
-
+    time.sleep(0.2)
     cancel_event.set()
-
-    time.sleep(1)
-
+    time.sleep(0.2)
     assert not thread.is_alive()
     assert called_with_url is None


### PR DESCRIPTION
Closes #412.

This PR adds functionality to check if a TCP port is open and to wait until a port opens, before opening a web browser. This functionality is used in `run.py`, in order to ensure that the UI is running before the browser opens.

The functionality is achieved using the `socket` and `threading` standard library modules. The port is checked to be open by trying to create a TCP connection. The waiting is made non-blocking by putting it into a separate thread.


I'm unsure about wether or not I found a good spot in the codebase to put my stuff. Also, this might be possible to do with async instead of a thread, but since `run()` is synchronous I don't think it fits here.

Tell me if I can improve anything.