### PR TITLE
Improve On Air reconnect

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -138,4 +138,5 @@ class Air:
         await self.relay.disconnect()
 
     async def emit(self, message_type: str, data: Dict[str, Any], room: str) -> None:
-        await self.relay.emit('forward', {'event': message_type, 'data': data, 'room': room})
+        if self.relay.connected:
+            await self.relay.emit('forward', {'event': message_type, 'data': data, 'room': room})

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -20,6 +20,7 @@ class Air:
         self.token = token
         self.relay = AsyncClient()
         self.client = httpx.AsyncClient(app=globals.app)
+        self.connecting = False
 
         @self.relay.on('http')
         async def on_http(data: Dict[str, Any]) -> Dict[str, Any]:
@@ -108,6 +109,9 @@ class Air:
             await self.connect()
 
     async def connect(self) -> None:
+        if self.connecting:
+            return
+        self.connecting = True
         backoff_time = 1
         while True:
             try:
@@ -128,6 +132,7 @@ class Air:
 
             await asyncio.sleep(backoff_time)
             backoff_time = min(backoff_time * 2, 32)
+        self.connecting = False
 
     async def disconnect(self) -> None:
         await self.relay.disconnect()


### PR DESCRIPTION
This PR introduces an increasing backoff between On Air reconnect attempts. Further we ensure only one reconnect is running at a given time and make it non-recursive to avoid "max recursion level depth" errors.