### PR TITLE
Clean up committed project settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,25 +1,17 @@
 {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true,
-    "isort.args": [
-        "--line-length",
-        "120"
-    ],
-    "prettier.printWidth": 120,
-    "python.formatting.provider": "autopep8",
-    "python.formatting.autopep8Args": [
-        "--max-line-length=120",
-        "--experimental"
-    ],
-    "python.testing.pytestArgs": [
-        "."
-    ],
-    "python.testing.pytestEnabled": true,
-    "python.testing.unittestEnabled": false,
-    "[python]": {
-        "editor.defaultFormatter": "ms-python.python",
-        "editor.codeActionsOnSave": {
-            "source.organizeImports": true
-        }
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "isort.args": ["--line-length", "120"],
+  "prettier.printWidth": 120,
+  "python.formatting.provider": "autopep8",
+  "python.formatting.autopep8Args": ["--max-line-length=120", "--experimental"],
+  "python.testing.pytestArgs": ["."],
+  "python.testing.pytestEnabled": true,
+  "python.testing.unittestEnabled": false,
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.python",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
     }
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,18 +1,25 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true,
-  "editor.minimap.enabled": false,
-  "isort.args": ["--line-length", "120"],
-  "prettier.printWidth": 120,
-  "python.formatting.provider": "autopep8",
-  "python.formatting.autopep8Args": ["--max-line-length=120", "--experimental"],
-  "python.testing.pytestArgs": ["."],
-  "python.testing.pytestEnabled": true,
-  "python.testing.unittestEnabled": false,
-  "[python]": {
-    "editor.defaultFormatter": "ms-python.python",
-    "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "isort.args": [
+        "--line-length",
+        "120"
+    ],
+    "prettier.printWidth": 120,
+    "python.formatting.provider": "autopep8",
+    "python.formatting.autopep8Args": [
+        "--max-line-length=120",
+        "--experimental"
+    ],
+    "python.testing.pytestArgs": [
+        "."
+    ],
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.python",
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": true
+        }
     }
-  }
 }


### PR DESCRIPTION
It's nice that this project has a bunch of stuff automatically configured like the formatting rules, but disabling the minimap is not a polite thing to inflict on random contributors.

Ironically, I tried to make this commit be a single line change of removing that setting, but the format-on-save wouldn't let me.

Additionally, this is good opportunity to point out that there are some settings in `settings.json` and some settings in `nicegui.code-workspace`, and it might make sense to consolidate them in one direction or the other.