### PR TITLE
catch gaierror and improve startup speed

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -93,7 +93,7 @@ def handle_startup(with_welcome_message: bool = True) -> None:
     background_tasks.create(prune_slot_stacks())
     globals.state = globals.State.STARTED
     if with_welcome_message:
-        welcome.print_message()
+        background_tasks.create(welcome.print_message())
     if globals.air:
         background_tasks.create(globals.air.connect())
 

--- a/nicegui/welcome.py
+++ b/nicegui/welcome.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import socket
 from typing import List
@@ -13,7 +14,11 @@ except ImportError:
 
 def get_all_ips() -> List[str]:
     if 'netifaces' not in globals.optional_features:
-        return [info[4][0] for info in socket.getaddrinfo(socket.gethostname(), None) if len(info[4]) == 2]
+        try:
+            hostname = socket.gethostname()
+            return socket.gethostbyname_ex(hostname)[2]
+        except socket.gaierror:
+            return []
     ips = []
     for interface in netifaces.interfaces():
         try:
@@ -23,12 +28,17 @@ def get_all_ips() -> List[str]:
     return ips
 
 
-def print_message() -> None:
+async def print_message() -> None:
+    print('NiceGUI ready to go ', end='', flush=True)
     host = os.environ['NICEGUI_HOST']
     port = os.environ['NICEGUI_PORT']
-    ips = set(get_all_ips() if host == '0.0.0.0' else [])
+    loop = asyncio.get_running_loop()
+    ips = set((await loop.run_in_executor(None, get_all_ips)) if host == '0.0.0.0' else [])
     ips.discard('127.0.0.1')
     addresses = [(f'http://{ip}:{port}' if port != '80' else f'http://{ip}') for ip in ['localhost'] + sorted(ips)]
     if len(addresses) >= 2:
         addresses[-1] = 'and ' + addresses[-1]
-    print(f'NiceGUI ready to go on {", ".join(addresses)}', flush=True)
+    extra = ''
+    if 'netifaces' not in globals.optional_features:
+        extra = ' (install netifaces to show all IPs and speedup this message)'
+    print(f'on {", ".join(addresses)}' + extra, flush=True)


### PR DESCRIPTION
This pull request fixes #1178 by catching `gaierror`. the error can be reproduced by deactivating all sharing features on in the MacOS settings, restarting the laptop and deinstalling `netifaces`.

While using this setup I noticed a significant delay of five seconds before NiceGUI really starts. This is caused by the default dns timeout on the hostname which seems not to be added to the /etc/hosts file if no sharing features are activated on MacOS (see https://apple.stackexchange.com/a/253834/26268). Making `netifaces` or `psutils` a dependency is not an option because it would require c++ and python-dev dependencies for building on some architectures. Thus I made the message printing async and hence independent of the startup.