### PR TITLE
Introduce ui.editor

### DIFF
--- a/nicegui/elements/editor.py
+++ b/nicegui/elements/editor.py
@@ -14,7 +14,8 @@ class Editor(ValueElement, DisableableElement):
                  ) -> None:
         """Editor
 
-        A code editor with syntax highlighting, based on `Quasar's QEditor <https://quasar.dev/vue-components/editor>`_.
+        A WYSIWYG editor based on `Quasar's QEditor <https://quasar.dev/vue-components/editor>`_.
+        The value is a string containing the formatted text as HTML code.
 
         :param value: initial value
         :param on_change: callback to be invoked when the value changes

--- a/nicegui/elements/editor.py
+++ b/nicegui/elements/editor.py
@@ -1,0 +1,24 @@
+from typing import Any, Callable, Optional
+
+from .mixins.disableable_element import DisableableElement
+from .mixins.value_element import ValueElement
+
+
+class Editor(ValueElement, DisableableElement):
+
+    def __init__(self,
+                 *,
+                 placeholder: Optional[str] = None,
+                 value: str = '',
+                 on_change: Optional[Callable[..., Any]] = None,
+                 ) -> None:
+        """Editor
+
+        A code editor with syntax highlighting, based on `Quasar's QEditor <https://quasar.dev/vue-components/editor>`_.
+
+        :param value: initial value
+        :param on_change: callback to be invoked when the value changes
+        """
+        super().__init__(tag='q-editor', value=value, on_value_change=on_change)
+        if placeholder is not None:
+            self._props['placeholder'] = placeholder

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -21,6 +21,7 @@ __all__ = [
     'date',
     'dialog',
     'echart',
+    'editor',
     'expansion',
     'grid',
     'html',
@@ -116,6 +117,7 @@ from .elements.dark_mode import DarkMode as dark_mode
 from .elements.date import Date as date
 from .elements.dialog import Dialog as dialog
 from .elements.echart import EChart as echart
+from .elements.editor import Editor as editor
 from .elements.expansion import Expansion as expansion
 from .elements.grid import Grid as grid
 from .elements.html import Html as html

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,0 +1,14 @@
+
+from nicegui import ui
+
+from .screen import Screen
+
+
+def test_editor(screen: Screen):
+    editor = ui.editor(placeholder='Type something here')
+    ui.markdown().bind_content_from(editor, 'value', backward=lambda v: f'HTML code:\n```\n{v}\n```')
+
+    screen.open('/')
+    screen.find_by_class('q-editor__content').click()
+    screen.type('Hello\nworld!')
+    screen.should_contain('Hello<div>world!</div>')

--- a/website/documentation.py
+++ b/website/documentation.py
@@ -143,6 +143,7 @@ def create_full() -> None:
     load_demo(ui.scene)
     load_demo(ui.tree)
     load_demo(ui.log)
+    load_demo(ui.editor)
     load_demo(ui.json_editor)
 
     heading('Layout')

--- a/website/more_documentation/editor_documentation.py
+++ b/website/more_documentation/editor_documentation.py
@@ -1,0 +1,7 @@
+from nicegui import ui
+
+
+def main_demo() -> None:
+    editor = ui.editor(placeholder='Type something here')
+    ui.markdown().bind_content_from(editor, 'value',
+                                    backward=lambda v: f'HTML code:\n```\n{v}\n```')


### PR DESCRIPTION
This PR implements a simple WYSIWYG editor based on Quasar's QEditor as requested in #1124.

```py
editor = ui.editor(placeholder='Type something here')
ui.markdown().bind_content_from(editor, 'value', backward=lambda v: f'HTML code:\n```\n{v}\n```')
```

<img width="351" alt="Screenshot 2023-09-19 at 17 05 54" src="https://github.com/zauberzeug/nicegui/assets/5767091/8f9a49ef-0ad6-476c-be49-1d1d1694edd2">
