### PR TITLE
Fixed and improved favicon routing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
           poetry install
           # install packages to run the examples
           pip install opencv-python opencv-contrib-python-headless httpx replicate langchain openai simpy
+          pip install -r tests/requirements.txt
           # try fix issue with importlib_resources
           pip install importlib-resources
       - name: test startup

--- a/nicegui/favicon.py
+++ b/nicegui/favicon.py
@@ -2,6 +2,7 @@ import urllib.parse
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
+from fastapi import Response
 from fastapi.responses import FileResponse
 
 from . import __version__, globals
@@ -26,11 +27,15 @@ def get_favicon_url(page: 'page', prefix: str) -> str:
     elif is_svg(favicon):
         return svg_to_data_url(favicon)
     elif is_char(favicon):
-        return char_to_data_url(favicon)
+        return svg_to_data_url(char_to_svg(favicon))
     elif page.path == '/':
         return f'{prefix}/favicon.ico'
     else:
         return f'{prefix}{page.path}/favicon.ico'
+
+
+def get_favicon_response() -> Response:
+    return Response(char_to_svg(globals.favicon), media_type='image/svg+xml')
 
 
 def is_remote_url(favicon: str) -> bool:
@@ -49,8 +54,8 @@ def is_data_url(favicon: str) -> bool:
     return favicon.startswith('data:')
 
 
-def char_to_data_url(char: str) -> str:
-    svg = f'''
+def char_to_svg(char: str) -> str:
+    return f'''
         <svg viewBox="0 0 128 128" width="128" height="128" xmlns="http://www.w3.org/2000/svg" >
             <style>
                 @supports (-moz-appearance:none) {{
@@ -66,7 +71,6 @@ def char_to_data_url(char: str) -> str:
             <text y=".9em" font-size="128" font-family="Georgia, sans-serif">{char}</text>
         </svg>
     '''
-    return svg_to_data_url(svg)
 
 
 def svg_to_data_url(svg: str) -> str:

--- a/nicegui/favicon.py
+++ b/nicegui/favicon.py
@@ -18,11 +18,12 @@ def create_favicon_route(path: str, favicon: Optional[str]) -> None:
 
 
 def get_favicon_url(page: 'page', prefix: str) -> str:
-    favicon = str(page.favicon or globals.favicon)
-    if favicon and is_remote_url(favicon):
-        return favicon
-    elif not favicon:
+    favicon = page.favicon or globals.favicon
+    if not favicon:
         return f'{prefix}/_nicegui/{__version__}/static/favicon.ico'
+    favicon = str(favicon)
+    if is_remote_url(favicon):
+        return favicon
     elif is_data_url(favicon):
         return favicon
     elif is_svg(favicon):
@@ -43,6 +44,8 @@ def get_favicon_response() -> Response:
         return StreamingResponse(io.BytesIO(bytes), media_type=media_type)
     elif is_char(globals.favicon):
         return Response(char_to_svg(globals.favicon), media_type='image/svg+xml')
+    else:
+        raise ValueError(f'invalid favicon: {globals.favicon}')
 
 
 def is_remote_url(favicon: str) -> bool:

--- a/nicegui/favicon.py
+++ b/nicegui/favicon.py
@@ -11,16 +11,12 @@ if TYPE_CHECKING:
 
 
 def create_favicon_route(path: str, favicon: Optional[str]) -> None:
-    if favicon and (is_remote_url(favicon) or is_char(favicon)):
-        return
-    fallback = Path(__file__).parent / 'static' / 'favicon.ico'
-    path = f'{"" if path == "/" else path}/favicon.ico'
-    globals.app.remove_route(path)
-    globals.app.add_route(path, lambda _: FileResponse(favicon or globals.favicon or fallback))
+    if favicon and Path(favicon).exists():
+        globals.app.add_route(path, lambda _: FileResponse(favicon))
 
 
 def get_favicon_url(page: 'page', prefix: str) -> str:
-    favicon = page.favicon or globals.favicon
+    favicon = str(page.favicon or globals.favicon)
     if favicon and is_remote_url(favicon):
         return favicon
     elif not favicon:

--- a/nicegui/favicon.py
+++ b/nicegui/favicon.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 def create_favicon_route(path: str, favicon: Optional[str]) -> None:
     if favicon and Path(favicon).exists():
-        globals.app.add_route(path, lambda _: FileResponse(favicon))
+        globals.app.add_route(f'{path}/favicon.ico', lambda _: FileResponse(favicon))
 
 
 def get_favicon_url(page: 'page', prefix: str) -> str:

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -15,7 +15,7 @@ from fastapi_socketio import SocketManager
 from nicegui import json
 from nicegui.json import NiceGUIJSONResponse
 
-from . import __version__, background_tasks, binding, globals, outbox
+from . import __version__, background_tasks, binding, favicon, globals, outbox
 from .app import App
 from .client import Client
 from .dependencies import js_components, js_dependencies
@@ -66,8 +66,11 @@ def handle_startup(with_welcome_message: bool = True) -> None:
                            'remove the guard or replace it with\n'
                            '   if __name__ in {"__main__", "__mp_main__"}:\n'
                            'to allow for multiprocessing.')
-    if globals.favicon and Path(globals.favicon).exists():
-        globals.app.add_route('/favicon.ico', lambda _: FileResponse(globals.favicon))
+    if globals.favicon:
+        if Path(globals.favicon).exists():
+            globals.app.add_route('/favicon.ico', lambda _: FileResponse(globals.favicon))
+        else:
+            globals.app.add_route('/favicon.ico', lambda _: favicon.get_favicon_response())
     else:
         globals.app.add_route('/favicon.ico', lambda _: FileResponse(Path(__file__).parent / 'static' / 'favicon.ico'))
     globals.state = globals.State.STARTING

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -66,6 +66,10 @@ def handle_startup(with_welcome_message: bool = True) -> None:
                            'remove the guard or replace it with\n'
                            '   if __name__ in {"__main__", "__mp_main__"}:\n'
                            'to allow for multiprocessing.')
+    if globals.favicon and Path(globals.favicon).exists():
+        globals.app.add_route('/favicon.ico', lambda _: FileResponse(globals.favicon))
+    else:
+        globals.app.add_route('/favicon.ico', lambda _: FileResponse(Path(__file__).parent / 'static' / 'favicon.ico'))
     globals.state = globals.State.STARTING
     globals.loop = asyncio.get_running_loop()
     with globals.index_client:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,10 +37,10 @@ def selenium(selenium: webdriver.Chrome) -> webdriver.Chrome:
 
 @pytest.fixture(autouse=True)
 def reset_globals() -> Generator[None, None, None]:
-    # we need to remove
-    [globals.app.routes.remove(r) for r in globals.app.routes if 'favicon' in r.path]
     for path in {'/'}.union(globals.page_routes.values()):
         globals.app.remove_route(path)
+    # NOTE favicon routes must be removed seperately because they are not "pages"
+    [globals.app.routes.remove(r) for r in globals.app.routes if 'favicon' in r.path]
     importlib.reload(globals)
     globals.index_client = Client(page('/'), shared=True).__enter__()
     globals.app.get('/')(globals.index_client.build_response)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,8 @@ def selenium(selenium: webdriver.Chrome) -> webdriver.Chrome:
 
 @pytest.fixture(autouse=True)
 def reset_globals() -> Generator[None, None, None]:
+    # we need to remove
+    [globals.app.routes.remove(r) for r in globals.app.routes if 'favicon' in r.path]
     for path in {'/'}.union(globals.page_routes.values()):
         globals.app.remove_route(path)
     importlib.reload(globals)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def reset_globals() -> Generator[None, None, None]:
     for path in {'/'}.union(globals.page_routes.values()):
         globals.app.remove_route(path)
     # NOTE favicon routes must be removed seperately because they are not "pages"
-    [globals.app.routes.remove(r) for r in globals.app.routes if 'favicon' in r.path]
+    [globals.app.routes.remove(r) for r in globals.app.routes if r.path.endswith('/favicon.ico')]
     importlib.reload(globals)
     globals.index_client = Client(page('/'), shared=True).__enter__()
     globals.app.get('/')(globals.index_client.build_response)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ pytest-asyncio
 selenium
 autopep8
 icecream
+beautifulsoup4

--- a/tests/screen.py
+++ b/tests/screen.py
@@ -21,16 +21,16 @@ IGNORED_CLASSES = ['row', 'column', 'q-card', 'q-field', 'q-field__label', 'q-in
 class Screen:
     IMPLICIT_WAIT = 4
     SCREENSHOT_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'screenshots')
-    UI_RUN_KWARGS = {'port': PORT, 'show': False, 'reload': False}
 
     def __init__(self, selenium: webdriver.Chrome, caplog: pytest.LogCaptureFixture) -> None:
         self.selenium = selenium
         self.caplog = caplog
         self.server_thread = None
+        self.ui_run_kwargs = {'port': PORT, 'show': False, 'reload': False}
 
     def start_server(self) -> None:
         '''Start the webserver in a separate thread. This is the equivalent of `ui.run()` in a normal script.'''
-        self.server_thread = threading.Thread(target=ui.run, kwargs=self.UI_RUN_KWARGS)
+        self.server_thread = threading.Thread(target=ui.run, kwargs=self.ui_run_kwargs)
         self.server_thread.start()
 
     @property

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -1,9 +1,10 @@
 from pathlib import Path
+from typing import Union
 
 import requests
 from bs4 import BeautifulSoup
 
-from nicegui import ui
+from nicegui import favicon, ui
 
 from .screen import PORT, Screen
 
@@ -17,10 +18,13 @@ def assert_favicon_url_starts_with(screen: Screen, content: str):
     assert icon_link['href'].startswith(content)
 
 
-def assert_favicon(file: Path, url_path: str = '/favicon.ico'):
+def assert_favicon(content: Union[Path, str], url_path: str = '/favicon.ico'):
     response = requests.get(f'http://localhost:{PORT}{url_path}')
     assert response.status_code == 200
-    assert file.read_bytes() == response.content
+    if isinstance(content, Path):
+        assert content.read_bytes() == response.content
+    else:
+        assert content == response.text
 
 
 def test_default(screen: Screen):
@@ -37,7 +41,7 @@ def test_emoji(screen: Screen):
     screen.open('/')
     assert_favicon_url_starts_with(screen, 'data:image/svg+xml')
     # the default favicon is still available (for example when accessing a plain FastAPI route with the browser)
-    assert_favicon(DEFAULT_FAVICON_PATH)
+    assert_favicon(favicon.char_to_svg('👋'))
 
 
 def test_custom_file(screen: Screen):

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import requests
+from bs4 import BeautifulSoup
+
+from nicegui import ui
+
+from .screen import PORT, Screen
+
+
+def assert_favicon_url_starts_with(screen: Screen, content: str):
+    soup = BeautifulSoup(screen.selenium.page_source, 'html.parser')
+    icon_link = soup.find("link", rel="icon")
+    assert icon_link['href'].startswith(content)
+
+
+def test_default(screen: Screen):
+    ui.label('Hello, world')
+
+    screen.open('/')
+    response = requests.get(f'http://localhost:{PORT}/favicon.ico')
+    assert response.status_code == 200
+
+
+def test_emoji(screen: Screen):
+    ui.label('Hello, world')
+
+    screen.ui_run_kwargs['favicon'] = '👋'
+    screen.open('/')
+    response = requests.get(f'http://localhost:{PORT}/favicon.ico')
+    assert response.status_code == 200, 'default favicon should still be available for plain FastAPI requests running in the browser'
+    assert (Path(__file__).parent.parent / 'nicegui' / 'static' / 'favicon.ico').read_bytes() == response.content
+    assert_favicon_url_starts_with(screen, 'data:image/svg+xml')
+
+
+def test_custom_file(screen: Screen):
+    ui.label('Hello, world')
+
+    screen.ui_run_kwargs['favicon'] = Path(__file__).parent.parent / 'website' / 'static' / 'logo_square.png'
+    screen.open('/')
+    assert_favicon_url_starts_with(screen, '/favicon.ico')
+    response = requests.get(f'http://localhost:{PORT}/favicon.ico')
+    assert response.status_code == 200
+    assert screen.ui_run_kwargs['favicon'].read_bytes() == response.content


### PR DESCRIPTION
As reported on [Discord](https://discord.com/channels/1089836369431498784/1111652411552038992), the combination of 

1. emoji favicon
2. a plain FastAPI get method
3. requesting this route from the browser (with cleared cache)

Produced a rather strange stacktrace:

```
 File "/home/linuxbrew/.linuxbrew/Cellar/python@3.11/3.11.3/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.11/3.11.3/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.11/3.11.3/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.11/3.11.3/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.11/3.11.3/lib/python3.11/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.11/3.11.3/lib/python3.11/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.11/3.11.3/lib/python3.11/site-packages/starlette/routing.py", line 69, in app
    await response(scope, receive, send)
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.11/3.11.3/lib/python3.11/site-packages/starlette/responses.py", line 338, in __call__
    raise RuntimeError(f"File at path {self.path} does not exist.")
RuntimeError: File at path 🚀 does not exist.
```

The underlying problem is that the browser always looks for a `/favicon.ico` file if none is defined on the page. And because it's a normal FastAPI route which returns plain text there is no favicon defined. The rules for how we create a `/favicon.ico` route where a bit complicated. This PR improves on that and also adds tests for main scenarios.