### PR TITLE
Fix typo in bindings docs

### DIFF
--- a/website/more_documentation/bindings_documentation.py
+++ b/website/more_documentation/bindings_documentation.py
@@ -63,7 +63,7 @@ def more() -> None:
 
         # @ui.page('/')
         # def index():
-        #     ui.textarea('This note is kept between visits') \
+        #     ui.textarea('This note is kept between visits') 
         #         .classes('w-full').bind_value(app.storage.user, 'note')
         # END OF DEMO
         ui.textarea('This note is kept between visits').classes('w-full').bind_value(app.storage.user, 'note')


### PR DESCRIPTION
Before:
```python
from nicegui import app, ui

@ui.page('/')
def index():
    ui.textarea('This note is kept between visits') \
        .classes('w-full').bind_value(app.storage.user, 'note')

ui.run()
```
After:
```Python
from nicegui import app, ui

@ui.page('/')
def index():
    ui.textarea('This note is kept between visits') 
        .classes('w-full').bind_value(app.storage.user, 'note')

ui.run()
```