### PR TITLE
Fixed table selection not going away after removing selection in table_and_slots example

### DIFF
--- a/examples/table_and_slots/main.py
+++ b/examples/table_and_slots/main.py
@@ -34,8 +34,12 @@ with ui.table(title='My Team', columns=columns, rows=rows, selection='multiple',
             with table.cell():
                 new_age = ui.number('Age')
 
+def remove_from_table():
+    table.remove_rows(*table.selected)
+    table.selected.clear()
+
 ui.label().bind_text_from(table, 'selected', lambda val: f'Current selection: {val}')
-ui.button('Remove', on_click=lambda: table.remove_rows(*table.selected)) \
+ui.button('Remove', on_click=remove_from_table) \
     .bind_visibility_from(table, 'selected', backward=lambda val: bool(val))
 
 ui.run()

--- a/examples/table_and_slots/main.py
+++ b/examples/table_and_slots/main.py
@@ -34,12 +34,8 @@ with ui.table(title='My Team', columns=columns, rows=rows, selection='multiple',
             with table.cell():
                 new_age = ui.number('Age')
 
-def remove_from_table():
-    table.remove_rows(*table.selected)
-    table.selected.clear()
-
 ui.label().bind_text_from(table, 'selected', lambda val: f'Current selection: {val}')
-ui.button('Remove', on_click=remove_from_table) \
+ui.button('Remove', on_click=lambda: table.remove_rows(*table.selected)) \
     .bind_visibility_from(table, 'selected', backward=lambda val: bool(val))
 
 ui.run()

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -71,6 +71,7 @@ class Table(FilterElement):
         """Remove rows from the table."""
         keys = [row[self.row_key] for row in rows]
         self.rows[:] = [row for row in self.rows if row[self.row_key] not in keys]
+        self.selected[:] = [row for row in self.selected if row[self.row_key] not in keys]
         self.update()
 
     class row(Element):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -110,3 +110,17 @@ def test_dynamic_column_attributes(screen: Screen):
 
     screen.open('/')
     screen.should_contain('18 years')
+
+
+def test_remove_selection(screen: Screen):
+    t = ui.table(columns=columns(), rows=rows(), selection='single')
+    ui.button('Remove first row', on_click=lambda: t.remove_rows(t.rows[0]))
+
+    screen.open('/')
+    screen.find('Alice').find_element(By.XPATH, 'preceding-sibling::td').click()
+    screen.should_contain('1 record selected.')
+
+    screen.click('Remove first row')
+    screen.wait(0.5)
+    screen.should_not_contain('Alice')
+    screen.should_not_contain('1 record selected.')


### PR DESCRIPTION
When the Remove button is clicked in the example, only the table content is changed, not the selection, as mentioned in [this issue](https://github.com/zauberzeug/nicegui/issues/1115). The added remove_from_table function both removes the rows from the table, as well as clears the selection, with table.selected.clear(). This might not be the most optimized implementation, but it does successfully clear the selection. 