### PR TITLE
Change link to material icons

### DIFF
--- a/nicegui/elements/icon.py
+++ b/nicegui/elements/icon.py
@@ -15,7 +15,7 @@ class Icon(TextColorElement):
 
         This element is based on Quasar's `QIcon <https://quasar.dev/vue-components/icon>`_ component.
 
-        `Here <https://fonts.google.com/icons>`_ is a reference of possible names.
+        `Here <https://fonts.google.com/icons?icon.set=Material+Icons>`_ is a reference of possible names.
 
         :param name: name of the icon
         :param size: size in CSS units, including unit name or standard size name (xs|sm|md|lg|xl), examples: 16px, 2rem


### PR DESCRIPTION
I tried using the icon `stat_3` which is a "material symbol" but not a "material icon" and it didn't work. I found this icon by following [the link in the documentation](https://fonts.google.com/icons). My guess is that the default icon element only works with "material icons" and not "material symbols" which means the link in the documentation is a bit off. I modified the link in the documentation to link to just the material icons to address this.