### PR TITLE
allow awaiting disconnect without connected

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -104,6 +104,8 @@ class Client:
 
     async def disconnected(self, check_interval: float = 0.1) -> None:
         """Block execution until the client disconnects."""
+        if not self.environ:
+            await self.connected()
         self.is_waiting_for_disconnect = True
         while self.id in globals.clients:
             await asyncio.sleep(check_interval)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -138,6 +138,21 @@ def test_wait_for_disconnect(screen: Screen):
     assert events == ['connected', 'disconnected', 'connected']
 
 
+def test_wait_for_disconnect_without_awaiting_connected(screen: Screen):
+    events = []
+
+    @ui.page('/')
+    async def page(client: Client):
+        await client.disconnected()
+        events.append('disconnected')
+
+    screen.open('/')
+    screen.wait(0.5)
+    screen.open('/')
+    screen.wait(0.5)
+    assert events == ['disconnected']
+
+
 def test_adding_elements_after_connected(screen: Screen):
     @ui.page('/')
     async def page(client: Client):


### PR DESCRIPTION
This pull request allows to write

```py
@ui.page('/')
async def page(client: Client):
    await client.disconnected()
    print('done', flush=True)
```