### PR TITLE
Re-use plotly plot if config did not change

### DIFF
--- a/nicegui/elements/plotly.py
+++ b/nicegui/elements/plotly.py
@@ -43,12 +43,8 @@ class Plotly(Element, component='plotly.vue', libraries=['lib/plotly/plotly.min.
         self.update()
 
     def update(self) -> None:
+        self._props['options'] = self._get_figure_json()
         super().update()
-        options = self._get_figure_json()
-        options['config'] = \
-            {**options['config'], **{'responsive': True}} if 'config' in options else {'responsive': True}
-        self._props['options'] = options
-        self.run_method('update', self._props['options'])
 
     def _get_figure_json(self) -> Dict:
         if isinstance(self.figure, go.Figure):

--- a/nicegui/elements/plotly.vue
+++ b/nicegui/elements/plotly.vue
@@ -6,15 +6,34 @@
 export default {
   async mounted() {
     await this.$nextTick();
-    Plotly.newPlot(this.$el.id, this.options.data, this.options.layout, this.options.config);
+    this.update();
   },
-
+  updated() {
+    this.update();
+  },
   methods: {
-    update(options) {
-      Plotly.newPlot(this.$el.id, options.data, options.layout, options.config);
+    update() {
+      // default responsive to true
+      const options = this.options;
+      if (options.config === undefined) options.config = { responsive: true };
+      if (options.config.responsive === undefined) options.config.responsive = true;
+
+      // re-use plotly instance if config is the same
+      if (JSON.stringify(options.config) == JSON.stringify(this.last_options.config)) {
+        Plotly.react(this.$el.id, this.options.data, this.options.layout);
+      } else {
+        Plotly.newPlot(this.$el.id, this.options.data, this.options.layout, options.config);
+      }
+
+      // store last options
+      this.last_options = options;
     },
   },
-
+  data() {
+    return {
+      last_options: {},
+    };
+  },
   props: {
     options: Object,
   },
@@ -23,10 +42,8 @@ export default {
 
 <style>
 /*
-  fix styles to correctly render modebar, otherwise large
-  buttons with unwanted line breaks are shown, possibly
-  due to other CSS libraries overriding default styles
-  affecting plotly styling.
+  fix styles to correctly render modebar, otherwise large buttons with unwanted line breaks are shown,
+  possibly due to other CSS libraries overriding default styles affecting plotly styling.
 */
 .js-plotly-plot .plotly .modebar-group {
   display: flex;


### PR DESCRIPTION
This PR solves #1386 using `Plotly.react` instead of `Plotly.newPlot` when the config did not change. This allows using `uirevision` to keep the user state (zoom level etc.) while updating the data.

The distinction whether the config changed is necessary because `Plotly.react` behaves badly if we pass `options.config` with `responsive=true` being set. But since it doesn't change when only updating data, we can still use the more efficient `Plotly.react` in these cases.

While being at this, I improved the update mechanism (implement the `updated` method instead of requiring to call `update` from the server) and moved the default setting of `responsive=true` to the client (simplifies the Python code, combines all config trickery in one place).

This test code provides a button to update the data as well as one to update the config:
```py
from random import random

fig = {
    'data': [{'x': [1, 2, 3], 'y': [0.5, 0.5, 0.5]}],
    'layout': {'uirevision': True},
}
with ui.row().classes('bg-red-100 p-2 w-full'):
    plot = ui.plotly(fig).classes('w-full')

def add_trace():
    fig['data'][0]['y'] = [random(), random(), random()]
    plot.update()

def show_display_mode_bar():
    fig['config'] = {'displayModeBar': True}
    plot.update()

ui.button('Update', on_click=add_trace)
ui.button('Show display mode bar', on_click=show_display_mode_bar)
```

The plot remains responsive (i.e. fills the width of the container when resizing the window) and keeps the user state (e.g. zoom level) when updating the data. Only when the config changes (e.g. `displayModeBar`) the user state resets because the plot is re-created.