### PR TITLE
check if event handler has parameters without default value

### DIFF
--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from inspect import signature
+from inspect import Parameter, signature
 from typing import TYPE_CHECKING, Any, BinaryIO, Callable, Dict, List, Optional, Union
 
 from . import background_tasks, globals
@@ -274,7 +274,7 @@ def handle_event(handler: Optional[Callable[..., Any]],
     try:
         if handler is None:
             return
-        no_arguments = not signature(handler).parameters
+        no_arguments = not any(p.default is Parameter.empty for p in signature(handler).parameters.values())
         sender = arguments.sender if isinstance(arguments, EventArguments) else sender
         assert sender is not None and sender.parent_slot is not None
         with sender.parent_slot:


### PR DESCRIPTION
This PR changes the way event handlers get called with or without event arguments. Consider this example:

```py
ui.button('1', on_click=lambda: ui.notify('1'))
ui.button('2', on_click=lambda _, x=2: ui.notify(x))
ui.button('3', on_click=lambda x=3: ui.notify(x))
```

In the last case, event arguments have been passed to `x` because the event handler does expect arguments. With this PR, however, `x` remains set to `3`, because the event handler does not expect any argument without a default value.

I think this is a reasonable distinction, because a parameter with a default value most certainly won't accept event arguments. And it helps in cases like https://stackoverflow.com/q/76348605/3419103 where local variables need to get captured in a lambda statement. Filling those parameters with event arguments confuses many users.