### PR TITLE
Support for emoji favicons

### DIFF
--- a/nicegui/favicon.py
+++ b/nicegui/favicon.py
@@ -1,3 +1,4 @@
+import urllib
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -10,7 +11,7 @@ if TYPE_CHECKING:
 
 
 def create_favicon_route(path: str, favicon: Optional[str]) -> None:
-    if favicon and is_remote_url(favicon):
+    if favicon and (is_remote_url(favicon) or is_char(favicon)):
         return
     fallback = Path(__file__).parent / 'static' / 'favicon.ico'
     path = f'{"" if path == "/" else path}/favicon.ico'
@@ -24,6 +25,8 @@ def get_favicon_url(page: 'page', prefix: str) -> str:
         return favicon
     elif not favicon:
         return f'{prefix}/_nicegui/{__version__}/static/favicon.ico'
+    if is_char(favicon):
+        return char_to_data_url(favicon)
     elif page.path == '/':
         return f'{prefix}/favicon.ico'
     else:
@@ -32,3 +35,29 @@ def get_favicon_url(page: 'page', prefix: str) -> str:
 
 def is_remote_url(favicon: str) -> bool:
     return favicon.startswith('http://') or favicon.startswith('https://')
+
+
+def is_char(favicon: str) -> bool:
+    return len(favicon) == 1
+
+
+def char_to_data_url(char: str):
+    svg = f'''
+        <svg viewBox="0 0 128 128" width="128" height="128" xmlns="http://www.w3.org/2000/svg" >
+            <style>
+                @supports (-moz-appearance:none) {{
+                    text {{
+                        font-size: 100px;
+                        transform: translateY(0.1em);
+                    }}
+                }}
+                text {{
+                    font-family: Arial, sans-serif;
+                }}
+            </style>
+            <text y=".9em" font-size="128" font-family="Georgia, sans-serif">{char}</text>
+        </svg>
+    '''
+    svg_urlencoded = urllib.parse.quote(svg)
+    data_url = f"data:image/svg+xml,{svg_urlencoded}"
+    return data_url

--- a/nicegui/favicon.py
+++ b/nicegui/favicon.py
@@ -41,7 +41,7 @@ def is_char(favicon: str) -> bool:
     return len(favicon) == 1
 
 
-def char_to_data_url(char: str):
+def char_to_data_url(char: str) -> str:
     svg = f'''
         <svg viewBox="0 0 128 128" width="128" height="128" xmlns="http://www.w3.org/2000/svg" >
             <style>

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -41,7 +41,7 @@ def run(*,
     :param port: use this port (default: `8080`)
     :param title: page title (default: `'NiceGUI'`, can be overwritten per page)
     :param viewport: page meta viewport content (default: `'width=device-width, initial-scale=1'`, can be overwritten per page)
-    :param favicon: relative filepath or absolute URL to a favicon (default: `None`, NiceGUI icon will be used)
+    :param favicon: relative filepath, absolute URL to a favicon (default: `None`, NiceGUI icon will be used) or emoji (e.g. `'🚀'`)
     :param dark: whether to use Quasar's dark mode (default: `False`, use `None` for "auto" mode)
     :param binding_refresh_interval: time between binding updates (default: `0.1` seconds, bigger is more CPU friendly)
     :param show: automatically open the UI in a browser tab (default: `True`)

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -41,7 +41,7 @@ def run(*,
     :param port: use this port (default: `8080`)
     :param title: page title (default: `'NiceGUI'`, can be overwritten per page)
     :param viewport: page meta viewport content (default: `'width=device-width, initial-scale=1'`, can be overwritten per page)
-    :param favicon: relative filepath, absolute URL to a favicon (default: `None`, NiceGUI icon will be used) or emoji (e.g. `'🚀'`, works for most browser)
+    :param favicon: relative filepath, absolute URL to a favicon (default: `None`, NiceGUI icon will be used) or emoji (e.g. `'🚀'`, works for most browsers)
     :param dark: whether to use Quasar's dark mode (default: `False`, use `None` for "auto" mode)
     :param binding_refresh_interval: time between binding updates (default: `0.1` seconds, bigger is more CPU friendly)
     :param show: automatically open the UI in a browser tab (default: `True`)

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -41,7 +41,7 @@ def run(*,
     :param port: use this port (default: `8080`)
     :param title: page title (default: `'NiceGUI'`, can be overwritten per page)
     :param viewport: page meta viewport content (default: `'width=device-width, initial-scale=1'`, can be overwritten per page)
-    :param favicon: relative filepath, absolute URL to a favicon (default: `None`, NiceGUI icon will be used) or emoji (e.g. `'🚀'`)
+    :param favicon: relative filepath, absolute URL to a favicon (default: `None`, NiceGUI icon will be used) or emoji (e.g. `'🚀'`, works for most browser)
     :param dark: whether to use Quasar's dark mode (default: `False`, use `None` for "auto" mode)
     :param binding_refresh_interval: time between binding updates (default: `0.1` seconds, bigger is more CPU friendly)
     :param show: automatically open the UI in a browser tab (default: `True`)


### PR DESCRIPTION
This PR allows to use emoji favicons as requested by [u/my_name_isnt_clever](https://www.reddit.com/user/my_name_isnt_clever/) on Reddit: 
https://www.reddit.com/r/Python/comments/12m03v5/comment/jgb5p96/. 

While it works on most browsers, SVG support is still not supported everywhere. Still I think it is very nice to have this option for small test apps.