### PR TITLE
add on_change parameter for ui.knob

### DIFF
--- a/nicegui/elements/knob.py
+++ b/nicegui/elements/knob.py
@@ -1,9 +1,8 @@
-from typing import Optional
-
-from .label import Label
-from .mixins.color_elements import TextColorElement
-from .mixins.disableable_element import DisableableElement
 from .mixins.value_element import ValueElement
+from .mixins.disableable_element import DisableableElement
+from .mixins.color_elements import TextColorElement
+from .label import Label
+from typing import Any, Callable, Optional
 
 
 class Knob(ValueElement, DisableableElement, TextColorElement):
@@ -19,6 +18,7 @@ class Knob(ValueElement, DisableableElement, TextColorElement):
                  track_color: Optional[str] = None,
                  size: Optional[str] = None,
                  show_value: bool = False,
+                 on_change: Optional[Callable[..., Any]] = None,
                  ) -> None:
         """Knob
 
@@ -34,8 +34,9 @@ class Knob(ValueElement, DisableableElement, TextColorElement):
         :param track_color: color name for the track of the component, examples: primary, teal-10
         :param size: size in CSS units, including unit name or standard size name (xs|sm|md|lg|xl), examples: 16px, 2rem
         :param show_value: whether to show the value as text
+        :param on_change: callback to execute when the value changes
         """
-        super().__init__(tag='q-knob', value=value, on_value_change=None, throttle=0.05, text_color=color)
+        super().__init__(tag='q-knob', value=value, on_value_change=on_change, throttle=0.05, text_color=color)
 
         self._props['min'] = min
         self._props['max'] = max

--- a/nicegui/elements/knob.py
+++ b/nicegui/elements/knob.py
@@ -1,8 +1,9 @@
-from .mixins.value_element import ValueElement
-from .mixins.disableable_element import DisableableElement
-from .mixins.color_elements import TextColorElement
-from .label import Label
 from typing import Any, Callable, Optional
+
+from .label import Label
+from .mixins.color_elements import TextColorElement
+from .mixins.disableable_element import DisableableElement
+from .mixins.value_element import ValueElement
 
 
 class Knob(ValueElement, DisableableElement, TextColorElement):


### PR DESCRIPTION
As discovered on [Discord](https://discord.com/channels/1089836369431498784/1124716770595438662), the `on_change` parameter for `ui.knob` was missing.