### PR TITLE
Prevent the page from scrolling when closing a dialog

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,6 +34,11 @@ app.add_static_files('/favicon', str(Path(__file__).parent / 'website' / 'favico
 app.add_static_files('/fonts', str(Path(__file__).parent / 'website' / 'fonts'))
 app.add_static_files('/static', str(Path(__file__).parent / 'website' / 'static'))
 
+# HACK: prevent the page from scrolling when closing a dialog (#1404)
+def on_dialog_value_change(sender, value, on_value_change=ui.dialog.on_value_change) -> None:
+    ui.query('html').classes(**{'add' if value else 'remove': 'has-dialog'})
+    on_value_change(sender, value)
+ui.dialog.on_value_change = on_dialog_value_change
 
 @app.get('/logo.png')
 def logo() -> FileResponse:

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -9,6 +9,9 @@ body {
 html:has(.body--dark) {
   background-color: #222;
 }
+html:not(.has-dialog) {
+  scroll-behavior: smooth;
+}
 .browser-window {
   font-family: Roboto, -apple-system, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
@@ -125,13 +128,6 @@ dl.docinfo p {
 }
 .body--dark .dark-box {
   background-color: #3e6a94;
-}
-
-@media only screen and (min-width: 1024px) {
-  html {
-    /* prevent issues with smooth scrolling while menu is closing */
-    scroll-behavior: smooth;
-  }
 }
 
 /* google-webfonts-helper (https://gwfh.mranftl.com/fonts) */


### PR DESCRIPTION
This PR monkey-patches the `ui.dialog.on_value_change` to disable smooth scrolling while the dialog is open. This solves #1404, i.e. the page scrolling whenever a dialog is closed.

While working at this I noticed that the media restriction to min. 1024px for smooth scrolling is no longer required. It works well, even on small screens and when the menu is used for navigation. (There was a comment in the code indicating a problem with smooth scrolling in combination with the menu.)