### PR TITLE
Fix refreshable with function references

### DIFF
--- a/nicegui/functions/refreshable.py
+++ b/nicegui/functions/refreshable.py
@@ -53,6 +53,15 @@ class refreshable:
         self.instance = instance
         return self
 
+    def __getattribute__(self, __name: str) -> Any:
+        attribute = object.__getattribute__(self, __name)
+        if __name == 'refresh':
+            def refresh(instance=self.instance, *args: Any, **kwargs: Any) -> None:
+                self.instance = instance
+                attribute(*args, **kwargs)
+            return refresh
+        return attribute
+
     def __call__(self, *args: Any, **kwargs: Any) -> Union[None, Awaitable]:
         self.prune()
         target = RefreshableTarget(container=RefreshableContainer(), instance=self.instance, args=args, kwargs=kwargs)

--- a/tests/test_refreshable.py
+++ b/tests/test_refreshable.py
@@ -31,7 +31,7 @@ def test_refreshable(screen: Screen) -> None:
     screen.should_contain('[]')
 
 
-async def test_async_refreshable(screen: Screen) -> None:
+def test_async_refreshable(screen: Screen) -> None:
     numbers = []
 
     @ui.refreshable
@@ -146,3 +146,26 @@ def test_refresh_deleted_element(screen: Screen):
 
     screen.click('Clear')
     screen.click('Refresh')
+
+
+def test_refresh_with_function_reference(screen: Screen):
+    # https://github.com/zauberzeug/nicegui/issues/1283
+    class Test:
+
+        def __init__(self, name):
+            self.name = name
+            self.ui()
+
+        @ui.refreshable
+        def ui(self):
+            ui.notify(f'Refreshing {self.name}')
+            ui.button(self.name, on_click=self.ui.refresh)
+
+    Test('A')
+    Test('B')
+
+    screen.open('/')
+    screen.click('A')
+    screen.should_contain('Refreshing A')
+    screen.click('B')
+    screen.should_contain('Refreshing B')


### PR DESCRIPTION
This PR fixes #1283. It can be tested with the following example:

```py
class Test:

    def __init__(self, name):
        self.name = name
        self.ui()

    @ui.refreshable
    def ui(self):
        ui.notify(f'Refreshing {self.name}')
        ui.button(self.name, on_click=self.ui.refresh)

Test('A')
Test('B')
```

Since the click handler holds a direct reference to the static refresh function, the instance isn't updated via `__get__` when the button is clicked. Therefore this PR uses `__getattribute__` to intercept when the `refresh` function is accessed while creating the button. It wraps `refresh` with the instance bound to the wrapper function. This way it always uses the right reference once the button is clicked.