### PR TITLE
Implement prod/dev mode for Vue and Quasar

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -89,6 +89,7 @@ class Client:
             'language': self.page.resolve_language(),
             'prefix': prefix,
             'tailwind': globals.tailwind,
+            'development': globals.development,
             'socket_io_js_extra_headers': globals.socket_io_js_extra_headers,
         }, status_code, {'Cache-Control': 'no-store', 'X-NiceGUI-Content': 'page'})
 

--- a/nicegui/globals.py
+++ b/nicegui/globals.py
@@ -4,7 +4,18 @@ import logging
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Iterator, List, Optional, Set, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Union,
+)
 
 from socketio import AsyncServer
 from uvicorn import Server
@@ -43,6 +54,7 @@ dark: Optional[bool]
 language: Language
 binding_refresh_interval: float
 tailwind: bool
+development: bool = True
 air: Optional['Air'] = None
 socket_io_js_extra_headers: Dict = {}
 

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -11,9 +11,8 @@ import uvicorn
 from uvicorn.main import STARTUP_FAILURE
 from uvicorn.supervisors import ChangeReload, Multiprocess
 
-from . import globals, helpers
+from . import globals, helpers, native_mode
 from . import native as native_module
-from . import native_mode
 from .air import Air
 from .language import Language
 
@@ -53,6 +52,7 @@ def run(*,
         uvicorn_reload_includes: str = '*.py',
         uvicorn_reload_excludes: str = '.*, .py[cod], .sw.*, ~*',
         tailwind: bool = True,
+        development: bool = True,
         storage_secret: Optional[str] = None,
         **kwargs: Any,
         ) -> None:
@@ -91,6 +91,7 @@ def run(*,
     globals.language = language
     globals.binding_refresh_interval = binding_refresh_interval
     globals.tailwind = tailwind
+    globals.development = development
 
     if on_air:
         globals.air = Air('' if on_air is True else on_air)

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -15,8 +15,15 @@
     {% if tailwind %}
     <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/tailwindcss.min.js"></script>
     {% endif %}
+
+    {% if development %}
+    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/vue.global.js"></script>
+    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/quasar.umd.js"></script>
+    {% else %}
     <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/vue.global.prod.js"></script>
     <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/quasar.umd.prod.js"></script>
+    {% endif %}
+
     <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/lang/{{ language }}.umd.prod.js"></script>
     <script type="importmap">
       {"imports": {{ imports | safe }}}


### PR DESCRIPTION
This is basically @dclause's PR #542 reimplemented after the new dependency management changes from `1.3.0`.

The main purpose of this version is to get dev mode for `Vue` so I can use the [Vue Devtools](https://devtools.vuejs.org/). I don't really care about the other libraries.

I only implemented dev/prod for `Vue` and `Quasar`, because those js files were already in the static directory. The original PR had dev/prod for `socket.io`, but I don't see the other js file for `socket.io` anymore. I also don't know why I would want to put socketio in dev mode.

I looked but couldn't find what exactly the difference is for running Quasar in dev vs prod. I don't know why I'd want dev mode, but the files were already there and just changing the path worked in my test, so I did it.

# Open questions:
- `development` vs `production`: I started writing this with `dev` before I read the code in #542 and saw that he used `prod`. I slightly prefer `development = True` to `production = False` but I anybody has a stronger opinion please let me know.
- default state: I can think of plenty of valid reasons for either mode being the default. Please weigh in.
- tests: see below

# Testing: how the %@%(?

I manually tested this with a little hello world app and confirmed that the Vue Devtools extension works when I launch with `development=True`. 

I have absolutely no idea how to write automated tests for this. I'm assuming I can't install the devtools extension in the chromedriver and somehow direct selenium to check if it loads. 

Can I just load `/` and regex the response for the expected dev/prod urls?