### PR TITLE
Improve Fly replay middleware to only replay if the target instance is still available

### DIFF
--- a/fly.dockerfile
+++ b/fly.dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Zauberzeug GmbH <nicegui@zauberzeug.com>"
 
 RUN apt update && apt install -y curl procps
 
-RUN pip install itsdangerous prometheus_client isort docutils pandas plotly matplotlib requests
+RUN pip install itsdangerous prometheus_client isort docutils pandas plotly matplotlib requests dnspython
 
 RUN curl -sSL https://install.python-poetry.org | python3 - && \
     cd /usr/local/bin && \

--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ class FlyReplayMiddleware(BaseHTTPMiddleware):
 
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
-        self.app_name = os.environ('FLY_APP_NAME')
+        self.app_name = os.environ.get('FLY_APP_NAME')
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         query_string = scope.get('query_string', b'').decode()
@@ -90,7 +90,7 @@ class FlyReplayMiddleware(BaseHTTPMiddleware):
         target_instance = query_params.get('fly_instance_id', [fly_instance_id])[0]
 
         async def send_wrapper(message):
-            if target_instance != fly_instance_id and self.is_online(fly_instance_id):
+            if target_instance != fly_instance_id and self.is_online(target_instance):
                 if message['type'] == 'websocket.close':
                     # fly.io only seems to look at the fly-replay header if websocket is accepted
                     message = {'type': 'websocket.accept'}


### PR DESCRIPTION
This PR ensures we do not lose time by replaying to instances which had been shut down earlier.