### PR TITLE
Cancel waiting coroutines before enqueueing the next lazy background task

### DIFF
--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -36,6 +36,8 @@ def create_lazy(coroutine: Awaitable[T], *, name: str) -> None:
     If a third task with the same name is created while the first one is still running, the second one is discarded.
     """
     if name in lazy_tasks_running:
+        if name in lazy_tasks_waiting:
+            asyncio.Task(lazy_tasks_waiting[name]).cancel()
         lazy_tasks_waiting[name] = coroutine
         return
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,4 +1,5 @@
 import asyncio
+import warnings
 from pathlib import Path
 
 import httpx
@@ -150,3 +151,19 @@ def test_user_and_general_storage_is_persisted(screen: Screen):
     screen.open('/')
     screen.should_contain('user: 1')
     screen.should_contain('general: 4')
+
+
+def test_rapid_storage(screen: Screen):
+    # https://github.com/zauberzeug/nicegui/issues/1099
+    warnings.simplefilter('error')
+
+    ui.button('test', on_click=lambda: (
+        app.storage.general.update(one=1),
+        app.storage.general.update(two=2),
+        app.storage.general.update(three=3),
+    ))
+
+    screen.open('/')
+    screen.click('test')
+    screen.wait(0.5)
+    assert '{"one": 1, "two": 2, "three": 3}' in Path('.nicegui', 'storage_general.json').read_text()


### PR DESCRIPTION
This PR fixes issue #1099, which occurred when a new lazy task replaced another one waiting for execution. The replaced coroutine is never awaited, causing a RuntimeWarning. By creating a task and immediately canceling it, the warning does not show up:
```py
asyncio.Task(lazy_tasks_waiting[name]).cancel()
```