### PR TITLE
Support multiple identical header fields in http responses "On Air"

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -43,10 +43,11 @@ class Air:
             if match:
                 new_js_object = match.group(1).decode().rstrip('}') + ", 'fly_instance_id' : '" + instance_id + "'}"
                 content = content.replace(match.group(0), f'const query = {new_js_object}'.encode())
-            response_headers = dict(response.headers)
-            response_headers['content-encoding'] = 'gzip'
+            response.headers.update({'content-encoding': 'gzip'})
             compressed = gzip.compress(content)
-            response_headers['content-length'] = str(len(compressed))
+            response.headers.update({'content-length': str(len(compressed))})
+            # NOTE the same header can occur multiple times so we send them as list of tuples
+            response_headers = [(k, v) for k, v in response.headers.items()]
             return {
                 'status_code': response.status_code,
                 'headers': response_headers,

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -47,7 +47,7 @@ class Air:
             response.headers.update({'content-encoding': 'gzip', 'content-length': str(len(compressed))})
             return {
                 'status_code': response.status_code,
-                'headers': list(response.headers.items()),  # NOTE items() concatenates values for duplicate keys
+                'headers': [(k.decode(), v.decode()) for k, v in headers.raw],
                 'content': compressed,
             }
 

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -47,7 +47,7 @@ class Air:
             response.headers.update({'content-encoding': 'gzip', 'content-length': str(len(compressed))})
             return {
                 'status_code': response.status_code,
-                'headers': [(k.decode(), v.decode()) for k, v in headers.raw],
+                'headers': response.headers.multi_items(),
                 'content': compressed,
             }
 

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -43,14 +43,11 @@ class Air:
             if match:
                 new_js_object = match.group(1).decode().rstrip('}') + ", 'fly_instance_id' : '" + instance_id + "'}"
                 content = content.replace(match.group(0), f'const query = {new_js_object}'.encode())
-            response.headers.update({'content-encoding': 'gzip'})
             compressed = gzip.compress(content)
-            response.headers.update({'content-length': str(len(compressed))})
-            # NOTE the same header can occur multiple times so we send them as list of tuples
-            response_headers = [(k, v) for k, v in response.headers.items()]
+            response.headers.update({'content-encoding': 'gzip', 'content-length': str(len(compressed))})
             return {
                 'status_code': response.status_code,
-                'headers': response_headers,
+                'headers': list(response.headers.items()),  # NOTE items() concatenates values for duplicate keys
                 'content': compressed,
             }
 


### PR DESCRIPTION
While working on #1603 it was discovered that we do not yet allow multiple 'set-cookie' entries in the header fields. This PR fixes that by transferring the response headers as list of tuples instead a dict.