### PR TITLE
Add min/max/step/prefix/suffix to ui.number

### DIFF
--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -10,6 +10,11 @@ class Number(ValueElement):
                  label: Optional[str] = None, *,
                  placeholder: Optional[str] = None,
                  value: Optional[float] = None,
+                 min: Optional[float] = None,
+                 max: Optional[float] = None,
+                 step: Optional[float] = None,
+                 prefix: Optional[str] = None,
+                 suffix: Optional[str] = None,
                  format: Optional[str] = None,
                  on_change: Optional[Callable] = None,
                  validation: Dict[str, Callable] = {}) -> None:
@@ -23,6 +28,11 @@ class Number(ValueElement):
         :param label: displayed name for the number input
         :param placeholder: text to show if no value is entered
         :param value: the initial value of the field
+        :param min: the minimum value allowed
+        :param max: the maximum value allowed
+        :param step: the step size for the stepper buttons
+        :param prefix: a prefix to prepend to the displayed value
+        :param suffix: a suffix to append to the displayed value
         :param format: a string like "%.2f" to format the displayed value
         :param on_change: callback to execute when the input is confirmed by leaving the focus
         :param validation: dictionary of validation rules, e.g. ``{'Too small!': lambda value: value < 3}``
@@ -34,6 +44,16 @@ class Number(ValueElement):
             self._props['label'] = label
         if placeholder is not None:
             self._props['placeholder'] = placeholder
+        if min is not None:
+            self._props['min'] = min
+        if max is not None:
+            self._props['max'] = max
+        if step is not None:
+            self._props['step'] = step
+        if prefix is not None:
+            self._props['prefix'] = prefix
+        if suffix is not None:
+            self._props['suffix'] = suffix
         self.validation = validation
         self.on('blur', self.update)  # NOTE: to apply format (#736)
 

--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -55,7 +55,13 @@ class Number(ValueElement):
         if suffix is not None:
             self._props['suffix'] = suffix
         self.validation = validation
-        self.on('blur', self.update)  # NOTE: to apply format (#736)
+        self.on('blur', self.sanitize)
+
+    def sanitize(self) -> None:
+        value = float(self.value or 0)
+        value = max(value, self._props.get('min', -float('inf')))
+        value = min(value, self._props.get('max', float('inf')))
+        self.set_value(self.format % value if self.format else str(value))
 
     def on_value_change(self, value: Any) -> None:
         super().on_value_change(value)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -16,3 +16,16 @@ def test_apply_format_on_blur(screen: Screen):
     element.send_keys('789')
     screen.click('Button')
     screen.should_contain_input('3.1417')
+
+
+def test_max_value(screen: Screen):
+    ui.number('Number', min=0, max=10, value=5)
+    ui.button('Button')
+
+    screen.open('/')
+    screen.should_contain_input('5')
+
+    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
+    element.send_keys('6')
+    screen.click('Button')
+    screen.should_contain_input('10')


### PR DESCRIPTION
Following the discussion #765 this PR extends the `ui.number` element with additional parameters.
On blur the value is sanitized using the min and max values as well as the format string - if given.