### PR TITLE
Defaulting Element Styling

### DIFF
--- a/website/more_documentation/button_documentation.py
+++ b/website/more_documentation/button_documentation.py
@@ -57,3 +57,14 @@ def more() -> None:
                     ui.notify(f'Response code: {response.status_code}')
 
         ui.button('Get slow response', on_click=lambda e: get_slow_response(e.sender))
+
+    @text_demo('Utilizing default props', '''
+            This shows utilizing default props to style multiple buttons.
+        ''')
+    def default_props() -> None:
+        ui.button("no props")
+        ui.button.default_props('square outline')
+        ui.button("new")
+        ui.button("props")
+        ui.button.default_props(remove='square outline')
+        ui.button("no props")


### PR DESCRIPTION
Per discussion https://github.com/zauberzeug/nicegui/discussions/1683 here is a POC for defaulting props. This will let clusters of elements or full pages to be set to the same props. The `default_props` method retains all the same arguments and functionality of the `props` method. Note that `default_props` modifies elements during `__init__` therefore after instantiation elements will no longer be modified by changes initiated by `default_props` to the class attribute.

If this looks promising I a can extend this to classes and/or style as well per the original discussion.