### PR TITLE
Add fullscreen property as well as toogle_fullscreen method to Table element

### DIFF
--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -44,6 +44,7 @@ class Table(FilterElement, component='table.js'):
         self._props['pagination'] = {'rowsPerPage': pagination or 0}
         self._props['selection'] = selection or 'none'
         self._props['selected'] = self.selected
+        self._props['fullscreen'] = False
 
         def handle_selection(e: GenericEventArguments) -> None:
             if e.args['added']:
@@ -56,6 +57,11 @@ class Table(FilterElement, component='table.js'):
             arguments = TableSelectionEventArguments(sender=self, client=self.client, selection=self.selected)
             handle_event(on_select, arguments)
         self.on('selection', handle_selection, ['added', 'rows', 'keys'])
+
+    def toggle_fullscreen(self) -> None:
+        """Toggle fullscreen mode."""
+        self._props['fullscreen'] = not self._props['fullscreen']
+        self.update()
 
     def add_rows(self, *rows: Dict) -> None:
         """Add rows to the table."""

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -58,10 +58,24 @@ class Table(FilterElement, component='table.js'):
             handle_event(on_select, arguments)
         self.on('selection', handle_selection, ['added', 'rows', 'keys'])
 
+    @property
+    def is_fullscreen(self) -> bool:
+        """Whether the table is in fullscreen mode."""
+        return self._props['fullscreen']
+
+    @is_fullscreen.setter
+    def is_fullscreen(self, value: bool) -> None:
+        """Set fullscreen mode."""
+        self._props['fullscreen'] = value
+        self.update()
+
+    def set_fullscreen(self, value: bool) -> None:
+        """Set fullscreen mode."""
+        self.is_fullscreen = value
+
     def toggle_fullscreen(self) -> None:
         """Toggle fullscreen mode."""
-        self._props['fullscreen'] = not self._props['fullscreen']
-        self.update()
+        self.is_fullscreen = not self.is_fullscreen
 
     def add_rows(self, *rows: Dict) -> None:
         """Add rows to the table."""

--- a/website/more_documentation/table_documentation.py
+++ b/website/more_documentation/table_documentation.py
@@ -186,3 +186,18 @@ def more() -> None:
             {'name': 'Carl', 'age': 42},
         ]
         ui.table(columns=columns, rows=rows, row_key='name')
+
+    @text_demo('Toggle fullscreen', '''
+        You can toggle the fullscreen mode of a table using the `toggle_fullscreen()` method.
+    ''')
+    def toggle_fullscreen():
+        table = ui.table(
+            columns=[{'name': 'name', 'label': 'Name', 'field': 'name'}],
+            rows=[{'name': 'Alice'}, {'name': 'Bob'}, {'name': 'Carol'}],
+        ).classes('w-full')
+
+        with table.add_slot('top-left'):
+            def toggle() -> None:
+                table.toggle_fullscreen()
+                button.props('icon=fullscreen_exit' if table.is_fullscreen else 'icon=fullscreen')
+            button = ui.button('Toggle fullscreen', icon='fullscreen', on_click=toggle).props('flat')


### PR DESCRIPTION
This PR extends the Table element to allow to put a table to fullscreen, as it is easily possible in Quasar shown here: https://quasar.dev/vue-components/table/#visible-columns-custom-top-fullscreen.



``` python
import time

from nicegui import ui

columns = [
    {'name': 'name', 'label': 'Name', 'field': 'name', 'required': True},
    {'name': 'age', 'label': 'Age', 'field': 'age', 'sortable': True},
]
rows = [
    {'id': 0, 'name': 'Alice', 'age': 18},
    {'id': 1, 'name': 'Bob', 'age': 21},
    {'id': 2, 'name': 'Lionel', 'age': 19},
    {'id': 3, 'name': 'Michael', 'age': 32},
    {'id': 4, 'name': 'Julie', 'age': 12},
    {'id': 5, 'name': 'Livia', 'age': 25},
    {'id': 6, 'name': 'Carol'},
]

def swap_icon(btn):
    table.toggle_fullscreen()
    if btn._props['icon'] == 'fullscreen':
        btn._props['icon'] = 'fullscreen_exit'
    else:
        btn._props['icon'] = 'fullscreen'
    btn.update()

with ui.table(title='My Team', columns=columns, rows=rows, selection='multiple', pagination=10).classes('w-96') as table:
    with table.add_slot('top-left'):
        ui.button(on_click=lambda e: swap_icon(e.sender), icon='fullscreen').props('flat')
    with table.add_slot('top-right'):
        with ui.input(placeholder='Search').props('type=search').bind_value(table, 'filter').add_slot('append'):
            ui.icon('search')
    with table.add_slot('bottom-row'):
        with table.row():
            with table.cell():
                ui.button(on_click=lambda: (
                    table.add_rows({'id': time.time(), 'name': new_name.value, 'age': new_age.value}),
                    new_name.set_value(None),
                    new_age.set_value(None),
                ), icon='add').props('flat fab-mini')
            with table.cell():
                new_name = ui.input('Name')
            with table.cell():
                new_age = ui.number('Age')

ui.label().bind_text_from(table, 'selected', lambda val: f'Current selection: {val}')
ui.button('Remove', on_click=lambda: table.remove_rows(*table.selected)) \
    .bind_visibility_from(table, 'selected', backward=lambda val: bool(val))

ui.run()
```