### PR TITLE
added reload and time_stamp parameter to set_source method

### DIFF
--- a/nicegui/elements/mixins/source_element.py
+++ b/nicegui/elements/mixins/source_element.py
@@ -1,4 +1,6 @@
-from typing import Any, Callable
+import time
+
+from typing import Any, Callable, Optional
 
 from typing_extensions import Self
 
@@ -61,11 +63,19 @@ class SourceElement(Element):
         bind(self, 'source', target_object, target_name, forward=forward, backward=backward)
         return self
 
-    def set_source(self, source: str) -> None:
+    def set_source(self, source: str, reload: bool = False, time_stamp: Optional[float] = None) -> None:
         """Set the source of this element.
 
         :param source: The new source.
+        :param reload: Update the time stamp of the source to force a reload.
+        :param time_stamp: Define a custom time stamp for an controlled reload of the source.
         """
+        if reload:
+            if time_stamp is None:
+                source = f'{source}?t={time.time()}'
+            else:
+                source = f'{source}?t={time_stamp}'
+
         self.source = source
 
     def on_source_change(self, source: str) -> None:


### PR DESCRIPTION
Adding '?t=time.time()' to the source path to ensure a reload doesn't seem very python native.

I suggest adding the reload parameter, which inserts the latest time into the source to ensure a forced reload.
Also, an optional time_stamp parameter should be added for an custom reloading of the content.

The source path string + '?t=time.time()'  pattern is still possible by default
