### PR TITLE
Ensure move events are only sent between start/end

### DIFF
--- a/nicegui/elements/joystick.py
+++ b/nicegui/elements/joystick.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Dict, Optional
 
 from ..dependencies import register_component
 from ..element import Element
@@ -29,21 +29,21 @@ class Joystick(Element):
         self._props['options'] = options
         self.active = False
 
-        def handle_start(msg):
+        def handle_start() -> None:
             self.active = True
             handle_event(on_start, JoystickEventArguments(sender=self,
                                                           client=self.client,
                                                           action='start'))
 
-        def handle_move(msg):
+        def handle_move(msg: Dict) -> None:
             if self.active:
                 handle_event(on_move, JoystickEventArguments(sender=self,
                                                              client=self.client,
                                                              action='move',
                                                              x=msg['args']['data']['vector']['x'],
-                                                             y=msg['args']['data']['vector']['y'])),
+                                                             y=msg['args']['data']['vector']['y']))
 
-        def handle_end(msg):
+        def handle_end() -> None:
             self.active = False
             handle_event(on_end, JoystickEventArguments(sender=self,
                                                         client=self.client,


### PR DESCRIPTION
This PR fixes a bug in `ui.joystick` where sometimes a `on_move` is called after `on_end`.

Reproduction:

```py
ui.joystick(color='blue', size=50,
            on_move=lambda e: coordinates.set_text(f"{e.x:.3f}, {e.y:.3f}"),
            on_end=lambda _: coordinates.set_text('0, 0'))
coordinates = ui.label('0, 0')
```

When releasing the mouse while dragging, the text is often not set back to `0, 0`.