### PR TITLE
event_handler: allow passing lambdas which call an async func 

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -25,7 +25,7 @@ strategy = "rolling"
   protocol = "tcp"
   script_checks = []
   [services.concurrency]
-    hard_limit = 30
+    hard_limit = 20
     soft_limit = 12
     type = "connections"
 

--- a/fly.toml
+++ b/fly.toml
@@ -25,7 +25,7 @@ strategy = "rolling"
   protocol = "tcp"
   script_checks = []
   [services.concurrency]
-    hard_limit = 20
+    hard_limit = 30
     soft_limit = 12
     type = "connections"
 

--- a/nicegui/functions/refreshable.py
+++ b/nicegui/functions/refreshable.py
@@ -6,7 +6,7 @@ from typing_extensions import Self
 from .. import background_tasks, globals
 from ..dependencies import register_component
 from ..element import Element
-from ..helpers import KWONLY_SLOTS, is_coroutine
+from ..helpers import KWONLY_SLOTS, is_coroutine_function
 
 register_component('refreshable', __file__, 'refreshable.js')
 
@@ -19,7 +19,7 @@ class RefreshableTarget:
     kwargs: Dict[str, Any]
 
     def run(self, func: Callable[..., Any]) -> Union[None, Awaitable]:
-        if is_coroutine(func):
+        if is_coroutine_function(func):
             async def wait_for_result() -> None:
                 with self.container:
                     if self.instance is None:
@@ -65,7 +65,7 @@ class refreshable:
                 continue
             target.container.clear()
             result = target.run(self.func)
-            if is_coroutine(self.func):
+            if is_coroutine_function(self.func):
                 assert result is not None
                 if globals.loop and globals.loop.is_running():
                     background_tasks.create(result)

--- a/nicegui/functions/timer.py
+++ b/nicegui/functions/timer.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Optional
 
 from .. import background_tasks, globals
 from ..binding import BindableProperty
-from ..helpers import is_coroutine
+from ..helpers import is_coroutine_function
 from ..slot import Slot
 
 
@@ -81,7 +81,7 @@ class Timer:
         try:
             assert self.callback is not None
             result = self.callback()
-            if is_coroutine(self.callback):
+            if is_coroutine_function(self.callback):
                 await result
         except Exception as e:
             globals.handle_exception(e)

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -20,7 +20,7 @@ KWONLY_SLOTS = {'kw_only': True, 'slots': True} if sys.version_info >= (3, 10) e
 def is_coroutine(object: Any) -> bool:
     while isinstance(object, functools.partial):
         object = object.func
-    return asyncio.iscoroutinefunction(object)
+    return asyncio.iscoroutinefunction(object) or asyncio.iscoroutine(object)
 
 
 def safe_invoke(func: Union[Callable[..., Any], Awaitable], client: Optional['Client'] = None) -> None:

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -21,10 +21,15 @@ if TYPE_CHECKING:
 KWONLY_SLOTS = {'kw_only': True, 'slots': True} if sys.version_info >= (3, 10) else {}
 
 
-def is_coroutine(object: Any) -> bool:
+def is_coroutine_function(object: Any) -> bool:
+    """Check if the object is a coroutine function.
+
+    This function is needed because functools.partial is not a coroutine function, but its func attribute is.
+    Note: It will return false for coroutine objects.
+    """
     while isinstance(object, functools.partial):
         object = object.func
-    return asyncio.iscoroutinefunction(object) or asyncio.iscoroutine(object)
+    return asyncio.iscoroutinefunction(object)
 
 
 def safe_invoke(func: Union[Callable[..., Any], Awaitable], client: Optional['Client'] = None) -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -26,21 +26,29 @@ async def click_async_with_args(_: ClickEventArguments):
     ui.label('click_async_with_args')
 
 
+async def click_lambda_with_async_and_parameters(msg: str):
+    await asyncio.sleep(0.1)
+    ui.label(f'click_lambda_with_async_and_parameters: {msg}')
+
+
 def test_click_events(screen: Screen):
     ui.button('click_sync_no_args', on_click=click_sync_no_args)
     ui.button('click_sync_with_args', on_click=click_sync_with_args)
     ui.button('click_async_no_args', on_click=click_async_no_args)
     ui.button('click_async_with_args', on_click=click_async_with_args)
+    ui.button('click_lambda_with_async_and_parameters', on_click=lambda: click_lambda_with_async_and_parameters('works'))
 
     screen.open('/')
     screen.click('click_sync_no_args')
     screen.click('click_sync_with_args')
     screen.click('click_async_no_args')
     screen.click('click_async_with_args')
+    screen.click('click_lambda_with_async_and_parameters')
     screen.should_contain('click_sync_no_args')
     screen.should_contain('click_sync_with_args')
     screen.should_contain('click_async_no_args')
     screen.should_contain('click_async_with_args')
+    screen.should_contain('click_lambda_with_async_and_parameters: works')
 
 
 def test_generic_events(screen: Screen):


### PR DESCRIPTION
As suggested on [Discord](https://discord.com/channels/1089836369431498784/1115780116119818280), this PR allows to do 

```py
async def delay(msg: str):
    await asyncio.sleep(1)
    ui.notify(msg)

ui.button('test', on_click=lambda: delay('hello'))
```