### PR TITLE
Introduce `ui.context_menu`

### DIFF
--- a/nicegui/elements/context_menu.py
+++ b/nicegui/elements/context_menu.py
@@ -1,0 +1,15 @@
+from ..element import Element
+
+
+class ContextMenu(Element):
+
+    def __init__(self) -> None:
+        """Context Menu
+
+        Creates a context menu based on Quasar's `QMenu <https://quasar.dev/vue-components/menu>`_ component.
+        The context menu should be placed inside the element where it should be shown.
+        It is automatically opened when the user right-clicks on the element and appears at the mouse position.
+        """
+        super().__init__('q-menu')
+        self._props['context-menu'] = True
+        self._props['touch-position'] = True

--- a/nicegui/elements/menu.py
+++ b/nicegui/elements/menu.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, Optional
 
 from .. import globals  # pylint: disable=redefined-builtin
+from ..element import Element
 from ..events import ClickEventArguments, handle_event
 from .mixins.text_element import TextElement
 from .mixins.value_element import ValueElement
@@ -29,6 +30,14 @@ class Menu(ValueElement):
     def toggle(self) -> None:
         """Toggle the menu."""
         self.value = not self.value
+
+
+class ContextMenu(Element):
+
+    def __init__(self) -> None:
+        super().__init__('q-menu')
+        self._props['context-menu'] = True
+        self._props['touch-position'] = True
 
 
 class MenuItem(TextElement):

--- a/nicegui/elements/menu.py
+++ b/nicegui/elements/menu.py
@@ -3,7 +3,6 @@ from typing import Any, Callable, Optional
 from typing_extensions import Self
 
 from .. import globals  # pylint: disable=redefined-builtin
-from ..element import Element
 from ..events import ClickEventArguments, handle_event
 from .mixins.text_element import TextElement
 from .mixins.value_element import ValueElement
@@ -39,22 +38,8 @@ class Menu(ValueElement):
             # https://github.com/zauberzeug/nicegui/issues/1738
             del self._props['touch-position']
             globals.log.warning('The prop "touch-position" is not supported by `ui.menu`.\n'
-                                'Use "ui.context-menu()" instead.')
+                                'Use "ui.context_menu()" instead.')
         return self
-
-
-class ContextMenu(Element):
-
-    def __init__(self) -> None:
-        """Context Menu
-
-        Creates a context menu based on Quasar's `QMenu <https://quasar.dev/vue-components/menu>`_ component.
-        The context menu should be placed inside the element where it should be shown.
-        It is automatically opened when the user right-clicks on the element and appears at the mouse position.
-        """
-        super().__init__('q-menu')
-        self._props['context-menu'] = True
-        self._props['touch-position'] = True
 
 
 class MenuItem(TextElement):

--- a/nicegui/elements/menu.py
+++ b/nicegui/elements/menu.py
@@ -1,5 +1,7 @@
 from typing import Any, Callable, Optional
 
+from typing_extensions import Self
+
 from .. import globals  # pylint: disable=redefined-builtin
 from ..element import Element
 from ..events import ClickEventArguments, handle_event
@@ -30,6 +32,15 @@ class Menu(ValueElement):
     def toggle(self) -> None:
         """Toggle the menu."""
         self.value = not self.value
+
+    def props(self, add: Optional[str] = None, *, remove: Optional[str] = None) -> Self:
+        super().props(add, remove=remove)
+        if 'touch-position' in self._props:
+            # https://github.com/zauberzeug/nicegui/issues/1738
+            del self._props['touch-position']
+            globals.log.warning('The prop "touch-position" is not supported by `ui.menu`.\n'
+                                'Use "ui.context-menu()" instead.')
+        return self
 
 
 class ContextMenu(Element):

--- a/nicegui/elements/menu.py
+++ b/nicegui/elements/menu.py
@@ -35,6 +35,12 @@ class Menu(ValueElement):
 class ContextMenu(Element):
 
     def __init__(self) -> None:
+        """Context Menu
+
+        Creates a context menu based on Quasar's `QMenu <https://quasar.dev/vue-components/menu>`_ component.
+        The context menu should be placed inside the element where it should be shown.
+        It is automatically opened when the user right-clicks on the element and appears at the mouse position.
+        """
         super().__init__('q-menu')
         self._props['context-menu'] = True
         self._props['touch-position'] = True

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -40,6 +40,7 @@ __all__ = [
     'link_target',
     'log',
     'markdown',
+    'context_menu',
     'menu',
     'menu_item',
     'mermaid',
@@ -137,6 +138,7 @@ from .elements.link import Link as link
 from .elements.link import LinkTarget as link_target
 from .elements.log import Log as log
 from .elements.markdown import Markdown as markdown
+from .elements.menu import ContextMenu as context_menu
 from .elements.menu import Menu as menu
 from .elements.menu import MenuItem as menu_item
 from .elements.mermaid import Mermaid as mermaid

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -18,6 +18,7 @@ __all__ = [
     'color_picker',
     'colors',
     'column',
+    'context_menu',
     'dark_mode',
     'date',
     'dialog',
@@ -40,7 +41,6 @@ __all__ = [
     'link_target',
     'log',
     'markdown',
-    'context_menu',
     'menu',
     'menu_item',
     'mermaid',
@@ -116,6 +116,7 @@ from .elements.color_input import ColorInput as color_input
 from .elements.color_picker import ColorPicker as color_picker
 from .elements.colors import Colors as colors
 from .elements.column import Column as column
+from .elements.context_menu import ContextMenu as context_menu
 from .elements.dark_mode import DarkMode as dark_mode
 from .elements.date import Date as date
 from .elements.dialog import Dialog as dialog
@@ -138,7 +139,6 @@ from .elements.link import Link as link
 from .elements.link import LinkTarget as link_target
 from .elements.log import Log as log
 from .elements.markdown import Markdown as markdown
-from .elements.menu import ContextMenu as context_menu
 from .elements.menu import Menu as menu
 from .elements.menu import MenuItem as menu_item
 from .elements.mermaid import Mermaid as mermaid

--- a/tests/screen.py
+++ b/tests/screen.py
@@ -119,6 +119,12 @@ class Screen:
             raise AssertionError(f'Could not click on "{target_text}" on:\n{element.get_attribute("outerHTML")}') from e
         return element
 
+    def context_click(self, target_text: str) -> WebElement:
+        element = self.find(target_text)
+        action = ActionChains(self.selenium)
+        action.context_click(element).perform()
+        return element
+
     def click_at_position(self, element: WebElement, x: int, y: int) -> None:
         action = ActionChains(self.selenium)
         action.move_to_element_with_offset(element, x, y).click().perform()

--- a/tests/test_context_menu.py
+++ b/tests/test_context_menu.py
@@ -3,13 +3,12 @@ from nicegui import ui
 from .screen import Screen
 
 
-def test_menu(screen: Screen):
-    with ui.button('Menu'):
-        with ui.menu():
+def test_context_menu(screen: Screen):
+    with ui.label('Right-click me'):
+        with ui.context_menu():
             ui.menu_item('Item 1')
             ui.menu_item('Item 2')
-            ui.menu_item('Item 3')
 
     screen.open('/')
-    screen.click('Menu')
+    screen.context_click('Right-click me')
     screen.should_contain('Item 1')

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,0 +1,26 @@
+from nicegui import ui
+
+from .screen import Screen
+
+
+def test_menu(screen: Screen):
+    with ui.button('Menu'):
+        with ui.menu():
+            ui.menu_item('Item 1')
+            ui.menu_item('Item 2')
+            ui.menu_item('Item 3')
+
+    screen.open('/')
+    screen.click('Menu')
+    screen.should_contain('Item 1')
+
+
+def test_context_menu(screen: Screen):
+    with ui.label('Right-click me'):
+        with ui.context_menu():
+            ui.menu_item('Item 1')
+            ui.menu_item('Item 2')
+
+    screen.open('/')
+    screen.context_click('Right-click me')
+    screen.should_contain('Item 1')

--- a/website/documentation.py
+++ b/website/documentation.py
@@ -187,6 +187,7 @@ def create_full() -> None:
     load_demo(ui.timeline)
     load_demo(ui.carousel)
     load_demo(ui.menu)
+    load_demo(ui.context_menu)
 
     @text_demo('Tooltips', '''
         Simply call the `tooltip(text:str)` method on UI elements to provide a tooltip.

--- a/website/more_documentation/context_menu_documentation.py
+++ b/website/more_documentation/context_menu_documentation.py
@@ -1,0 +1,10 @@
+from nicegui import ui
+
+
+def main_demo() -> None:
+    with ui.image('https://picsum.photos/id/377/640/360'):
+        with ui.context_menu():
+            ui.menu_item('Flip horizontally')
+            ui.menu_item('Flip vertically')
+            ui.separator()
+            ui.menu_item('Reset')

--- a/website/more_documentation/menu_documentation.py
+++ b/website/more_documentation/menu_documentation.py
@@ -17,14 +17,13 @@ def main_demo() -> None:
 
 
 def more() -> None:
-    @text_demo('Custom Context Menu', '''
-        Using [Quasar's `context-menu`](https://quasar.dev/vue-components/menu#context-menu) and `touch-position` props, 
-        you can create custom context menus. 
-        These open by right-clicking on the parent.
+    @text_demo('Context Menu', '''
+        For context menus, use `ui.context_menu()` instead of `ui.menu()`.
+        It will open the menu on right-click at the current mouse position.
     ''')
-    def custom_context_menu() -> None:
+    def context_menu() -> None:
         with ui.image('https://picsum.photos/id/377/640/360'):
-            with ui.menu().props('context-menu touch-position'):
+            with ui.context_menu():
                 ui.menu_item('Flip horizontally')
                 ui.menu_item('Flip vertically')
                 ui.separator()

--- a/website/more_documentation/menu_documentation.py
+++ b/website/more_documentation/menu_documentation.py
@@ -1,7 +1,5 @@
 from nicegui import ui
 
-from ..documentation_tools import text_demo
-
 
 def main_demo() -> None:
     with ui.row().classes('w-full items-center'):
@@ -14,17 +12,3 @@ def main_demo() -> None:
                              lambda: result.set_text('Selected item 3'), auto_close=False)
                 ui.separator()
                 ui.menu_item('Close', on_click=menu.close)
-
-
-def more() -> None:
-    @text_demo('Context Menu', '''
-        For context menus, use `ui.context_menu()` instead of `ui.menu()`.
-        It will open the menu on right-click at the current mouse position.
-    ''')
-    def context_menu() -> None:
-        with ui.image('https://picsum.photos/id/377/640/360'):
-            with ui.context_menu():
-                ui.menu_item('Flip horizontally')
-                ui.menu_item('Flip vertically')
-                ui.separator()
-                ui.menu_item('Reset')


### PR DESCRIPTION
This PR introduces a dedicated context menu, since `ui.menu` doesn't work well with `.props('context-menu touch-position')` as discussed in #1738.

Open questions:
- [x] Should we add a warning if someone tries to use `ui.menu` as a context menu?
- [x] Should we move the context menu demo into a separate file context_menu_documentation.py, i.e. onto a separate page?