### PR TITLE
#948 correctly track count of chart series

### DIFF
--- a/nicegui/elements/chart.js
+++ b/nicegui/elements/chart.js
@@ -4,6 +4,7 @@ export default {
     setTimeout(() => {
       const imports = this.extras.map((extra) => import(window.path_prefix + extra));
       Promise.allSettled(imports).then(() => {
+        this.seriesCount = this.options.series ? this.options.series.length : 0;
         this.chart = Highcharts[this.type](this.$el, this.options);
         this.chart.reflow();
       });
@@ -18,16 +19,22 @@ export default {
   methods: {
     update_chart() {
       if (this.chart) {
-        while (this.chart.series.length > this.options.series.length) this.chart.series[0].remove();
-        while (this.chart.series.length < this.options.series.length) this.chart.addSeries({}, false);
+        while (this.seriesCount > this.options.series.length) {
+          this.chart.series[0].remove();
+          this.seriesCount--;
+        }
+        while (this.seriesCount < this.options.series.length) {
+          this.chart.addSeries({}, false);
+          this.seriesCount++;
+        }
         this.chart.update(this.options);
       }
     },
-    destroyChart () {
+    destroyChart() {
       if (this.chart) {
-        this.chart.destroy()
+        this.chart.destroy();
       }
-    }
+    },
   },
   props: {
     type: String,


### PR DESCRIPTION
This PR fixes an issue we stock charts where new series are not correctly added to a chart.
See #948 for a related discussion.

The behavior can be tested with this minimal reproduction:
```py
chart = ui.chart({'legend': {'enabled': True}, 'series': []}, type='stockChart', extras=['stock'])
ui.button('update', on_click=lambda: (
    chart.options['series'].extend([{'name': 'alice'}, {'name': 'bob'}]),
    chart.update(),
))
```

After clicking the "update" button, two new series should be added to the legend each time.