### PR TITLE
Ensure timer runs awaitable

### DIFF
--- a/nicegui/functions/timer.py
+++ b/nicegui/functions/timer.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from typing import Any, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 from .. import background_tasks, globals
 from ..binding import BindableProperty
@@ -89,7 +89,7 @@ class Timer:
         try:
             assert self.callback is not None
             result = self.callback()
-            if is_coroutine_function(self.callback):
+            if isinstance(result, Awaitable):
                 await result
         except Exception as e:
             globals.handle_exception(e)

--- a/nicegui/functions/timer.py
+++ b/nicegui/functions/timer.py
@@ -4,7 +4,6 @@ from typing import Any, Awaitable, Callable, Optional
 
 from .. import background_tasks, globals
 from ..binding import BindableProperty
-from ..helpers import is_coroutine_function
 from ..slot import Slot
 
 

--- a/tests/screen.py
+++ b/tests/screen.py
@@ -31,7 +31,7 @@ class Screen:
         self.ui_run_kwargs = {'port': PORT, 'show': False, 'reload': False}
 
     def start_server(self) -> None:
-        '''Start the webserver in a separate thread. This is the equivalent of `ui.run()` in a normal script.'''
+        """Start the webserver in a separate thread. This is the equivalent of `ui.run()` in a normal script."""
         self.server_thread = threading.Thread(target=ui.run, kwargs=self.ui_run_kwargs)
         self.server_thread.start()
 
@@ -45,17 +45,17 @@ class Screen:
             return False
 
     def stop_server(self) -> None:
-        '''Stop the webserver.'''
+        """Stop the webserver."""
         self.close()
         self.caplog.clear()
         globals.server.should_exit = True
         self.server_thread.join()
 
     def open(self, path: str, timeout: float = 3.0) -> None:
-        '''Try to open the page until the server is ready or we time out.
+        """Try to open the page until the server is ready or we time out.
 
         If the server is not yet running, start it.
-        '''
+        """
         if self.server_thread is None:
             self.start_server()
         deadline = time.time() + timeout
@@ -166,7 +166,7 @@ class Screen:
         self.selenium.get_screenshot_as_file(filename)
 
     def assert_py_logger(self, level: str, message: str) -> None:
-        '''Assert that the Python logger has received a message with the given level and text'''
+        """Assert that the Python logger has received a message with the given level and text."""
         try:
             assert self.caplog.records, 'Expected a log message'
             record = self.caplog.records[0]

--- a/tests/screen.py
+++ b/tests/screen.py
@@ -166,6 +166,7 @@ class Screen:
         self.selenium.get_screenshot_as_file(filename)
 
     def assert_py_logger(self, level: str, message: str) -> None:
+        '''Assert that the Python logger has received a message with the given level and text'''
         try:
             assert self.caplog.records, 'Expected a log message'
             record = self.caplog.records[0]

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -63,7 +63,7 @@ def test_setting_visibility(screen: Screen, once: bool):
     screen.should_not_contain('Some Label')
 
 
-def test_awaiting_coroutine(screen: Screen, capfd):
+def test_awaiting_coroutine(screen: Screen):
     warnings.simplefilter('error')
 
     async def update_user():

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -1,3 +1,6 @@
+import asyncio
+import warnings
+
 import pytest
 
 from nicegui import ui
@@ -58,3 +61,15 @@ def test_setting_visibility(screen: Screen, once: bool):
     screen.open('/')
     screen.wait(0.5)
     screen.should_not_contain('Some Label')
+
+
+def test_awaiting_coroutine(screen: Screen, capfd):
+    warnings.simplefilter('error')
+
+    async def update_user():
+        await asyncio.sleep(0.1)
+
+    ui.timer(1, lambda: update_user())
+
+    screen.open('/')
+    screen.wait(1)


### PR DESCRIPTION
The code 

```py
async def update_user():
    await asyncio.sleep(1)

ui.timer(1, lambda: update_user())
```

Produces the warning `Enable tracemalloc to get traceback where the object was allocated.`. While the reproduction is a bit artificial, it is beneficial to define lambda statements which return an awaitable because it simplifies passing parameters. We did something similar for button click handlers. This PR adds the same behaviour to ui.timer.