### PR TITLE
Introducing AuthMiddleware in the authentication example

### DIFF
--- a/examples/authentication/main.py
+++ b/examples/authentication/main.py
@@ -6,7 +6,6 @@ use the great `Authlib package <https://docs.authlib.org/en/v0.13/client/starlet
 Here we just demonstrate the NiceGUI integration.
 """
 from typing import Optional
-from urllib.parse import quote
 
 from fastapi import Request
 from fastapi.responses import RedirectResponse
@@ -18,12 +17,14 @@ from nicegui import app, ui
 # in reality users passwords would obviously need to be hashed
 passwords = {'user1': 'pass1', 'user2': 'pass2'}
 
-unrestricted_page_routes = ['/login']
+unrestricted_page_routes = {'/login'}
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
     """This middleware restricts access to all NiceGUI pages.
-    It redirects the user to the login page if they are not authenticated."""
+
+    It redirects the user to the login page if they are not authenticated.
+    """
 
     async def dispatch(self, request: Request, call_next):
         if not app.storage.user.get('authenticated', False):
@@ -45,7 +46,7 @@ def main_page() -> None:
 
 @ui.page('/subpage')
 def test_page() -> None:
-    ui.label('This is a subpage page.')
+    ui.label('This is a sub page.')
 
 
 @ui.page('/login')

--- a/examples/authentication/main.py
+++ b/examples/authentication/main.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
-"""This is just a very simple authentication example.
+"""This is just a simple authentication example.
 
 Please see the `OAuth2 example at FastAPI <https://fastapi.tiangolo.com/tutorial/security/simple-oauth2/>`_  or
 use the great `Authlib package <https://docs.authlib.org/en/v0.13/client/starlette.html#using-fastapi>`_ to implement a classing real authentication system.
 Here we just demonstrate the NiceGUI integration.
 """
+from urllib.parse import quote
+
+from fastapi import Request
 from fastapi.responses import RedirectResponse
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from nicegui import app, ui
 
@@ -13,21 +17,36 @@ from nicegui import app, ui
 passwords = {'user1': 'pass1', 'user2': 'pass2'}
 
 
+class AuthMiddleware(BaseHTTPMiddleware):
+    """This middleware redirects the user to the login page if they are not authenticated."""
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path not in ['/login'] and not app.storage.user.get('authenticated', False):
+            return RedirectResponse(f'/login?referer_path={quote(request.url.path)}')
+        return await call_next(request)
+
+
+app.add_middleware(AuthMiddleware)
+
+
 @ui.page('/')
 def main_page() -> None:
-    if not app.storage.user.get('authenticated', False):
-        return RedirectResponse('/login')
     with ui.column().classes('absolute-center items-center'):
         ui.label(f'Hello {app.storage.user["username"]}!').classes('text-2xl')
         ui.button(on_click=lambda: (app.storage.user.clear(), ui.open('/login')), icon='logout').props('outline round')
 
 
+@ui.page('/subpage')
+def test_page() -> None:
+    ui.label('This is a subpage page.')
+
+
 @ui.page('/login')
-def login() -> None:
+def login(referer_path: str = '') -> None:
     def try_login() -> None:  # local function to avoid passing username and password as arguments
         if passwords.get(username.value) == password.value:
             app.storage.user.update({'username': username.value, 'authenticated': True})
-            ui.open('/')
+            ui.open(referer_path or '/')
         else:
             ui.notify('Wrong username or password', color='negative')
 

--- a/examples/authentication/main.py
+++ b/examples/authentication/main.py
@@ -5,6 +5,7 @@ Please see the `OAuth2 example at FastAPI <https://fastapi.tiangolo.com/tutorial
 use the great `Authlib package <https://docs.authlib.org/en/v0.13/client/starlette.html#using-fastapi>`_ to implement a classing real authentication system.
 Here we just demonstrate the NiceGUI integration.
 """
+from typing import Optional
 from urllib.parse import quote
 
 from fastapi import Request
@@ -22,7 +23,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         if request.url.path not in ['/login'] and not app.storage.user.get('authenticated', False):
-            return RedirectResponse(f'/login?referer_path={quote(request.url.path)}')
+            return RedirectResponse(f'/login?referrer_path={quote(request.url.path)}')
         return await call_next(request)
 
 
@@ -42,11 +43,11 @@ def test_page() -> None:
 
 
 @ui.page('/login')
-def login(referer_path: str = '') -> None:
+def login(referrer_path: str = '') -> Optional[RedirectResponse]:
     def try_login() -> None:  # local function to avoid passing username and password as arguments
         if passwords.get(username.value) == password.value:
             app.storage.user.update({'username': username.value, 'authenticated': True})
-            ui.open(referer_path or '/')
+            ui.open(referrer_path or '/')
         else:
             ui.notify('Wrong username or password', color='negative')
 


### PR DESCRIPTION
As mentioned in #1555 it would be good to have the auth-checks in one place. This pull request shows the usage of a custom middleware to check if access to a page is allowed. To demonstrate the back-routing after login it also adds another subpage.