### PR TITLE
Allow creating scene objects without context

### DIFF
--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -82,6 +82,16 @@ class Scene(Element,
         self.on('init', self.handle_init)
         self.on('click3d', self.handle_click)
 
+    def __enter__(self) -> 'Scene':
+        Object3D.current_scene = self
+        return super().__enter__()
+
+    def __getattribute__(self, name: str) -> Any:
+        attribute = super().__getattribute__(name)
+        if isinstance(attribute, type) and issubclass(attribute, Object3D):
+            Object3D.current_scene = self
+        return attribute
+
     def handle_init(self, e: GenericEventArguments) -> None:
         self.is_initialized = True
         with globals.socket_id(e.args['socket_id']):

--- a/nicegui/elements/scene_object3d.py
+++ b/nicegui/elements/scene_object3d.py
@@ -1,20 +1,19 @@
 import math
 import uuid
-from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
-
-from .. import globals
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 if TYPE_CHECKING:
     from .scene import Scene, SceneObject
 
 
 class Object3D:
+    current_scene: Optional['Scene'] = None
 
     def __init__(self, type: str, *args: Any) -> None:
         self.type = type
         self.id = str(uuid.uuid4())
         self.name: Optional[str] = None
-        self.scene: 'Scene' = cast('Scene', globals.get_slot().parent)
+        self.scene: 'Scene' = self.current_scene
         self.scene.objects[self.id] = self
         self.parent: Union[Object3D, SceneObject] = self.scene.stack[-1]
         self.args: List = list(args)

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -129,4 +129,4 @@ def test_object_creation_via_attribute(screen: Screen):
 
     screen.open('/')
     screen.wait(0.5)
-    assert screen.selenium.execute_script(f'return scene_c{scene.id}.children[4].type') == 'box'
+    assert screen.selenium.execute_script(f'return scene_c{scene.id}.children[4].name') == 'box'

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -112,3 +112,21 @@ def test_rotation_matrix_from_euler():
     Rz = np.array([[np.cos(kappa), -np.sin(kappa), 0], [np.sin(kappa), np.cos(kappa), 0], [0, 0, 1]])
     R = Rz @ Ry @ Rx
     assert np.allclose(Object3D.rotation_matrix_from_euler(omega, phi, kappa), R)
+
+
+def test_object_creation_via_context(screen: Screen):
+    with ui.scene() as scene:
+        scene.box().with_name('box')
+
+    screen.open('/')
+    screen.wait(0.5)
+    assert screen.selenium.execute_script(f'return scene_c{scene.id}.children[4].name') == 'box'
+
+
+def test_object_creation_via_attribute(screen: Screen):
+    scene = ui.scene()
+    scene.box().with_name('box')
+
+    screen.open('/')
+    screen.wait(0.5)
+    assert screen.selenium.execute_script(f'return scene_c{scene.id}.children[4].type') == 'box'


### PR DESCRIPTION
There has been confusion about creating scene objects (#1203).

Normally we always need to enter the scene context like this
```py
with ui.scene() as scene:
    scene.sphere()
```
or like this (after importing the class `Sphere` from `nicegui.elements.scene_objects`):
```py
with ui.scene():
    Sphere()
```

But in case we already have a `scene`, it was unclear why we can't write
```py
scene.sphere()
```

The reason is that `scene.sphere` is a static attribute. When `sphere()` is called, it looks into the slot stack to find its scene. But if we didn't enter a scene context, the sphere can't find it.

Of course, we could simply implement non-static factory methods that instantiate objects. But this would require lots of code duplication to mirror the class signatures and possibly docstrings.

This PR solves this problem by storing the `current_scene` when a scene is entered as well as when `__getattribute__` is called for one of the static 3D object classes. Now the object initializer can simply use `current_scene` to get its own scene.

To summarize, these are the possible methods to place objects in a scene:

```py
with ui.scene() as scene:
    scene.box()

with ui.scene():
    ui.scene.box()

with ui.scene():
    Box()

scene = ui.scene()
scene.box()
```