### PR TITLE
Simplifying tree example and showing disable feature

### DIFF
--- a/website/more_documentation/tree_documentation.py
+++ b/website/more_documentation/tree_documentation.py
@@ -36,18 +36,19 @@ def more() -> None:
 
     @text_demo('Expand and collapse programmatically', '''
         The whole tree or individual nodes can be toggled programmatically using the `expand()` and `collapse()` methods.
+        This even works if a node is disabled (eg. not clickable by the user).
     ''')
     def expand_programmatically():
-        with ui.row():
-            ui.button('+ all', on_click=lambda: t.expand())
-            ui.button('- all', on_click=lambda: t.collapse())
-            ui.button('+ A', on_click=lambda: t.expand(['A']))
-            ui.button('- A', on_click=lambda: t.collapse(['A']))
-
         t = ui.tree([
-            {'id': 'A', 'children': [{'id': 'A1'}, {'id': 'A2'}]},
+            {'id': 'A', 'disabled': True, 'children': [{'id': 'A1'}, {'id': 'A2'}]},
             {'id': 'B', 'children': [{'id': 'B1'}, {'id': 'B2'}]},
         ], label_key='id').expand()
+
+        with ui.row():
+            ui.button('+ all', on_click=t.expand)
+            ui.button('- all', on_click=t.collapse)
+            ui.button('+ A', on_click=lambda: t.expand(['A']))
+            ui.button('- A', on_click=lambda: t.collapse(['A']))
 
     @text_demo('Tree with checkboxes', '''
         The tree can be used with checkboxes by setting the "tick-strategy" prop.

--- a/website/more_documentation/tree_documentation.py
+++ b/website/more_documentation/tree_documentation.py
@@ -36,11 +36,11 @@ def more() -> None:
 
     @text_demo('Expand and collapse programmatically', '''
         The whole tree or individual nodes can be toggled programmatically using the `expand()` and `collapse()` methods.
-        This even works if a node is disabled (eg. not clickable by the user).
+        This even works if a node is disabled (e.g. not clickable by the user).
     ''')
     def expand_programmatically():
         t = ui.tree([
-            {'id': 'A', 'disabled': True, 'children': [{'id': 'A1'}, {'id': 'A2'}]},
+            {'id': 'A', 'children': [{'id': 'A1'}, {'id': 'A2'}], 'disabled': True},
             {'id': 'B', 'children': [{'id': 'B1'}, {'id': 'B2'}]},
         ], label_key='id').expand()
 


### PR DESCRIPTION
This PR puts the button in the collapse-tree example to the button so we do not need the lambda. It also marks the A-node as "disabled" to show that it can still be collapsed programatically.