### PR TITLE
Implement clear method for ui.scene

### DIFF
--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -155,3 +155,9 @@ class Scene(Element,
     def delete(self) -> None:
         binding.remove(list(self.objects.values()), Object3D)
         super().delete()
+
+    def clear(self) -> None:
+        """Remove all objects from the scene."""
+        super().clear()
+        for object in list(self.objects.values()):
+            object.delete()

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -130,3 +130,17 @@ def test_object_creation_via_attribute(screen: Screen):
     screen.open('/')
     screen.wait(0.5)
     assert screen.selenium.execute_script(f'return scene_c{scene.id}.children[4].name') == 'box'
+
+
+def test_clearing_scene(screen: Screen):
+    with ui.scene() as scene:
+        scene.box().with_name('box')
+        scene.box().with_name('box2')
+    ui.button('Clear', on_click=scene.clear)
+
+    screen.open('/')
+    screen.wait(0.5)
+    assert len(scene.objects) == 2
+    screen.click('Clear')
+    screen.wait(0.5)
+    assert len(scene.objects) == 0


### PR DESCRIPTION
Discussions #803 and #1246 asked for a way to clear a 3D scene. The `clear()` method inherited from `ui.element` only cleared child elements, but not 3D objects.

This PR overrides `clear()` to also delete each object.