### PR TITLE
Introduce `validate()` method for validation elements

### DIFF
--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -15,13 +15,17 @@ class ValidationElement(ValueElement):
         """The latest error message from the validation functions."""
         return self._error
 
-    def on_value_change(self, value: Any) -> None:
-        super().on_value_change(value)
+    def validate(self) -> None:
+        """Validate the current value and set the error message if necessary."""
         for message, check in self.validation.items():
-            if not check(value):
+            if not check(self.value):
                 self._error = message
                 self.props(f'error error-message="{message}"')
                 break
         else:
             self._error = None
             self.props(remove='error')
+
+    def on_value_change(self, value: Any) -> None:
+        super().on_value_change(value)
+        self.validate()


### PR DESCRIPTION
Inspired by a discussion [on Discord](https://discord.com/channels/1089836369431498784/1161056791925375016/1161056791925375016) this PR introduces a `validate()` method for validation elements. This allows to trigger the input validation programmatically, i.e. if some other dependency updates:
```py
pw1 = ui.input('Password', password=True, on_change=lambda: pw2.validate())
pw2 = ui.input('Password2', password=True, validation={'Passwords must match': lambda x: x == pw1.value})
```