### PR TITLE
add `create_folder_dialog`

### DIFF
--- a/nicegui/native.py
+++ b/nicegui/native.py
@@ -107,6 +107,18 @@ try:
                 file_types=file_types,
             )
 
+        async def create_folder_dialog(
+            self,
+            dialog_type: int = webview.FOLDER_DIALOG,
+            directory: str = '',
+            allow_multiple: bool = False
+        ) -> Tuple[str, ...]:
+            return await self._request(
+                dialog_type=dialog_type,
+                directory=directory,
+                allow_multiple=allow_multiple
+            )
+
         def expose(self, function: Callable) -> None:
             raise NotImplementedError(f'exposing "{function}" is not supported')
 


### PR DESCRIPTION
I would like to be able to select a folder / directory.

The suggested code is a copy/paste (which some edits) from https://github.com/zauberzeug/nicegui/blob/3790d1527b2f0111744f2a6c6529df015cabe8a6/nicegui/native.py#L94

I found this https://pywebview.flowrl.com/guide/api.html#window-create-file-dialog and saw the note below it `open folder (webview.FOLDER_DIALOG)` and thought I'd give it a shot.