### PR TITLE
Fix closeBtn argument in ui.notify documentation

### DIFF
--- a/website/more_documentation/notify_documentation.py
+++ b/website/more_documentation/notify_documentation.py
@@ -4,7 +4,7 @@ from ..documentation_tools import text_demo
 
 
 def main_demo() -> None:
-    ui.button('Say hi!', on_click=lambda: ui.notify('Hi!', close_button='OK'))
+    ui.button('Say hi!', on_click=lambda: ui.notify('Hi!', closeBtn='OK'))
 
 
 def more() -> None:


### PR DESCRIPTION
For `ui.notify`, the documentation under `main_demo()` shows `close_button` as an argument, but the function's actual argument is `closeBtn`.  Fixed the demo to match.

(First-ever pull request!  Let's start small.)