### PR TITLE
chore: condense mypy and pytest config files to pyproject.toml

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,0 @@
-[mypy]
-ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,10 @@ requires = [
     "poetry-core>=1.0.0"
 ]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+addopts = "--driver Chrome"
+asyncio_mode = "auto"
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-addopts = --driver Chrome
-asyncio_mode = auto


### PR DESCRIPTION
Per conversation [here](https://github.com/zauberzeug/nicegui/issues/1018#issuecomment-1595939724), starting in [PEP 518](https://peps.python.org/pep-0518/) the pyproject.toml is beginning to become the centralized location for all configuration. Both [mypy](https://mypy.readthedocs.io/en/stable/config_file.html#using-a-pyproject-toml-file) and [pytest](https://docs.pytest.org/en/7.3.x/reference/customize.html) use it. This is in preparation for simplifying some of the dev environment to make contribution a bit smoother