### PR TITLE
ignore events on disabled or hidden elements by default

### DIFF
--- a/nicegui/elements/mixins/disableable_element.py
+++ b/nicegui/elements/mixins/disableable_element.py
@@ -12,6 +12,14 @@ class DisableableElement(Element):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.enabled = True
+        self.ignores_events_when_disabled = True
+
+    @property
+    def is_ignoring_events(self) -> bool:
+        """Return whether the element is currently ignoring events."""
+        if super().is_ignoring_events:
+            return True
+        return not self.enabled and self.ignores_events_when_disabled
 
     def enable(self) -> None:
         """Enable the element."""

--- a/nicegui/elements/mixins/visibility.py
+++ b/nicegui/elements/mixins/visibility.py
@@ -14,6 +14,12 @@ class Visibility:
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.visible = True
+        self.ignores_events_when_hidden = True
+
+    @property
+    def is_ignoring_events(self) -> bool:
+        """Return whether the element is currently ignoring events."""
+        return
 
     def bind_visibility_to(self,
                            target_object: Any,

--- a/nicegui/elements/mixins/visibility.py
+++ b/nicegui/elements/mixins/visibility.py
@@ -19,7 +19,7 @@ class Visibility:
     @property
     def is_ignoring_events(self) -> bool:
         """Return whether the element is currently ignoring events."""
-        return
+        return not self.visible and self.ignores_events_when_hidden
 
     def bind_visibility_to(self,
                            target_object: Any,

--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -277,6 +277,8 @@ def handle_event(handler: Optional[Callable[..., Any]],
         no_arguments = not any(p.default is Parameter.empty for p in signature(handler).parameters.values())
         sender = arguments.sender if isinstance(arguments, EventArguments) else sender
         assert sender is not None and sender.parent_slot is not None
+        if sender.is_ignoring_events:
+            return
         with sender.parent_slot:
             result = handler() if no_arguments else handler(arguments)
         if isinstance(result, Awaitable):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 from selenium.webdriver.common.by import By
+from typing_extensions import Literal
 
 from nicegui import ui
 from nicegui.events import ClickEventArguments
@@ -161,10 +162,10 @@ def test_throttling_variants(screen: Screen):
     assert events == [3]
 
 
-@pytest.mark.parametrize('attribue', ['disabled', 'hidden'])
-def test_server_side_validation(screen: Screen, attribue: str):
+@pytest.mark.parametrize('attribute', ['disabled', 'hidden'])
+def test_server_side_validation(screen: Screen, attribute: Literal['disabled', 'hidden']):
     b = ui.button('Button', on_click=lambda: ui.label('Success'))
-    b.disable() if attribue == 'disabled' else b.set_visibility(False)
+    b.disable() if attribute == 'disabled' else b.set_visibility(False)
     ui.button('Hack', on_click=lambda: ui.run_javascript(f'''
         getElement({b.id}).$emit("click", {{"id": {b.id}, "listener_id": "{list(b._event_listeners.keys())[0]}"}});
     ''', respond=False))


### PR DESCRIPTION
This PR proposes a solution for #983, where we discussed the current possibility to trigger events on elements that are either disabled or hidden.