### PR TITLE
avoid treating base64 data as filename

### DIFF
--- a/nicegui/api_router.py
+++ b/nicegui/api_router.py
@@ -1,4 +1,5 @@
-from typing import Callable, Optional
+from pathlib import Path
+from typing import Callable, Optional, Union
 
 import fastapi
 
@@ -11,7 +12,7 @@ class APIRouter(fastapi.APIRouter):
              path: str, *,
              title: Optional[str] = None,
              viewport: Optional[str] = None,
-             favicon: Optional[str] = None,
+             favicon: Optional[Union[str, Path]] = None,
              dark: Optional[bool] = ...,
              response_timeout: float = 3.0,
              **kwargs,

--- a/nicegui/elements/mixins/source_element.py
+++ b/nicegui/elements/mixins/source_element.py
@@ -13,7 +13,7 @@ class SourceElement(Element):
 
     def __init__(self, *, source: Union[str, Path], **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        if not source.startswith('data:') and Path(source).is_file():
+        if not str(source).strip().startswith('data:') and Path(source).is_file():
             source = globals.app.add_static_file(local_file=source)
         self.source = source
         self._props['src'] = source

--- a/nicegui/elements/mixins/source_element.py
+++ b/nicegui/elements/mixins/source_element.py
@@ -13,7 +13,7 @@ class SourceElement(Element):
 
     def __init__(self, *, source: Union[str, Path], **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        if Path(source).is_file():
+        if not source.startswith('data:') and Path(source).is_file():
             source = globals.app.add_static_file(local_file=source)
         self.source = source
         self._props['src'] = source

--- a/nicegui/elements/mixins/source_element.py
+++ b/nicegui/elements/mixins/source_element.py
@@ -6,6 +6,7 @@ from typing_extensions import Self
 from ... import globals
 from ...binding import BindableProperty, bind, bind_from, bind_to
 from ...element import Element
+from ...helpers import is_file
 
 
 class SourceElement(Element):
@@ -13,7 +14,7 @@ class SourceElement(Element):
 
     def __init__(self, *, source: Union[str, Path], **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        if not str(source).strip().startswith('data:') and Path(source).is_file():
+        if is_file(source):
             source = globals.app.add_static_file(local_file=source)
         self.source = source
         self._props['src'] = source

--- a/nicegui/favicon.py
+++ b/nicegui/favicon.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 def create_favicon_route(path: str, favicon: Optional[str]) -> None:
-    if favicon and Path(favicon).exists():
+    if favicon and not favicon.startswith('data:') and Path(favicon).exists():
         globals.app.add_route(f'{path}/favicon.ico', lambda _: FileResponse(favicon))
 
 

--- a/nicegui/favicon.py
+++ b/nicegui/favicon.py
@@ -7,13 +7,14 @@ from typing import TYPE_CHECKING, Optional, Tuple, Union
 from fastapi.responses import FileResponse, Response, StreamingResponse
 
 from . import __version__, globals
+from .helpers import is_file
 
 if TYPE_CHECKING:
     from .page import page
 
 
 def create_favicon_route(path: str, favicon: Optional[Union[str, Path]]) -> None:
-    if favicon and not str(favicon).strip().startswith('data:') and Path(favicon).exists():
+    if is_file(favicon):
         globals.app.add_route(f'{path}/favicon.ico', lambda _: FileResponse(favicon))
 
 

--- a/nicegui/globals.py
+++ b/nicegui/globals.py
@@ -3,6 +3,7 @@ import inspect
 import logging
 from contextlib import contextmanager
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Iterator, List, Optional, Union
 
 from socketio import AsyncServer
@@ -35,7 +36,7 @@ ui_run_has_been_called: bool = False
 reload: bool
 title: str
 viewport: str
-favicon: Optional[str]
+favicon: Optional[Union[str, Path]]
 dark: Optional[bool]
 language: Language
 binding_refresh_interval: float

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -38,6 +38,15 @@ def is_coroutine_function(object: Any) -> bool:
     return asyncio.iscoroutinefunction(object)
 
 
+def is_file(path: Optional[Union[str, Path]]) -> bool:
+    """Check if the path is a file that exists."""
+    if not path:
+        return False
+    elif isinstance(path, str) and path.strip().startswith('data:'):
+        return False  # NOTE: avoid passing data URLs to Path
+    return Path(path).is_file()
+
+
 def safe_invoke(func: Union[Callable[..., Any], Awaitable], client: Optional['Client'] = None) -> None:
     try:
         if isinstance(func, Awaitable):

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -67,7 +67,7 @@ def handle_startup(with_welcome_message: bool = True) -> None:
                            '   if __name__ in {"__main__", "__mp_main__"}:\n'
                            'to allow for multiprocessing.')
     if globals.favicon:
-        if not globals.favicon.startswith('data:') and Path(globals.favicon).exists():
+        if not str(globals.favicon).strip().startswith('data:') and Path(globals.favicon).exists():
             globals.app.add_route('/favicon.ico', lambda _: FileResponse(globals.favicon))
         else:
             globals.app.add_route('/favicon.ico', lambda _: favicon.get_favicon_response())

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -67,7 +67,7 @@ def handle_startup(with_welcome_message: bool = True) -> None:
                            '   if __name__ in {"__main__", "__mp_main__"}:\n'
                            'to allow for multiprocessing.')
     if globals.favicon:
-        if Path(globals.favicon).exists():
+        if not globals.favicon.startswith('data:') and Path(globals.favicon).exists():
             globals.app.add_route('/favicon.ico', lambda _: FileResponse(globals.favicon))
         else:
             globals.app.add_route('/favicon.ico', lambda _: favicon.get_favicon_response())

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -21,7 +21,7 @@ from .client import Client
 from .dependencies import js_components, js_dependencies
 from .element import Element
 from .error import error_content
-from .helpers import safe_invoke
+from .helpers import is_file, safe_invoke
 from .page import page
 
 globals.app = app = App(default_response_class=NiceGUIJSONResponse)
@@ -67,7 +67,7 @@ def handle_startup(with_welcome_message: bool = True) -> None:
                            '   if __name__ in {"__main__", "__mp_main__"}:\n'
                            'to allow for multiprocessing.')
     if globals.favicon:
-        if not str(globals.favicon).strip().startswith('data:') and Path(globals.favicon).exists():
+        if is_file(globals.favicon):
             globals.app.add_route('/favicon.ico', lambda _: FileResponse(globals.favicon))
         else:
             globals.app.add_route('/favicon.ico', lambda _: favicon.get_favicon_response())

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -1,7 +1,8 @@
 import asyncio
 import inspect
 import time
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from fastapi import Request, Response
 
@@ -20,7 +21,7 @@ class page:
                  path: str, *,
                  title: Optional[str] = None,
                  viewport: Optional[str] = None,
-                 favicon: Optional[str] = None,
+                 favicon: Optional[Union[str, Path]] = None,
                  dark: Optional[bool] = ...,
                  language: Language = ...,
                  response_timeout: float = 3.0,

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -3,7 +3,8 @@ import multiprocessing
 import os
 import socket
 import sys
-from typing import Any, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, List, Optional, Tuple, Union
 
 import __main__
 import uvicorn
@@ -34,7 +35,7 @@ def run(*,
         port: int = 8080,
         title: str = 'NiceGUI',
         viewport: str = 'width=device-width, initial-scale=1',
-        favicon: Optional[str] = None,
+        favicon: Optional[Union[str, Path]] = None,
         dark: Optional[bool] = False,
         language: Language = 'en-US',
         binding_refresh_interval: float = 0.1,

--- a/nicegui/run_with.py
+++ b/nicegui/run_with.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
 
 from fastapi import FastAPI
 
@@ -12,7 +13,7 @@ def run_with(
     app: FastAPI, *,
     title: str = 'NiceGUI',
     viewport: str = 'width=device-width, initial-scale=1',
-    favicon: Optional[str] = None,
+    favicon: Optional[Union[str, Path]] = None,
     dark: Optional[bool] = False,
     language: Language = 'en-US',
     binding_refresh_interval: float = 0.1,


### PR DESCRIPTION
This PR fixes a [bug](https://github.com/zauberzeug/nicegui/discussions/789#discussioncomment-6161471) spotted by @gitUser000. It was caused by treating base64 data as a filepath and checking if the file exists. Depending on the OS, longer or shorter image data leads to an OSError.

The following code includes all three individual bugs (SourceElement, page favicon and global favicon):

```py
from nicegui import ui

data = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAIRlWElmTU0AKgAAAAgABQESAAMAAA\
ABAAEAAAEaAAUAAAABAAAASgEbAAUAAAABAAAAUgEoAAMAAAABAAIAAIdpAAQAAAABAAAAWgAAAAAAAABIAAAAAQAAAEgAAAABAAOgAQADAAAAAQABAACgAgAEAAA\
AAQAAACCgAwAEAAAAAQAAACAAAAAAX7wP8AAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6\
eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDYuMC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyL\
zIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2\
JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICA\
gPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KGV7hBwAABAJJREFUWAm1lk2olVUUhs/V/A1qoJQ6EAwHJaSgDYTiioPQgRNRp4qNRGjmRJJIR4JQOAh0lKE40EZBoCJ4\
FfG3TJwEFUKSdQdFZg78t+f5vv0ev3s9nnOv5/rC++2919p7rbXX/vtarbFhEt1eGVvXqtdkvrInBnr0UK+hh6XfTMpB+AF8B74BDe4W/BWeh0NwGAp12nhkY7xoz\
mARgw/D+/AJ/B0OwW/gEXgc/gIfQ/Vn4CoYjCd71ZgMmEbrANSoM/wYzoPPw6soNsDT0DGX4EIoYrNudflOKbrFlLfhHbi+yFK8R+Uj+An8FG6FK+FMGCylchUayM\
YibGa1iEYWiXIFYgcegwnoTeq74XWorhP/Qn4Q6jzYRcW+24sgPqJvl4nOmTvgq7am1dpC/d8iV+daPxhFN5q6cC91N6HYDJVrRzwThDtVuOam3ZkH+6nEqJtQRwY\
QWbNUZ5/oL1CfBcU2aF+XT2TCVSMRHaB1Bybt+6g7KI6bzrrVDeBuGXuFcgYUnpYbVa3+VBNPmhYh0+j60sF0xXlm1M1pJ12COFRseoLs56YV1cQze8+5R0244bLm\
o9e2k6NuMveK+jVQuKR/VLXGx+Njmj3nYjd0kLJuxseiSwBnsSWS6cG6WX9XU2jMFInr0Ha/s0+AWcIlGge/wS+sZP29229CU+MuXQAdHD3VvuBExId10TpH+b71O\
PBhyfp7D4gMqlsT800GrmFuviYTgK+at5iYWxcv5asf8Sd8DU5NAJaukxhxQdSivr+56GLb7OpzIAH4nr9e3CQTpTkhhftJ/FMXrdmUXnj3E4Dr/1ZR/lTK6Eqzry\
IBxLZ7bhg+iZPzNAzA9/wi/Buqy0CqfSGpP1WsLKf8oWlxDg2d5Ro+WNoTcRHlLvm5OHQj6mtdabc33RkEQ0Xoe24nN2YuEdsvwntlXG7Z7bSVTYcVkp5VtHSQnwn\
fc9t5UPpxfhk7wtPwH/zcBsg71L4PLiH8sVLVe+AC9RcNIjN3t79dbO4p9rwDRI5nexkWItThTrXAn4krUFn+gHplwjVvOq+uXGQri51NlKI9+7r5VLARgU42F4U/\
E4eKTLl7IsGMLrPh7Pc9zMzzAn6NTGTZ61bjm6jcKBrZ1tD5np8tcnXPo7s9G45qe+bHbBQMpNKpTHRbUOrkOJzb6OiDYmAe1RPwJDwKd0HTHOgka56Zq/N+6YlkY\
hk9b0AD2Q9NZS94zs2gu91xm2DwjPNuqTCIh2XkVsod0EwYkO+5T6qvmus+G3q9esO9C73AvoSfwdvQrOY+ofoU3QKwlwN1EAxSWQvd2fOhx8lZedSGodfrt/A76P\
0hmhOpJeP8GmSWZPTQqQimwU4TcUwn+Qgb/wPbAY+ggabXAAAAAABJRU5ErkJggg=='

@ui.page('/', favicon=data)
def index():
    ui.image(data)

ui.run(port=1234, uvicorn_reload_includes='*.py, *.js, *.html, *.css, *.vue', favicon=data)
```