### PR TITLE
allow configuration of socket.io transport options

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,6 +63,8 @@ async def redirect_reference_to_documentation(request: Request,
 fly_instance_id = os.environ.get('FLY_ALLOC_ID', '').split('-')[0]
 if fly_instance_id:
     nicegui_globals.socket_io_js_extra_headers['fly-force-instance-id'] = fly_instance_id
+    # NOTE polling is required for fly.io to use the force-instance header
+    nicegui_globals.socket_io_js_transports = ['polling']
 
 
 def add_head_html() -> None:

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -90,6 +90,7 @@ class Client:
             'prefix': prefix,
             'tailwind': globals.tailwind,
             'socket_io_js_extra_headers': globals.socket_io_js_extra_headers,
+            'socket_io_js_transports': globals.socket_io_js_transports,
         }, status_code, {'Cache-Control': 'no-store', 'X-NiceGUI-Content': 'page'})
 
     async def connected(self, timeout: float = 3.0, check_interval: float = 0.1) -> None:

--- a/nicegui/globals.py
+++ b/nicegui/globals.py
@@ -45,6 +45,7 @@ binding_refresh_interval: float
 tailwind: bool
 air: Optional['Air'] = None
 socket_io_js_extra_headers: Dict = {}
+socket_io_js_transports: List = ['websocket', 'polling']
 
 _socket_id: Optional[str] = None
 slot_stacks: Dict[int, List['Slot']] = {}

--- a/nicegui/globals.py
+++ b/nicegui/globals.py
@@ -4,7 +4,7 @@ import logging
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Iterator, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Iterator, List, Literal, Optional, Set, Union
 
 from socketio import AsyncServer
 from uvicorn import Server
@@ -45,7 +45,7 @@ binding_refresh_interval: float
 tailwind: bool
 air: Optional['Air'] = None
 socket_io_js_extra_headers: Dict = {}
-socket_io_js_transports: List = ['websocket', 'polling']
+socket_io_js_transports: List[Literal['websocket', 'polling']] = ['websocket', 'polling']
 
 _socket_id: Optional[str] = None
 slot_stacks: Dict[int, List['Slot']] = {}

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -216,7 +216,7 @@
           const query = { client_id: "{{ client_id }}" };
           const url = window.location.protocol === 'https:' ? 'wss://' : 'ws://' + window.location.host;
           const extraHeaders = {{ socket_io_js_extra_headers | safe }};
-          const transports = ['websocket', 'polling'];
+          const transports = {{ socket_io_js_transports | safe }};
           window.path_prefix = "{{ prefix | safe }}";
           window.socket = io(url, { path: "{{ prefix | safe }}/_nicegui_ws/socket.io", query, extraHeaders, transports });
           const messageHandlers = {


### PR DESCRIPTION
With this PR, `nicegui.globals.socket_io_js_transports` can be changed from the outside. With this it is for example possible to change the default communication from websocket to long polling. The PR does this for our hosted website, because fly.io requires a header to find the right instance which is only supported by browsers when using http polling, not websockets.

This will fix #1211 (see https://github.com/zauberzeug/nicegui/issues/1211#issuecomment-1651084723 for details).