### PR TITLE
fix TabPanels.value type hint

### DIFF
--- a/nicegui/elements/tabs.py
+++ b/nicegui/elements/tabs.py
@@ -51,7 +51,7 @@ class TabPanels(ValueElement):
 
     def __init__(self,
                  tabs: Tabs, *,
-                 value: Union[Tab, TabPanel, None] = None,
+                 value: Union[Tab, TabPanel, str, None] = None,
                  on_change: Optional[Callable[..., Any]] = None,
                  animated: bool = True,
                  keep_alive: bool = True,


### PR DESCRIPTION
The `ui.tab_panels` argument `value` can be the name of a tab. [There is an example in the documentation](https://nicegui.io/documentation/tabs#name__label__icon) where the argument `value` of `ui.tab_panels` is given as a string.
However, the argument `value` of `ui.tab_panels` does not allow strings, and VS Code type checking, etc. will show an error.

![image](https://github.com/zauberzeug/nicegui/assets/7953751/64b586ff-7da1-4941-9e28-f11151d683b5)
