### PR TITLE
Fix for ctrl-c not closing the pywebview window.

### DIFF
--- a/nicegui/native_mode.py
+++ b/nicegui/native_mode.py
@@ -106,7 +106,7 @@ def activate(host: str, port: int, title: str, width: int, height: int, fullscre
 
     mp.freeze_support()
     args = host, port, title, width, height, fullscreen, frameless, native.method_queue, native.response_queue
-    process = mp.Process(target=open_window, args=args, daemon=False)
+    process = mp.Process(target=open_window, args=args, daemon=True)
     process.start()
 
     Thread(target=check_shutdown, daemon=True).start()


### PR DESCRIPTION
Changes the process, in which the pywebview window runs, to a daemon.
This causes the pywebview window to terminate once the uvicorn server stops, which causes the main process to finish, unless user code comes after ui.run().

I have run ***most*** tests with succes.
There is at least one race condition that affects multiple tests, which I have fixed and will open an issue and corresponding pull request for.

The only failed tests that remain are these:
![image](https://github.com/zauberzeug/nicegui/assets/24941186/b22d5fc0-5082-47bb-9b9e-e4b819745c61)

These are probably unrelated to the change in native mode, as I'm certain that the native_mode.py code is never called during the tests.

I will investigate these a bit more, as most, if not all, seem to be platform dependent.
I will open an issue for this for a more detailed discussion.

Until then, this pull request probably has to stay open in order to conform to the formalities.

fixes #604