### PR TITLE
Removed unused param in open.py docstring

### DIFF
--- a/nicegui/functions/open.py
+++ b/nicegui/functions/open.py
@@ -12,7 +12,6 @@ def open(target: Union[Callable[..., Any], str]) -> None:
     User events like button clicks provide such a socket.
 
     :param target: page function or string that is a an absolute URL or relative path from base URL
-    :param socket: optional WebSocket defining the target client
     """
     path = target if isinstance(target, str) else globals.page_routes[target]
     globals.get_client().open(path)


### PR DESCRIPTION
I think there is a leftover param in the docstring of `open.py`. This PR removes it.