### PR TITLE
Implement line_plot.clear()

### DIFF
--- a/nicegui/elements/line_plot.py
+++ b/nicegui/elements/line_plot.py
@@ -62,3 +62,14 @@ class LinePlot(Pyplot):
         self.fig.gca().set_ylim(min_y - pad_y, max_y + pad_y)
         self._convert_to_html()
         self.update()
+
+    def clear(self) -> None:
+        """Clear the line plot."""
+        super().clear()
+        self.x.clear()
+        for y in self.Y:
+            y.clear()
+        for line in self.lines:
+            line.set_data([], [])
+        self._convert_to_html()
+        self.update()


### PR DESCRIPTION
This PR implements the feature requested in #1316 providing a proper clear method for line plots. Example:

```py
line_plot = ui.line_plot(n=2, limit=20, update_every=5) \
    .with_legend(['sin', 'cos'], loc='upper center', ncol=2)

def update_line_plot() -> None:
    now = datetime.now()
    x = now.timestamp()
    y1 = math.sin(x)
    y2 = math.cos(x)
    line_plot.push([now], [[y1], [y2]])

line_updates = ui.timer(0.1, update_line_plot)
line_checkbox = ui.checkbox('active').bind_value(line_updates, 'active')

ui.button('clear plot', on_click=line_plot.clear)
```