### PR TITLE
Add websocket connection timeout handling

### DIFF
--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -237,7 +237,14 @@
           const extraHeaders = {{ socket_io_js_extra_headers | safe }};
           const transports = {{ socket_io_js_transports | safe }};
           window.path_prefix = "{{ prefix | safe }}";
-          window.socket = io(url, { path: "{{ prefix | safe }}/_nicegui_ws/socket.io", query, extraHeaders, transports });
+          window.socket = io(url, {
+            path: "{{ prefix | safe }}/_nicegui_ws/socket.io",
+            query, extraHeaders, transports,
+            timeout: 20000,
+            reconnectionDelay: 5000,
+            reconnectionDelayMax: 20000,
+            reconnectionAttempts: 5
+          });          
           const messageHandlers = {
             connect: () => {
               window.socket.emit("handshake", window.client_id, (ok) => {


### PR DESCRIPTION
### Summary:
- Fix continuous and certain reconnections on slow networks
- Mitigate occasional localhost reconnection issues

### To Reproduce the Localhost Issue:

1. Launch the server locally.
2. Open multiple tabs in Chrome/Firefox, accessing the web app. Ideally, have numerous other tabs opened or induce some CPU load.
3. Highlight all the web app's tabs and use the context menu to refresh them simultaneously.
   Alternatively:
   3.1. Restart the local server.

**Expected Result:** All tabs should complete the refreshing process.
**Actual Result:** Some tabs do not finish refreshing.

### To Reproduce the Slow Network Issue:

1. Launch the web app in a Firefox tab (Chrome is also suitable but may require slight variation in steps).
2. Access dev tools, navigate to the Network tab, set the network speed to "Regular 3G" and turn off caching.
3. Refresh the web app's tab.

**Expected Result:** The page should reload successfully.
**Actual Result:** The page remains stuck in the refreshing phase.