### PR TITLE
Disable default aggrid column fit

### DIFF
--- a/nicegui/elements/aggrid.js
+++ b/nicegui/elements/aggrid.js
@@ -7,8 +7,7 @@ export default {
     update_grid() {
       this.$el.textContent = "";
       this.gridOptions = {
-        ...this.options,
-        onGridReady: (params) => params.api.sizeColumnsToFit(),
+        ...this.options
       };
       for (const column of this.html_columns) {
         if (this.gridOptions.columnDefs[column].cellRenderer === undefined) {

--- a/nicegui/elements/aggrid.js
+++ b/nicegui/elements/aggrid.js
@@ -7,7 +7,8 @@ export default {
     update_grid() {
       this.$el.textContent = "";
       this.gridOptions = {
-        ...this.options
+        ...this.options,
+        onGridReady: this.auto_size_columns ? (params) => params.api.sizeColumnsToFit() : undefined,
       };
       for (const column of this.html_columns) {
         if (this.gridOptions.columnDefs[column].cellRenderer === undefined) {
@@ -87,5 +88,6 @@ export default {
   props: {
     options: Object,
     html_columns: Array,
+    auto_size_columns: Boolean,
   },
 };

--- a/nicegui/elements/aggrid.py
+++ b/nicegui/elements/aggrid.py
@@ -16,7 +16,12 @@ except ImportError:
 
 class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-community.min.js']):
 
-    def __init__(self, options: Dict, *, html_columns: List[int] = [], theme: str = 'balham') -> None:
+    def __init__(self,
+                 options: Dict, *,
+                 html_columns: List[int] = [],
+                 theme: str = 'balham',
+                 auto_size_columns: bool = True,
+                 ) -> None:
         """AG Grid
 
         An element to create a grid using `AG Grid <https://www.ag-grid.com/>`_.
@@ -26,10 +31,12 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
         :param options: dictionary of AG Grid options
         :param html_columns: list of columns that should be rendered as HTML (default: `[]`)
         :param theme: AG Grid theme (default: 'balham')
+        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: `True`)
         """
         super().__init__()
         self._props['options'] = options
         self._props['html_columns'] = html_columns
+        self._props['auto_size_columns'] = auto_size_columns
         self._classes = ['nicegui-aggrid', f'ag-theme-{theme}']
 
     @staticmethod


### PR DESCRIPTION
This is not desirable if you have a table with a big amount of columns. If you have 30+ columns, the column will be wrap and no header displayed.

We could control it by props but it might just work as expected in most of cases by simply disabling it.