### PR TITLE
Ensure robust dependency paths to improve caching

### DIFF
--- a/nicegui/dependencies.py
+++ b/nicegui/dependencies.py
@@ -34,7 +34,7 @@ dependency_ids = IncrementingStringIds()
 
 vue_components: Dict[str, Component] = {}
 js_components: Dict[str, Component] = {}
-js_dependencies: Dict[int, Dependency] = {}
+js_dependencies: Dict[str, Dependency] = {}
 
 
 def register_component(name: str, py_filepath: str, component_filepath: str, dependencies: List[str] = [],
@@ -50,11 +50,10 @@ def register_component(name: str, py_filepath: str, component_filepath: str, dep
     for dependency in dependencies + optional_dependencies:
         path = Path(py_filepath).parent / dependency
         assert path.suffix == '.js', 'Only JS dependencies are supported.'
-        id = dependency_ids.get(str(path.resolve()))
-        if id not in js_dependencies:
+        if name not in js_dependencies:
             optional = dependency in optional_dependencies
-            js_dependencies[id] = Dependency(name=name, path=path, dependents=set(), optional=optional)
-        js_dependencies[id].dependents.add(name)
+            js_dependencies[name] = Dependency(name=name, path=path, dependents=set(), optional=optional)
+        js_dependencies[name].dependents.add(name)
 
 
 def generate_vue_content() -> Tuple[str, str, str]:

--- a/nicegui/dependencies.py
+++ b/nicegui/dependencies.py
@@ -20,14 +20,14 @@ class Component:
 
 @dataclass
 class Dependency:
-    id: int
+    name: str
     path: Path
     dependents: Set[str]
     optional: bool
 
     @property
     def import_path(self) -> str:
-        return f'/_nicegui/{__version__}/dependencies/{self.id}/{self.path.name}'
+        return f'/_nicegui/{__version__}/dependencies/{self.name}/{self.path.name}'
 
 
 dependency_ids = IncrementingStringIds()
@@ -53,7 +53,7 @@ def register_component(name: str, py_filepath: str, component_filepath: str, dep
         id = dependency_ids.get(str(path.resolve()))
         if id not in js_dependencies:
             optional = dependency in optional_dependencies
-            js_dependencies[id] = Dependency(id=id, path=path, dependents=set(), optional=optional)
+            js_dependencies[id] = Dependency(name=name, path=path, dependents=set(), optional=optional)
         js_dependencies[id].dependents.add(name)
 
 

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -43,11 +43,11 @@ def index(request: Request) -> Response:
     return globals.index_client.build_response(request)
 
 
-@app.get(f'/_nicegui/{__version__}' + '/dependencies/{id}/{name}')
-def get_dependencies(id: int, name: str):
-    if id in js_dependencies and js_dependencies[id].path.exists() and js_dependencies[id].path.name == name:
-        return FileResponse(js_dependencies[id].path, media_type='text/javascript')
-    raise HTTPException(status_code=404, detail=f'dependency "{name}" with ID {id} not found')
+@app.get(f'/_nicegui/{__version__}' + '/dependencies/{component}/{name}')
+def get_dependencies(component: str, name: str):
+    if component in js_dependencies and js_dependencies[component].path.exists() and js_dependencies[component].path.name == name:
+        return FileResponse(js_dependencies[component].path, media_type='text/javascript')
+    raise HTTPException(status_code=404, detail=f'dependency "{name}" with ID {component} not found')
 
 
 @app.get(f'/_nicegui/{__version__}' + '/components/{name}')


### PR DESCRIPTION
This PR uses the non-volatile name of the components instead of their possibly changing id numbers (which are generated on the fly). That way caching can be done in more cases than before which can improve page load significantly.