### PR TITLE
add NO_NETIFACES env variable for docker releases

### DIFF
--- a/nicegui/welcome.py
+++ b/nicegui/welcome.py
@@ -41,6 +41,6 @@ async def print_message() -> None:
     if len(urls) >= 2:
         urls[-1] = 'and ' + urls[-1]
     extra = ''
-    if 'netifaces' not in globals.optional_features:
+    if 'netifaces' not in globals.optional_features and os.environ.get('NO_NETIFACES', 'false').lower() != 'true':
         extra = ' (install netifaces to show all IPs and speedup this message)'
     print(f'on {", ".join(urls)}' + extra, flush=True)

--- a/release.dockerfile
+++ b/release.dockerfile
@@ -16,7 +16,7 @@ RUN chmod 777 /resources/docker-entrypoint.sh
 
 EXPOSE 8080
 ENV PYTHONUNBUFFERED True
-ENV NO_NETIFACES=1
+ENV NO_NETIFACES=true
 
 ENTRYPOINT ["/resources/docker-entrypoint.sh"]
 CMD ["python", "main.py"]

--- a/release.dockerfile
+++ b/release.dockerfile
@@ -3,7 +3,7 @@ ARG VERSION
 
 LABEL maintainer="Zauberzeug GmbH <info@zauberzeug.com>"
 
-RUN python -m pip install nicegui==$VERSION itsdangerous isort docutils requests netifaces
+RUN python -m pip install nicegui==$VERSION itsdangerous isort docutils requests
 
 WORKDIR /app
 
@@ -16,6 +16,7 @@ RUN chmod 777 /resources/docker-entrypoint.sh
 
 EXPOSE 8080
 ENV PYTHONUNBUFFERED True
+ENV NO_NETIFACES=1
 
 ENTRYPOINT ["/resources/docker-entrypoint.sh"]
 CMD ["python", "main.py"]

--- a/website/documentation.py
+++ b/website/documentation.py
@@ -617,6 +617,7 @@ def create_full() -> None:
             This will make `ui.pyplot` and `ui.line_plot` unavailable.
         - `NICEGUI_STORAGE_PATH` (default: local ".nicegui") can be set to change the location of the storage files.
         - `MARKDOWN_CONTENT_CACHE_SIZE` (default: 1000): The maximum number of Markdown content snippets that are cached in memory.
+        - `NO_NETIFACES` (default: `false`): Can be set to `true` to hide the netifaces startup warning (e.g. in docker container).
     ''')
     def env_var_demo():
         from nicegui.elements import markdown


### PR DESCRIPTION
This pull request introduces `NO_NETIFACES` which can be set to `true` to hide the warning about netifaces not beeing installed. That simplifies/cleans/fixes the docker release build where `netifaces` needs gcc to build on arm.