### PR TITLE
Fix element.run_method('focus')

### DIFF
--- a/nicegui/elements/image.js
+++ b/nicegui/elements/image.js
@@ -1,6 +1,10 @@
 export default {
   template: `
-    <q-img v-bind="$attrs" :src="computed_src">
+    <q-img
+      ref="qRef"
+      v-bind="$attrs"
+      :src="computed_src"
+    >
       <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
         <slot :name="slot" v-bind="slotProps || {}" />
       </template>

--- a/nicegui/elements/input.js
+++ b/nicegui/elements/input.js
@@ -1,7 +1,7 @@
 export default {
   template: `
     <q-input
-      ref="inputRef"
+      ref="qRef"
       v-bind="$attrs"
       v-model="inputValue"
       :shadow-text="shadowText"
@@ -60,21 +60,6 @@ export default {
         this.inputValue += this.shadowText;
         e.preventDefault();
       }
-    },
-    resetValidation() {
-      this.$refs.inputRef.resetValidation();
-    },
-    validate(value) {
-      return this.$refs.inputRef.validate(value);
-    },
-    focus() {
-      this.$refs.inputRef.focus();
-    },
-    blur() {
-      this.$refs.inputRef.blur();
-    },
-    select() {
-      this.$refs.inputRef.select();
     },
   },
 };

--- a/nicegui/elements/input.js
+++ b/nicegui/elements/input.js
@@ -1,6 +1,7 @@
 export default {
   template: `
     <q-input
+      ref="inputRef"
       v-bind="$attrs"
       v-model="inputValue"
       :shadow-text="shadowText"
@@ -59,6 +60,21 @@ export default {
         this.inputValue += this.shadowText;
         e.preventDefault();
       }
+    },
+    resetValidation() {
+      this.$refs.inputRef.resetValidation();
+    },
+    validate(value) {
+      return this.$refs.inputRef.validate(value);
+    },
+    focus() {
+      this.$refs.inputRef.focus();
+    },
+    blur() {
+      this.$refs.inputRef.blur();
+    },
+    select() {
+      this.$refs.inputRef.select();
     },
   },
 };

--- a/nicegui/elements/select.js
+++ b/nicegui/elements/select.js
@@ -1,12 +1,17 @@
 export default {
   props: ["options"],
   template: `
-      <q-select v-bind="$attrs" :options="filteredOptions" @filter="filterFn">
-          <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
-              <slot :name="slot" v-bind="slotProps || {}" />
-          </template>
-      </q-select>
-    `,
+    <q-select
+      ref="qRef"
+      v-bind="$attrs"
+      :options="filteredOptions"
+      @filter="filterFn"
+    >
+      <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
+        <slot :name="slot" v-bind="slotProps || {}" />
+      </template>
+    </q-select>
+  `,
   data() {
     return {
       initialOptions: this.options,

--- a/nicegui/elements/table.js
+++ b/nicegui/elements/table.js
@@ -1,6 +1,10 @@
 export default {
   template: `
-    <q-table v-bind="$attrs" :columns="convertedColumns">
+    <q-table
+      ref="qRef"
+      v-bind="$attrs"
+      :columns="convertedColumns"
+    >
       <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
         <slot :name="slot" v-bind="slotProps || {}" />
       </template>

--- a/nicegui/elements/upload.js
+++ b/nicegui/elements/upload.js
@@ -1,9 +1,12 @@
 export default {
   template: `
-    <q-uploader ref="uploader" :url="computed_url">
-        <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
-            <slot :name="slot" v-bind="slotProps || {}" />
-        </template>
+    <q-uploader
+      ref="qRef"
+      :url="computed_url"
+    >
+      <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
+        <slot :name="slot" v-bind="slotProps || {}" />
+      </template>
     </q-uploader>
   `,
   mounted() {
@@ -15,9 +18,6 @@ export default {
   methods: {
     compute_url() {
       this.computed_url = (this.url.startsWith("/") ? window.path_prefix : "") + this.url;
-    },
-    reset() {
-      this.$refs.uploader.reset();
     },
   },
   props: {

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -178,7 +178,15 @@
             document.getElementById('popup').style.opacity = 1;
           });
           window.socket.on("update", (msg) => Object.entries(msg).forEach(([id, el]) => this.elements[el.id] = el));
-          window.socket.on("run_method", (msg) => getElement(msg.id)?.[msg.name](...msg.args));
+          window.socket.on("run_method", (msg) => {
+            const element = getElement(msg.id);
+            if (element === null || element === undefined) return;
+            if (msg.name in element) {
+              element[msg.name](...msg.args);
+            } else {
+              element.$refs.qRef[msg.name](...msg.args);
+            }
+          });
           window.socket.on("run_javascript", (msg) => runJavascript(msg['code'], msg['request_id']));
           window.socket.on("open", (msg) => (location.href = msg.startsWith('/') ? "{{ prefix | safe }}" + msg : msg));
           window.socket.on("download", (msg) => download(msg.url, msg.filename));

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -141,3 +141,20 @@ def test_update_input(screen: Screen):
     input.value = 'Pete'
     screen.wait(0.5)
     assert element.get_attribute('value') == 'Pete'
+
+
+def test_switching_focus(screen: Screen):
+    input1 = ui.input()
+    input2 = ui.input()
+    ui.button('focus 1', on_click=lambda: input1.run_method('focus'))
+    ui.button('focus 2', on_click=lambda: input2.run_method('focus'))
+
+    screen.open('/')
+    elements = screen.selenium.find_elements(By.XPATH, '//input')
+    assert len(elements) == 2
+    screen.click('focus 1')
+    screen.wait(0.3)
+    assert elements[0] == screen.selenium.switch_to.active_element
+    screen.click('focus 2')
+    screen.wait(0.3)
+    assert elements[1] == screen.selenium.switch_to.active_element


### PR DESCRIPTION
Calling `.run_method('focus')` on an element stopped working with v1.2.22; worked fine with 1.2.21 as reported in #1092. This PR aims to fix the issue.

- [x] write a test to reproduce the issue
- [x] fix code
- [ ] merge into main
