### PR TITLE
Use flex layout per default for layout elements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,8 @@
   "prettier.printWidth": 120,
   "pylint.args": [
     "--disable=C0103", // Invalid name (e.g., variable/function/class naming conventions)
-    "--disable=C0111", // Missing docstring (in function/class/method)
+    "--disable=C0114", // Missing module docstring
+    "--disable=C0115", // Missing class docstring
     "--disable=C0301", // Line too long (exceeds character limit)
     "--disable=C0302", // Too many lines in module
     "--disable=R0801", // Similar lines in files

--- a/examples/custom_binding/main.py
+++ b/examples/custom_binding/main.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import random
-from typing import Optional, Self, cast
+from typing import Optional
+
+from typing_extensions import Self, cast
 
 from nicegui import ui
 from nicegui.binding import BindableProperty, bind_from

--- a/examples/custom_binding/main.py
+++ b/examples/custom_binding/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import random
-from typing import Optional
+from typing import Optional, Self, cast
 
 from nicegui import ui
 from nicegui.binding import BindableProperty, bind_from
@@ -10,13 +10,14 @@ class colorful_label(ui.label):
     """A label with a bindable background color."""
 
     # This class variable defines what happens when the background property changes.
-    background = BindableProperty(on_change=lambda sender, value: sender.on_background_change(value))
+    background = BindableProperty(
+        on_change=lambda sender, value: cast(Self, sender)._handle_background_change(value))
 
     def __init__(self, text: str = '') -> None:
         super().__init__(text)
         self.background: Optional[str] = None  # initialize the background property
 
-    def on_background_change(self, bg_class: str) -> None:
+    def _handle_background_change(self, bg_class: str) -> None:
         """Update the classes of the label when the background property changes."""
         self._classes = [c for c in self._classes if not c.startswith('bg-')]
         self._classes.append(bg_class)

--- a/examples/docker_image/app/main.py
+++ b/examples/docker_image/app/main.py
@@ -9,9 +9,9 @@ def index():
         .classes('w-96').bind_value(app.storage.user, 'note')
 
 
-def on_shutdown():
+def handle_shutdown():
     print('Shutdown has been initiated!')
 
 
-app.on_shutdown(on_shutdown)
+app.on_shutdown(handle_shutdown)
 ui.run(storage_secret=os.environ['STORAGE_SECRET'])

--- a/examples/lightbox/main.py
+++ b/examples/lightbox/main.py
@@ -13,7 +13,7 @@ class Lightbox:
 
     def __init__(self) -> None:
         with ui.dialog().props('maximized').classes('bg-black') as self.dialog:
-            ui.keyboard(self._on_key)
+            ui.keyboard(self._handle_key)
             self.large_image = ui.image().props('no-spinner fit=scale-down')
         self.image_list: List[str] = []
 
@@ -23,7 +23,7 @@ class Lightbox:
         with ui.button(on_click=lambda: self._open(orig_url)).props('flat dense square'):
             return ui.image(thumb_url)
 
-    def _on_key(self, event_args: events.KeyEventArguments) -> None:
+    def _handle_key(self, event_args: events.KeyEventArguments) -> None:
         if not event_args.action.keydown:
             return
         if event_args.key.escape:

--- a/fetch_tailwind.py
+++ b/fetch_tailwind.py
@@ -112,6 +112,7 @@ with (Path(__file__).parent / 'nicegui' / 'tailwind.py').open('w') as f:
     f.write('        self._classes: List[str] = []\n')
     f.write('\n')
     f.write('    def classes(self, add: str) -> None:\n')
+    f.write('        """Add the given classes to the element."""\n')
     f.write('        self._classes.append(add)\n')
     f.write('\n')
     f.write('\n')
@@ -138,6 +139,7 @@ with (Path(__file__).parent / 'nicegui' / 'tailwind.py').open('w') as f:
     f.write('        return self\n')
     f.write('\n')
     f.write("    def apply(self, element: Element) -> None:\n")
+    f.write('        """Apply the tailwind classes to the given element."""\n')
     f.write('        element._classes.extend(self.element._classes)  # pylint: disable=protected-access\n')
     f.write('        element.update()\n')
     for property_ in properties:

--- a/main.py
+++ b/main.py
@@ -33,10 +33,10 @@ app.add_static_files('/fonts', str(Path(__file__).parent / 'website' / 'fonts'))
 app.add_static_files('/static', str(Path(__file__).parent / 'website' / 'static'))
 
 if True:  # HACK: prevent the page from scrolling when closing a dialog (#1404)
-    def on_dialog_value_change(sender, value, on_value_change=ui.dialog._on_value_change) -> None:
+    def _handle_value_change(sender, value, on_value_change=ui.dialog._handle_value_change) -> None:
         ui.query('html').classes(**{'add' if value else 'remove': 'has-dialog'})
         on_value_change(sender, value)
-    ui.dialog._on_value_change = on_dialog_value_change
+    ui.dialog._handle_value_change = _handle_value_change
 
 
 @app.get('/logo.png')

--- a/main.py
+++ b/main.py
@@ -33,10 +33,10 @@ app.add_static_files('/fonts', str(Path(__file__).parent / 'website' / 'fonts'))
 app.add_static_files('/static', str(Path(__file__).parent / 'website' / 'static'))
 
 if True:  # HACK: prevent the page from scrolling when closing a dialog (#1404)
-    def on_dialog_value_change(sender, value, on_value_change=ui.dialog.on_value_change) -> None:
+    def on_dialog_value_change(sender, value, on_value_change=ui.dialog._on_value_change) -> None:
         ui.query('html').classes(**{'add' if value else 'remove': 'has-dialog'})
         on_value_change(sender, value)
-    ui.dialog.on_value_change = on_dialog_value_change
+    ui.dialog._on_value_change = on_dialog_value_change
 
 
 @app.get('/logo.png')

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -107,6 +107,7 @@ class Air:
             await self.connect()
 
     async def connect(self) -> None:
+        """Connect to the NiceGUI On Air server."""
         if self.connecting:
             return
         self.connecting = True
@@ -133,8 +134,10 @@ class Air:
         self.connecting = False
 
     async def disconnect(self) -> None:
+        """Disconnect from the NiceGUI On Air server."""
         await self.relay.disconnect()
 
     async def emit(self, message_type: str, data: Dict[str, Any], room: str) -> None:
+        """Emit a message to the NiceGUI On Air server."""
         if self.relay.connected:
             await self.relay.emit('forward', {'event': message_type, 'data': data, 'room': room})

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -22,7 +22,7 @@ class Air:
         self.connecting = False
 
         @self.relay.on('http')
-        async def on_http(data: Dict[str, Any]) -> Dict[str, Any]:
+        async def _handle_http(data: Dict[str, Any]) -> Dict[str, Any]:
             headers: Dict[str, Any] = data['headers']
             headers.update({'Accept-Encoding': 'identity', 'X-Forwarded-Prefix': data['prefix']})
             url = 'http://test' + data['path']
@@ -52,16 +52,16 @@ class Air:
             }
 
         @self.relay.on('ready')
-        def on_ready(data: Dict[str, Any]) -> None:
+        def _handle_ready(data: Dict[str, Any]) -> None:
             globals.app.urls.add(data['device_url'])
             print(f'NiceGUI is on air at {data["device_url"]}', flush=True)
 
         @self.relay.on('error')
-        def on_error(data: Dict[str, Any]) -> None:
+        def _handleerror(data: Dict[str, Any]) -> None:
             print('Error:', data['message'], flush=True)
 
         @self.relay.on('handshake')
-        def on_handshake(data: Dict[str, Any]) -> bool:
+        def _handle_handshake(data: Dict[str, Any]) -> bool:
             client_id = data['client_id']
             if client_id not in globals.clients:
                 return False
@@ -72,7 +72,7 @@ class Air:
             return True
 
         @self.relay.on('client_disconnect')
-        def on_disconnect(data: Dict[str, Any]) -> None:
+        def _handle_disconnect(data: Dict[str, Any]) -> None:
             client_id = data['client_id']
             if client_id not in globals.clients:
                 return
@@ -80,7 +80,7 @@ class Air:
             client.disconnect_task = background_tasks.create(handle_disconnect(client))
 
         @self.relay.on('event')
-        def on_event(data: Dict[str, Any]) -> None:
+        def _handle_event(data: Dict[str, Any]) -> None:
             client_id = data['client_id']
             if client_id not in globals.clients:
                 return
@@ -90,7 +90,7 @@ class Air:
             handle_event(client, data['msg'])
 
         @self.relay.on('javascript_response')
-        def on_javascript_response(data: Dict[str, Any]) -> None:
+        def _handle_javascript_response(data: Dict[str, Any]) -> None:
             client_id = data['client_id']
             if client_id not in globals.clients:
                 return
@@ -98,12 +98,12 @@ class Air:
             handle_javascript_response(client, data['msg'])
 
         @self.relay.on('out_of_time')
-        async def on_move() -> None:
+        async def _handle_out_of_time() -> None:
             print('Sorry, you have reached the time limit of this NiceGUI On Air preview.', flush=True)
             await self.connect()
 
         @self.relay.on('reconnect')
-        async def on_reconnect(_: Dict[str, Any]) -> None:
+        async def _handle_reconnect(_: Dict[str, Any]) -> None:
             await self.connect()
 
     async def connect(self) -> None:

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -13,19 +13,19 @@ bindable_properties: Dict[Tuple[int, str], Any] = {}
 active_links: List[Tuple[Any, str, Any, str, Callable[[Any], Any]]] = []
 
 
-def has_attribute(obj: Union[object, Mapping], name: str) -> Any:
+def _has_attribute(obj: Union[object, Mapping], name: str) -> Any:
     if isinstance(obj, Mapping):
         return name in obj
     return hasattr(obj, name)
 
 
-def get_attribute(obj: Union[object, Mapping], name: str) -> Any:
+def _get_attribute(obj: Union[object, Mapping], name: str) -> Any:
     if isinstance(obj, Mapping):
         return obj[name]
     return getattr(obj, name)
 
 
-def set_attribute(obj: Union[object, Mapping], name: str, value: Any) -> None:
+def _set_attribute(obj: Union[object, Mapping], name: str, value: Any) -> None:
     if isinstance(obj, dict):
         obj[name] = value
     else:
@@ -33,6 +33,7 @@ def set_attribute(obj: Union[object, Mapping], name: str, value: Any) -> None:
 
 
 async def refresh_loop() -> None:
+    """Refresh all bindings in an endless loop."""
     while True:
         _refresh_step()
         await asyncio.sleep(globals.binding_refresh_interval)
@@ -43,47 +44,78 @@ def _refresh_step():
     t = time.time()
     for link in active_links:
         (source_obj, source_name, target_obj, target_name, transform) = link
-        if has_attribute(source_obj, source_name):
-            value = transform(get_attribute(source_obj, source_name))
-            if not has_attribute(target_obj, target_name) or get_attribute(target_obj, target_name) != value:
-                set_attribute(target_obj, target_name, value)
-                propagate(target_obj, target_name, visited)
+        if _has_attribute(source_obj, source_name):
+            value = transform(_get_attribute(source_obj, source_name))
+            if not _has_attribute(target_obj, target_name) or _get_attribute(target_obj, target_name) != value:
+                _set_attribute(target_obj, target_name, value)
+                _propagate(target_obj, target_name, visited)
         del link, source_obj, target_obj  # pylint: disable=modified-iterating-list
     if time.time() - t > MAX_PROPAGATION_TIME:
         globals.log.warning(
             f'binding propagation for {len(active_links)} active links took {time.time() - t:.3f} s')
 
 
-def propagate(source_obj: Any, source_name: str, visited: Optional[Set[Tuple[int, str]]] = None) -> None:
+def _propagate(source_obj: Any, source_name: str, visited: Optional[Set[Tuple[int, str]]] = None) -> None:
     if visited is None:
         visited = set()
     visited.add((id(source_obj), source_name))
     for _, target_obj, target_name, transform in bindings.get((id(source_obj), source_name), []):
         if (id(target_obj), target_name) in visited:
             continue
-        if has_attribute(source_obj, source_name):
-            target_value = transform(get_attribute(source_obj, source_name))
-            if not has_attribute(target_obj, target_name) or get_attribute(target_obj, target_name) != target_value:
-                set_attribute(target_obj, target_name, target_value)
-                propagate(target_obj, target_name, visited)
+        if _has_attribute(source_obj, source_name):
+            target_value = transform(_get_attribute(source_obj, source_name))
+            if not _has_attribute(target_obj, target_name) or _get_attribute(target_obj, target_name) != target_value:
+                _set_attribute(target_obj, target_name, target_value)
+                _propagate(target_obj, target_name, visited)
 
 
 def bind_to(self_obj: Any, self_name: str, other_obj: Any, other_name: str, forward: Callable[[Any], Any]) -> None:
+    """Bind the property of one object to the property of another object.
+
+    The binding works one way only, from the first object to the second.
+
+    :param self_obj: The object to bind from.
+    :param self_name: The name of the property to bind from.
+    :param other_obj: The object to bind to.
+    :param other_name: The name of the property to bind to.
+    :param forward: A function to apply to the value before applying it.
+    """
     bindings[(id(self_obj), self_name)].append((self_obj, other_obj, other_name, forward))
     if (id(self_obj), self_name) not in bindable_properties:
         active_links.append((self_obj, self_name, other_obj, other_name, forward))
-    propagate(self_obj, self_name)
+    _propagate(self_obj, self_name)
 
 
 def bind_from(self_obj: Any, self_name: str, other_obj: Any, other_name: str, backward: Callable[[Any], Any]) -> None:
+    """Bind the property of one object from the property of another object.
+
+    The binding works one way only, from the second object to the first.
+
+    :param self_obj: The object to bind to.
+    :param self_name: The name of the property to bind to.
+    :param other_obj: The object to bind from.
+    :param other_name: The name of the property to bind from.
+    :param backward: A function to apply to the value before applying it.
+    """
     bindings[(id(other_obj), other_name)].append((other_obj, self_obj, self_name, backward))
     if (id(other_obj), other_name) not in bindable_properties:
         active_links.append((other_obj, other_name, self_obj, self_name, backward))
-    propagate(other_obj, other_name)
+    _propagate(other_obj, other_name)
 
 
 def bind(self_obj: Any, self_name: str, other_obj: Any, other_name: str, *,
          forward: Callable[[Any], Any] = lambda x: x, backward: Callable[[Any], Any] = lambda x: x) -> None:
+    """Bind the property of one object to the property of another object.
+
+    The binding works both ways, from the first object to the second and from the second to the first.
+
+    :param self_obj: First object to bind.
+    :param self_name: The name of the first property to bind.
+    :param other_obj: The second object to bind.
+    :param other_name: The name of the second property to bind.
+    :param forward: A function to apply to the value before applying it to the second object.
+    :param backward: A function to apply to the value before applying it to the first object.
+    """
     bind_from(self_obj, self_name, other_obj, other_name, backward=backward)
     bind_to(self_obj, self_name, other_obj, other_name, forward=forward)
 
@@ -106,12 +138,19 @@ class BindableProperty:
             return
         setattr(owner, '___' + self.name, value)
         bindable_properties[(id(owner), self.name)] = owner
-        propagate(owner, self.name)
+        _propagate(owner, self.name)
         if value_changed and self.on_change is not None:
             self.on_change(owner, value)
 
 
 def remove(objects: Iterable[Any], type_: Type) -> None:
+    """Remove all bindings that involve the given objects.
+
+    The ``type_`` argument is as a quick pre-filter.
+
+    :param objects: The objects to remove.
+    :param type_: The type of the objects to remove.
+    """
     active_links[:] = [
         (source_obj, source_name, target_obj, target_name, transform)
         for source_obj, source_name, target_obj, target_name, transform in active_links

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -123,7 +123,7 @@ def bind(self_obj: Any, self_name: str, other_obj: Any, other_name: str, *,
 class BindableProperty:
 
     def __init__(self, on_change: Optional[Callable[..., Any]] = None) -> None:
-        self.on_change = on_change
+        self._change_handler = on_change
 
     def __set_name__(self, _, name: str) -> None:
         self.name = name  # pylint: disable=attribute-defined-outside-init
@@ -139,8 +139,8 @@ class BindableProperty:
         setattr(owner, '___' + self.name, value)
         bindable_properties[(id(owner), self.name)] = owner
         _propagate(owner, self.name)
-        if value_changed and self.on_change is not None:
-            self.on_change(owner, value)
+        if value_changed and self._change_handler is not None:
+            self._change_handler(owner, value)
 
 
 def remove(objects: Iterable[Any], type_: Type) -> None:

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -172,7 +172,7 @@ class Client:
         for element_id in element_ids:
             del self.elements[element_id]
         for element in elements:
-            element._on_delete()  # pylint: disable=protected-access
+            element._handle_delete()  # pylint: disable=protected-access
             element._deleted = True  # pylint: disable=protected-access
             outbox.enqueue_delete(element)
 

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -73,6 +73,7 @@ class Client:
         self.content.__exit__()
 
     def build_response(self, request: Request, status_code: int = 200) -> Response:
+        """Build a FastAPI response for the client."""
         prefix = request.headers.get('X-Forwarded-Prefix', request.scope.get('root_path', ''))
         elements = json.dumps({
             id: element._to_dict() for id, element in self.elements.items()  # pylint: disable=protected-access

--- a/nicegui/dependencies.py
+++ b/nicegui/dependencies.py
@@ -22,6 +22,7 @@ class Component:
 
     @property
     def tag(self) -> str:
+        """The tag of the component."""
         return f'nicegui-{self.name}'
 
 
@@ -58,7 +59,7 @@ def register_vue_component(path: Path) -> Component:
     and to avoid building the component on every single request.
     """
     key = compute_key(path)
-    name = get_name(path)
+    name = _get_name(path)
     if path.suffix == '.vue':
         if key in vue_components and vue_components[key].path == path:
             return vue_components[key]
@@ -78,7 +79,7 @@ def register_vue_component(path: Path) -> Component:
 def register_library(path: Path, *, expose: bool = False) -> Library:
     """Register a *.js library."""
     key = compute_key(path)
-    name = get_name(path)
+    name = _get_name(path)
     if path.suffix in {'.js', '.mjs'}:
         if key in libraries and libraries[key].path == path:
             return libraries[key]
@@ -101,7 +102,7 @@ def compute_key(path: Path) -> str:
     return f'{hash_file_path(path.parent)}/{path.name}'
 
 
-def get_name(path: Path) -> str:
+def _get_name(path: Path) -> str:
     return path.name.split('.', 1)[0]
 
 
@@ -110,6 +111,7 @@ def generate_resources(prefix: str, elements: Iterable[Element]) -> Tuple[List[s
                                                                           List[str],
                                                                           Dict[str, str],
                                                                           List[str]]:
+    """Generate the resources required by the elements to be sent to the client."""
     done_libraries: Set[str] = set()
     done_components: Set[str] = set()
     vue_scripts: List[str] = []

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -422,7 +422,7 @@ class Element(Visibility):
         assert self.parent_slot is not None
         self.parent_slot.children.remove(self)
 
-    def _on_delete(self) -> None:
+    def _handle_delete(self) -> None:
         """Called when the element is deleted.
 
         This method can be overridden in subclasses to perform cleanup tasks.

--- a/nicegui/elements/aggrid.py
+++ b/nicegui/elements/aggrid.py
@@ -77,6 +77,7 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
 
     @property
     def options(self) -> Dict:
+        """The options dictionary."""
         return self._props['options']
 
     def update(self) -> None:

--- a/nicegui/elements/audio.py
+++ b/nicegui/elements/audio.py
@@ -1,4 +1,3 @@
-import warnings
 from pathlib import Path
 from typing import Union
 
@@ -13,7 +12,6 @@ class Audio(Element, component='audio.js'):
                  autoplay: bool = False,
                  muted: bool = False,
                  loop: bool = False,
-                 type: str = '',  # DEPRECATED, pylint: disable=redefined-builtin
                  ) -> None:
         """Audio
 
@@ -36,10 +34,6 @@ class Audio(Element, component='audio.js'):
         self._props['autoplay'] = autoplay
         self._props['muted'] = muted
         self._props['loop'] = loop
-
-        if type:
-            url = 'https://github.com/zauberzeug/nicegui/pull/624'
-            warnings.warn(DeprecationWarning(f'The type parameter for ui.audio is deprecated and ineffective ({url}).'))
 
     def seek(self, seconds: float) -> None:
         """Seek to a specific position in the audio.

--- a/nicegui/elements/carousel.py
+++ b/nicegui/elements/carousel.py
@@ -65,5 +65,6 @@ class CarouselSlide(DisableableElement):
         self.carousel = cast(ValueElement, globals.get_slot().parent)
         name = name or f'slide_{len(self.carousel.default_slot.children)}'
         self._props['name'] = name
+        self._classes = ['nicegui-carousel-slide']
         if self.carousel.value is None:
             self.carousel.value = name

--- a/nicegui/elements/carousel.py
+++ b/nicegui/elements/carousel.py
@@ -35,8 +35,8 @@ class Carousel(ValueElement):
     def _value_to_model_value(self, value: Any) -> Any:
         return value._props['name'] if isinstance(value, CarouselSlide) else value  # pylint: disable=protected-access
 
-    def _on_value_change(self, value: Any) -> None:
-        super()._on_value_change(value)
+    def _handle_value_change(self, value: Any) -> None:
+        super()._handle_value_change(value)
         names = [slide._props['name'] for slide in self]  # pylint: disable=protected-access
         for i, slide in enumerate(self):
             done = i < names.index(value) if value in names else False

--- a/nicegui/elements/carousel.py
+++ b/nicegui/elements/carousel.py
@@ -35,8 +35,8 @@ class Carousel(ValueElement):
     def _value_to_model_value(self, value: Any) -> Any:
         return value._props['name'] if isinstance(value, CarouselSlide) else value  # pylint: disable=protected-access
 
-    def on_value_change(self, value: Any) -> None:
-        super().on_value_change(value)
+    def _on_value_change(self, value: Any) -> None:
+        super()._on_value_change(value)
         names = [slide._props['name'] for slide in self]  # pylint: disable=protected-access
         for i, slide in enumerate(self):
             done = i < names.index(value) if value in names else False

--- a/nicegui/elements/chart.py
+++ b/nicegui/elements/chart.py
@@ -90,6 +90,7 @@ class Chart(Element,
 
     @property
     def options(self) -> Dict:
+        """The options dictionary."""
         return self._props['options']
 
     def update(self) -> None:

--- a/nicegui/elements/code.py
+++ b/nicegui/elements/code.py
@@ -29,6 +29,7 @@ class Code(Element):
                 .props('round flat size=sm').classes('absolute right-2 top-2 opacity-20 hover:opacity-80')
 
     async def copy_to_clipboard(self) -> None:
+        """Copy the code to the clipboard."""
         await run_javascript('navigator.clipboard.writeText(`' + self.content + '`)', respond=False)
         self.copy_button.props('icon=check')
         await asyncio.sleep(3.0)

--- a/nicegui/elements/color_input.py
+++ b/nicegui/elements/color_input.py
@@ -46,8 +46,8 @@ class ColorInput(ValueElement, DisableableElement):
             self.picker.set_color(self.value)
         self.picker.open()
 
-    def on_value_change(self, value: Any) -> None:
-        super().on_value_change(value)
+    def _on_value_change(self, value: Any) -> None:
+        super()._on_value_change(value)
         self._update_preview()
 
     def _update_preview(self) -> None:

--- a/nicegui/elements/color_input.py
+++ b/nicegui/elements/color_input.py
@@ -46,8 +46,8 @@ class ColorInput(ValueElement, DisableableElement):
             self.picker.set_color(self.value)
         self.picker.open()
 
-    def _on_value_change(self, value: Any) -> None:
-        super()._on_value_change(value)
+    def _handle_value_change(self, value: Any) -> None:
+        super()._handle_value_change(value)
         self._update_preview()
 
     def _update_preview(self) -> None:

--- a/nicegui/elements/column.py
+++ b/nicegui/elements/column.py
@@ -3,10 +3,15 @@ from ..element import Element
 
 class Column(Element):
 
-    def __init__(self) -> None:
+    def __init__(self, *, wrap: bool = False) -> None:
         """Column Element
 
         Provides a container which arranges its child in a column.
+
+        :param wrap: whether to wrap the content (default: `False`)
         """
         super().__init__('div')
         self._classes = ['nicegui-column']
+
+        if wrap:
+            self._classes.append('wrap')

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -21,14 +21,17 @@ class Dialog(ValueElement):
 
     @property
     def submitted(self) -> asyncio.Event:
+        """An event that is set when the dialog is submitted."""
         if self._submitted is None:
             self._submitted = asyncio.Event()
         return self._submitted
 
     def open(self) -> None:
+        """Open the dialog."""
         self.value = True
 
     def close(self) -> None:
+        """Close the dialog."""
         self.value = False
 
     def __await__(self):
@@ -41,11 +44,12 @@ class Dialog(ValueElement):
         return result
 
     def submit(self, result: Any) -> None:
+        """Submit the dialog with the given result."""
         self._result = result
         self.submitted.set()
 
-    def on_value_change(self, value: Any) -> None:
-        super().on_value_change(value)
+    def _on_value_change(self, value: Any) -> None:
+        super()._on_value_change(value)
         if not self.value:
             self._result = None
             self.submitted.set()

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -48,8 +48,8 @@ class Dialog(ValueElement):
         self._result = result
         self.submitted.set()
 
-    def _on_value_change(self, value: Any) -> None:
-        super()._on_value_change(value)
+    def _handle_value_change(self, value: Any) -> None:
+        super()._handle_value_change(value)
         if not self.value:
             self._result = None
             self.submitted.set()

--- a/nicegui/elements/echart.py
+++ b/nicegui/elements/echart.py
@@ -49,6 +49,7 @@ class EChart(Element, component='echart.js', libraries=['lib/echarts/echarts.min
 
     @property
     def options(self) -> Dict:
+        """The options dictionary."""
         return self._props['options']
 
     def update(self) -> None:

--- a/nicegui/elements/expansion.py
+++ b/nicegui/elements/expansion.py
@@ -25,6 +25,7 @@ class Expansion(ValueElement, DisableableElement):
         if text is not None:
             self._props['label'] = text
         self._props['icon'] = icon
+        self._classes = ['nicegui-expansion']
 
     def open(self) -> None:
         """Open the expansion."""

--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -60,7 +60,7 @@ class Input(ValidationElement, DisableableElement, component='input.js'):
         self._props['autocomplete'] = autocomplete
         self.update()
 
-    def _on_value_change(self, value: Any) -> None:
-        super()._on_value_change(value)
+    def _handle_value_change(self, value: Any) -> None:
+        super()._handle_value_change(value)
         if self._send_update_on_value_change:
             self.run_method('updateValue')

--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -60,7 +60,7 @@ class Input(ValidationElement, DisableableElement, component='input.js'):
         self._props['autocomplete'] = autocomplete
         self.update()
 
-    def on_value_change(self, value: Any) -> None:
-        super().on_value_change(value)
+    def _on_value_change(self, value: Any) -> None:
+        super()._on_value_change(value)
         if self._send_update_on_value_change:
             self.run_method('updateValue')

--- a/nicegui/elements/json_editor.py
+++ b/nicegui/elements/json_editor.py
@@ -36,6 +36,7 @@ class JsonEditor(Element, component='json_editor.js', exposed_libraries=['lib/va
 
     @property
     def properties(self) -> Dict:
+        """The property dictionary."""
         return self._props['properties']
 
     def update(self) -> None:

--- a/nicegui/elements/keyboard.py
+++ b/nicegui/elements/keyboard.py
@@ -31,9 +31,9 @@ class Keyboard(Element, component='keyboard.js'):
         self._props['events'] = ['keydown', 'keyup']
         self._props['repeating'] = repeating
         self._props['ignore'] = ignore
-        self.on('key', self.handle_key)
+        self.on('key', self._handle_key)
 
-    def handle_key(self, e: GenericEventArguments) -> None:
+    def _handle_key(self, e: GenericEventArguments) -> None:
         if not self.active:
             return
 

--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -40,11 +40,13 @@ class Markdown(ContentElement, component='markdown.js'):
 
 @lru_cache(maxsize=int(os.environ.get('MARKDOWN_CONTENT_CACHE_SIZE', '1000')))
 def prepare_content(content: str, extras: str) -> str:
+    """Render Markdown content to HTML."""
     html = markdown2.markdown(remove_indentation(content), extras=extras.split())
     return apply_tailwind(html)  # we need explicit Markdown styling because tailwind CSS removes all default styles
 
 
 def apply_tailwind(html: str) -> str:
+    """Apply tailwind CSS classes to the HTML."""
     rep = {
         '<h1': '<h1 class="text-5xl mb-4 mt-6"',
         '<h2': '<h2 class="text-4xl mb-3 mt-5"',

--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -31,7 +31,7 @@ class Markdown(ContentElement, component='markdown.js'):
             self._props['use_mermaid'] = True
             self.libraries.append(Mermaid.exposed_libraries[0])
 
-    def on_content_change(self, content: str) -> None:
+    def _handle_content_change(self, content: str) -> None:
         html = prepare_content(content, extras=' '.join(self.extras))
         if self._props.get('innerHTML') != html:
             self._props['innerHTML'] = html

--- a/nicegui/elements/mermaid.py
+++ b/nicegui/elements/mermaid.py
@@ -17,6 +17,6 @@ class Mermaid(ContentElement,
         """
         super().__init__(content=content)
 
-    def on_content_change(self, content: str) -> None:
+    def _handle_content_change(self, content: str) -> None:
         self._props[self.CONTENT_PROP] = content.strip()
         self.run_method('update', content.strip())

--- a/nicegui/elements/mixins/content_element.py
+++ b/nicegui/elements/mixins/content_element.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable
 
-from typing_extensions import Self
+from typing_extensions import Self, cast
 
 from ...binding import BindableProperty, bind, bind_from, bind_to
 from ...element import Element
@@ -8,12 +8,13 @@ from ...element import Element
 
 class ContentElement(Element):
     CONTENT_PROP = 'innerHTML'
-    content = BindableProperty(on_change=lambda sender, content: sender.on_content_change(content))
+    content = BindableProperty(
+        on_change=lambda sender, content: cast(Self, sender)._handle_content_change(content))  # pylint: disable=protected-access
 
     def __init__(self, *, content: str, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.content = content
-        self.on_content_change(content)
+        self._handle_content_change(content)
 
     def bind_content_to(self,
                         target_object: Any,
@@ -72,7 +73,7 @@ class ContentElement(Element):
         """
         self.content = content
 
-    def on_content_change(self, content: str) -> None:
+    def _handle_content_change(self, content: str) -> None:
         """Called when the content of this element changes.
 
         :param content: The new content.

--- a/nicegui/elements/mixins/disableable_element.py
+++ b/nicegui/elements/mixins/disableable_element.py
@@ -1,13 +1,14 @@
 from typing import Any, Callable
 
-from typing_extensions import Self
+from typing_extensions import Self, cast
 
 from ...binding import BindableProperty, bind, bind_from, bind_to
 from ...element import Element
 
 
 class DisableableElement(Element):
-    enabled = BindableProperty(on_change=lambda sender, value: sender.on_enabled_change(value))
+    enabled = BindableProperty(
+        on_change=lambda sender, value: cast(Self, sender)._handle_enabled_change(value))  # pylint: disable=protected-access
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -83,7 +84,7 @@ class DisableableElement(Element):
         """Set the enabled state of the element."""
         self.enabled = value
 
-    def on_enabled_change(self, enabled: bool) -> None:
+    def _handle_enabled_change(self, enabled: bool) -> None:
         """Called when the element is enabled or disabled.
 
         :param enabled: The new state.

--- a/nicegui/elements/mixins/filter_element.py
+++ b/nicegui/elements/mixins/filter_element.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Optional
 
-from typing_extensions import Self
+from typing_extensions import Self, cast
 
 from ...binding import BindableProperty, bind, bind_from, bind_to
 from ...element import Element
@@ -8,7 +8,8 @@ from ...element import Element
 
 class FilterElement(Element):
     FILTER_PROP = 'filter'
-    filter = BindableProperty(on_change=lambda sender, filter: sender.on_filter_change(filter))
+    filter = BindableProperty(
+        on_change=lambda sender, filter: cast(Self, sender)._handle_filter_change(filter))  # pylint: disable=protected-access
 
     def __init__(self, *, filter: Optional[str] = None, **kwargs: Any) -> None:  # pylint: disable=redefined-builtin
         super().__init__(**kwargs)
@@ -72,7 +73,7 @@ class FilterElement(Element):
         """
         self.filter = filter_
 
-    def on_filter_change(self, filter_: str) -> None:
+    def _handle_filter_change(self, filter_: str) -> None:
         """Called when the filter of this element changes.
 
         :param filter: The new filter.

--- a/nicegui/elements/mixins/name_element.py
+++ b/nicegui/elements/mixins/name_element.py
@@ -1,13 +1,14 @@
 from typing import Any, Callable
 
-from typing_extensions import Self
+from typing_extensions import Self, cast
 
 from ...binding import BindableProperty, bind, bind_from, bind_to
 from ...element import Element
 
 
 class NameElement(Element):
-    name = BindableProperty(on_change=lambda sender, name: sender.on_name_change(name))
+    name = BindableProperty(
+        on_change=lambda sender, name: cast(Self, sender)._handle_name_change(name))  # pylint: disable=protected-access
 
     def __init__(self, *, name: str, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -71,7 +72,7 @@ class NameElement(Element):
         """
         self.name = name
 
-    def on_name_change(self, name: str) -> None:
+    def _handle_name_change(self, name: str) -> None:
         """Called when the name of this element changes.
 
         :param name: The new name.

--- a/nicegui/elements/mixins/source_element.py
+++ b/nicegui/elements/mixins/source_element.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Any, Callable, Union
 
-from typing_extensions import Self
+from typing_extensions import Self, cast
 
 from ... import globals  # pylint: disable=redefined-builtin
 from ...binding import BindableProperty, bind, bind_from, bind_to
@@ -10,7 +10,8 @@ from ...helpers import is_file
 
 
 class SourceElement(Element):
-    source = BindableProperty(on_change=lambda sender, source: sender.on_source_change(source))
+    source = BindableProperty(
+        on_change=lambda sender, source: cast(Self, sender)._handle_source_change(source))  # pylint: disable=protected-access
 
     def __init__(self, *, source: Union[str, Path], **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -76,7 +77,7 @@ class SourceElement(Element):
         """
         self.source = source
 
-    def on_source_change(self, source: Union[str, Path]) -> None:
+    def _handle_source_change(self, source: Union[str, Path]) -> None:
         """Called when the source of this element changes.
 
         :param source: The new source.

--- a/nicegui/elements/mixins/text_element.py
+++ b/nicegui/elements/mixins/text_element.py
@@ -1,13 +1,14 @@
 from typing import Any, Callable
 
-from typing_extensions import Self
+from typing_extensions import Self, cast
 
 from ...binding import BindableProperty, bind, bind_from, bind_to
 from ...element import Element
 
 
 class TextElement(Element):
-    text = BindableProperty(on_change=lambda sender, text: sender.on_text_change(text))
+    text = BindableProperty(
+        on_change=lambda sender, text: cast(Self, sender)._handle_text_change(text))  # pylint: disable=protected-access
 
     def __init__(self, *, text: str, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -71,7 +72,7 @@ class TextElement(Element):
         """
         self.text = text
 
-    def on_text_change(self, text: str) -> None:
+    def _handle_text_change(self, text: str) -> None:
         """Called when the text of this element changes.
 
         :param text: The new text.

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -26,6 +26,6 @@ class ValidationElement(ValueElement):
             self._error = None
             self.props(remove='error')
 
-    def _on_value_change(self, value: Any) -> None:
-        super()._on_value_change(value)
+    def _handle_value_change(self, value: Any) -> None:
+        super()._handle_value_change(value)
         self.validate()

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -26,6 +26,6 @@ class ValidationElement(ValueElement):
             self._error = None
             self.props(remove='error')
 
-    def on_value_change(self, value: Any) -> None:
-        super().on_value_change(value)
+    def _on_value_change(self, value: Any) -> None:
+        super()._on_value_change(value)
         self.validate()

--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Optional
 
-from typing_extensions import Self
+from typing_extensions import Self, cast
 
 from ...binding import BindableProperty, bind, bind_from, bind_to
 from ...element import Element
@@ -10,7 +10,8 @@ from ...events import GenericEventArguments, ValueChangeEventArguments, handle_e
 class ValueElement(Element):
     VALUE_PROP: str = 'model-value'
     LOOPBACK: bool = True
-    value = BindableProperty(on_change=lambda sender, value: sender.on_value_change(value))
+    value = BindableProperty(
+        on_change=lambda sender, value: cast(Self, sender)._handle_value_change(value))  # pylint: disable=protected-access
 
     def __init__(self, *,
                  value: Any,
@@ -23,7 +24,7 @@ class ValueElement(Element):
         self._props[self.VALUE_PROP] = self._value_to_model_value(value)
         self._props['loopback'] = self.LOOPBACK
         self._send_update_on_value_change = True
-        self.change_handler = on_value_change
+        self._change_handler = on_value_change
 
         def handle_change(e: GenericEventArguments) -> None:
             self._send_update_on_value_change = self.LOOPBACK
@@ -88,12 +89,12 @@ class ValueElement(Element):
         """
         self.value = value
 
-    def _on_value_change(self, value: Any) -> None:
+    def _handle_value_change(self, value: Any) -> None:
         self._props[self.VALUE_PROP] = self._value_to_model_value(value)
         if self._send_update_on_value_change:
             self.update()
         args = ValueChangeEventArguments(sender=self, client=self.client, value=self._value_to_event_value(value))
-        handle_event(self.change_handler, args)
+        handle_event(self._change_handler, args)
 
     def _event_args_to_value(self, e: GenericEventArguments) -> Any:
         return e.args

--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -88,11 +88,7 @@ class ValueElement(Element):
         """
         self.value = value
 
-    def on_value_change(self, value: Any) -> None:
-        """Called when the value of this element changes.
-
-        :param value: The new value.
-        """
+    def _on_value_change(self, value: Any) -> None:
         self._props[self.VALUE_PROP] = self._value_to_model_value(value)
         if self._send_update_on_value_change:
             self.update()

--- a/nicegui/elements/mixins/visibility.py
+++ b/nicegui/elements/mixins/visibility.py
@@ -11,7 +11,8 @@ if TYPE_CHECKING:
 
 
 class Visibility:
-    visible = BindableProperty(on_change=lambda sender, visible: sender.on_visibility_change(visible))
+    visible = BindableProperty(
+        on_change=lambda sender, visible: cast(Self, sender)._handle_visibility_change(visible))  # pylint: disable=protected-access
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -89,7 +90,7 @@ class Visibility:
         """
         self.visible = visible
 
-    def on_visibility_change(self, visible: str) -> None:
+    def _handle_visibility_change(self, visible: str) -> None:
         """Called when the visibility of this element changes.
 
         :param visible: Whether the element should be visible.

--- a/nicegui/elements/row.py
+++ b/nicegui/elements/row.py
@@ -3,10 +3,15 @@ from ..element import Element
 
 class Row(Element):
 
-    def __init__(self) -> None:
+    def __init__(self, *, wrap: bool = False) -> None:
         """Row Element
 
         Provides a container which arranges its child in a row.
+
+        :param wrap: whether to wrap the content (default: `False`)
         """
         super().__init__('div')
         self._classes = ['nicegui-row']
+
+        if wrap:
+            self._classes.append('wrap')

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -92,10 +92,10 @@ class Scene(Element,
         self.on_drag_start = on_drag_start
         self.on_drag_end = on_drag_end
         self.is_initialized = False
-        self.on('init', self.handle_init)
-        self.on('click3d', self.handle_click)
-        self.on('dragstart', self.handle_drag)
-        self.on('dragend', self.handle_drag)
+        self.on('init', self._handle_init)
+        self.on('click3d', self._handle_click)
+        self.on('dragstart', self._handle_drag)
+        self.on('dragend', self._handle_drag)
         self._props['drag_constraints'] = drag_constraints
 
     def __enter__(self) -> Self:
@@ -109,7 +109,7 @@ class Scene(Element,
             Object3D.current_scene = self
         return attribute
 
-    def handle_init(self, e: GenericEventArguments) -> None:
+    def _handle_init(self, e: GenericEventArguments) -> None:
         self.is_initialized = True
         with globals.socket_id(e.args['socket_id']):
             self.move_camera(duration=0)
@@ -126,7 +126,7 @@ class Scene(Element,
             return
         super().run_method(name, *args)
 
-    def handle_click(self, e: GenericEventArguments) -> None:
+    def _handle_click(self, e: GenericEventArguments) -> None:
         arguments = SceneClickEventArguments(
             sender=self,
             client=self.client,
@@ -146,7 +146,7 @@ class Scene(Element,
         )
         handle_event(self.on_click, arguments)
 
-    def handle_drag(self, e: GenericEventArguments) -> None:
+    def _handle_drag(self, e: GenericEventArguments) -> None:
         arguments = SceneDragEventArguments(
             sender=self,
             client=self.client,

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -88,9 +88,9 @@ class Scene(Element,
         self.objects: Dict[str, Object3D] = {}
         self.stack: List[Union[Object3D, SceneObject]] = [SceneObject()]
         self.camera: SceneCamera = SceneCamera()
-        self.on_click = on_click
-        self.on_drag_start = on_drag_start
-        self.on_drag_end = on_drag_end
+        self._click_handler = on_click
+        self._drag_start_handler = on_drag_start
+        self._drag_end_handler = on_drag_end
         self.is_initialized = False
         self.on('init', self._handle_init)
         self.on('click3d', self._handle_click)
@@ -144,7 +144,7 @@ class Scene(Element,
                 z=hit['point']['z'],
             ) for hit in e.args['hits']],
         )
-        handle_event(self.on_click, arguments)
+        handle_event(self._click_handler, arguments)
 
     def _handle_drag(self, e: GenericEventArguments) -> None:
         arguments = SceneDragEventArguments(
@@ -159,7 +159,7 @@ class Scene(Element,
         )
         if arguments.type == 'dragend':
             self.objects[arguments.object_id].move(arguments.x, arguments.y, arguments.z)
-        handle_event(self.on_drag_start if arguments.type == 'dragstart' else self.on_drag_end, arguments)
+        handle_event(self._drag_start_handler if arguments.type == 'dragstart' else self._drag_end_handler, arguments)
 
     def __len__(self) -> int:
         return len(self.objects)
@@ -202,9 +202,9 @@ class Scene(Element,
                         self.camera.look_at_x, self.camera.look_at_y, self.camera.look_at_z,
                         self.camera.up_x, self.camera.up_y, self.camera.up_z, duration)
 
-    def _on_delete(self) -> None:
+    def _handle_delete(self) -> None:
         binding.remove(list(self.objects.values()), Object3D)
-        super()._on_delete()
+        super()._handle_delete()
 
     def delete_objects(self, predicate: Callable[[Object3D], bool] = lambda _: True) -> None:
         """Remove objects from the scene.

--- a/nicegui/elements/scene_object3d.py
+++ b/nicegui/elements/scene_object3d.py
@@ -43,6 +43,7 @@ class Object3D:
         return self
 
     def send(self) -> None:
+        """Send the object to the client."""
         self._create()
         self._name()
         self._material()

--- a/nicegui/elements/scroll_area.py
+++ b/nicegui/elements/scroll_area.py
@@ -29,8 +29,8 @@ class ScrollArea(Element):
                 'horizontalContainerSize',
             ])
 
-    def _handle_scroll(self, on_scroll: Optional[Callable[..., Any]], e: GenericEventArguments) -> None:
-        handle_event(on_scroll, ScrollEventArguments(
+    def _handle_scroll(self, handler: Optional[Callable[..., Any]], e: GenericEventArguments) -> None:
+        handle_event(handler, ScrollEventArguments(
             sender=self,
             client=self.client,
             vertical_position=e.args['verticalPosition'],

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -1,4 +1,3 @@
-import re
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -49,14 +48,6 @@ class Select(ChoiceElement, DisableableElement, component='select.js'):
             self._props['input-debounce'] = 0
         self._props['multiple'] = multiple
         self._props['clearable'] = clearable
-
-    def on_filter(self, e: GenericEventArguments) -> None:
-        self.options = [
-            option
-            for option in self.original_options
-            if not e.args or re.search(e.args, option, re.IGNORECASE)
-        ]
-        self.update()
 
     def _event_args_to_value(self, e: GenericEventArguments) -> Any:
         # pylint: disable=no-else-return

--- a/nicegui/elements/splitter.py
+++ b/nicegui/elements/splitter.py
@@ -34,6 +34,7 @@ class Splitter(ValueElement, DisableableElement):
         self._props['horizontal'] = horizontal
         self._props['limits'] = limits
         self._props['reverse'] = reverse
+        self._classes = ['nicegui-splitter']
 
         self.before = self.add_slot('before')
         self.after = self.add_slot('after')

--- a/nicegui/elements/stepper.py
+++ b/nicegui/elements/stepper.py
@@ -65,6 +65,7 @@ class Step(DisableableElement):
         super().__init__(tag='q-step')
         self._props['name'] = name
         self._props['title'] = title if title is not None else name
+        self._classes = ['nicegui-step']
         if icon:
             self._props['icon'] = icon
         self.stepper = cast(ValueElement, globals.get_slot().parent)

--- a/nicegui/elements/stepper.py
+++ b/nicegui/elements/stepper.py
@@ -34,8 +34,8 @@ class Stepper(ValueElement):
     def _value_to_model_value(self, value: Any) -> Any:
         return value._props['name'] if isinstance(value, Step) else value  # pylint: disable=protected-access
 
-    def on_value_change(self, value: Any) -> None:
-        super().on_value_change(value)
+    def _on_value_change(self, value: Any) -> None:
+        super()._on_value_change(value)
         names = [step._props['name'] for step in self]  # pylint: disable=protected-access
         for i, step in enumerate(self):
             done = i < names.index(value) if value in names else False

--- a/nicegui/elements/stepper.py
+++ b/nicegui/elements/stepper.py
@@ -30,6 +30,7 @@ class Stepper(ValueElement):
         """
         super().__init__(tag='q-stepper', value=value, on_value_change=on_value_change)
         self._props['keep-alive'] = keep_alive
+        self._classes = ['nicegui-stepper']
 
     def _value_to_model_value(self, value: Any) -> Any:
         return value._props['name'] if isinstance(value, Step) else value  # pylint: disable=protected-access

--- a/nicegui/elements/stepper.py
+++ b/nicegui/elements/stepper.py
@@ -34,8 +34,8 @@ class Stepper(ValueElement):
     def _value_to_model_value(self, value: Any) -> Any:
         return value._props['name'] if isinstance(value, Step) else value  # pylint: disable=protected-access
 
-    def _on_value_change(self, value: Any) -> None:
-        super()._on_value_change(value)
+    def _handle_value_change(self, value: Any) -> None:
+        super()._handle_value_change(value)
         names = [step._props['name'] for step in self]  # pylint: disable=protected-access
         for i, step in enumerate(self):
             done = i < names.index(value) if value in names else False

--- a/nicegui/elements/tabs.py
+++ b/nicegui/elements/tabs.py
@@ -92,3 +92,4 @@ class TabPanel(DisableableElement):
         """
         super().__init__(tag='q-tab-panel')
         self._props['name'] = name._props['name'] if isinstance(name, Tab) else name
+        self._classes = ['nicegui-tab-panel']

--- a/nicegui/elements/timeline.py
+++ b/nicegui/elements/timeline.py
@@ -71,3 +71,4 @@ class TimelineEntry(Element):
             self._props['title'] = title
         if subtitle is not None:
             self._props['subtitle'] = subtitle
+        self._classes = ['nicegui-timeline-entry']

--- a/nicegui/elements/upload.py
+++ b/nicegui/elements/upload.py
@@ -70,6 +70,6 @@ class Upload(DisableableElement, component='upload.js'):
         """Clear the upload queue."""
         self.run_method('reset')
 
-    def _on_delete(self) -> None:
+    def _handle_delete(self) -> None:
         app.remove_route(self._props['url'])
-        super()._on_delete()
+        super()._handle_delete()

--- a/nicegui/elements/video.py
+++ b/nicegui/elements/video.py
@@ -1,4 +1,3 @@
-import warnings
 from pathlib import Path
 from typing import Union
 
@@ -13,7 +12,6 @@ class Video(Element, component='video.js'):
                  autoplay: bool = False,
                  muted: bool = False,
                  loop: bool = False,
-                 type: str = '',  # DEPRECATED, pylint: disable=redefined-builtin
                  ) -> None:
         """Video
 
@@ -36,10 +34,6 @@ class Video(Element, component='video.js'):
         self._props['autoplay'] = autoplay
         self._props['muted'] = muted
         self._props['loop'] = loop
-
-        if type:
-            url = 'https://github.com/zauberzeug/nicegui/pull/624'
-            warnings.warn(DeprecationWarning(f'The type parameter for ui.video is deprecated and ineffective ({url}).'))
 
     def seek(self, seconds: float) -> None:
         """Seek to a specific position in the video.

--- a/nicegui/error.py
+++ b/nicegui/error.py
@@ -7,6 +7,11 @@ from .elements.label import Label as label
 
 
 def error_content(status_code: int, exception: Union[str, Exception] = '') -> None:
+    """Create an error page.
+
+    :param status_code: HTTP status code
+    :param exception: exception that caused the error
+    """
     if 400 <= status_code <= 499:
         title = "This page doesn't exist."
     elif 500 <= status_code <= 599:

--- a/nicegui/event_listener.py
+++ b/nicegui/event_listener.py
@@ -23,6 +23,7 @@ class EventListener:
         self.id = str(uuid.uuid4())
 
     def to_dict(self) -> Dict[str, Any]:
+        """Return a dictionary representation of the event listener."""
         words = self.type.split('.')
         type_ = words.pop(0)
         specials = [w for w in words if w in {'capture', 'once', 'passive'}]

--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -199,7 +199,8 @@ class KeyboardKey:
         return str(self.name)
 
     @property
-    def is_cursorkey(self):
+    def is_cursorkey(self) -> bool:
+        """Whether the key is a cursor key (arrow keys)."""
         return self.code.startswith('Arrow')
 
     @property
@@ -209,138 +210,172 @@ class KeyboardKey:
 
     @property
     def backspace(self) -> bool:
+        """Whether the key is the backspace key."""
         return self.name == 'Backspace'
 
     @property
     def tab(self) -> bool:
+        """Whether the key is the tab key."""
         return self.name == 'Tab'
 
     @property
     def enter(self) -> bool:
+        """Whether the key is the enter key."""
         return self.name == 'enter'
 
     @property
     def shift(self) -> bool:
+        """Whether the key is the shift key."""
         return self.name == 'Shift'
 
     @property
     def control(self) -> bool:
+        """Whether the key is the control key."""
         return self.name == 'Control'
 
     @property
     def alt(self) -> bool:
+        """Whether the key is the alt key."""
         return self.name == 'Alt'
 
     @property
     def pause(self) -> bool:
+        """Whether the key is the pause key."""
         return self.name == 'Pause'
 
     @property
     def caps_lock(self) -> bool:
+        """Whether the key is the caps lock key."""
         return self.name == 'CapsLock'
 
     @property
     def escape(self) -> bool:
+        """Whether the key is the escape key."""
         return self.name == 'Escape'
 
     @property
     def space(self) -> bool:
+        """Whether the key is the space key."""
         return self.name == 'Space'
 
     @property
     def page_up(self) -> bool:
+        """Whether the key is the page up key."""
         return self.name == 'PageUp'
 
     @property
     def page_down(self) -> bool:
+        """Whether the key is the page down key."""
         return self.name == 'PageDown'
 
     @property
     def end(self) -> bool:
+        """Whether the key is the end key."""
         return self.name == 'End'
 
     @property
     def home(self) -> bool:
+        """Whether the key is the home key."""
         return self.name == 'Home'
 
     @property
     def arrow_left(self) -> bool:
+        """Whether the key is the arrow left key."""
         return self.name == 'ArrowLeft'
 
     @property
     def arrow_up(self) -> bool:
+        """Whether the key is the arrow up key."""
         return self.name == 'ArrowUp'
 
     @property
     def arrow_right(self) -> bool:
+        """Whether the key is the arrow right key."""
         return self.name == 'ArrowRight'
 
     @property
     def arrow_down(self) -> bool:
+        """Whether the key is the arrow down key."""
         return self.name == 'ArrowDown'
 
     @property
     def print_screen(self) -> bool:
+        """Whether the key is the print screen key."""
         return self.name == 'PrintScreen'
 
     @property
     def insert(self) -> bool:
+        """Whether the key is the insert key."""
         return self.name == 'Insert'
 
     @property
     def delete(self) -> bool:
+        """Whether the key is the delete key."""
         return self.name == 'Delete'
 
     @property
     def meta(self) -> bool:
+        """Whether the key is the meta key."""
         return self.name == 'Meta'
 
     @property
     def f1(self) -> bool:
+        """Whether the key is the F1 key."""
         return self.name == 'F1'
 
     @property
     def f2(self) -> bool:
+        """Whether the key is the F2 key."""
         return self.name == 'F2'
 
     @property
     def f3(self) -> bool:
+        """Whether the key is the F3 key."""
         return self.name == 'F3'
 
     @property
     def f4(self) -> bool:
+        """Whether the key is the F4 key."""
         return self.name == 'F4'
 
     @property
     def f5(self) -> bool:
+        """Whether the key is the F5 key."""
         return self.name == 'F5'
 
     @property
     def f6(self) -> bool:
+        """Whether the key is the F6 key."""
         return self.name == 'F6'
 
     @property
     def f7(self) -> bool:
+        """Whether the key is the F7 key."""
         return self.name == 'F7'
 
     @property
     def f8(self) -> bool:
+        """Whether the key is the F8 key."""
         return self.name == 'F8'
 
     @property
     def f9(self) -> bool:
+        """Whether the key is the F9 key."""
         return self.name == 'F9'
 
     @property
     def f10(self) -> bool:
+        """Whether the key is the F10 key."""
         return self.name == 'F10'
 
     @property
     def f11(self) -> bool:
+        """Whether the key is the F11 key."""
         return self.name == 'F11'
 
     @property
     def f12(self) -> bool:
+        """Whether the key is the F12 key."""
         return self.name == 'F12'
 
 
@@ -375,6 +410,16 @@ class JsonEditorChangeEventArguments(UiEventArguments):
 
 
 def handle_event(handler: Optional[Callable[..., Any]], arguments: EventArguments) -> None:
+    """Call the given event handler.
+
+    The handler is called within the context of the parent slot of the sender.
+    If the handler is a coroutine, it is scheduled as a background task.
+    If the handler expects arguments, the arguments are passed to the handler.
+    Exceptions are caught and handled globally.
+
+    :param handler: the event handler
+    :param arguments: the event arguments
+    """
     if handler is None:
         return
     try:

--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -35,13 +35,6 @@ class UiEventArguments(EventArguments):
 class GenericEventArguments(UiEventArguments):
     args: Any
 
-    def __getitem__(self, key: str) -> Any:
-        if key == 'args':
-            globals.log.warning('msg["args"] is deprecated, use e.args instead '
-                                '(see https://github.com/zauberzeug/nicegui/pull/1095)')  # DEPRECATED
-            return self.args
-        raise KeyError(key)
-
 
 @dataclass(**KWONLY_SLOTS)
 class ClickEventArguments(UiEventArguments):

--- a/nicegui/favicon.py
+++ b/nicegui/favicon.py
@@ -17,25 +17,27 @@ if TYPE_CHECKING:
 
 
 def create_favicon_route(path: str, favicon: Optional[Union[str, Path]]) -> None:
+    """Create a favicon route for the given path."""
     if is_file(favicon):
         globals.app.add_route('/favicon.ico' if path == '/' else f'{path}/favicon.ico',
                               lambda _: FileResponse(favicon))  # type: ignore
 
 
 def get_favicon_url(page: page, prefix: str) -> str:
+    """Return the URL of the favicon for a given page."""
     favicon = page.favicon or globals.favicon
     if not favicon:
         return f'{prefix}/_nicegui/{__version__}/static/favicon.ico'
 
     favicon = str(favicon).strip()
-    if is_remote_url(favicon):
+    if _is_remote_url(favicon):
         return favicon
-    if is_data_url(favicon):
+    if _is_data_url(favicon):
         return favicon
-    if is_svg(favicon):
-        return svg_to_data_url(favicon)
-    if is_char(favicon):
-        return svg_to_data_url(char_to_svg(favicon))
+    if _is_svg(favicon):
+        return _svg_to_data_url(favicon)
+    if _is_char(favicon):
+        return _svg_to_data_url(_char_to_svg(favicon))
     if page.path == '/' or page.favicon is None:
         return f'{prefix}/favicon.ico'
 
@@ -43,38 +45,39 @@ def get_favicon_url(page: page, prefix: str) -> str:
 
 
 def get_favicon_response() -> Response:
+    """Return the FastAPI response for the global favicon."""
     if not globals.favicon:
         raise ValueError(f'invalid favicon: {globals.favicon}')
     favicon = str(globals.favicon).strip()
 
-    if is_svg(favicon):
+    if _is_svg(favicon):
         return Response(favicon, media_type='image/svg+xml')
-    if is_data_url(favicon):
-        media_type, bytes_ = data_url_to_bytes(favicon)
+    if _is_data_url(favicon):
+        media_type, bytes_ = _data_url_to_bytes(favicon)
         return StreamingResponse(io.BytesIO(bytes_), media_type=media_type)
-    if is_char(favicon):
-        return Response(char_to_svg(favicon), media_type='image/svg+xml')
+    if _is_char(favicon):
+        return Response(_char_to_svg(favicon), media_type='image/svg+xml')
 
     raise ValueError(f'invalid favicon: {favicon}')
 
 
-def is_remote_url(favicon: str) -> bool:
+def _is_remote_url(favicon: str) -> bool:
     return favicon.startswith('http://') or favicon.startswith('https://')
 
 
-def is_char(favicon: str) -> bool:
+def _is_char(favicon: str) -> bool:
     return len(favicon) == 1
 
 
-def is_svg(favicon: str) -> bool:
+def _is_svg(favicon: str) -> bool:
     return favicon.strip().startswith('<svg')
 
 
-def is_data_url(favicon: str) -> bool:
+def _is_data_url(favicon: str) -> bool:
     return favicon.startswith('data:')
 
 
-def char_to_svg(char: str) -> str:
+def _char_to_svg(char: str) -> str:
     return f'''
         <svg viewBox="0 0 128 128" width="128" height="128" xmlns="http://www.w3.org/2000/svg" >
             <style>
@@ -93,12 +96,12 @@ def char_to_svg(char: str) -> str:
     '''
 
 
-def svg_to_data_url(svg: str) -> str:
+def _svg_to_data_url(svg: str) -> str:
     svg_urlencoded = urllib.parse.quote(svg)
     return f'data:image/svg+xml,{svg_urlencoded}'
 
 
-def data_url_to_bytes(data_url: str) -> Tuple[str, bytes]:
+def _data_url_to_bytes(data_url: str) -> Tuple[str, bytes]:
     media_type, base64_image = data_url.split(',', 1)
     media_type = media_type.split(':')[1].split(';')[0]
     return media_type, base64.b64decode(base64_image)

--- a/nicegui/functions/html.py
+++ b/nicegui/functions/html.py
@@ -2,8 +2,10 @@ from .. import globals  # pylint: disable=redefined-builtin
 
 
 def add_body_html(code: str) -> None:
+    """Add HTML code to the body of the page."""
     globals.get_client().body_html += code + '\n'
 
 
 def add_head_html(code: str) -> None:
+    """Add HTML code to the head of the page."""
     globals.get_client().head_html += code + '\n'

--- a/nicegui/functions/refreshable.py
+++ b/nicegui/functions/refreshable.py
@@ -17,6 +17,7 @@ class RefreshableTarget:
     kwargs: Dict[str, Any]
 
     def run(self, func: Callable[..., Any]) -> Union[None, Awaitable]:
+        """Run the function and return the result."""
         # pylint: disable=no-else-return
         if is_coroutine_function(func):
             async def wait_for_result() -> None:
@@ -71,6 +72,7 @@ class refreshable:
         return target.run(self.func)
 
     def refresh(self, *args: Any, **kwargs: Any) -> None:
+        """Refresh the UI elements created by this function."""
         self.prune()
         for target in self.targets:
             if target.instance != self.instance:
@@ -95,6 +97,10 @@ class refreshable:
                     globals.app.on_startup(result)
 
     def prune(self) -> None:
+        """Remove all targets that are no longer on a page with a client connection.
+
+        This method is called automatically before each refresh.
+        """
         self.targets = [
             target
             for target in self.targets

--- a/nicegui/functions/update.py
+++ b/nicegui/functions/update.py
@@ -2,5 +2,6 @@ from ..element import Element
 
 
 def update(*elements: Element) -> None:
+    """Update the given elements."""
     for element in elements:
         element.update()

--- a/nicegui/globals.py
+++ b/nicegui/globals.py
@@ -78,6 +78,7 @@ exception_handlers: List[Callable[..., Any]] = [log.exception]
 
 
 def get_task_id() -> int:
+    """Return the ID of the current asyncio task."""
     try:
         return id(asyncio.current_task())
     except RuntimeError:
@@ -85,6 +86,7 @@ def get_task_id() -> int:
 
 
 def get_slot_stack() -> List[Slot]:
+    """Return the slot stack of the current asyncio task."""
     task_id = get_task_id()
     if task_id not in slot_stacks:
         slot_stacks[task_id] = []
@@ -92,21 +94,25 @@ def get_slot_stack() -> List[Slot]:
 
 
 def prune_slot_stack() -> None:
+    """Remove the current slot stack if it is empty."""
     task_id = get_task_id()
     if not slot_stacks[task_id]:
         del slot_stacks[task_id]
 
 
 def get_slot() -> Slot:
+    """Return the current slot."""
     return get_slot_stack()[-1]
 
 
 def get_client() -> Client:
+    """Return the current client."""
     return get_slot().parent.client
 
 
 @contextmanager
 def socket_id(id_: str) -> Iterator[None]:
+    """Enter a context with a specific socket ID."""
     global _socket_id  # pylint: disable=global-statement
     _socket_id = id_
     yield
@@ -114,6 +120,7 @@ def socket_id(id_: str) -> Iterator[None]:
 
 
 def handle_exception(exception: Exception) -> None:
+    """Handle an exception by invoking all registered exception handlers."""
     for handler in exception_handlers:
         result = handler() if not inspect.signature(handler).parameters else handler(exception)
         if isinstance(result, Awaitable):

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -57,10 +57,12 @@ def is_file(path: Optional[Union[str, Path]]) -> bool:
 
 
 def hash_file_path(path: Path) -> str:
+    """Hash the given path."""
     return hashlib.sha256(path.as_posix().encode()).hexdigest()[:32]
 
 
 def safe_invoke(func: Union[Callable[..., Any], Awaitable], client: Optional[Client] = None) -> None:
+    """Invoke the potentially async function in the client context and catch any exceptions."""
     try:
         if isinstance(func, Awaitable):
             async def func_with_client():
@@ -134,6 +136,7 @@ def set_storage_secret(storage_secret: Optional[str] = None) -> None:
 
 
 def get_streaming_response(file: Path, request: Request) -> StreamingResponse:
+    """Get a StreamingResponse for the given file and request."""
     file_size = file.stat().st_size
     start = 0
     end = file_size - 1

--- a/nicegui/native.py
+++ b/nicegui/native.py
@@ -125,6 +125,7 @@ try:
             return await io_bound(wrapper, *args, **kwargs)
 
         def signal_server_shutdown(self) -> None:
+            """Signal the server shutdown."""
             self._send()
 
 except ModuleNotFoundError:

--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -19,25 +19,29 @@ message_queue: Deque[Message] = deque()
 
 
 def enqueue_update(element: Element) -> None:
+    """Enqueue an update for the given element."""
     update_queue[element.client.id][element.id] = element
 
 
 def enqueue_delete(element: Element) -> None:
+    """Enqueue a deletion for the given element."""
     update_queue[element.client.id][element.id] = None
 
 
 def enqueue_message(message_type: MessageType, data: Any, target_id: ClientId) -> None:
+    """Enqueue a message for the given client."""
     message_queue.append((target_id, message_type, data))
 
 
 async def _emit(message_type: MessageType, data: Any, target_id: ClientId) -> None:
     await globals.sio.emit(message_type, data, room=target_id)
-    if is_target_on_air(target_id):
+    if _is_target_on_air(target_id):
         assert globals.air is not None
         await globals.air.emit(message_type, data, room=target_id)
 
 
 async def loop() -> None:
+    """Emit queued updates and messages in an endless loop."""
     while True:
         if not update_queue and not message_queue:
             await asyncio.sleep(0.01)
@@ -67,7 +71,7 @@ async def loop() -> None:
             await asyncio.sleep(0.1)
 
 
-def is_target_on_air(target_id: str) -> bool:
+def _is_target_on_air(target_id: str) -> bool:
     if target_id in globals.clients:
         return globals.clients[target_id].on_air
 

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -64,18 +64,23 @@ class page:
 
     @property
     def path(self) -> str:
+        """The path of the page including the APIRouter's prefix."""
         return self.api_router.prefix + self._path
 
     def resolve_title(self) -> str:
+        """Return the title of the page."""
         return self.title if self.title is not None else globals.title
 
     def resolve_viewport(self) -> str:
+        """Return the viewport of the page."""
         return self.viewport if self.viewport is not None else globals.viewport
 
     def resolve_dark(self) -> Optional[bool]:
+        """Return whether the page should use dark mode."""
         return self.dark if self.dark is not ... else globals.dark
 
     def resolve_language(self) -> Optional[str]:
+        """Return the language of the page."""
         return self.language if self.language is not ... else globals.language
 
     def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]:

--- a/nicegui/page_layout.py
+++ b/nicegui/page_layout.py
@@ -26,7 +26,7 @@ class Header(ValueElement):
                  fixed: bool = True,
                  bordered: bool = False,
                  elevated: bool = False,
-                 add_scroll_padding: bool = False,  # DEPRECATED: will be True in v1.4
+                 add_scroll_padding: bool = True,
                  ) -> None:
         """Header
 
@@ -39,7 +39,7 @@ class Header(ValueElement):
         :param fixed: whether the header should be fixed to the top of the page (default: `True`)
         :param bordered: whether the header should have a border (default: `False`)
         :param elevated: whether the header should have a shadow (default: `False`)
-        :param add_scroll_padding: whether to automatically prevent link targets from being hidden behind the header (default: `False`, will be `True` in v1.4)
+        :param add_scroll_padding: whether to automatically prevent link targets from being hidden behind the header (default: `True`)
         """
         with globals.get_client().layout:
             super().__init__(tag='q-header', value=value, on_value_change=None)

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -11,9 +11,9 @@ from starlette.routing import Route
 from uvicorn.main import STARTUP_FAILURE
 from uvicorn.supervisors import ChangeReload, Multiprocess
 
+from . import native_mode  # pylint: disable=redefined-builtin
 from . import globals, helpers  # pylint: disable=redefined-builtin
 from . import native as native_module
-from . import native_mode  # pylint: disable=redefined-builtin
 from .air import Air
 from .language import Language
 
@@ -49,7 +49,7 @@ def run(*,
         dark: Optional[bool] = False,
         language: Language = 'en-US',
         binding_refresh_interval: float = 0.1,
-        reconnect_timeout: float = 0.0,  # NOTE: the value of 0.0 is DEPRECATED, change to 3.0 in 1.4 release
+        reconnect_timeout: float = 3.0,
         show: bool = True,
         on_air: Optional[Union[str, Literal[True]]] = None,
         native: bool = False,
@@ -79,7 +79,7 @@ def run(*,
     :param dark: whether to use Quasar's dark mode (default: `False`, use `None` for "auto" mode)
     :param language: language for Quasar elements (default: `'en-US'`)
     :param binding_refresh_interval: time between binding updates (default: `0.1` seconds, bigger is more CPU friendly)
-    :param reconnect_timeout: maximum time the server waits for the browser to reconnect (default: 0.0 seconds, i.e. no reconnect)
+    :param reconnect_timeout: maximum time the server waits for the browser to reconnect (default: 3.0 seconds)
     :param show: automatically open the UI in a browser tab (default: `True`)
     :param on_air: tech preview: `allows temporary remote access <https://nicegui.io/documentation#nicegui_on_air>`_ if set to `True` (default: disabled)
     :param native: open the UI in a native window of size 800x600 (default: `False`, deactivates `show`, automatically finds an open port)

--- a/nicegui/run_with.py
+++ b/nicegui/run_with.py
@@ -23,6 +23,21 @@ def run_with(
     prod_js: bool = True,
     storage_secret: Optional[str] = None,
 ) -> None:
+    """Run NiceGUI with FastAPI.
+
+    :param app: FastAPI app
+    :param title: page title (default: `'NiceGUI'`, can be overwritten per page)
+    :param viewport: page meta viewport content (default: `'width=device-width, initial-scale=1'`, can be overwritten per page)
+    :param favicon: relative filepath, absolute URL to a favicon (default: `None`, NiceGUI icon will be used) or emoji (e.g. `'🚀'`, works for most browsers)
+    :param dark: whether to use Quasar's dark mode (default: `False`, use `None` for "auto" mode)
+    :param language: language for Quasar elements (default: `'en-US'`)
+    :param binding_refresh_interval: time between binding updates (default: `0.1` seconds, bigger is more CPU friendly)
+    :param reconnect_timeout: maximum time the server waits for the browser to reconnect (default: 0.0 seconds, i.e. no reconnect)
+    :param mount_path: mount NiceGUI at this path (default: `'/'`)
+    :param tailwind: whether to use Tailwind CSS (experimental, default: `True`)
+    :param prod_js: whether to use the production version of Vue and Quasar dependencies (default: `True`)
+    :param storage_secret: secret key for browser-based storage (default: `None`, a value is required to enable ui.storage.individual and ui.storage.browser)
+    """
     globals.ui_run_has_been_called = True
     globals.title = title
     globals.viewport = viewport

--- a/nicegui/run_with.py
+++ b/nicegui/run_with.py
@@ -17,7 +17,7 @@ def run_with(
     dark: Optional[bool] = False,
     language: Language = 'en-US',
     binding_refresh_interval: float = 0.1,
-    reconnect_timeout: float = 0.0,  # NOTE: the value of 0.0 is DEPRECATED, change to 3.0 in 1.4 release
+    reconnect_timeout: float = 3.0,
     mount_path: str = '/',
     tailwind: bool = True,
     prod_js: bool = True,
@@ -32,7 +32,7 @@ def run_with(
     :param dark: whether to use Quasar's dark mode (default: `False`, use `None` for "auto" mode)
     :param language: language for Quasar elements (default: `'en-US'`)
     :param binding_refresh_interval: time between binding updates (default: `0.1` seconds, bigger is more CPU friendly)
-    :param reconnect_timeout: maximum time the server waits for the browser to reconnect (default: 0.0 seconds, i.e. no reconnect)
+    :param reconnect_timeout: maximum time the server waits for the browser to reconnect (default: 3.0 seconds)
     :param mount_path: mount NiceGUI at this path (default: `'/'`)
     :param tailwind: whether to use Tailwind CSS (experimental, default: `True`)
     :param prod_js: whether to use the production version of Vue and Quasar dependencies (default: `True`)

--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -1,52 +1,63 @@
+/* prevent q-layout from getting strange outline when focussed */
 .nicegui-layout {
   outline: 2px solid transparent;
   outline-offset: 2px;
 }
+
+/* flex containers */
+.nicegui-content,
 .nicegui-header,
-.nicegui-footer {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  gap: 1rem;
-  padding: 16px;
-}
-.nicegui-drawer {
-  padding: 16px;
-}
-.nicegui-content {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  gap: 1rem;
-  padding: 16px;
-}
-.nicegui-row {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  gap: 1rem;
-}
+.nicegui-footer,
+.nicegui-drawer,
+.nicegui-tab-panel,
+.nicegui-card,
+.nicegui-carousel-slide,
+.nicegui-step .q-stepper__nav,
+.nicegui-step .q-stepper__step-inner,
+.nicegui-expansion .q-expansion-item__content,
+.nicegui-scroll-area .q-scrollarea__content,
+.nicegui-splitter .q-splitter__panel,
+.nicegui-timeline-entry .q-timeline__content,
+.nicegui-row,
 .nicegui-column {
   display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
   align-items: flex-start;
   gap: 1rem;
+  padding: 1rem;
 }
+.nicegui-header,
+.nicegui-footer,
+.nicegui-step .q-stepper__nav,
+.nicegui-row {
+  flex-direction: row;
+}
+.nicegui-row,
+.nicegui-column {
+  padding: 0;
+}
+
+/* original padding for some Quasar elements */
+.nicegui-step .q-stepper__nav {
+  padding: 8px 0 0 0;
+}
+.nicegui-timeline-entry .q-timeline__content {
+  padding: 0 0 24px 0;
+}
+
+/* HACK: avoid stutter when expansion item is toggled */
+.nicegui-expansion .q-expansion-item__content {
+  padding: 0 1rem;
+}
+.nicegui-expansion .q-expansion-item__content::before,
+.nicegui-expansion .q-expansion-item__content::after {
+  content: ""; /* the gap compensates for the missing vertical padding */
+}
+
+/* other NiceGUI elements */
 .nicegui-grid {
   display: grid;
   gap: 1rem;
-}
-.nicegui-card {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  gap: 1rem;
-  padding: 16px;
 }
 .nicegui-link:link,
 .nicegui-link:visited {
@@ -60,14 +71,8 @@
 .nicegui-separator {
   width: 100%;
 }
-.nicegui-aggrid {
-  width: 100%;
-  height: 16rem;
-}
-.nicegui-echart {
-  width: 100%;
-  height: 16rem;
-}
+.nicegui-aggrid,
+.nicegui-echart,
 .nicegui-scroll-area {
   width: 100%;
   height: 16rem;
@@ -105,6 +110,7 @@ h6.q-timeline__title {
   border-radius: 0.25rem;
 }
 
+/* connection popup */
 #popup {
   position: fixed;
   bottom: 0;

--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -40,9 +40,13 @@
 /* original padding for some Quasar elements */
 .nicegui-step .q-stepper__nav {
   padding: 8px 0 0 0;
+  gap: 8px;
 }
 .nicegui-timeline-entry .q-timeline__content {
   padding: 0 0 24px 0;
+}
+.nicegui-splitter .q-splitter__panel {
+  padding: 0;
 }
 
 /* HACK: avoid stutter when expansion item is toggled */

--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -49,6 +49,19 @@
   padding: 0;
 }
 
+/* let step content fill the whole stepper for easier layout manipulation (#1788) */
+.nicegui-stepper {
+  display: flex;
+  flex-direction: column;
+}
+.nicegui-stepper .q-stepper__content {
+  flex-grow: 1;
+}
+.nicegui-stepper .q-stepper__step-content,
+.nicegui-stepper .q-stepper__step-inner {
+  height: 100%;
+}
+
 /* HACK: avoid stutter when expansion item is toggled */
 .nicegui-expansion .q-expansion-item__content {
   padding: 0 1rem;

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -45,6 +45,7 @@ class PersistentDict(observables.ObservableDict):
         super().__init__(data, on_change=self.backup)
 
     def backup(self) -> None:
+        """Back up the data to the given file path."""
         if not self.filepath.exists():
             if not self:
                 return

--- a/nicegui/tailwind.py
+++ b/nicegui/tailwind.py
@@ -172,6 +172,7 @@ class PseudoElement:
         self._classes: List[str] = []
 
     def classes(self, add: str) -> None:
+        """Add the given classes to the element."""
         self._classes.append(add)
 
 
@@ -198,6 +199,7 @@ class Tailwind:
         return self
 
     def apply(self, element: Element) -> None:
+        """Apply the tailwind classes to the given element."""
         element._classes.extend(self.element._classes)  # pylint: disable=protected-access
         element.update()
 

--- a/nicegui/welcome.py
+++ b/nicegui/welcome.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 
-def get_all_ips() -> List[str]:
+def _get_all_ips() -> List[str]:
     if 'netifaces' not in globals.optional_features:
         try:
             hostname = socket.gethostname()
@@ -30,10 +30,11 @@ def get_all_ips() -> List[str]:
 
 
 async def print_message() -> None:
+    """Print a welcome message with URLs to access the NiceGUI app."""
     print('NiceGUI ready to go ', end='', flush=True)
     host = os.environ['NICEGUI_HOST']
     port = os.environ['NICEGUI_PORT']
-    ips = set((await io_bound(get_all_ips)) if host == '0.0.0.0' else [])
+    ips = set((await io_bound(_get_all_ips)) if host == '0.0.0.0' else [])
     ips.discard('127.0.0.1')
     urls = [(f'http://{ip}:{port}' if port != '80' else f'http://{ip}') for ip in ['localhost'] + sorted(ips)]
     globals.app.urls.update(urls)

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -124,9 +124,9 @@ def test_on_delete(screen: Screen):
         def __init__(self, text: str) -> None:
             super().__init__(text)
 
-        def _on_delete(self) -> None:
+        def _handle_delete(self) -> None:
             deleted_labels.append(self.text)
-            super()._on_delete()
+            super()._handle_delete()
 
     with ui.row() as row:
         CustomLabel('Label A')

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -44,7 +44,7 @@ def test_emoji(screen: Screen):
     screen.ui_run_kwargs['favicon'] = '👋'
     screen.open('/')
     assert_favicon_url_starts_with(screen, 'data:image/svg+xml')
-    assert_favicon(favicon.char_to_svg('👋'))
+    assert_favicon(favicon._char_to_svg('👋'))
 
 
 def test_data_url(screen: Screen):
@@ -54,7 +54,7 @@ def test_data_url(screen: Screen):
     screen.ui_run_kwargs['favicon'] = icon
     screen.open('/')
     assert_favicon_url_starts_with(screen, 'data:image/png;base64')
-    _, bytes_ = favicon.data_url_to_bytes(icon)
+    _, bytes_ = favicon._data_url_to_bytes(icon)
     assert_favicon(bytes_)
 
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -34,7 +34,7 @@ def test_async_connect_handler(screen: Screen):
 def test_connect_disconnect_is_called_for_each_client(screen: Screen):
     events: List[str] = []
 
-    @ui.page('/')
+    @ui.page('/', reconnect_timeout=0)
     def page(client: Client):
         ui.label(f'client id: {client.id}')
     app.on_connect(lambda: events.append('connect'))

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -127,7 +127,7 @@ def test_wait_for_connected(screen: Screen):
 def test_wait_for_disconnect(screen: Screen):
     events = []
 
-    @ui.page('/')
+    @ui.page('/', reconnect_timeout=0)
     async def page(client: Client):
         await client.connected()
         events.append('connected')
@@ -144,7 +144,7 @@ def test_wait_for_disconnect(screen: Screen):
 def test_wait_for_disconnect_without_awaiting_connected(screen: Screen):
     events = []
 
-    @ui.page('/')
+    @ui.page('/', reconnect_timeout=0)
     async def page(client: Client):
         await client.disconnected()
         events.append('disconnected')

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -47,7 +47,7 @@ def test_timer(screen: Screen):
 def test_timer_on_private_page(screen: Screen):
     counter = Counter()
 
-    @ui.page('/')
+    @ui.page('/', reconnect_timeout=0)
     def page():
         ui.timer(0.1, counter.increment)
 

--- a/website/build_search_index.py
+++ b/website/build_search_index.py
@@ -52,7 +52,7 @@ class DocVisitor(ast.NodeVisitor):
         else:
             raise NotImplementedError(f'Unknown function type: {node.func}')
         if function_name in ['heading', 'subheading']:
-            self.on_new_heading()
+            self._handle_new_heading()
             self.current_title = node.args[0].s
         elif function_name == 'markdown':
             if node.args:
@@ -61,7 +61,7 @@ class DocVisitor(ast.NodeVisitor):
                 self.current_content.append(cleanup(raw))
         self.generic_visit(node)
 
-    def on_new_heading(self) -> None:
+    def _handle_new_heading(self) -> None:
         if self.current_title:
             self.add_to_search_index(self.current_title, self.current_content if self.current_content else 'Overview')
             self.current_content = []
@@ -146,7 +146,7 @@ def generate_for(file: Path, topic: Optional[str] = None) -> None:
     doc_visitor = DocVisitor(topic)
     doc_visitor.visit(tree)
     if doc_visitor.current_title:
-        doc_visitor.on_new_heading()  # to finalize the last heading
+        doc_visitor._handle_new_heading()  # to finalize the last heading
 
 
 documents = []

--- a/website/more_documentation/label_documentation.py
+++ b/website/more_documentation/label_documentation.py
@@ -9,13 +9,13 @@ def main_demo() -> None:
 
 def more() -> None:
     @text_demo('Change Appearance Depending on the Content', '''
-        You can overwrite the `on_text_change` method to update other attributes of a label depending on its content. 
+        You can overwrite the `_handle_text_change` method to update other attributes of a label depending on its content. 
         This technique also works for bindings as shown in the example below.
     ''')
     def status():
         class status_label(ui.label):
-            def on_text_change(self, text: str) -> None:
-                super().on_text_change(text)
+            def _handle_text_change(self, text: str) -> None:
+                super()._handle_text_change(text)
                 if text == 'ok':
                     self.classes(replace='text-positive')
                 else:


### PR DESCRIPTION
This PR makes flex layout the default for NiceGUI's layout elements. This way you don't need to nest the content of, e.g., a `ui.header` in a `ui.row` to get proper item alignment, padding and gaps. Instead, these elements will automatically behave like `ui.row` or `ui.column`:

rows:
- `ui.row`
- `ui.footer`
- `ui.header`
- `ui.stepper_navigation`

columns:
- `ui.column`
- `ui.card`
- `ui.carousel_slide`
- `ui.drawer`
- `ui.expansion`
- `ui.scroll_area`
- `ui.splitter`
- `ui.step`
- `ui.tab_panel`
- `ui.timeline_entry`

There's one question though that came up when working on `ui.expansion`: The element doesn't open and close smoothly if the contained flex column is allowed to wrap. Therefore I removed the default wrapping and made `wrap: bool = False` an opt-in parameter for `ui.row` and `ui.column`. Since we had multiple users that got confused by the default wrapping, this change might simplify things. And "no-wrap" is the CSS default. (In contrast: "wrap" is the default for Quasar's layout elements...)