### PR TITLE
Allow using NiceGUI elements as link targets and adding demos to the documentation

### DIFF
--- a/nicegui/elements/link.py
+++ b/nicegui/elements/link.py
@@ -10,7 +10,8 @@ register_component('link', __file__, 'link.js')
 
 class Link(TextElement):
 
-    def __init__(self, text: str = '', target: Union[Callable[..., Any], str] = '#', new_tab: bool = False) -> None:
+    def __init__(self, text: str = '', target: Union[Callable[..., Any],
+                                                     str, Element] = '#', new_tab: bool = False) -> None:
         """Link
 
         Create a hyperlink.
@@ -19,11 +20,16 @@ class Link(TextElement):
         and link to it with `ui.link(target="#name")`.
 
         :param text: display text
-        :param target: page function or string that is a an absolute URL or relative path from base URL
+        :param target: page function, NiceGUI element on the same page or string that is a an absolute URL or relative path from base URL
         :param new_tab: open link in new tab (default: False)
         """
         super().__init__(tag='link', text=text)
-        self._props['href'] = target if isinstance(target, str) else globals.page_routes[target]
+        if isinstance(target, str):
+            self._props['href'] = target
+        elif isinstance(target, Element):
+            self._props['href'] = f'#{target.id}'
+        elif isinstance(target, Callable):
+            self._props['href'] = globals.page_routes[target]
         self._props['target'] = '_blank' if new_tab else '_self'
         self._classes = ['nicegui-link']
 

--- a/nicegui/elements/link.py
+++ b/nicegui/elements/link.py
@@ -10,8 +10,11 @@ register_component('link', __file__, 'link.js')
 
 class Link(TextElement):
 
-    def __init__(self, text: str = '', target: Union[Callable[..., Any],
-                                                     str, Element] = '#', new_tab: bool = False) -> None:
+    def __init__(self,
+                 text: str = '',
+                 target: Union[Callable[..., Any], str, Element] = '#',
+                 new_tab: bool = False,
+                 ) -> None:
         """Link
 
         Create a hyperlink.

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -60,3 +60,21 @@ def test_updating_href_prop(screen: Screen):
     assert screen.find('nicegui.io').get_attribute('href') == 'https://nicegui.io/'
     screen.click('change href')
     assert screen.find('nicegui.io').get_attribute('href') == 'https://github.com/zauberzeug/nicegui'
+
+
+def test_link_to_elements(screen: Screen):
+    navigation = ui.row()
+    for i in range(100):
+        ui.label(f'label {i}')
+    link = ui.link('goto top', navigation)
+    with navigation:
+        ui.link('goto bottom', link)
+
+    screen.open('/')
+    assert screen.selenium.execute_script('return window.scrollY') == 0
+    screen.click('goto bottom')
+    screen.wait(0.5)
+    assert screen.selenium.execute_script('return window.scrollY') > 100
+    screen.click('goto top')
+    screen.wait(0.5)
+    assert screen.selenium.execute_script('return window.scrollY') < 100

--- a/website/demo.py
+++ b/website/demo.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 from typing import Callable, Optional, Union
 
 import isort
@@ -15,9 +16,12 @@ BROWSER_BGCOLOR = '#00000010'
 BROWSER_COLOR = '#ffffff'
 
 
-def remove_comment(text: str) -> str:
+uncomment_pattern = re.compile(r'^(\s*)# ?')
+
+
+def uncomment(text: str) -> str:
     """non-executed lines should be shown in the code examples"""
-    return text.replace('# ', '')
+    return uncomment_pattern.sub(r'\1', text)
 
 
 def demo(f: Callable) -> Callable:
@@ -33,7 +37,7 @@ def demo(f: Callable) -> Callable:
             del code[0]
         indentation = len(code[0]) - len(code[0].lstrip())
         code = [line[indentation:] for line in code]
-        code = ['from nicegui import ui'] + [remove_comment(line) for line in code]
+        code = ['from nicegui import ui'] + [uncomment(line) for line in code]
         code = ['' if line == '#' else line for line in code]
         if not code[-1].startswith('ui.run('):
             code.append('')

--- a/website/demo.py
+++ b/website/demo.py
@@ -15,13 +15,15 @@ BROWSER_BGCOLOR = '#00000010'
 BROWSER_COLOR = '#ffffff'
 
 
-def remove_prefix(text: str, prefix: str) -> str:
-    return text[len(prefix):] if text.startswith(prefix) else text
+def remove_comment(text: str) -> str:
+    """non-executed lines should be shown in the code examples"""
+    return text.replace('# ', '')
 
 
 def demo(f: Callable) -> Callable:
     with ui.column().classes('w-full items-stretch gap-8 no-wrap min-[1500px]:flex-row'):
         code = inspect.getsource(f).split('# END OF DEMO')[0].strip().splitlines()
+        code = [line for line in code if not line.endswith("# HIDE")]
         while not code[0].strip().startswith('def') and not code[0].strip().startswith('async def'):
             del code[0]
         del code[0]
@@ -31,7 +33,7 @@ def demo(f: Callable) -> Callable:
             del code[0]
         indentation = len(code[0]) - len(code[0].lstrip())
         code = [line[indentation:] for line in code]
-        code = ['from nicegui import ui'] + [remove_prefix(line, '# ') for line in code]
+        code = ['from nicegui import ui'] + [remove_comment(line) for line in code]
         code = ['' if line == '#' else line for line in code]
         if not code[-1].startswith('ui.run('):
             code.append('')

--- a/website/more_documentation/link_documentation.py
+++ b/website/more_documentation/link_documentation.py
@@ -31,3 +31,15 @@ def more() -> None:
             ui.link('Goto A', '#target_A')
             # ui.link('Goto B', label_B)
             ui.link('Goto B', '#target_B')  # HIDE
+
+    @text_demo('Links to other pages', '''
+        You can link to other pages by providing the link target as path or function reference.
+    ''')
+    def link_to_other_page():
+        @ui.page('/some_other_page')
+        def my_page():
+            ui.label('This is another page')
+
+        ui.label('Go to other page')
+        ui.link('... with path', '/some_other_page')
+        ui.link('... with function reference', my_page)

--- a/website/more_documentation/link_documentation.py
+++ b/website/more_documentation/link_documentation.py
@@ -1,5 +1,33 @@
 from nicegui import ui
 
+from ..documentation_tools import text_demo
+from ..style import link_target
+
 
 def main_demo() -> None:
     ui.link('NiceGUI on GitHub', 'https://github.com/zauberzeug/nicegui')
+
+
+def more() -> None:
+    @text_demo('Navigate on large pages', '''
+        To jump to a specific location within a page you can place linkable anchors with `ui.link_target('target_name')`
+        or simply pass a NiceGUI element as link target.
+    ''')
+    def same_page_links():
+        navigation = ui.row()
+        # ui.link_target('target_A')
+        link_target('target_A', '-10px')  # HIDE
+        ui.label(
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, '
+            'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+        )
+        link_target('target_B', '70px')  # HIDE
+        label_B = ui.label(
+            'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+            'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.'
+            'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+        )
+        with navigation:
+            ui.link('Goto A', '#target_A')
+            # ui.link('Goto B', label_B)
+            ui.link('Goto B', '#target_B')  # HIDE

--- a/website/more_documentation/link_documentation.py
+++ b/website/more_documentation/link_documentation.py
@@ -23,8 +23,8 @@ def more() -> None:
         )
         link_target('target_B', '70px')  # HIDE
         label_B = ui.label(
-            'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
-            'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.'
+            'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. '
+            'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. '
             'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
         )
         with navigation:


### PR DESCRIPTION
With this pull request it is possible to link to other elements on the same page. It also adds demos to the link documentation.