### PR TITLE
Use snake_case style arguments for ui.notify()

### DIFF
--- a/website/more_documentation/notify_documentation.py
+++ b/website/more_documentation/notify_documentation.py
@@ -17,7 +17,7 @@ def more() -> None:
         ui.button('warning', on_click=lambda: ui.notify('warning', type='warning'))
 
     @text_demo('Multiline Notifications', '''
-        To allow a notification text to span multiple lines, it is sufficient to pass the `mutliLine` keyword with `True`.
+        To allow a notification text to span multiple lines, it is sufficient to set `multi_line=True`.
         If manual newline breaks are required (e.g. `\n`), you need to define a CSS style and pass it to the notification as shown in the example.
     ''')
     def multiline():


### PR DESCRIPTION
From @rodja's comment in #928 as a potential change for 1.3...

Draft pull request to change arguments in `notify.py` to use snake_case style names (and convert to Quasar option names where appropriate).  

Also added `multi_line` as an argument since there is a specific example for multi-line notifications in the documentation, renamed the `**kwargs` argument to `**_kwargs` so it is excluded from `options` (just for clarity), and updated documentation to new argument names.

Not sure if this is the best approach, just putting it out there for consideration.  