### PR TITLE
adapt socket.io heartbeat depending on the provided reconnect_timeout

### DIFF
--- a/main.py
+++ b/main.py
@@ -447,4 +447,4 @@ def status():
     return 'Ok'
 
 
-ui.run(uvicorn_reload_includes='*.py, *.css, *.html', reconnect_timeout=3.0)
+ui.run(uvicorn_reload_includes='*.py, *.css, *.html', reconnect_timeout=10.0)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -71,6 +71,10 @@ def get_component(key: str) -> FileResponse:
 
 @app.on_event('startup')
 def handle_startup(with_welcome_message: bool = True) -> None:
+    if globals.reconnect_timeout > 0:  # TODO in 1.4 we DEPRECATED a value of 0 and should remove this check
+        # NOTE ping interval and timeout need to be lower than the reconnect timeout, but can't be too low
+        globals.sio.eio.ping_interval = max(globals.reconnect_timeout * 0.8, 4)
+        globals.sio.eio.ping_timeout = max(globals.reconnect_timeout * 0.4, 2)
     if not globals.ui_run_has_been_called:
         raise RuntimeError('\n\n'
                            'You must call ui.run() to start the server.\n'

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -242,7 +242,7 @@
             connect: () => {
               window.socket.emit("handshake", window.client_id, (ok) => {
                 if (!ok) {
-                  console.log('reloading because handshake failed')
+                  console.log('reloading because handshake failed for client_id ' + window.client_id)
                   window.location.reload();
                 }
                 document.getElementById('popup').style.opacity = 0;


### PR DESCRIPTION
The heartbeat of socket.io (i.e. `ping_timeout` and `ping_intervall`) where larger than `reconnect_timeout` the browser sometimes did not recognized a dropped connection in time to establish a new connection. This PR ensures the heartbeat is lower than the reconnection timeout.

But it's crucial that the heartbeat is not to low (because it increases network traffic and uses resources), so a larger `reconnect_timeout` is advisable.