### PR TITLE
Synchronize scroll padding with header height

### DIFF
--- a/nicegui/page_layout.py
+++ b/nicegui/page_layout.py
@@ -3,6 +3,7 @@ from typing import Literal, Optional
 from . import globals
 from .element import Element
 from .elements.mixins.value_element import ValueElement
+from .functions.html import add_body_html
 
 DrawerSides = Literal['left', 'right']
 
@@ -24,7 +25,9 @@ class Header(ValueElement):
                  value: bool = True,
                  fixed: bool = True,
                  bordered: bool = False,
-                 elevated: bool = False) -> None:
+                 elevated: bool = False,
+                 add_scroll_padding: bool = False,
+                 ) -> None:
         '''Header
 
         Note: The header is automatically placed above other layout elements in the DOM to improve accessibility.
@@ -34,6 +37,7 @@ class Header(ValueElement):
         :param fixed: whether the header should be fixed to the top of the page (default: `True`)
         :param bordered: whether the header should have a border (default: `False`)
         :param elevated: whether the header should have a shadow (default: `False`)
+        :param add_scroll_padding: whether to automatically prevent link targets from being hidden behind the header (default: `False`)
         '''
         with globals.get_client().layout:
             super().__init__(tag='q-header', value=value, on_value_change=None)
@@ -45,6 +49,18 @@ class Header(ValueElement):
         self.client.layout._props['view'] = ''.join(code)
 
         self.move(target_index=0)
+
+        if add_scroll_padding:
+            add_body_html(f'''
+                <script>
+                    window.onload = () => {{
+                        const header = getElement({self.id}).$el;
+                        new ResizeObserver(() => {{
+                            document.documentElement.style.scrollPaddingTop = `${{header.offsetHeight}}px`;
+                        }}).observe(header);
+                    }};
+                </script>
+            ''')
 
     def toggle(self):
         '''Toggle the header'''

--- a/nicegui/page_layout.py
+++ b/nicegui/page_layout.py
@@ -26,7 +26,7 @@ class Header(ValueElement):
                  fixed: bool = True,
                  bordered: bool = False,
                  elevated: bool = False,
-                 add_scroll_padding: bool = False,
+                 add_scroll_padding: bool = False,  # DEPRECATED: will be True in v1.4
                  ) -> None:
         '''Header
 
@@ -37,7 +37,7 @@ class Header(ValueElement):
         :param fixed: whether the header should be fixed to the top of the page (default: `True`)
         :param bordered: whether the header should have a border (default: `False`)
         :param elevated: whether the header should have a shadow (default: `False`)
-        :param add_scroll_padding: whether to automatically prevent link targets from being hidden behind the header (default: `False`)
+        :param add_scroll_padding: whether to automatically prevent link targets from being hidden behind the header (default: `False`, will be `True` in v1.4)
         '''
         with globals.get_client().layout:
             super().__init__(tag='q-header', value=value, on_value_change=None)

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -33,6 +33,14 @@
     <script type="importmap">
       {"imports": {{ imports | safe }}}
     </script>
+    <script>
+      window.onload = () => {
+        const header = document.querySelector(".nicegui-header.fixed-top");
+        if (!header) return;
+        const updatePadding = () => (document.documentElement.style.scrollPaddingTop = `${header.offsetHeight}px`);
+        new ResizeObserver(updatePadding).observe(header);
+      };
+    </script>
     {{ body_html | safe }}
 
     <div id="app"></div>

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -33,14 +33,6 @@
     <script type="importmap">
       {"imports": {{ imports | safe }}}
     </script>
-    <script>
-      window.onload = () => {
-        const header = document.querySelector(".nicegui-header.fixed-top");
-        if (!header) return;
-        const updatePadding = () => (document.documentElement.style.scrollPaddingTop = `${header.offsetHeight}px`);
-        new ResizeObserver(updatePadding).observe(header);
-      };
-    </script>
     {{ body_html | safe }}
 
     <div id="app"></div>

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,0 +1,23 @@
+import pytest
+
+from nicegui import ui
+
+from .screen import Screen
+
+
+@pytest.mark.parametrize('add_scroll_padding', [True, False])
+def test_no_scroll_padding(screen: Screen, add_scroll_padding: bool):
+    ui.header(add_scroll_padding=add_scroll_padding).classes('h-[50px]')
+    for i in range(100):
+        with ui.link_target(f'line{i}'):
+            ui.link(f'Line {i}', f'#line{i}')
+
+    screen.open('/')
+    screen.should_contain('Line 0')
+    screen.click('Line 10')
+    screen.wait(0.5)
+    line_y = screen.selenium.execute_script("return arguments[0].getBoundingClientRect()['y'];", screen.find('Line 10'))
+    if add_scroll_padding:
+        assert line_y > 50
+    else:
+        assert line_y < 50


### PR DESCRIPTION
Based on a [discussion on Discord](https://discord.com/channels/1089836369431498784/1135584321466548374/1135584321466548374) by @miek770 this PR experiments with dynamically setting the scroll padding to the current header height. The feature can be tested with the following code:

```py
with ui.header(fixed=True) as header:
    ui.label('HEADER')
    ui.button('+', on_click=lambda: header.classes(add='h-60'))
    ui.button('-', on_click=lambda: header.classes(remove='h-60'))

for i in range(100):
    with ui.link_target(f'line{i}'):
        ui.link(f'Line {i}', f'#line{i}')
```

The buttons can be used to change the header height.
The links should always scroll right below the header.
With `fixed=False` the links should scroll below the top edge of the screen.

The question is: Should we add this as the new behavior? This brakes existing solutions (like nicegui.io) that already compensate for the header height. Should we postpone it to 1.4? Or should we provide an opt-in, but how?

- [x] make scroll padding configurable in `ui.header`?
- [x] pytest