### PR TITLE
Use a machine-independent Python path instead of "python3"

### DIFF
--- a/examples/script_executor/main.py
+++ b/examples/script_executor/main.py
@@ -3,6 +3,7 @@ import asyncio
 import os.path
 import platform
 import shlex
+import sys
 
 from nicegui import ui
 
@@ -11,6 +12,7 @@ async def run_command(command: str) -> None:
     """Run a command in the background and display the output in the pre-created dialog."""
     dialog.open()
     result.content = ''
+    command = command.replace('python3', sys.executable)  # NOTE replace with machine-independent Python path (#1240)
     process = await asyncio.create_subprocess_exec(
         *shlex.split(command),
         stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,


### PR DESCRIPTION
This PR solves issue #1240 by replacing the "python3" command in the script executor example with the Python path from `sys.executable`.