### PR TITLE
Change styles suggestion to style

### DIFF
--- a/website/documentation.py
+++ b/website/documentation.py
@@ -210,7 +210,7 @@ def create_full() -> None:
         Props with a leading `:` can contain JavaScript expressions that are evaluated on the client.
         You can also apply [Tailwind CSS](https://tailwindcss.com/) utility classes with the `classes` method.
 
-        If you really need to apply CSS, you can use the `styles` method. Here the delimiter is `;` instead of a blank space.
+        If you really need to apply CSS, you can use the `style` method. Here the delimiter is `;` instead of a blank space.
 
         All three functions also provide `remove` and `replace` parameters in case the predefined look is not wanted in a particular styling.
     ''')


### PR DESCRIPTION
Just a tiny documentation change since we don't have a 'styles' method for NiceGUI elements.

I'm actually wondering why the plural .props and plural .classes but the singular .style methods are used on elements instead of .styles. Probably intentional but I was curious either way :smile: 