### PR TITLE
Add expand/collapse functions to ui.tree and warn when using the expand_all prop

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,37 @@
+from nicegui import ui
+
+from .screen import Screen
+
+
+def test_tree(screen: Screen):
+    ui.tree([
+        {'id': 'numbers', 'children': [{'id': '1'}, {'id': '2'}]},
+        {'id': 'letters', 'children': [{'id': 'A'}, {'id': 'B'}]},
+    ], label_key='id')
+
+    screen.open('/')
+    screen.should_contain('numbers')
+    screen.should_contain('letters')
+    screen.should_not_contain('1')
+    screen.should_not_contain('2')
+    screen.should_not_contain('A')
+    screen.should_not_contain('B')
+
+    screen.find_by_class('q-icon').click()
+    screen.should_contain('1')
+    screen.should_contain('2')
+
+
+def test_default_expand_all(screen: Screen):
+    ui.tree([
+        {'id': 'numbers', 'children': [{'id': '1'}, {'id': '2'}]},
+        {'id': 'letters', 'children': [{'id': 'A'}, {'id': 'B'}]},
+    ], label_key='id', default_expand_all=True)
+
+    screen.open('/')
+    screen.should_contain('numbers')
+    screen.should_contain('letters')
+    screen.should_contain('1')
+    screen.should_contain('2')
+    screen.should_contain('A')
+    screen.should_contain('B')

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -22,16 +22,43 @@ def test_tree(screen: Screen):
     screen.should_contain('2')
 
 
-def test_default_expand_all(screen: Screen):
-    ui.tree([
+def test_expand_and_collapse_nodes(screen: Screen):
+    tree = ui.tree([
         {'id': 'numbers', 'children': [{'id': '1'}, {'id': '2'}]},
         {'id': 'letters', 'children': [{'id': 'A'}, {'id': 'B'}]},
-    ], label_key='id', default_expand_all=True)
+    ], label_key='id')
+
+    ui.button('Expand all', on_click=tree.expand)
+    ui.button('Collapse all', on_click=tree.collapse)
+    ui.button('Expand numbers', on_click=lambda: tree.expand(['numbers']))
+    ui.button('Collapse numbers', on_click=lambda: tree.collapse(['numbers']))
 
     screen.open('/')
-    screen.should_contain('numbers')
-    screen.should_contain('letters')
+    screen.click('Expand all')
+    screen.wait(0.5)
     screen.should_contain('1')
     screen.should_contain('2')
+    screen.should_contain('A')
+    screen.should_contain('B')
+
+    screen.click('Collapse all')
+    screen.wait(0.5)
+    screen.should_not_contain('1')
+    screen.should_not_contain('2')
+    screen.should_not_contain('A')
+    screen.should_not_contain('B')
+
+    screen.click('Expand numbers')
+    screen.wait(0.5)
+    screen.should_contain('1')
+    screen.should_contain('2')
+    screen.should_not_contain('A')
+    screen.should_not_contain('B')
+
+    screen.click('Expand all')
+    screen.click('Collapse numbers')
+    screen.wait(0.5)
+    screen.should_not_contain('1')
+    screen.should_not_contain('2')
     screen.should_contain('A')
     screen.should_contain('B')

--- a/website/more_documentation/tree_documentation.py
+++ b/website/more_documentation/tree_documentation.py
@@ -34,26 +34,20 @@ def more() -> None:
             <span :props="props">Description: "{{ props.node.description }}"</span>
         ''')
 
-    @text_demo('Expand programmatically', '''
-        The tree can be expanded programmatically by modifying the "expanded" prop.
+    @text_demo('Expand and collapse programmatically', '''
+        The whole tree or individual nodes can be toggled programmatically using the `expand()` and `collapse()` methods.
     ''')
     def expand_programmatically():
-        from typing import List
-
-        def expand(node_ids: List[str]) -> None:
-            t._props['expanded'] = node_ids
-            t.update()
-
         with ui.row():
-            ui.button('all', on_click=lambda: expand(['A', 'B']))
-            ui.button('A', on_click=lambda: expand(['A']))
-            ui.button('B', on_click=lambda: expand(['B']))
-            ui.button('none', on_click=lambda: expand([]))
+            ui.button('+ all', on_click=lambda: t.expand())
+            ui.button('- all', on_click=lambda: t.collapse())
+            ui.button('+ A', on_click=lambda: t.expand(['A']))
+            ui.button('- A', on_click=lambda: t.collapse(['A']))
 
         t = ui.tree([
             {'id': 'A', 'children': [{'id': 'A1'}, {'id': 'A2'}]},
             {'id': 'B', 'children': [{'id': 'B1'}, {'id': 'B2'}]},
-        ], label_key='id')
+        ], label_key='id').expand()
 
     @text_demo('Tree with checkboxes', '''
         The tree can be used with checkboxes by setting the "tick-strategy" prop.


### PR DESCRIPTION
When using the `default_expand_all` prop for `ui.tree`, the expanded nodes are not synchronized correctly (see #1385).

This PR adds a new parameter `default_expand_all` for `ui.tree`, so the prop isn't needed anymore. Furthermore, it warns when the prop "default_expand_all" is still used. It also adds pytests for `ui.tree` with and without this parameter being set.