### PR TITLE
Color background of color_input

### DIFF
--- a/nicegui/elements/color_input.py
+++ b/nicegui/elements/color_input.py
@@ -15,7 +15,7 @@ class ColorInput(ValueElement, DisableableElement):
                  placeholder: Optional[str] = None,
                  value: str = '',
                  on_change: Optional[Callable[..., Any]] = None,
-                 preview: bool = True,
+                 preview: bool = False,
                  ) -> None:
         """Color Input
 
@@ -23,7 +23,7 @@ class ColorInput(ValueElement, DisableableElement):
         :param placeholder: text to show if no color is selected
         :param value: the current color value
         :param on_change: callback to execute when the value changes
-        :param preview: change button background to selected color
+        :param preview: change button background to selected color (default: False)
         """
         super().__init__(tag='q-input', value=value, on_value_change=on_change)
         if label is not None:
@@ -37,10 +37,7 @@ class ColorInput(ValueElement, DisableableElement):
                 .props('flat round', remove='color').classes('cursor-pointer')
 
         self.preview = preview
-        if self.preview:
-            self.button.style(f'background-color: {value or "#fff"}')
-            self.button.style(
-                'text-shadow: 2px 0 #fff, -2px 0 #fff, 0 2px #fff, 0 -2px #fff, 1px 1px #fff, -1px -1px #fff, 1px -1px #fff, -1px 1px #fff')
+        self._update_preview()
 
     def open_picker(self) -> None:
         """Open the color picker"""
@@ -49,10 +46,13 @@ class ColorInput(ValueElement, DisableableElement):
         self.picker.open()
 
     def on_value_change(self, value: Any) -> None:
-        """Modify button color.
-
-        :param value: The new value.
-        """
         super().on_value_change(value)
-        if self.preview:
-            self.button.style(f'background-color: {value or "#fff"}')
+        self._update_preview()
+
+    def _update_preview(self) -> None:
+        if not self.preview:
+            return
+        self.button.style(f'''
+            background-color: {(self.value or "#fff").split(";", 1)[0]};
+            text-shadow: 2px 0 #fff, -2px 0 #fff, 0 2px #fff, 0 -2px #fff, 1px 1px #fff, -1px -1px #fff, 1px -1px #fff, -1px 1px #fff;
+        ''')

--- a/nicegui/elements/color_input.py
+++ b/nicegui/elements/color_input.py
@@ -15,6 +15,7 @@ class ColorInput(ValueElement, DisableableElement):
                  placeholder: Optional[str] = None,
                  value: str = '',
                  on_change: Optional[Callable[..., Any]] = None,
+                 preview: bool = True,
                  ) -> None:
         """Color Input
 
@@ -22,6 +23,7 @@ class ColorInput(ValueElement, DisableableElement):
         :param placeholder: text to show if no color is selected
         :param value: the current color value
         :param on_change: callback to execute when the value changes
+        :param preview: change button background to selected color
         """
         super().__init__(tag='q-input', value=value, on_value_change=on_change)
         if label is not None:
@@ -34,8 +36,22 @@ class ColorInput(ValueElement, DisableableElement):
             self.button = ui.button(on_click=self.open_picker, icon='colorize') \
                 .props('flat round', remove='color').classes('cursor-pointer')
 
+        self.preview = preview
+        if self.preview:
+            self.button.style(f'background-color: {value or "#fff"}')
+            self.button.style('text-shadow: 2px 0 #fff, -2px 0 #fff, 0 2px #fff, 0 -2px #fff, 1px 1px #fff, -1px -1px #fff, 1px -1px #fff, -1px 1px #fff')
+
     def open_picker(self) -> None:
         """Open the color picker"""
         if self.value:
             self.picker.set_color(self.value)
         self.picker.open()
+
+    def on_value_change(self, value: Any) -> None:
+        """Modify button color.
+
+        :param value: The new value.
+        """
+        super().on_value_change(value)
+        if self.preview:
+            self.button.style(f'background-color: {value or "#fff"}')

--- a/nicegui/elements/color_input.py
+++ b/nicegui/elements/color_input.py
@@ -39,7 +39,8 @@ class ColorInput(ValueElement, DisableableElement):
         self.preview = preview
         if self.preview:
             self.button.style(f'background-color: {value or "#fff"}')
-            self.button.style('text-shadow: 2px 0 #fff, -2px 0 #fff, 0 2px #fff, 0 -2px #fff, 1px 1px #fff, -1px -1px #fff, 1px -1px #fff, -1px 1px #fff')
+            self.button.style(
+                'text-shadow: 2px 0 #fff, -2px 0 #fff, 0 2px #fff, 0 -2px #fff, 1px 1px #fff, -1px -1px #fff, 1px -1px #fff, -1px 1px #fff')
 
     def open_picker(self) -> None:
         """Open the color picker"""

--- a/tests/test_color_input.py
+++ b/tests/test_color_input.py
@@ -7,13 +7,14 @@ from .screen import Screen
 
 
 def test_entering_color(screen: Screen):
-    ui.color_input(label='Color', on_change=lambda e: ui.label(f'content: {e.value}'))
+    ui.color_input(label='Color', on_change=lambda e: ui.label(f'content: {e.value}'), preview=True)
 
     screen.open('/')
     screen.type(Keys.TAB)
     screen.type('#001100')
     screen.should_contain('content: #001100')
-
+    button = screen.selenium.find_element(By.CLASS_NAME, 'q-btn')
+    assert button.value_of_css_property('background-color') == 'rgba(0, 17, 0, 1)'
 
 def test_picking_color(screen: Screen):
     ui.color_input(label='Color', on_change=lambda e: output.set_text(e.value))

--- a/tests/test_color_input.py
+++ b/tests/test_color_input.py
@@ -16,6 +16,7 @@ def test_entering_color(screen: Screen):
     button = screen.selenium.find_element(By.CLASS_NAME, 'q-btn')
     assert button.value_of_css_property('background-color') == 'rgba(0, 17, 0, 1)'
 
+
 def test_picking_color(screen: Screen):
     ui.color_input(label='Color', on_change=lambda e: output.set_text(e.value))
     output = ui.label()


### PR DESCRIPTION
This changes the background of the `color_input` buttons to preview the selected color.

To allow the icon to stay visible regardless of selected color, a white border is added around it.

![grafik](https://github.com/zauberzeug/nicegui/assets/3721366/65d9ead7-3fa4-4fec-bac6-f179c71a831e)

As suggested in #1390, this is implemented as `preview=True` parameter (default enabled).