### PR TITLE
let ui.select support "multiple" prop

### DIFF
--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -48,3 +48,17 @@ def test_replace_select(screen: Screen):
     screen.click('Replace')
     screen.should_contain('B')
     screen.should_not_contain('A')
+
+
+def test_multi_select(screen: Screen):
+    s = ui.select(['Alice', 'Bob', 'Carol'], value='Alice', multiple=True).props('use-chips')
+    ui.label().bind_text_from(s, 'value', backward=str)
+
+    screen.open('/')
+    screen.should_contain("['Alice']")
+    screen.click('Alice')
+    screen.click('Bob')
+    screen.should_contain("['Alice', 'Bob']")
+
+    screen.click('cancel')  # remove icon
+    screen.should_contain("['Bob']")

--- a/website/more_documentation/select_documentation.py
+++ b/website/more_documentation/select_documentation.py
@@ -31,7 +31,7 @@ def more() -> None:
     ''')
     def multi_select():
         names = ['Alice', 'Bob', 'Carol']
-        ui.select(names, multiple=True, label='comma-separated') \
+        ui.select(names, multiple=True, value=names[:2],  label='comma-separated') \
             .classes('w-64')
-        ui.select(names, multiple=True, label='with chips') \
+        ui.select(names, multiple=True, value=names[:2], label='with chips') \
             .props('use-chips').classes('w-64')

--- a/website/more_documentation/select_documentation.py
+++ b/website/more_documentation/select_documentation.py
@@ -25,3 +25,13 @@ def more() -> None:
         ]
         ui.select(options=continents, with_input=True,
                   on_change=lambda e: ui.notify(e.value)).classes('w-40')
+
+    @text_demo('Multi selection', '''
+        You can activate `multiple` to allow the selection of more than one item.
+    ''')
+    def multi_select():
+        names = ['Alice', 'Bob', 'Carol']
+        ui.select(names, multiple=True, label='comma-separated') \
+            .classes('w-64')
+        ui.select(names, multiple=True, label='with chips') \
+            .props('use-chips').classes('w-64')


### PR DESCRIPTION
This PR implements mutli-select support for `ui.select` as discussed in https://github.com/zauberzeug/nicegui/discussions/817.

Some code to play around with:

```py
ui.select(['Alice', 'Bob', 'Carol'])
ui.select(['Alice', 'Bob', 'Carol'], multiple=True)
s = ui.select(['Alice', 'Bob', 'Carol'], value='Alice', multiple=True).props('use-chips')
ui.label().bind_text_from(s, 'value', backward=str)
```