### PR TITLE
Fix two favicon issues

### DIFF
--- a/nicegui/favicon.py
+++ b/nicegui/favicon.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 def create_favicon_route(path: str, favicon: Optional[Union[str, Path]]) -> None:
     if is_file(favicon):
-        globals.app.add_route(f'{path}/favicon.ico', lambda _: FileResponse(favicon))
+        globals.app.add_route('/favicon.ico' if path == '/' else f'{path}/favicon.ico', lambda _: FileResponse(favicon))
 
 
 def get_favicon_url(page: 'page', prefix: str) -> str:
@@ -31,7 +31,7 @@ def get_favicon_url(page: 'page', prefix: str) -> str:
         return svg_to_data_url(favicon)
     elif is_char(favicon):
         return svg_to_data_url(char_to_svg(favicon))
-    elif page.path == '/':
+    elif page.path == '/' or page.favicon is None:
         return f'{prefix}/favicon.ico'
     else:
         return f'{prefix}{page.path}/favicon.ico'


### PR DESCRIPTION
This PR fixes the following two issues regarding favicons:

1. The following code should use logo.png as favicon on "/":
    ```py
    @ui.page('/', favicon='website/static/logo.png')
    def test():
        ui.label('The default favicon is used instead of logo.png!')
    
    ui.run()
    ```
    But the route is incorrectly created at "//favicon.ico". By explicitly handling the index path "/" in `create_favicon_route()`, this bug is easily fixed.

2. The following code should use logo.png as favicon on "/test":
    ```py
    @ui.page('/test')
    def test():
        ui.label('The favicon is not served.')
    
    ui.run(favicon='website/static/logo.png')
    ```
    But there is no favicon route created for "/test", because the page favicon is `None`. Instead the global favicon should be used. This is fixed by ignoring the page path in `get_favicon_url()` in this case.