### PR TITLE
Refresh binding before page delivery

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -91,7 +91,7 @@ def handle_startup(with_welcome_message: bool = True) -> None:
     with globals.index_client:
         for t in globals.startup_handlers:
             safe_invoke(t)
-    background_tasks.create(binding.loop(), name='refresh bindings')
+    background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(outbox.loop(), name='send outbox')
     background_tasks.create(prune_clients(), name='prune clients')
     background_tasks.create(prune_slot_stacks(), name='prune slot stacks')

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from fastapi import Request, Response
 
-from . import background_tasks, globals  # pylint: disable=redefined-builtin
+from . import background_tasks, binding, globals  # pylint: disable=redefined-builtin
 from .client import Client
 from .favicon import create_favicon_route
 from .language import Language
@@ -100,6 +100,7 @@ class page:
                 result = task.result() if task.done() else None
             if isinstance(result, Response):  # NOTE if setup returns a response, we don't need to render the page
                 return result
+            binding._refresh_step()  # pylint: disable=protected-access
             return client.build_response(request)
 
         parameters = [p for p in inspect.signature(func).parameters.values() if p.name != 'client']

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -1,4 +1,3 @@
-
 from selenium.webdriver.common.keys import Keys
 
 from nicegui import ui
@@ -83,3 +82,15 @@ def test_binding_to_input(screen: Screen):
     element.value = 'five'
     screen.should_contain_input('five')
     assert data.text == 'five'
+
+
+def test_binding_refresh_before_page_delivery(screen: Screen):
+    state = {'count': 0}
+
+    @ui.page('/')
+    def main_page() -> None:
+        ui.label().bind_text_from(state, 'count')
+        state['count'] += 1
+
+    screen.open('/')
+    screen.should_contain('1')


### PR DESCRIPTION
Following up on the discussion #1561 with @laserir, this PR adds another binding refresh step right before generating the page response. This fixes this minimal example:

```py
state = {'count': 0}

@ui.page('/')
def main_page() -> None:
    ui.label().bind_text_from(state, 'count')
    state['count'] += 1
    print(state)  # Output: 1, but label still displays 0
```