### PR TITLE
Move Quasar config to Python

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -82,6 +82,7 @@ class Client:
             'vue_scripts': '\n'.join(vue_scripts),
             'imports': json.dumps(imports),
             'js_imports': '\n'.join(js_imports),
+            'quasar_config': json.dumps(globals.quasar_config),
             'title': self.page.resolve_title(),
             'viewport': self.page.resolve_viewport(),
             'favicon_url': get_favicon_url(self.page, prefix),

--- a/nicegui/globals.py
+++ b/nicegui/globals.py
@@ -46,11 +46,19 @@ tailwind: bool
 air: Optional['Air'] = None
 socket_io_js_extra_headers: Dict = {}
 socket_io_js_transports: List[Literal['websocket', 'polling']] = ['websocket', 'polling']
-
 _socket_id: Optional[str] = None
 slot_stacks: Dict[int, List['Slot']] = {}
 clients: Dict[str, 'Client'] = {}
 index_client: 'Client'
+quasar_config: Dict = {
+    'brand': {
+        'primary': '#5898d4',
+    },
+    'loadingBar': {
+        'color': 'primary',
+        'skipHijack': False,
+    },
+}
 
 page_routes: Dict[Callable[..., Any], str] = {}
 

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -291,14 +291,7 @@
           }
         },
       }).use(Quasar, {
-        config: {
-          brand: {
-            primary: '#5898d4',
-          },
-          loadingBar: {
-            color: 'primary'
-          },
-        }
+        config: {{ quasar_config | safe }}
       });
 
       {{ js_imports | safe }}


### PR DESCRIPTION
By making the Quasar config available through `globals.quasar_config` it can be configured/changed by the app. This can for example be used to disable the loading bar:

```py
from nicegui import globals as nicegui_globals
...

nicegui_globals.quasar_config.["loadingBar"]["skipHijack"] = False

...
```