### PR TITLE
#848 Use `root_path` as prefix

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -68,7 +68,7 @@ class Client:
         self.content.__exit__()
 
     def build_response(self, request: Request, status_code: int = 200) -> Response:
-        prefix = request.headers.get('X-Forwarded-Prefix', '')
+        prefix = request.headers.get('X-Forwarded-Prefix', request.scope.get('root_path', ''))
         vue_html, vue_styles, vue_scripts = generate_vue_content()
         elements = json.dumps({id: element._to_dict() for id, element in self.elements.items()})
         return templates.TemplateResponse('index.html', {


### PR DESCRIPTION
From the issue #848. The [ASGI spec](https://asgi.readthedocs.io/en/latest/specs/www.html?highlight=root-path#http-connection-scope) provides scope that can be used to retrieve the prefix to use.

This patch prioritize the use of `X-Forwarded-Prefix` and only use `root_path` if `X-Forwarded-Prefix` is empty

The suggestion was made by @rodja