### PR TITLE
improved discoverability for "more docs"

### DIFF
--- a/website/documentation_tools.py
+++ b/website/documentation_tools.py
@@ -38,8 +38,7 @@ def subheading(text: str, *, make_menu_entry: bool = True, more_link: Optional[s
     ui.html(f'<div id="{name}"></div>').style('position: relative; top: -90px')
     with ui.row().classes('gap-2 items-center relative'):
         if more_link:
-            with ui.link(text, f'documentation/{more_link}').classes('text-2xl'):
-                ui.icon('open_in_new', size='0.75em').classes('mb-1 ml-2')
+            ui.link(text, f'documentation/{more_link}').classes('text-2xl')
         else:
             ui.label(text).classes('text-2xl')
         with ui.link(target=f'#{name}').classes('absolute').style('transform: translateX(-150%)'):
@@ -99,7 +98,10 @@ class element_demo:
         with ui.column().classes('w-full mb-8 gap-2'):
             subheading(title, more_link=more_link)
             render_docstring(documentation, with_params=more_link is None)
-            return demo(f)
+            result = demo(f)
+            if more_link:
+                ui.markdown(f'See [more...](documentation/{more_link})').classes('bold-links arrow-links')
+        return result
 
 
 def load_demo(api: Union[type, Callable, str]) -> None:


### PR DESCRIPTION
On Discord we got the suggestion to [improve discoverability](https://discord.com/channels/1089836369431498784/1089836370043883654/1103354979596632115) of the "more documentation" for each element. This PR makes it the additional page more explicit by placing a "more" link below the demo.

Before:
<img width="1154" alt="Screen Shot 2023-05-04 at 05 16 38" src="https://user-images.githubusercontent.com/131391/236105389-fd67e443-50f9-40e6-8b77-c41bbd5418fe.png">

After:
<img width="1155" alt="Screen Shot 2023-05-04 at 05 16 17" src="https://user-images.githubusercontent.com/131391/236105410-f994ffc2-98ee-4660-9627-b5509e668ae6.png">

