### PR TITLE
HTML-encode element text to prevent XSS

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -1,4 +1,5 @@
 import asyncio
+import html
 import time
 import uuid
 from pathlib import Path
@@ -76,7 +77,7 @@ class Client:
             'request': request,
             'version': __version__,
             'client_id': str(self.id),
-            'elements': elements,
+            'elements': html.escape(elements),
             'head_html': self.head_html,
             'body_html': '<style>' + '\n'.join(vue_styles) + '</style>\n' + self.body_html + '\n' + '\n'.join(vue_html),
             'vue_scripts': '\n'.join(vue_scripts),

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -77,7 +77,10 @@ class Client:
             'request': request,
             'version': __version__,
             'client_id': str(self.id),
-            'elements': html.escape(elements),
+            'elements': elements.replace('&', '&amp;')
+                                .replace('<', '&lt;')
+                                .replace('>', '&gt;')
+                                .replace('`', '&#96;'),
             'head_html': self.head_html,
             'body_html': '<style>' + '\n'.join(vue_styles) + '</style>\n' + self.body_html + '\n' + '\n'.join(vue_html),
             'vue_scripts': '\n'.join(vue_scripts),

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import html
 import re
 from copy import copy, deepcopy
 from pathlib import Path
@@ -131,7 +132,7 @@ class Element(Visibility):
             'class': self._classes,
             'style': self._style,
             'props': self._props,
-            'text': self._text,
+            'text': html.escape(self._text) if self._text is not None else None,
             'slots': self._collect_slot_dict(),
             'events': [listener.to_dict() for listener in self._event_listeners.values()],
             'component': {

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-import html
 import re
 from copy import copy, deepcopy
 from pathlib import Path
@@ -132,7 +131,7 @@ class Element(Visibility):
             'class': self._classes,
             'style': self._style,
             'props': self._props,
-            'text': html.escape(self._text) if self._text is not None else None,
+            'text': self._text,
             'slots': self._collect_slot_dict(),
             'events': [listener.to_dict() for listener in self._event_listeners.values()],
             'component': {

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -43,7 +43,8 @@
       const loaded_components = new Set();
 
       const domParser = new DOMParser();
-      const elements = JSON.parse(domParser.parseFromString('{{ elements | safe }}', 'text/html').documentElement.textContent);
+      const raw_elements = String.raw`{{ elements | safe }}`;
+      const elements = JSON.parse(domParser.parseFromString(raw_elements, 'text/html').documentElement.textContent);
 
       function stringifyEventArgs(args, event_args) {
         const result = [];

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -42,9 +42,11 @@
       const loaded_libraries = new Set();
       const loaded_components = new Set();
 
-      const domParser = new DOMParser();
       const raw_elements = String.raw`{{ elements | safe }}`;
-      const elements = JSON.parse(domParser.parseFromString(raw_elements, 'text/html').documentElement.textContent);
+      const elements = JSON.parse(raw_elements.replace(/&#96;/g, '`')
+                                              .replace(/&gt;/g, '>')
+                                              .replace(/&lt;/g, '<')
+                                              .replace(/&amp;/g, '&'));
 
       function stringifyEventArgs(args, event_args) {
         const result = [];

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -43,6 +43,8 @@
       const loaded_components = new Set();
       const elements = {{ elements | safe }};
 
+      const domParser = new DOMParser();
+
       function stringifyEventArgs(args, event_args) {
         const result = [];
         args.forEach((arg, i) => {
@@ -155,7 +157,7 @@
             }
             const children = data.ids.map(id => renderRecursively(elements, id));
             if (name === 'default' && element.text !== null) {
-              children.unshift(element.text);
+              children.unshift(domParser.parseFromString(element.text, 'text/html').documentElement.textContent);
             }
             return [ ...rendered, ...children]
           }

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -41,9 +41,9 @@
 
       const loaded_libraries = new Set();
       const loaded_components = new Set();
-      const elements = {{ elements | safe }};
 
       const domParser = new DOMParser();
+      const elements = JSON.parse(domParser.parseFromString('{{ elements | safe }}', 'text/html').documentElement.textContent);
 
       function stringifyEventArgs(args, event_args) {
         const result = [];
@@ -157,7 +157,7 @@
             }
             const children = data.ids.map(id => renderRecursively(elements, id));
             if (name === 'default' && element.text !== null) {
-              children.unshift(domParser.parseFromString(element.text, 'text/html').documentElement.textContent);
+              children.unshift(element.text);
             }
             return [ ...rendered, ...children]
           }

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -166,13 +166,18 @@ def test_move(screen: Screen):
 def test_xss(screen: Screen):
     ui.label('</script><script>alert(1)</script>')
     ui.label('<b>Bold 1</b>')
-    ui.button('Button 1', on_click=lambda: ui.label('</script><script>alert(2)</script>'))
-    ui.button('Button 2', on_click=lambda: ui.label('<b>Bold 2</b>'))
+    ui.label('multi\nline 1')
+    ui.button('Button', on_click=lambda: (
+        ui.label('</script><script>alert(2)</script>'),
+        ui.label('<b>Bold 2</b>'),
+        ui.label('multi\nline 2'),
+    ))
 
     screen.open('/')
-    screen.click('Button 1')
-    screen.click('Button 2')
+    screen.click('Button')
     screen.should_contain('</script><script>alert(1)</script>')
     screen.should_contain('</script><script>alert(2)</script>')
     screen.should_contain('<b>Bold 1</b>')
     screen.should_contain('<b>Bold 2</b>')
+    screen.should_contain('multi\nline 1')
+    screen.should_contain('multi\nline 2')

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -165,19 +165,15 @@ def test_move(screen: Screen):
 
 def test_xss(screen: Screen):
     ui.label('</script><script>alert(1)</script>')
-    ui.label('<b>Bold 1</b>')
-    ui.label('multi\nline 1')
+    ui.label('<b>Bold 1</b>, `code`, copy&paste, multi\nline')
     ui.button('Button', on_click=lambda: (
         ui.label('</script><script>alert(2)</script>'),
-        ui.label('<b>Bold 2</b>'),
-        ui.label('multi\nline 2'),
+        ui.label('<b>Bold 2</b>, `code`, copy&paste, multi\nline'),
     ))
 
     screen.open('/')
     screen.click('Button')
     screen.should_contain('</script><script>alert(1)</script>')
     screen.should_contain('</script><script>alert(2)</script>')
-    screen.should_contain('<b>Bold 1</b>')
-    screen.should_contain('<b>Bold 2</b>')
-    screen.should_contain('multi\nline 1')
-    screen.should_contain('multi\nline 2')
+    screen.should_contain('<b>Bold 1</b>, `code`, copy&paste, multi\nline')
+    screen.should_contain('<b>Bold 2</b>, `code`, copy&paste, multi\nline')

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -161,3 +161,18 @@ def test_move(screen: Screen):
     screen.click('Move X to top')
     screen.wait(0.5)
     assert screen.find('X').location['y'] < screen.find('A').location['y'] < screen.find('B').location['y']
+
+
+def test_xss(screen: Screen):
+    ui.label('</script><script>alert(1)</script>')
+    ui.label('<b>Bold 1</b>')
+    ui.button('Button 1', on_click=lambda: ui.label('</script><script>alert(2)</script>'))
+    ui.button('Button 2', on_click=lambda: ui.label('<b>Bold 2</b>'))
+
+    screen.open('/')
+    screen.click('Button 1')
+    screen.click('Button 2')
+    screen.should_contain('</script><script>alert(1)</script>')
+    screen.should_contain('</script><script>alert(2)</script>')
+    screen.should_contain('<b>Bold 1</b>')
+    screen.should_contain('<b>Bold 2</b>')


### PR DESCRIPTION
This PR tries to prevent XSS, as discussed in issue #1067, by HTML-encoding and -decoding UI elements.

Currently it only converts the text of, e.g., labels. We should certainly extend it to other attributes.

- [x] find a solution for #1067
- [x] extend solution to the whole element dictionary generated by `_to_dict()`
- [x] make sure dynamically created elements are encoded as well
- [x] correctly encode line breaks
- [x] pytest
- [x] Why is main.py not working?
- [x] How to reduce the payload size?

Some test code:
```py
ui.label('</script><script>alert(1)</script>')
ui.label('<b>2</b>')
ui.label('3\n4')

ui.button('Button 1', on_click=lambda: ui.label('</script><script>alert(5)</script>'))
ui.button('Button 2', on_click=lambda: ui.label('<b>6</b>'))
ui.button('Button 3', on_click=lambda: ui.label('7\n8'))
```