### PR TITLE
do not use python-magic for mime type detection

### DIFF
--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import inspect
+import mimetypes
 import socket
 import sys
 import threading
@@ -10,7 +11,6 @@ from contextlib import nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generator, Optional, Tuple, Union
 
-import magic
 from fastapi import Request
 from fastapi.responses import StreamingResponse
 from starlette.middleware import Middleware
@@ -18,6 +18,8 @@ from starlette.middleware.sessions import SessionMiddleware
 
 from . import background_tasks, globals
 from .storage import RequestTrackingMiddleware
+
+mimetypes.init()
 
 if TYPE_CHECKING:
     from .client import Client
@@ -139,7 +141,7 @@ def get_streaming_response(file: Path, request: Request) -> StreamingResponse:
 
     return StreamingResponse(
         content_reader(file, start, end),
-        media_type=magic.from_file(str(file), mime=True),
+        media_type=mimetypes.guess_type(str(file))[0] or 'application/octet-stream',
         headers=headers,
         status_code=206,
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1759,17 +1759,6 @@ asyncio-client = ["aiohttp (>=3.4)"]
 client = ["requests (>=2.21.0)", "websocket-client (>=0.54.0)"]
 
 [[package]]
-name = "python-magic"
-version = "0.4.27"
-description = "File type identification using libmagic"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b"},
-    {file = "python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3"},
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.6"
 description = "A streaming multipart parser for Python"
@@ -2358,4 +2347,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "1a742c40e30d5ab7652be705fef2a96dc06a8a8f23e8ff4cc6b7190212a5a3fe"
+content-hash = "01dd4e6d62f913d2f5206dcd946dc9804767c4b57b115ef69eb56a73213ae5e4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ pywebview = "^4.0.2"
 importlib_metadata = { version = "^6.0.0", markers = "python_version ~= '3.7'" } # Python 3.7 has no importlib.metadata
 itsdangerous = "^2.1.2"
 aiofiles = "^23.1.0"
-python-magic = "^0.4.27"
 
 [tool.poetry.group.dev.dependencies]
 icecream = "^2.1.0"


### PR DESCRIPTION
build-in mimetype module is good enough and does not need a system dependency like libmagic1 so it is much mor protable.