### PR TITLE
Resize scene canvas and text renderers with container div

### DIFF
--- a/website/more_documentation/scene_documentation.py
+++ b/website/more_documentation/scene_documentation.py
@@ -4,7 +4,7 @@ from ..documentation_tools import text_demo
 
 
 def main_demo() -> None:
-    with ui.scene(width=285, height=285) as scene:
+    with ui.scene().classes('w-full h-64') as scene:
         scene.sphere().material('#4488ff')
         scene.cylinder(1, 0.5, 2, 20).material('#ff8800', opacity=0.5).move(-2, 1)
         scene.extrusion([[0, 0], [0, 1], [1, 0.5]], 0.1).material('#ff8888').move(-2, -2)


### PR DESCRIPTION
This PR implements feature request #1163: It resizes the canvas and text renderers of a `ui.scene` automatically to match the size of its container div. This allows for using layout classes like `w-full` or `h-64` on the scene element.

Most of the code changes convert the local renderer objects into component members, so that a new `resize` method can access them whenever the window triggers a "resize" event.