### PR TITLE
Switch docstrings from reST to Markdown 

### DIFF
--- a/nicegui/elements/icon.py
+++ b/nicegui/elements/icon.py
@@ -14,13 +14,14 @@ class Icon(Element):
                  ) -> None:
         """Icon
 
-        This element is based on Quasar's `QIcon <https://quasar.dev/vue-components/icon>`_ component.
+        This element is based on Quasar's [QIcon](https://quasar.dev/vue-components/icon>) component.
 
-        `Here <https://material.io/icons/>`_ is a reference of possible names.
+        [Here](https://material.io/icons/>) is a reference of possible names.
 
-        :param name: name of the icon
-        :param size: size in CSS units, including unit name or standard size name (xs|sm|md|lg|xl), examples: 16px, 2rem
-        :param color: icon color (either a Quasar, Tailwind, or CSS color or `None`, default: `None`)
+        ### Parameters
+        - `name`: name of the icon
+        - `size`: size in CSS units, including unit name or standard size name (xs|sm|md|lg|xl), examples: 16px, 2rem
+        - `color`: icon color (either a Quasar, Tailwind, or CSS color or `None`, default: `None`)
         """
         super().__init__('q-icon')
         self._props['name'] = name

--- a/website/documentation_tools.py
+++ b/website/documentation_tools.py
@@ -53,13 +53,11 @@ def subheading(text: str, *, make_menu_entry: bool = True, more_link: Optional[s
 
 
 def render_docstring(doc: str, with_params: bool = True) -> ui.html:
-    doc = remove_indentation(doc)
-    doc = doc.replace('param ', '')
-    html = docutils.core.publish_parts(doc, writer_name='html5_polyglot')['html_body']
-    html = apply_tailwind(html)
     if not with_params:
-        html = re.sub(r'<dl class=".* simple">.*?</dl>', '', html, flags=re.DOTALL)
-    return ui.html(html).classes('documentation bold-links arrow-links')
+        doc = doc.split('###', 1)[0]
+    else:
+        doc = doc.replace('### Parameters', '')
+    return ui.markdown(doc).classes('bold-links arrow-links')
 
 
 class text_demo:


### PR DESCRIPTION
This pull request aims to change all our reST docstrings into Markdown. Not only is Markdown much simpler to write and read, it also enhances the in-place documentation in vscode:

Before:
<img width="547" alt="Screen Shot 2023-06-09 at 11 51 24" src="https://github.com/zauberzeug/nicegui/assets/131391/ca4f29e7-42e6-4eb4-9f2f-3ce7830271af">

After:
<img width="527" alt="Screen Shot 2023-06-09 at 11 57 12" src="https://github.com/zauberzeug/nicegui/assets/131391/e8e9c892-2270-4cd2-9572-e1bd79bab255">
