### PR TITLE
#714 serve static files individually

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import platform
 import time
 import urllib.parse
 from pathlib import Path
@@ -9,7 +8,6 @@ from typing import Dict, Optional
 from fastapi import HTTPException, Request
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, Response
-from fastapi.staticfiles import StaticFiles
 from fastapi_socketio import SocketManager
 
 from nicegui import json
@@ -30,11 +28,6 @@ socket_manager = SocketManager(app=app, mount_location='/_nicegui_ws/', json=jso
 globals.sio = sio = app.sio
 
 app.add_middleware(GZipMiddleware)
-static_files = StaticFiles(
-    directory=Path(__file__).parent / 'static',
-    follow_symlink=platform.system().lower() != 'windows'
-)
-app.mount(f'/_nicegui/{__version__}/static', static_files, name='static')
 
 globals.index_client = Client(page('/'), shared=True).__enter__()
 
@@ -42,6 +35,16 @@ globals.index_client = Client(page('/'), shared=True).__enter__()
 @app.get('/')
 def index(request: Request) -> Response:
     return globals.index_client.build_response(request)
+
+
+@app.get(f'/_nicegui/{__version__}' + '/static/{name}')
+def get_static(name: str):
+    return FileResponse(Path(__file__).parent / 'static' / name)
+
+
+@app.get(f'/_nicegui/{__version__}' + '/static/fonts/{name}')
+def get_static(name: str):
+    return FileResponse(Path(__file__).parent / 'static' / 'fonts' / name)
 
 
 @app.get(f'/_nicegui/{__version__}' + '/dependencies/{id}/{name}')


### PR DESCRIPTION
In #714 we discussed several problems related to how NiceGUI serves static files. In order to successfully run on replit.com (an environment which caches Python packages using symlinks pointing somewhere outside the original static directory), we introduced `follow_symlink=True`. Due to an implementation detail in Starlette, this introduced a bug with venvs on Windows. Similarly, packaging with PyInstaller on Mac doesn't work either.

This PR removes Starlette's `StaticFiles` altogether and uses two "normal" get endpoints for static files and fonts. It has successfully been tested on Mac, with and without PyInstaller, and passed all GitHub actions. Before merging, we should test it on Windows.