### PR TITLE
improve the chat_app example for test leading/trailing debounce and throttle

### DIFF
--- a/examples/chat_app/main.py
+++ b/examples/chat_app/main.py
@@ -30,7 +30,10 @@ async def main(client: Client):
     ui.add_head_html(f'<style>{anchor_style}</style>')
     with ui.footer().classes('bg-white'), ui.column().classes('w-full max-w-3xl mx-auto my-6'):
         with ui.row().classes('w-full no-wrap items-center'):
-            with ui.avatar().on('click', lambda: ui.open(main)):
+            with ui.avatar().on('click', lambda: ui.open(main)).on(
+                'mousemove', lambda e: ui.notify(f'Click avatar for new session. Id now is {user_id}.'),
+                throttle=5, leading_events=True, trailing_events=False
+            ):
                 ui.image(avatar)
             text = ui.input(placeholder='message').on('keydown.enter', send, throttle=1.5) \
                 .props('rounded outlined input-class=mx-3').classes('flex-grow')

--- a/examples/chat_app/main.py
+++ b/examples/chat_app/main.py
@@ -32,7 +32,7 @@ async def main(client: Client):
         with ui.row().classes('w-full no-wrap items-center'):
             with ui.avatar().on('click', lambda: ui.open(main)):
                 ui.image(avatar)
-            text = ui.input(placeholder='message').on('keydown.enter', send) \
+            text = ui.input(placeholder='message').on('keydown.enter', send, throttle=1.5) \
                 .props('rounded outlined input-class=mx-3').classes('flex-grow')
         ui.markdown('simple chat app built with [NiceGUI](https://nicegui.io)') \
             .classes('text-xs self-end mr-8 m-[-1em] text-primary')

--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -15,7 +15,11 @@ class ValueElement(Element):
     def __init__(self, *,
                  value: Any,
                  on_value_change: Optional[Callable[..., Any]],
-                 throttle: float = 0,
+                 # use trailing throttle for value element. for example:
+                 # input element should not send each time when user input every char in a word.
+                 throttle: float = 0.5,
+                 leading_events: bool = False,
+                 trailing_events: bool = True,
                  **kwargs: Any,
                  ) -> None:
         super().__init__(**kwargs)
@@ -29,7 +33,8 @@ class ValueElement(Element):
             self._send_update_on_value_change = self.LOOPBACK
             self.set_value(self._event_args_to_value(e))
             self._send_update_on_value_change = True
-        self.on(f'update:{self.VALUE_PROP}', handle_change, [None], throttle=throttle)
+        self.on(f'update:{self.VALUE_PROP}', handle_change, [None], throttle=throttle,
+                leading_events=leading_events, trailing_events=trailing_events)
 
     def bind_value_to(self,
                       target_object: Any,


### PR DESCRIPTION
make chat app can test for #1483 

1. improve the chat_app example for test leading/trailing debounce and throttle
2.  use trailing throttle for value element