### PR TITLE
#714 use Starlette's StaticFiles again

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional
 from fastapi import HTTPException, Request
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, Response
+from fastapi.staticfiles import StaticFiles
 from fastapi_socketio import SocketManager
 
 from nicegui import json
@@ -28,6 +29,11 @@ socket_manager = SocketManager(app=app, mount_location='/_nicegui_ws/', json=jso
 globals.sio = sio = app.sio
 
 app.add_middleware(GZipMiddleware)
+static_files = StaticFiles(
+    directory=(Path(__file__).parent / 'static').resolve(),
+    follow_symlink=True,
+)
+app.mount(f'/_nicegui/{__version__}/static', static_files, name='static')
 
 globals.index_client = Client(page('/'), shared=True).__enter__()
 
@@ -35,16 +41,6 @@ globals.index_client = Client(page('/'), shared=True).__enter__()
 @app.get('/')
 def index(request: Request) -> Response:
     return globals.index_client.build_response(request)
-
-
-@app.get(f'/_nicegui/{__version__}' + '/static/{name}')
-def get_static(name: str):
-    return FileResponse(Path(__file__).parent / 'static' / name)
-
-
-@app.get(f'/_nicegui/{__version__}' + '/static/fonts/{name}')
-def get_static(name: str):
-    return FileResponse(Path(__file__).parent / 'static' / 'fonts' / name)
 
 
 @app.get(f'/_nicegui/{__version__}' + '/dependencies/{id}/{name}')


### PR DESCRIPTION
In #714 we discussed problems with how Starlette serves static files behind symlinks.
In #720 I proposed a solution using individual file responses instead. Although we merged and released this PR, concerns about performance remained.

This PR uses `StaticFiles` again, but resolving the path before passing it to Starlette. This calls `os.path.realpath` internally, which should fix the issue with PyInstaller on Mac and venvs on Windows.

Argument for `follow_symlink`: Whether following symlinks implicitly with `FileResponse` or explicitly with `StaticFiles(..., follow_symlink=True)`, we need to be able to reach out of the static directory in many cases where the OS, packaging framework or hosting platform rearranges and symlinks files internally.

But again, we need to test it on all platforms first.