### PR TITLE
fix grabbing client ip from sio environ

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -53,7 +53,7 @@ class Client:
     @property
     def ip(self) -> Optional[str]:
         """Return the IP address of the client, or None if the client is not connected."""
-        return self.environ.get('REMOTE_ADDR') if self.environ else None
+        return self.environ['asgi.scope']['client'][0] if self.environ else None
 
     @property
     def has_socket_connection(self) -> bool:


### PR DESCRIPTION
In discussion #875 @eponymic reported the malfunction of `client.ip` property. This PR fixed the issue.

Test with 

```py
from nicegui import ui, Client

@ui.page('/')
async def index(client: Client):
    await client.connected()
    ui.label(f'Your IP is {client.ip}')

ui.run()
```

If accessed locally the ip is 127.0.0.1 as expected. But it was also 127.0.0.1, if the page was accessed remotely.