### PR TITLE
Add workaround to docs for native mode when WebView2Loader.dll fails load

### DIFF
--- a/website/documentation.py
+++ b/website/documentation.py
@@ -604,6 +604,16 @@ def create_full() -> None:
     # HACK: restore color
     demo.BROWSER_BGCOLOR = demo_BROWSER_BGCOLOR
 
+    # Show a helpful workaround until issue is fixed upstream.
+    # For more info see: https://github.com/r0x0r/pywebview/issues/1078
+    ui.markdown('''
+        If webview has trouble finding required libraries, you may get an error relating to 'WebView2Loader.dll'.
+        To workaround around this issue, try moving the dll file up a directory.
+        
+        * From: `.venv/Lib/site-packages/webview/lib/x64/WebView2Loader.dll`
+        * To: `.venv/Lib/site-packages/webview/lib/WebView2Loader.dll`
+    ''')
+
     @text_demo('Environment Variables', '''
         You can set the following environment variables to configure NiceGUI:
 


### PR DESCRIPTION
Myself and a couple other users so far have run into this hiccup with running in native mode.

Adds a helpful workaround to the docs to ease confusion until the issue is fixed in pywebview.