### PR TITLE
Make storage path configurable via environment variable

### DIFF
--- a/nicegui/globals.py
+++ b/nicegui/globals.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import os
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
@@ -48,6 +49,7 @@ tailwind: bool
 prod_js: bool
 endpoint_documentation: Literal['none', 'internal', 'page', 'all'] = 'none'
 air: Optional[Air] = None
+storage_path: Path = Path(os.environ.get('NICEGUI_STORAGE_PATH', '.nicegui'))
 socket_io_js_query_params: Dict = {}
 socket_io_js_extra_headers: Dict = {}
 # NOTE we favor websocket over polling

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -74,8 +74,7 @@ class RequestTrackingMiddleware(BaseHTTPMiddleware):
 class Storage:
 
     def __init__(self) -> None:
-        self.storage_path = Path('.nicegui')
-        self._general = PersistentDict(self.storage_path / 'storage_general.json')
+        self._general = PersistentDict(globals.storage_path / 'storage_general.json')
         self._users: Dict[str, PersistentDict] = {}
 
     @property
@@ -116,7 +115,7 @@ class Storage:
                 raise RuntimeError('app.storage.user needs a storage_secret passed in ui.run()')
         id = request.session['id']
         if id not in self._users:
-            self._users[id] = PersistentDict(self.storage_path / f'storage_user_{id}.json')
+            self._users[id] = PersistentDict(globals.storage_path / f'storage_user_{id}.json')
         return self._users[id]
 
     @property
@@ -128,5 +127,5 @@ class Storage:
         """Clears all storage."""
         self._general.clear()
         self._users.clear()
-        for filepath in self.storage_path.glob('storage_*.json'):
+        for filepath in globals.storage_path.glob('storage_*.json'):
             filepath.unlink()

--- a/website/documentation.py
+++ b/website/documentation.py
@@ -589,6 +589,7 @@ def create_full() -> None:
 
         - `MATPLOTLIB` (default: true) can be set to `false` to avoid the potentially costly import of Matplotlib.
             This will make `ui.pyplot` and `ui.line_plot` unavailable.
+        - `NICEGUI_STORAGE_PATH` (default: local ".nicegui") can be set to change the location of the storage files.
         - `MARKDOWN_CONTENT_CACHE_SIZE` (default: 1000): The maximum number of Markdown content snippets that are cached in memory.
     ''')
     def env_var_demo():


### PR DESCRIPTION
This PR is a follow-up to https://github.com/zauberzeug/nicegui/discussions/1418 and https://github.com/zauberzeug/nicegui/pull/1426. In contrast to setting the storage path via `ui.run` (which is too late), it introduces a new environment variable "NICEGUI_STORAGE_PATH".

The following call will create a new storage directory in /tmp/nicegui:
```bash
NICEGUI_STORAGE_PATH=/tmp/nicegui ./test.py
```