### PR TITLE
make ui.tab_panels can work with other components

### DIFF
--- a/nicegui/elements/tabs.py
+++ b/nicegui/elements/tabs.py
@@ -50,7 +50,7 @@ class Tab(DisableableElement):
 class TabPanels(ValueElement):
 
     def __init__(self,
-                 tabs: Tabs, *,
+                 tabs: Optional[Tabs]=None, *,
                  value: Union[Tab, TabPanel, str, None] = None,
                  on_change: Optional[Callable[..., Any]] = None,
                  animated: bool = True,
@@ -72,7 +72,8 @@ class TabPanels(ValueElement):
         :param keep_alive: whether to use Vue's keep-alive component on the content (default: `True`)
         """
         super().__init__(tag='q-tab-panels', value=value, on_value_change=on_change)
-        tabs.bind_value(self, 'value')
+        if tabs:
+            tabs.bind_value(self, 'value')
         self._props['animated'] = animated
         self._props['keep-alive'] = keep_alive
 

--- a/nicegui/elements/tabs.py
+++ b/nicegui/elements/tabs.py
@@ -50,7 +50,7 @@ class Tab(DisableableElement):
 class TabPanels(ValueElement):
 
     def __init__(self,
-                 tabs: Optional[Tabs]=None, *,
+                 tabs: Optional[Tabs] = None, *,
                  value: Union[Tab, TabPanel, str, None] = None,
                  on_change: Optional[Callable[..., Any]] = None,
                  animated: bool = True,
@@ -65,14 +65,14 @@ class TabPanels(ValueElement):
         this element uses Vue's `keep-alive <https://vuejs.org/guide/built-ins/keep-alive.html>`_ component.
         If client-side performance is an issue, you can disable this feature.
 
-        :param tabs: the `ui.tabs` element that controls this element
+        :param tabs: an optional `ui.tabs` element that controls this element
         :param value: `ui.tab`, `ui.tab_panel`, or name of the tab panel to be initially visible
         :param on_change: callback to be executed when the visible tab panel changes
         :param animated: whether the tab panels should be animated (default: `True`)
         :param keep_alive: whether to use Vue's keep-alive component on the content (default: `True`)
         """
         super().__init__(tag='q-tab-panels', value=value, on_value_change=on_change)
-        if tabs:
+        if tabs is not None:
             tabs.bind_value(self, 'value')
         self._props['animated'] = animated
         self._props['keep-alive'] = keep_alive


### PR DESCRIPTION
This PR make tab_panels can work with other components, not just tabs. It is based on this discussion #1894.