### PR TITLE
Fix serving media files from subdirectories

### DIFF
--- a/nicegui/app.py
+++ b/nicegui/app.py
@@ -126,7 +126,7 @@ class App(FastAPI):
         :param url_path: string that starts with a slash "/" and identifies the path at which the files should be served
         :param local_directory: local folder with files to serve as media content
         """
-        @self.get(url_path + '/{filename}')
+        @self.get(url_path + '/{filename:path}')
         async def read_item(request: Request, filename: str) -> StreamingResponse:
             filepath = Path(local_directory) / filename
             if not filepath.is_file():


### PR DESCRIPTION
After writing
```py
app.add_media_files('/media', Path('/Users/falko/music'))
```
I couldn't access files like "/media/house/track.mp3" because "house/music.mp3" isn't matched with the `filename` parameter. This PR fixes it by allowing `filename` to be a path.

Note that this allows accessing the whole directory tree underneath "/Users/falko/music". But I guess this is expected behavior and nicely in line with `add_static_files`.