### PR TITLE
Fixed chart events for new hierarchy

### DIFF
--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -49,7 +49,7 @@ class ClickEventArguments(UiEventArguments):
 
 
 @dataclass(**KWONLY_SLOTS)
-class ChartEventArguments(EventArguments):
+class ChartEventArguments(UiEventArguments):
     event_type: str
 
 


### PR DESCRIPTION
It looks like there is a new hierarchy for events that I didn't account for in my original PR. I believe this small change is all that should be required to get events on the chart element working again.