### PR TITLE
Warn if notification can not be displayed

### DIFF
--- a/nicegui/functions/notify.py
+++ b/nicegui/functions/notify.py
@@ -49,4 +49,7 @@ def notify(message: Any, *,
     options = {ARG_MAP.get(key, key): value for key, value in locals().items() if key != 'kwargs' and value is not None}
     options['message'] = str(message)
     options.update(kwargs)
-    outbox.enqueue_message('notify', options, globals.get_client().id)
+    if not globals.get_client().has_socket_connection:
+        globals.log.warning(f'notification "{message}" was ignored because the client is not connected')
+    else:
+        outbox.enqueue_message('notify', options, globals.get_client().id)

--- a/nicegui/functions/notify.py
+++ b/nicegui/functions/notify.py
@@ -49,7 +49,7 @@ def notify(message: Any, *,
     options = {ARG_MAP.get(key, key): value for key, value in locals().items() if key != 'kwargs' and value is not None}
     options['message'] = str(message)
     options.update(kwargs)
-    if not globals.get_client().has_socket_connection:
-        globals.log.warning(f'notification "{message}" was ignored because the client is not connected')
-    else:
+    if globals.get_client().has_socket_connection:
         outbox.enqueue_message('notify', options, globals.get_client().id)
+    else:
+        globals.log.warning(f'Ignoring notification "{message}" because the client is not connected.')


### PR DESCRIPTION
Initially raised on [Discord](https://discord.com/channels/1089836369431498784/1159483459341926491), this pull request adds a warning if `ui.notify` is called before the client is connected.