### PR TITLE
fix layout issue with ui.refreshable

### DIFF
--- a/nicegui/functions/refreshable.js
+++ b/nicegui/functions/refreshable.js
@@ -1,0 +1,3 @@
+export default {
+  template: `<slot></slot>`,
+};

--- a/nicegui/functions/refreshable.py
+++ b/nicegui/functions/refreshable.py
@@ -2,7 +2,10 @@ from typing import Callable, List
 
 from typing_extensions import Self
 
+from ..dependencies import register_component
 from ..element import Element
+
+register_component('refreshable', __file__, 'refreshable.js')
 
 
 class refreshable:
@@ -22,7 +25,7 @@ class refreshable:
         return self
 
     def __call__(self) -> None:
-        with Element('div') as container:
+        with Element('refreshable') as container:
             self.func() if self.instance is None else self.func(self.instance)
         self.containers.append(container)
 


### PR DESCRIPTION
In #837 we noticed that `ui.refreshable` has impact on the layout of its children. Consider the following example:

```py
@ui.refreshable  # without this decorator, the label fills the whole card
def number_ui() -> None:
    ui.label('Hi!').classes('bg-red-100 w-full')

with ui.card().classes('w-96'):
    number_ui()
```

The additional container introduced by `ui.refreshable` yields a different width than the surrounding card. Therefore the label doesn't fill the whole card, but only the container, which has no width constrain.

I fixed it by introducing a custom `refreshable` component that acts as a simple pass-through component. This component acts as a wrapper for child components without applying any styling or layout constraints on them.