### PR TITLE
adhere forwarded-prefix for redirects

### DIFF
--- a/nicegui/middlewares.py
+++ b/nicegui/middlewares.py
@@ -1,0 +1,11 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class RedirectWithPrefixMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        prefix = request.headers.get('X-Forwarded-Prefix', '')
+        response = await call_next(request)
+        if 'Location' in response.headers:
+            new_location = prefix + response.headers['Location']
+            response.headers['Location'] = new_location
+        return response

--- a/nicegui/middlewares.py
+++ b/nicegui/middlewares.py
@@ -1,8 +1,11 @@
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
 
 
 class RedirectWithPrefixMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request, call_next):
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         prefix = request.headers.get('X-Forwarded-Prefix', '')
         response = await call_next(request)
         if 'Location' in response.headers:

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -10,19 +10,17 @@ from fastapi.responses import FileResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi_socketio import SocketManager
 
-from nicegui import json
-from nicegui.json import NiceGUIJSONResponse
-
-from . import (__version__, background_tasks, binding, favicon, globals, outbox,  # pylint: disable=redefined-builtin
-               welcome)
+from . import (__version__, background_tasks, binding, favicon, globals, json,  # pylint: disable=redefined-builtin
+               outbox, welcome)
 from .app import App
 from .client import Client
 from .dependencies import js_components, libraries
 from .element import Element
 from .error import error_content
 from .helpers import is_file, safe_invoke
-from .page import page
+from .json import NiceGUIJSONResponse
 from .middlewares import RedirectWithPrefixMiddleware
+from .page import page
 
 globals.app = app = App(default_response_class=NiceGUIJSONResponse)
 # NOTE we use custom json module which wraps orjson

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -22,6 +22,7 @@ from .element import Element
 from .error import error_content
 from .helpers import is_file, safe_invoke
 from .page import page
+from .middlewares import RedirectWithPrefixMiddleware
 
 globals.app = app = App(default_response_class=NiceGUIJSONResponse)
 # NOTE we use custom json module which wraps orjson
@@ -29,6 +30,7 @@ socket_manager = SocketManager(app=app, mount_location='/_nicegui_ws/', json=jso
 globals.sio = sio = socket_manager._sio  # pylint: disable=protected-access
 
 app.add_middleware(GZipMiddleware)
+app.add_middleware(RedirectWithPrefixMiddleware)
 static_files = StaticFiles(
     directory=(Path(__file__).parent / 'static').resolve(),
     follow_symlink=True,

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, Optional, Union
 
 import aiofiles
-from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
 from starlette.responses import Response
 
 from . import background_tasks, globals, observables  # pylint: disable=redefined-builtin


### PR DESCRIPTION
This pull request fixes #1464 by introducing a middleware which prepends the correct path-prefix for redirect responses.

Simplest reproduction is with On Air:

```py
from nicegui import ui

@ui.page('/')
def test():
    return RedirectResponse('/hello')


@ui.page('/hello')
def hello():
    ui.label('it works')

ui.run(on_air=True)
```

Another way would be to setup a Treafik reverse proxy and serve an app with similar `RedirectResponse` on a sub-path.