### PR TITLE
Add startup and shutdown handlers to existing FastAPI app

### DIFF
--- a/nicegui/ui_run_with.py
+++ b/nicegui/ui_run_with.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 
 from . import core, storage
 from .language import Language
+from .nicegui import _shutdown, _startup
 
 
 def run_with(
@@ -52,3 +53,5 @@ def run_with(
     storage.set_storage_secret(storage_secret)
 
     app.mount(mount_path, core.app)
+    app.on_event('startup')(_startup)
+    app.on_event('shutdown')(_shutdown)

--- a/nicegui/ui_run_with.py
+++ b/nicegui/ui_run_with.py
@@ -59,8 +59,8 @@ def run_with(
     @asynccontextmanager
     async def lifespan_wrapper(app):
         _startup()
-        async with main_app_lifespan(app) as maybe_state:
-            yield maybe_state
+        async with main_app_lifespan(app):
+            yield
         _shutdown()
 
     app.router.lifespan_context = lifespan_wrapper


### PR DESCRIPTION
This PR tries to solve #1870 and #1874 by adding startup and shutdown handlers to an existing FastAPI app.
This has been broken by switching to the new lifespan API. But the lifespan events of a sub application don't seem to be executed. Therefore this extra step is necessary.