### PR TITLE
Fix and improve clear, remove and delete methods

### DIFF
--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -126,3 +126,13 @@ def remove(objects: List[Any], type_: Type) -> None:
     for (obj_id, name), obj in list(bindable_properties.items()):
         if isinstance(obj, type_) and obj in objects:
             del bindable_properties[(obj_id, name)]
+
+
+def reset() -> None:
+    """Clear all bindings.
+
+    This function is intended for testing purposes only.
+    """
+    bindings.clear()
+    bindable_properties.clear()
+    active_links.clear()

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -2,7 +2,7 @@ import asyncio
 import time
 from collections import defaultdict
 from collections.abc import Mapping
-from typing import Any, Callable, DefaultDict, Dict, List, Optional, Set, Tuple, Type, Union
+from typing import Any, Callable, DefaultDict, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
 
 from . import globals  # pylint: disable=redefined-builtin
 
@@ -107,7 +107,7 @@ class BindableProperty:
             self.on_change(owner, value)
 
 
-def remove(objects: List[Any], type_: Type) -> None:
+def remove(objects: Iterable[Any], type_: Type) -> None:
     active_links[:] = [
         (source_obj, source_name, target_obj, target_name, transform)
         for source_obj, source_name, target_obj, target_name, transform in active_links

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -170,6 +170,7 @@ class Client:
         for element_id in element_ids:
             del self.elements[element_id]
         for element in elements:
+            element._on_delete()  # pylint: disable=protected-access
             element._deleted = True  # pylint: disable=protected-access
             outbox.enqueue_delete(element)
 

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -184,9 +184,9 @@ class Scene(Element,
                         self.camera.look_at_x, self.camera.look_at_y, self.camera.look_at_z,
                         self.camera.up_x, self.camera.up_y, self.camera.up_z, duration)
 
-    def delete(self) -> None:
+    def _on_delete(self) -> None:
         binding.remove(list(self.objects.values()), Object3D)
-        super().delete()
+        super()._on_delete()
 
     def delete_objects(self, predicate: Callable[[Object3D], bool] = lambda _: True) -> None:
         for obj in list(self.objects.values()):

--- a/nicegui/elements/upload.py
+++ b/nicegui/elements/upload.py
@@ -69,6 +69,6 @@ class Upload(DisableableElement, component='upload.js'):
     def reset(self) -> None:
         self.run_method('reset')
 
-    def delete(self) -> None:
+    def _on_delete(self) -> None:
         app.remove_route(self._props['url'])
-        super().delete()
+        super()._on_delete()

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -14,7 +14,6 @@ from . import background_tasks, binding, favicon, globals, json, outbox, welcome
 from .app import App
 from .client import Client
 from .dependencies import js_components, libraries
-from .element import Element
 from .error import error_content
 from .helpers import is_file, safe_invoke
 from .json import NiceGUIJSONResponse
@@ -229,6 +228,4 @@ async def prune_slot_stacks() -> None:
 
 
 def delete_client(client_id: str) -> None:
-    elements = globals.clients[client_id].elements.values()
-    Element._delete_elements(elements)  # pylint: disable=protected-access
-    del globals.clients[client_id]
+    globals.clients.pop(client_id).remove_all_elements()

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -229,7 +229,6 @@ async def prune_slot_stacks() -> None:
 
 
 def delete_client(client_id: str) -> None:
-    binding.remove(list(globals.clients[client_id].elements.values()), Element)
-    for element in globals.clients[client_id].elements.values():
-        element.delete()
+    elements = globals.clients[client_id].elements.values()
+    Element._delete_elements(elements)  # pylint: disable=protected-access
     del globals.clients[client_id]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 
-from nicegui import Client, globals  # pylint: disable=redefined-builtin
+from nicegui import Client, binding, globals  # pylint: disable=redefined-builtin
 from nicegui.elements import plotly, pyplot
 from nicegui.page import page
 
@@ -57,6 +57,7 @@ def reset_globals() -> Generator[None, None, None]:
     globals.app.storage.clear()
     globals.index_client = Client(page('/'), shared=True).__enter__()
     globals.app.get('/')(globals.index_client.build_response)
+    binding.reset()
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -105,40 +105,6 @@ def test_props(screen: Screen):
     assert_props('standard')
 
 
-def test_remove_and_clear(screen: Screen):
-    with ui.row() as row:
-        ui.label('Label A')
-        b = ui.label('Label B')
-        ui.label('Label C')
-
-    ui.button('Remove B', on_click=lambda: row.remove(b))
-    ui.button('Remove 0', on_click=lambda: row.remove(0))
-    ui.button('Clear', on_click=row.clear)
-
-    screen.open('/')
-    screen.should_contain('Label A')
-    screen.should_contain('Label B')
-    screen.should_contain('Label C')
-
-    screen.click('Remove B')
-    screen.wait(0.5)
-    screen.should_contain('Label A')
-    screen.should_not_contain('Label B')
-    screen.should_contain('Label C')
-
-    screen.click('Remove 0')
-    screen.wait(0.5)
-    screen.should_not_contain('Label A')
-    screen.should_not_contain('Label B')
-    screen.should_contain('Label C')
-
-    screen.click('Clear')
-    screen.wait(0.5)
-    screen.should_not_contain('Label A')
-    screen.should_not_contain('Label B')
-    screen.should_not_contain('Label C')
-
-
 def test_move(screen: Screen):
     with ui.card() as a:
         ui.label('A')

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -21,6 +21,7 @@ def test_remove_element_by_reference(screen: Screen):
     screen.should_not_contain('Label B')
     screen.should_contain('Label C')
     assert b.is_deleted
+    assert b.id not in row.client.elements
     assert len(row.default_slot.children) == 2
     assert len(binding.active_links) == 2
 
@@ -41,6 +42,7 @@ def test_remove_element_by_index(screen: Screen):
     screen.should_not_contain('Label B')
     screen.should_contain('Label C')
     assert b.is_deleted
+    assert b.id not in row.client.elements
     assert len(row.default_slot.children) == 2
     assert len(binding.active_links) == 2
 
@@ -63,6 +65,7 @@ def test_clear(screen: Screen):
     assert a.is_deleted
     assert b.is_deleted
     assert c.is_deleted
+    assert b.id not in row.client.elements
     assert len(row.default_slot.children) == 0
     assert len(binding.active_links) == 0
 
@@ -88,6 +91,9 @@ def test_remove_parent(screen: Screen):
     assert a.is_deleted
     assert b.is_deleted
     assert c.is_deleted
+    assert a.id not in container.client.elements
+    assert b.id not in container.client.elements
+    assert c.id not in container.client.elements
     assert len(container.default_slot.children) == 0
     assert len(row.default_slot.children) == 0
     assert len(binding.active_links) == 0
@@ -110,5 +116,6 @@ def test_delete_element(screen: Screen):
     screen.should_not_contain('Label B')
     screen.should_contain('Label C')
     assert b.is_deleted
+    assert b.id not in row.client.elements
     assert len(row.default_slot.children) == 2
     assert len(binding.active_links) == 2

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -1,3 +1,5 @@
+import pytest
+
 from nicegui import ui
 
 from .screen import Screen
@@ -51,6 +53,28 @@ def test_clear(screen: Screen):
     screen.should_not_contain('Label A')
     screen.should_not_contain('Label B')
     screen.should_not_contain('Label C')
+    assert a.is_deleted
+    assert b.is_deleted
+    assert c.is_deleted
+
+
+@pytest.mark.skip(reason='needs fix in element.py')  # TODO
+def test_remove_parent(screen: Screen):
+    with ui.element() as container:
+        with ui.row() as row:
+            a = ui.label('Label A')
+            b = ui.label('Label B')
+            c = ui.label('Label C')
+
+    ui.button('Remove parent', on_click=lambda: container.remove(row))
+
+    screen.open('/')
+    screen.click('Remove parent')
+    screen.wait(0.5)
+    screen.should_not_contain('Label A')
+    screen.should_not_contain('Label B')
+    screen.should_not_contain('Label C')
+    assert row.is_deleted
     assert a.is_deleted
     assert b.is_deleted
     assert c.is_deleted

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -20,6 +20,7 @@ def test_remove_element_by_reference(screen: Screen):
     screen.should_not_contain('Label B')
     screen.should_contain('Label C')
     assert b.is_deleted
+    assert len(row.default_slot.children) == 2
 
 
 def test_remove_element_by_index(screen: Screen):
@@ -37,6 +38,7 @@ def test_remove_element_by_index(screen: Screen):
     screen.should_not_contain('Label B')
     screen.should_contain('Label C')
     assert b.is_deleted
+    assert len(row.default_slot.children) == 2
 
 
 def test_clear(screen: Screen):
@@ -56,6 +58,7 @@ def test_clear(screen: Screen):
     assert a.is_deleted
     assert b.is_deleted
     assert c.is_deleted
+    assert len(row.default_slot.children) == 0
 
 
 @pytest.mark.skip(reason='needs fix in element.py')  # TODO
@@ -78,3 +81,22 @@ def test_remove_parent(screen: Screen):
     assert a.is_deleted
     assert b.is_deleted
     assert c.is_deleted
+
+
+@pytest.mark.skip(reason='needs fix in element.py')  # TODO
+def test_delete_element(screen: Screen):
+    with ui.row() as row:
+        ui.label('Label A')
+        b = ui.label('Label B')
+        ui.label('Label C')
+
+    ui.button('Delete', on_click=b.delete)
+
+    screen.open('/')
+    screen.click('Delete')
+    screen.wait(0.5)
+    screen.should_contain('Label A')
+    screen.should_not_contain('Label B')
+    screen.should_contain('Label C')
+    assert b.is_deleted
+    assert len(row.default_slot.children) == 2

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -1,15 +1,16 @@
 import pytest
 
-from nicegui import ui
+from nicegui import binding, ui
 
 from .screen import Screen
 
 
 def test_remove_element_by_reference(screen: Screen):
+    texts = {'a': 'Label A', 'b': 'Label B', 'c': 'Label C'}
     with ui.row() as row:
-        ui.label('Label A')
-        b = ui.label('Label B')
-        ui.label('Label C')
+        ui.label().bind_text_from(texts, 'a')
+        b = ui.label().bind_text_from(texts, 'b')
+        ui.label().bind_text_from(texts, 'c')
 
     ui.button('Remove', on_click=lambda: row.remove(b))
 
@@ -21,13 +22,15 @@ def test_remove_element_by_reference(screen: Screen):
     screen.should_contain('Label C')
     assert b.is_deleted
     assert len(row.default_slot.children) == 2
+    assert len(binding.active_links) == 2
 
 
 def test_remove_element_by_index(screen: Screen):
+    texts = {'a': 'Label A', 'b': 'Label B', 'c': 'Label C'}
     with ui.row() as row:
-        ui.label('Label A')
-        b = ui.label('Label B')
-        ui.label('Label C')
+        ui.label().bind_text_from(texts, 'a')
+        b = ui.label().bind_text_from(texts, 'b')
+        ui.label().bind_text_from(texts, 'c')
 
     ui.button('Remove', on_click=lambda: row.remove(1))
 
@@ -39,13 +42,15 @@ def test_remove_element_by_index(screen: Screen):
     screen.should_contain('Label C')
     assert b.is_deleted
     assert len(row.default_slot.children) == 2
+    assert len(binding.active_links) == 2
 
 
 def test_clear(screen: Screen):
+    texts = {'a': 'Label A', 'b': 'Label B', 'c': 'Label C'}
     with ui.row() as row:
-        a = ui.label('Label A')
-        b = ui.label('Label B')
-        c = ui.label('Label C')
+        a = ui.label().bind_text_from(texts, 'a')
+        b = ui.label().bind_text_from(texts, 'b')
+        c = ui.label().bind_text_from(texts, 'c')
 
     ui.button('Clear', on_click=row.clear)
 
@@ -59,15 +64,17 @@ def test_clear(screen: Screen):
     assert b.is_deleted
     assert c.is_deleted
     assert len(row.default_slot.children) == 0
+    assert len(binding.active_links) == 0
 
 
 @pytest.mark.skip(reason='needs fix in element.py')  # TODO
 def test_remove_parent(screen: Screen):
+    texts = {'a': 'Label A', 'b': 'Label B', 'c': 'Label C'}
     with ui.element() as container:
         with ui.row() as row:
-            a = ui.label('Label A')
-            b = ui.label('Label B')
-            c = ui.label('Label C')
+            a = ui.label().bind_text_from(texts, 'a')
+            b = ui.label().bind_text_from(texts, 'b')
+            c = ui.label().bind_text_from(texts, 'c')
 
     ui.button('Remove parent', on_click=lambda: container.remove(row))
 
@@ -81,14 +88,18 @@ def test_remove_parent(screen: Screen):
     assert a.is_deleted
     assert b.is_deleted
     assert c.is_deleted
+    assert len(container.default_slot.children) == 0
+    assert len(row.default_slot.children) == 0
+    assert len(binding.active_links) == 0
 
 
 @pytest.mark.skip(reason='needs fix in element.py')  # TODO
 def test_delete_element(screen: Screen):
+    texts = {'a': 'Label A', 'b': 'Label B', 'c': 'Label C'}
     with ui.row() as row:
-        ui.label('Label A')
-        b = ui.label('Label B')
-        ui.label('Label C')
+        ui.label().bind_text_from(texts, 'a')
+        b = ui.label().bind_text_from(texts, 'b')
+        ui.label().bind_text_from(texts, 'c')
 
     ui.button('Delete', on_click=b.delete)
 
@@ -100,3 +111,4 @@ def test_delete_element(screen: Screen):
     screen.should_contain('Label C')
     assert b.is_deleted
     assert len(row.default_slot.children) == 2
+    assert len(binding.active_links) == 2

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -114,3 +114,32 @@ def test_delete_element(screen: Screen):
     assert b.id not in row.client.elements
     assert len(row.default_slot.children) == 2
     assert len(binding.active_links) == 2
+
+
+def test_on_delete(screen: Screen):
+    deleted_labels = []
+
+    class CustomLabel(ui.label):
+
+        def __init__(self, text: str) -> None:
+            super().__init__(text)
+
+        def _on_delete(self) -> None:
+            deleted_labels.append(self.text)
+            super()._on_delete()
+
+    with ui.row() as row:
+        CustomLabel('Label A')
+        b = CustomLabel('Label B')
+        CustomLabel('Label C')
+
+    ui.button('Delete C', on_click=lambda: row.remove(2))
+    ui.button('Delete B', on_click=lambda: row.remove(b))
+    ui.button('Clear row', on_click=row.clear)
+
+    screen.open('/')
+    screen.click('Delete C')
+    screen.click('Delete B')
+    screen.click('Clear row')
+    screen.wait(0.5)
+    assert deleted_labels == ['Label C', 'Label B', 'Label A']

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -1,5 +1,3 @@
-import pytest
-
 from nicegui import binding, ui
 
 from .screen import Screen
@@ -70,7 +68,6 @@ def test_clear(screen: Screen):
     assert len(binding.active_links) == 0
 
 
-@pytest.mark.skip(reason='needs fix in element.py')  # TODO
 def test_remove_parent(screen: Screen):
     texts = {'a': 'Label A', 'b': 'Label B', 'c': 'Label C'}
     with ui.element() as container:
@@ -95,11 +92,9 @@ def test_remove_parent(screen: Screen):
     assert b.id not in container.client.elements
     assert c.id not in container.client.elements
     assert len(container.default_slot.children) == 0
-    assert len(row.default_slot.children) == 0
     assert len(binding.active_links) == 0
 
 
-@pytest.mark.skip(reason='needs fix in element.py')  # TODO
 def test_delete_element(screen: Screen):
     texts = {'a': 'Label A', 'b': 'Label B', 'c': 'Label C'}
     with ui.row() as row:

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -1,0 +1,56 @@
+from nicegui import ui
+
+from .screen import Screen
+
+
+def test_remove_element_by_reference(screen: Screen):
+    with ui.row() as row:
+        ui.label('Label A')
+        b = ui.label('Label B')
+        ui.label('Label C')
+
+    ui.button('Remove', on_click=lambda: row.remove(b))
+
+    screen.open('/')
+    screen.click('Remove')
+    screen.wait(0.5)
+    screen.should_contain('Label A')
+    screen.should_not_contain('Label B')
+    screen.should_contain('Label C')
+    assert b.is_deleted
+
+
+def test_remove_element_by_index(screen: Screen):
+    with ui.row() as row:
+        ui.label('Label A')
+        b = ui.label('Label B')
+        ui.label('Label C')
+
+    ui.button('Remove', on_click=lambda: row.remove(1))
+
+    screen.open('/')
+    screen.click('Remove')
+    screen.wait(0.5)
+    screen.should_contain('Label A')
+    screen.should_not_contain('Label B')
+    screen.should_contain('Label C')
+    assert b.is_deleted
+
+
+def test_clear(screen: Screen):
+    with ui.row() as row:
+        a = ui.label('Label A')
+        b = ui.label('Label B')
+        c = ui.label('Label C')
+
+    ui.button('Clear', on_click=row.clear)
+
+    screen.open('/')
+    screen.click('Clear')
+    screen.wait(0.5)
+    screen.should_not_contain('Label A')
+    screen.should_not_contain('Label B')
+    screen.should_not_contain('Label C')
+    assert a.is_deleted
+    assert b.is_deleted
+    assert c.is_deleted

--- a/website/documentation.py
+++ b/website/documentation.py
@@ -153,9 +153,16 @@ def create_full() -> None:
     load_demo(ui.grid)
 
     @text_demo('Clear Containers', '''
-        To remove all elements from a row, column or card container, use the `clear()` method.
+        To remove all elements from a row, column or card container, use can call
+        ```py
+        container.clear()
+        ```
 
-        Alternatively, you can remove individual elements with `remove(element)`, where `element` is an Element or an index.
+        Alternatively, you can remove individual elements by calling
+        
+        - `container.remove(element: Element)`,
+        - `container.remove(index: int)`, or
+        - `element.delete()`.
     ''')
     def clear_containers_demo():
         container = ui.row()


### PR DESCRIPTION
This PR attempts to solve #1512.
It is currently work in progress, extending the tests to unveil two issues with the current implementation.

Open tasks:

- [x] let `delete()` correctly remove the element from its parent (`test_delete_element`)
- [x] correctly call `_on_delete()` for all children of a removed parent (`test_remove_parent`)
- [x] fix "RuntimeError: dictionary changed size during iteration"
- [x] extend the documentation about `clear()`, `remove()` and `delete()`