### PR TITLE
Chat message improvements

### DIFF
--- a/nicegui/elements/chat_message.js
+++ b/nicegui/elements/chat_message.js
@@ -1,7 +1,7 @@
 export default {
   template: `
     <q-chat-message
-      :text="[text]"
+      :text="text"
       :name="name"
       :label="label"
       :stamp="stamp"
@@ -10,7 +10,7 @@ export default {
     />
   `,
   props: {
-    text: String,
+    text: Array,
     name: String,
     label: String,
     stamp: String,

--- a/nicegui/elements/chat_message.py
+++ b/nicegui/elements/chat_message.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional, Union
 
 from ..dependencies import register_component
 from ..element import Element
@@ -9,7 +9,7 @@ register_component('chat_message', __file__, 'chat_message.js')
 class ChatMessage(Element):
 
     def __init__(self,
-                 text: str, *,
+                 text: Union[str, List[str]], *,
                  name: Optional[str] = None,
                  label: Optional[str] = None,
                  stamp: Optional[str] = None,
@@ -20,7 +20,7 @@ class ChatMessage(Element):
 
         Based on Quasar's `Chat Message <https://quasar.dev/vue-components/chat/>`_ component.
 
-        :param text: the message body
+        :param text: the message body (can be a list of strings for multiple message parts)
         :param name: the name of the message author
         :param label: renders a label header/section only
         :param stamp: timestamp of the message
@@ -28,7 +28,7 @@ class ChatMessage(Element):
         :param sent: render as a sent message (so from current user) (default: False)
         """
         super().__init__('chat_message')
-        self._props['text'] = text
+        self._props['text'] = [text] if isinstance(text, str) else text
         if name is not None:
             self._props['name'] = name
         if label is not None:

--- a/nicegui/elements/chat_message.py
+++ b/nicegui/elements/chat_message.py
@@ -1,3 +1,4 @@
+import html
 from typing import List, Optional, Union
 
 from ..dependencies import register_component
@@ -15,6 +16,7 @@ class ChatMessage(Element):
                  stamp: Optional[str] = None,
                  avatar: Optional[str] = None,
                  sent: bool = False,
+                 text_html: bool = False,
                  ) -> None:
         """Chat Message
 
@@ -26,9 +28,17 @@ class ChatMessage(Element):
         :param stamp: timestamp of the message
         :param avatar: URL to an avatar
         :param sent: render as a sent message (so from current user) (default: False)
+        :param text_html: render text as HTML (default: False)
         """
         super().__init__('chat_message')
-        self._props['text'] = [text] if isinstance(text, str) else text
+
+        if isinstance(text, str):
+            text = [text]
+        if not text_html:
+            text = [html.escape(part) for part in text]
+        self._props['text'] = ['<br />'.join(part.split('\n')) for part in text]
+        self._props['text-html'] = True
+
         if name is not None:
             self._props['name'] = name
         if label is not None:

--- a/nicegui/elements/chat_message.py
+++ b/nicegui/elements/chat_message.py
@@ -36,7 +36,8 @@ class ChatMessage(Element):
             text = [text]
         if not text_html:
             text = [html.escape(part) for part in text]
-        self._props['text'] = ['<br />'.join(part.split('\n')) for part in text]
+            text = [part.replace('\n', '<br />') for part in text]
+        self._props['text'] = text
         self._props['text-html'] = True
 
         if name is not None:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -22,8 +22,6 @@ def test_html(screen: Screen):
 
 def test_newline(screen: Screen):
     ui.chat_message('Hello\nNiceGUI!')
-    ui.chat_message('Hi\nnice guy!', text_html=True)
 
     screen.open('/')
     assert screen.find('Hello').find_element(By.TAG_NAME, 'br')
-    assert screen.find('Hi').find_element(By.TAG_NAME, 'br')

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,29 @@
+from selenium.webdriver.common.by import By
+
+from nicegui import ui
+
+from .screen import Screen
+
+
+def test_no_html(screen: Screen):
+    ui.chat_message('<strong>HTML</strong>')
+
+    screen.open('/')
+    screen.should_contain('<strong>HTML</strong>')
+
+
+def test_html(screen: Screen):
+    ui.chat_message('<strong>HTML</strong>', text_html=True)
+
+    screen.open('/')
+    screen.should_contain('HTML')
+    screen.should_not_contain('<strong>HTML</strong>')
+
+
+def test_newline(screen: Screen):
+    ui.chat_message('Hello\nNiceGUI!')
+    ui.chat_message('Hi\nnice guy!', text_html=True)
+
+    screen.open('/')
+    assert screen.find('Hello').find_element(By.TAG_NAME, 'br')
+    assert screen.find('Hi').find_element(By.TAG_NAME, 'br')

--- a/website/more_documentation/chat_message_documentation.py
+++ b/website/more_documentation/chat_message_documentation.py
@@ -1,8 +1,31 @@
 from nicegui import ui
 
+from ..documentation_tools import text_demo
+
 
 def main_demo() -> None:
     ui.chat_message('Hello NiceGUI!',
                     name='Robot',
                     stamp='now',
                     avatar='https://robohash.org/ui')
+
+
+def more() -> None:
+    @text_demo('HTML text', '''
+        Using the `text_html` parameter, you can send HTML text to the chat.
+    ''')
+    def html_text():
+        ui.chat_message('Without <strong>HTML</strong>')
+        ui.chat_message('With <strong>HTML</strong>', text_html=True)
+
+    @text_demo('Newline', '''
+        You can use newlines in the chat message.
+    ''')
+    def newline():
+        ui.chat_message('This is a\nlong line!')
+
+    @text_demo('Multi-part messages', '''
+        You can send multiple message parts by passing a list of strings.
+    ''')
+    def multiple_messages():
+        ui.chat_message(['Hi! 😀', 'How are you?'])


### PR DESCRIPTION
This PR
- allows passing HTML as text,
- allows passing multiple message parts as list of strings,
- translates newline characters into HTML line breaks,
- adds pytests and demos.

```py
ui.chat_message('Without <strong>HTML</strong>')
ui.chat_message('With <strong>HTML</strong>', text_html=True)
ui.chat_message(['Hello', 'NiceGUI!'])
ui.chat_message('Hello\nNiceGUI!')
```