### PR TITLE
Add `Input.error` property

### DIFF
--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -16,7 +16,7 @@ class Input(ValueElement, DisableableElement):
                  password_toggle_button: bool = False,
                  on_change: Optional[Callable] = None,
                  autocomplete: Optional[List[str]] = None,
-                 validation: Dict[str, Callable] = {}) -> None:
+                 validation: Optional[Dict[str, Callable[[Any], bool]]] = None) -> None:
         """Text Input
 
         This element is based on Quasar's `QInput <https://quasar.dev/vue-components/input>`_ component.
@@ -52,7 +52,7 @@ class Input(ValueElement, DisableableElement):
                     self.props(f'type={"text" if is_hidden else "password"}')
                 icon = Icon('visibility_off').classes('cursor-pointer').on('click', toggle_type)
 
-        self.validation = validation
+        self.validation = validation or {}
 
         if autocomplete:
             def find_autocompletion() -> Optional[str]:

--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -35,7 +35,7 @@ class Input(ValueElement, DisableableElement):
         :param password_toggle_button: whether to show a button to toggle the password visibility (default: False)
         :param on_change: callback to execute when the value changes
         :param autocomplete: optional list of strings for autocompletion
-        :param validation: dictionary of validation rules, e.g. ``{'Too short!': lambda value: len(value) < 3}``
+        :param validation: dictionary of validation rules, executed in dict order. e.g. ``{'Too long!': lambda value: len(value) < 3}``
         """
         super().__init__(tag='q-input', value=value, on_value_change=on_change)
         if label is not None:
@@ -71,7 +71,7 @@ class Input(ValueElement, DisableableElement):
                 match = find_autocompletion()
                 if match:
                     self.set_value(match)
-                self.props(f'shadow-text=""')
+                self.props('shadow-text=""')
 
             self.on('keyup', autocomplete_input)
             self.on('keydown.tab', complete_input)

--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -53,6 +53,7 @@ class Input(ValueElement, DisableableElement):
                 icon = Icon('visibility_off').classes('cursor-pointer').on('click', toggle_type)
 
         self.validation = validation or {}
+        self._error: Optional[str] = None
 
         if autocomplete:
             def find_autocompletion() -> Optional[str]:
@@ -79,7 +80,13 @@ class Input(ValueElement, DisableableElement):
         super().on_value_change(value)
         for message, check in self.validation.items():
             if not check(value):
+                self._error = message
                 self.props(f'error error-message="{message}"')
                 break
         else:
             self.props(remove='error')
+
+    @property
+    def error(self) -> Optional[str]:
+        """The latest error message from the validation functions."""
+        return self._error

--- a/website/more_documentation/button_documentation.py
+++ b/website/more_documentation/button_documentation.py
@@ -14,10 +14,10 @@ def more() -> None:
     async def await_button_click() -> None:
         # @ui.page('/')
         # async def index():
-            b = ui.button('Step')
-            await b.clicked()
-            ui.label('One')
-            await b.clicked()
-            ui.label('Two')
-            await b.clicked()
-            ui.label('Three')
+        b = ui.button('Step')
+        await b.clicked()
+        ui.label('One')
+        await b.clicked()
+        ui.label('Two')
+        await b.clicked()
+        ui.label('Three')

--- a/website/svg.py
+++ b/website/svg.py
@@ -19,5 +19,6 @@ def word() -> ui.html:
 def github() -> ui.html:
     return ui.html((PATH / 'github.svg').read_text())
 
+
 def discord() -> ui.html:
     return ui.html((PATH / 'discord.svg').read_text())


### PR DESCRIPTION
Added an `error` property to the `Input` element which always contains the latest error message from the given validators.

# Motivation
Say we have the following `ui.input` setup:
```python
inp = ui.input(label=..., validation={'Input too long': lambda value: len(value) < 20})
def on_submit():
    ... # content of following code blocks here
inp.on("keydown.enter", on_submit)
```
Say in the `on_submit` callback we want to base behavior on the error state.

How would that look before and after this PR?

## Checking if an error is active
### Before
```python
# access to "private" member :(
if "error-message" in inp._props:
    ... # do something with `inp.value`
```
### After
```python
if inp.error:
    ... # do something with `inp.value`
```

## Checking if a specific error is active
### Before
```python
# access to "private" member :(
if inp._props.get("error-message") == "Input too long":
    ... # do something with `inp.value`
```
### After
```python
if inp.error == "Input too long"::
    ... # do something with `inp.value`
```