### PR TITLE
Allow canceling a timer

### DIFF
--- a/nicegui/functions/timer.py
+++ b/nicegui/functions/timer.py
@@ -32,6 +32,7 @@ class Timer:
         self.callback: Optional[Callable[..., Any]] = callback
         self.active = active
         self.slot: Optional[Slot] = globals.get_slot()
+        self._is_canceled: bool = False
 
         coroutine = self._run_once if once else self._run_in_loop
         if globals.state == globals.State.STARTED:
@@ -41,11 +42,17 @@ class Timer:
 
     def activate(self) -> None:
         """Activate the timer."""
+        assert not self._is_canceled, 'Cannot activate a canceled timer'
         self.active = True
 
     def deactivate(self) -> None:
         """Deactivate the timer."""
+        assert not self._is_canceled, 'Cannot deactivate a canceled timer'
         self.active = False
+
+    def cancel(self) -> None:
+        """Cancel the timer."""
+        self._is_canceled = True
 
     async def _run_once(self) -> None:
         try:
@@ -54,8 +61,13 @@ class Timer:
             assert self.slot is not None
             with self.slot:
                 await asyncio.sleep(self.interval)
-                if self.active and globals.state not in {globals.State.STOPPING, globals.State.STOPPED}:
-                    await self._invoke_callback()
+                if self._is_canceled:
+                    return
+                if not self.active:
+                    return
+                if globals.state in {globals.State.STOPPING, globals.State.STOPPED}:
+                    return
+                await self._invoke_callback()
         finally:
             self._cleanup()
 
@@ -67,6 +79,8 @@ class Timer:
             with self.slot:
                 while True:
                     if self.slot.parent.client.id not in globals.clients:
+                        break
+                    if self._is_canceled:
                         break
                     if globals.state in {globals.State.STOPPING, globals.State.STOPPED}:
                         break

--- a/nicegui/functions/timer.py
+++ b/nicegui/functions/timer.py
@@ -47,7 +47,6 @@ class Timer:
 
     def deactivate(self) -> None:
         """Deactivate the timer."""
-        assert not self._is_canceled, 'Cannot deactivate a canceled timer'
         self.active = False
 
     def cancel(self) -> None:

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -17,7 +17,7 @@ class Counter:
 
 def test_timer(screen: Screen):
     counter = Counter()
-    ui.timer(0.1, counter.increment)
+    t = ui.timer(0.1, counter.increment)
 
     assert counter.value == 0, 'count is initially zero'
     screen.wait(0.5)
@@ -26,6 +26,22 @@ def test_timer(screen: Screen):
     screen.start_server()
     screen.wait(0.5)
     assert counter.value > 0, 'timer is running after starting the server'
+
+    t.deactivate()
+    screen.wait(0.5)
+    c = counter.value
+    screen.wait(0.5)
+    assert counter.value == c, 'timer is not running anymore after deactivating it'
+
+    t.activate()
+    screen.wait(0.5)
+    assert counter.value > c, 'timer is running again after activating it'
+
+    t.cancel()
+    screen.wait(0.5)
+    c = counter.value
+    screen.wait(0.5)
+    assert counter.value == c, 'timer is not running anymore after canceling it'
 
 
 def test_timer_on_private_page(screen: Screen):
@@ -52,7 +68,7 @@ def test_timer_on_private_page(screen: Screen):
 
 @pytest.mark.parametrize('once', [True, False])
 def test_setting_visibility(screen: Screen, once: bool):
-    '''reproduction of https://github.com/zauberzeug/nicegui/issues/206'''
+    """reproduction of https://github.com/zauberzeug/nicegui/issues/206"""
     @ui.page('/')
     def page():
         label = ui.label('Some Label')

--- a/website/more_documentation/timer_documentation.py
+++ b/website/more_documentation/timer_documentation.py
@@ -11,13 +11,16 @@ def main_demo() -> None:
 
 
 def more() -> None:
-    @text_demo('Activate and deactivate a timer', '''
+    @text_demo('Activate, deactivate and cancel a timer', '''
         You can activate and deactivate a timer using the `active` property.
+        You can cancel a timer using the `cancel` method.
+        After canceling a timer, it cannot be activated anymore.
     ''')
     def activate_deactivate_demo():
-        slider = ui.slider(min=-1, max=1, value=0)
+        slider = ui.slider(min=0, max=1, value=0.5)
         timer = ui.timer(0.1, lambda: slider.set_value((slider.value + 0.01) % 1.0))
         ui.switch('active').bind_value_to(timer, 'active')
+        ui.button('Cancel', on_click=timer.cancel)
 
     @text_demo('Call a function after a delay', '''
         You can call a function after a delay using a timer with the `once` parameter.


### PR DESCRIPTION
As requested in #1477, this PR adds the possibility to cancel a timer.
This stops the infinite while loop. Afterwards the timer cannot be activated again.