### PR TITLE
Add on_value_change parameter to ui.expansion

### DIFF
--- a/nicegui/elements/expansion.py
+++ b/nicegui/elements/expansion.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Callable, Optional
 
 from .mixins.disableable_element import DisableableElement
 from .mixins.value_element import ValueElement
@@ -6,16 +6,22 @@ from .mixins.value_element import ValueElement
 
 class Expansion(ValueElement, DisableableElement):
 
-    def __init__(self, text: Optional[str] = None, *, icon: Optional[str] = None, value: bool = False) -> None:
-        '''Expansion Element
+    def __init__(self,
+                 text: Optional[str] = None, *,
+                 icon: Optional[str] = None,
+                 value: bool = False,
+                 on_value_change: Optional[Callable[..., Any]] = None
+                 ) -> None:
+        """Expansion Element
 
         Provides an expandable container.
 
         :param text: title text
         :param icon: optional icon (default: None)
         :param value: whether the expansion should be opened on creation (default: `False`)
-        '''
-        super().__init__(tag='q-expansion-item', value=value, on_value_change=None)
+        :param on_value_change: callback to execute when value changes
+        """
+        super().__init__(tag='q-expansion-item', value=value, on_value_change=on_value_change)
         if text is not None:
             self._props['label'] = text
         self._props['icon'] = icon


### PR DESCRIPTION
This PR implements the idea from https://github.com/zauberzeug/nicegui/discussions/1354.

Try it with:
```py
with ui.expansion('Expansion', on_value_change=lambda e: ui.notify(e.value)) as expansion:
    ui.label('Inside expansion')
```