### PR TITLE
initiate react style reactive component for NiceGUI

### DIFF
--- a/nicegui/functions/reactive.py
+++ b/nicegui/functions/reactive.py
@@ -1,0 +1,96 @@
+'''React Style Reactive Component for NiceGUI, it enables us to write code like this:
+```python
+from nicegui import ui
+
+@reactive
+def comp():
+    count, set_count = use_state(0)
+    ui.label('Count: ' + str(count))
+    ui.button('Increment').on('click', lambda: set_count(count + 1))
+```
+
+See more examples in ./extras.py
+
+'''
+from nicegui import ui
+from typing import Callable
+import sys
+import uuid
+import asyncio
+from nicegui.helpers import is_coroutine_function
+
+refreshable_func_key = '_refreshable_func'
+
+def use_state(default: any):
+    '''Should ONLY be used in a function that is decorated by `@reactive`, And should never call this conditionally.
+    The lifecycle of the state is the same as the component rendered in the page. Internally the state is tied to the
+    Result of a component call, which means for `
+    ``python
+    @reactive
+    def comp():
+        count, set_count = use_state(0)
+        ui.label('Count: ' + str(count))
+        ui.button('Increment').on('click', lambda: set_count(count + 1))
+
+    a = comp()
+    b = comp()
+    ```
+    All operations on `a` and `b` will be independent, and the state of `a` will not affect `b`. AND all operations on a will see same state.
+    '''
+    for i in range(10):
+        frame = sys._getframe(i)
+        locals_ = frame.f_locals
+        if '_context_state_' in locals_:
+            state = locals_['_context_state_']
+            refreshable_func = state.get(refreshable_func_key)
+            break
+
+    key = state['__idx']
+    value = state.setdefault(key, default)
+    state['__idx'] += 1
+    def set_value(value):
+        state.update({key: value})
+        refreshable_func.refresh()
+    return value, set_value
+
+
+def reactive(func: Callable):
+    '''Reactive Component Decorator for NiceGUI.
+
+    Use `ui.reactive` to decorate a function, and then you can use `use_state` to create a state variable and manage state in a React way.
+    '''
+    def __refresh_wrapper__(*args, classes=None, style=None, **kwargs):
+        def _co():
+            _context_state_ = {
+                '_id': uuid.uuid4()
+            }
+            if not is_coroutine_function(func):
+                def __state_wrapper__(*args, **kwargs):
+                    nonlocal _context_state_
+                    try:
+                        _context_state_['__idx'] = 0
+                        ret = func(*args, **kwargs)
+                        # if ret is not None:
+                        #     ret.classes(classes).style(style)
+                    finally:
+                        _context_state_['__idx'] = 0
+                    return ret
+                return __state_wrapper__, _context_state_
+            else:
+                async def __state_wrapper__(*args, **kwargs):
+                    nonlocal _context_state_
+                    try:
+                        _context_state_['__idx'] = 0
+                        ret = await func(*args, **kwargs)
+                        # if ret is not None:
+                        #     ret.classes(classes).style(style)
+                    finally:
+                        _context_state_['__idx'] = 0
+                    return ret
+                return __state_wrapper__, _context_state_
+                
+        f, state = _co()
+        _refreshable_func = ui.refreshable(f)
+        state[refreshable_func_key] = _refreshable_func
+        return _refreshable_func(*args, **kwargs)
+    return __refresh_wrapper__

--- a/nicegui/functions/reactive.py
+++ b/nicegui/functions/reactive.py
@@ -1,4 +1,6 @@
-'''React Style Reactive Component for NiceGUI, it enables us to write code like this:
+"""React Style Reactive Component for NiceGUI.
+
+It enables us to write code like this:
 ```python
 from nicegui import ui
 
@@ -8,23 +10,20 @@ def comp():
     ui.label('Count: ' + str(count))
     ui.button('Increment').on('click', lambda: set_count(count + 1))
 ```
-
-
-'''
-from nicegui import ui
-from typing import Callable
+"""
 import sys
-import uuid
-import asyncio
+from typing import Callable
+
+from nicegui import ui
 from nicegui.helpers import is_coroutine_function
 
-refreshable_func_key = '_refreshable_func'
 
 def use_state(default: any):
-    '''Should ONLY be used in a function that is decorated by `@reactive`, And should never call this conditionally.
-    The lifecycle of the state is the same as the component rendered in the page. Internally the state is tied to the
-    Result of a component call, which means for `
-    ``python
+    """Should ONLY be used in a function that is decorated by `@reactive`, and should never call this conditionally.
+    The lifecycle of the state is the same as the component rendered in the page.
+    Internally the state is tied to the result of a component call.
+    This means in the following example, `a` and `b` will have different states and all operations on `a` will see the same state.
+    ```python
     @reactive
     def comp():
         count, set_count = use_state(0)
@@ -34,72 +33,59 @@ def use_state(default: any):
     a = comp()
     b = comp()
     ```
-    All operations on `a` and `b` will be independent, and the state of `a` will not affect `b`. AND all operations on a will see same state.
-    '''
-    for i in range(10):
-        frame = sys._getframe(i)
-        locals_ = frame.f_locals
-        if '_context_state_' in locals_:
-            state = locals_['_context_state_']
-            refreshable_func = state.get(refreshable_func_key)
-            break
+    """
+    frame = sys._getframe()
+    while not '_context_state_' in frame.f_locals:
+        frame = frame.f_back
+    state = frame.f_locals['_context_state_']
+    refreshable_func = state.get('_refreshable_func')
 
     key = state['__idx']
     value = state.setdefault(key, default)
     state['__idx'] += 1
+
     def set_value(value):
         state.update({key: value})
         refreshable_func.refresh()
     return value, set_value
 
+
 def use_thread(fn):
-    '''Trigger a task on component mounted, ONLY ONCE during the lifetime of the component.
+    """Trigger a task on component mounted, ONLY ONCE during the lifetime of the component.
 
     This is useful when you want to trigger a task on component mounted, and you don't want to trigger it again when the component is refreshed.
     Typically used when you want to show a skeleton when the component is mounted, and then fetch data and render the real content.
-    '''
+    """
     runned, set_runned = ui.use_state(False)
     if not runned:
         set_runned(True)
         return ui.timer(0, fn, once=True)
 
-def reactive(func: Callable):
-    '''Reactive Component Decorator for NiceGUI.
 
-    Use `ui.reactive` to decorate a function, and then you can use `use_state` to create a state variable and manage state in a React way.
-    '''
-    def __refresh_wrapper__(*args, classes=None, style=None, **kwargs):
+def reactive(func: Callable):
+    """Reactive Component Decorator for NiceGUI.
+
+    Use `ui.reactive` to decorate a function.
+    Then you can use `use_state` to create a state variable and manage state in a React way.
+    """
+    def __refresh_wrapper__(*args, **kwargs):
         def _co():
-            _context_state_ = {
-                '_id': uuid.uuid4()
-            }
+            _context_state_ = {}
             if not is_coroutine_function(func):
                 def __state_wrapper__(*args, **kwargs):
                     nonlocal _context_state_
-                    try:
-                        _context_state_['__idx'] = 0
-                        ret = func(*args, **kwargs)
-                        # if ret is not None:
-                        #     ret.classes(classes).style(style)
-                    finally:
-                        _context_state_['__idx'] = 0
-                    return ret
+                    _context_state_['__idx'] = 0
+                    return func(*args, **kwargs)
                 return __state_wrapper__, _context_state_
             else:
                 async def __state_wrapper__(*args, **kwargs):
                     nonlocal _context_state_
-                    try:
-                        _context_state_['__idx'] = 0
-                        ret = await func(*args, **kwargs)
-                        # if ret is not None:
-                        #     ret.classes(classes).style(style)
-                    finally:
-                        _context_state_['__idx'] = 0
-                    return ret
+                    _context_state_['__idx'] = 0
+                    return await func(*args, **kwargs)
                 return __state_wrapper__, _context_state_
-                
+
         f, state = _co()
         _refreshable_func = ui.refreshable(f)
-        state[refreshable_func_key] = _refreshable_func
+        state['_refreshable_func'] = _refreshable_func
         return _refreshable_func(*args, **kwargs)
     return __refresh_wrapper__

--- a/nicegui/functions/reactive.py
+++ b/nicegui/functions/reactive.py
@@ -52,6 +52,16 @@ def use_state(default: any):
         refreshable_func.refresh()
     return value, set_value
 
+def use_thread(fn):
+    '''Trigger a task on component mounted, ONLY ONCE during the lifetime of the component.
+
+    This is useful when you want to trigger a task on component mounted, and you don't want to trigger it again when the component is refreshed.
+    Typically used when you want to show a skeleton when the component is mounted, and then fetch data and render the real content.
+    '''
+    runned, set_runned = ui.use_state(False)
+    if not runned:
+        set_runned(True)
+        return ui.timer(0, fn, once=True)
 
 def reactive(func: Callable):
     '''Reactive Component Decorator for NiceGUI.

--- a/nicegui/functions/reactive.py
+++ b/nicegui/functions/reactive.py
@@ -9,7 +9,6 @@ def comp():
     ui.button('Increment').on('click', lambda: set_count(count + 1))
 ```
 
-See more examples in ./extras.py
 
 '''
 from nicegui import ui

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -77,6 +77,8 @@ __all__ = [
     'notify',
     'open',
     'refreshable',
+    'reactive',
+    'use_state',
     'timer',
     'update',
     'page',
@@ -167,6 +169,7 @@ from .functions.javascript import run_javascript
 from .functions.notify import notify
 from .functions.open import open
 from .functions.refreshable import refreshable
+from .functions.reactive import reactive, use_state
 from .functions.timer import Timer as timer
 from .functions.update import update
 from .page import page


### PR DESCRIPTION
see the discussion: https://github.com/zauberzeug/nicegui/discussions/1410

Added `ui.reactive` decorator and hooks `use_state` and `use_thread`.

tested on my local but not yet add a demo.

It's not obvious to me whether we want to call it `reactive` or `component`, I am guessing `reactive` would make it a little bit clearer in NiceGUI context.

I think if we agree to bring react style component mechanism into NiceGUI. This might be the obvious only way to design the interface. For people comes from React, it's intuitive and almost identical. We can see this implementation as experimental but the interface should be stable.


Copy explanation from the discussion:
for those who are not familiar with React, I can explain with a simple example:

```py
@reactive
def demo():
    count, set_count = use_state(0)
    ui.label(f'Count: {count}')
    ui.button('Increment').on('click', lambda e: set_count(count + 1))
```
In this demo component, you can build UI entirely based on the count variable from use_state(0) without need to maintain the value binding yourself, and when you want to update the UI, you call the set_count which would cause a refresh of the component. This simplified the mind model here. For the example that I demonstrated in the video, I think the reactive way is much simpler than the value_binding way.

As for the implementation, basically, in the reactive decorator, I made a wrapper so that when the  component function (reactive(demo)) was called, a closure would be generated and it will capture a _context_state_ variable to maintain state of the created component instance.

Then, use_state will search upper function frame to find the _context_state_ and set/get value, and a little bit magic is used to maintain the index so that everytime the use_state call will get the same context variable.