### PR TITLE
Adds drive selector to local_file_picker example on Windows

### DIFF
--- a/examples/local_file_picker/local_file_picker.py
+++ b/examples/local_file_picker/local_file_picker.py
@@ -39,7 +39,7 @@ class local_file_picker(ui.dialog):
         self.update_grid()
 
     def add_drives_toggle(self):
-        if platform.system() == "Windows":
+        if platform.system() == 'Windows':
             import win32api
             drives = win32api.GetLogicalDriveStrings().split('\000')[:-1]
             self.drives_toggle = ui.toggle(drives, value=drives[0], on_change=self.update_drive)
@@ -70,7 +70,7 @@ class local_file_picker(ui.dialog):
             })
         self.grid.update()
 
-    async def handle_double_click(self, msg: Dict) -> None:
+    def handle_double_click(self, msg: Dict) -> None:
         self.path = Path(msg['args']['data']['path'])
         if self.path.is_dir():
             self.update_grid()

--- a/examples/local_file_picker/local_file_picker.py
+++ b/examples/local_file_picker/local_file_picker.py
@@ -1,3 +1,4 @@
+import platform
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -27,6 +28,7 @@ class local_file_picker(ui.dialog):
         self.show_hidden_files = show_hidden_files
 
         with self, ui.card():
+            self.add_drives_toggle()
             self.grid = ui.aggrid({
                 'columnDefs': [{'field': 'name', 'headerName': 'File'}],
                 'rowSelection': 'multiple' if multiple else 'single',
@@ -34,6 +36,16 @@ class local_file_picker(ui.dialog):
             with ui.row().classes('w-full justify-end'):
                 ui.button('Cancel', on_click=self.close).props('outline')
                 ui.button('Ok', on_click=self._handle_ok)
+        self.update_grid()
+
+    def add_drives_toggle(self):
+        if platform.system() == "Windows":
+            import win32api
+            drives = win32api.GetLogicalDriveStrings().split('\000')[:-1]
+            self.drives_toggle = ui.toggle(drives, value=drives[0], on_change=self.update_drive)
+
+    def update_drive(self):
+        self.path = Path(self.drives_toggle.value).expanduser()
         self.update_grid()
 
     def update_grid(self) -> None:


### PR DESCRIPTION
I scrolled through this [Discussion #283](https://github.com/zauberzeug/nicegui/discussions/283) and added a drive selector to the local_file_picker example (based off [this comment](https://github.com/zauberzeug/nicegui/discussions/283#discussioncomment-4819450)).

If the example is run on Windows it will add a dive selector toggle at the top.

![image](https://github.com/zauberzeug/nicegui/assets/22006760/9aaba82c-42b6-4314-88aa-abaf20b6fdf6)
