### PR TITLE
clarify usage of `ui.open` on auto-index pages

### DIFF
--- a/nicegui/functions/open.py
+++ b/nicegui/functions/open.py
@@ -12,10 +12,9 @@ def open(target: Union[Callable[..., Any], str], new_tab: bool = False) -> None:
     This is a browser setting and cannot be changed by the application.
     You might want to use `ui.link` and its `new_tab` parameter instead.
 
-    Note: When using an `auto-index page </documentation#auto-index_page>`_ (eg. no `@page` decorator), 
+    Note: When using an `auto-index page </documentation#auto-index_page>`_ (e.g. no `@page` decorator), 
     all clients (i.e. browsers) connected to the page will open the target URL unless a socket is specified.
     User events like button clicks provide such a socket.
-
 
     :param target: page function or string that is a an absolute URL or relative path from base URL
     :param new_tab: whether to open the target in a new tab (might be blocked by the browser)

--- a/nicegui/functions/open.py
+++ b/nicegui/functions/open.py
@@ -8,12 +8,14 @@ def open(target: Union[Callable[..., Any], str], new_tab: bool = False) -> None:
 
     Can be used to programmatically trigger redirects for a specific client.
 
-    Note that *all* clients (i.e. browsers) connected to the page will open the target URL *unless* a socket is specified.
-    User events like button clicks provide such a socket.
-
     When using the `new_tab` parameter, the browser might block the new tab.
     This is a browser setting and cannot be changed by the application.
     You might want to use `ui.link` and its `new_tab` parameter instead.
+
+    Note: When using an `auto-index page </documentation#auto-index_page>`_ (eg. no `@page` decorator), 
+    all clients (i.e. browsers) connected to the page will open the target URL unless a socket is specified.
+    User events like button clicks provide such a socket.
+
 
     :param target: page function or string that is a an absolute URL or relative path from base URL
     :param new_tab: whether to open the target in a new tab (might be blocked by the browser)


### PR DESCRIPTION
This pull request improves the documentation for `ui.open` about using it with auto-index pages.