### PR TITLE
Raise exception if `ui.element` is called with an invalid HTML tag

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -46,7 +46,10 @@ PROPS_PATTERN = re.compile(r'''
 (?:$|\s)            # Match end of string or whitespace
 ''', re.VERBOSE)
 
-TAG_PATTERN = re.compile(r'^[a-z][a-z0-9\-]*$', re.IGNORECASE)
+# https://www.w3.org/TR/xml/#sec-common-syn
+TAG_START_CHAR = r':|[A-Z]|_|[a-z]|[\u00C0-\u00D6]|[\u00D8-\u00F6]|[\u00F8-\u02FF]|[\u0370-\u037D]|[\u037F-\u1FFF]|[\u200C-\u200D]|[\u2070-\u218F]|[\u2C00-\u2FEF]|[\u3001-\uD7FF]|[\uF900-\uFDCF]|[\uFDF0-\uFFFD]|[\U00010000-\U000EFFFF]'
+TAG_CHAR = TAG_START_CHAR + r'|-|\.|[0-9]|\u00B7|[\u0300-\u036F]|[\u203F-\u2040]'
+TAG_PATTERN = re.compile(fr'^({TAG_START_CHAR})({TAG_CHAR})*$')
 
 
 class Element(Visibility):

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -46,6 +46,8 @@ PROPS_PATTERN = re.compile(r'''
 (?:$|\s)            # Match end of string or whitespace
 ''', re.VERBOSE)
 
+TAG_PATTERN = re.compile(r'^[a-z][a-z0-9\-]*$', re.IGNORECASE)
+
 
 class Element(Visibility):
     component: Optional[Component] = None
@@ -70,6 +72,8 @@ class Element(Visibility):
         self.id = self.client.next_element_id
         self.client.next_element_id += 1
         self.tag = tag if tag else self.component.tag if self.component else 'div'
+        if not TAG_PATTERN.match(self.tag):
+            raise ValueError(f'Invalid HTML tag: {self.tag}')
         self._classes: List[str] = []
         self._classes.extend(self._default_classes)
         self._style: Dict[str, str] = {}

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -1,3 +1,4 @@
+import pytest
 from selenium.webdriver.common.by import By
 
 from nicegui import ui
@@ -262,3 +263,15 @@ def test_default_style():
     button_f = ui.button()
     assert button_f._style.get('border') == '2px'
     assert button_f._style.get('padding') == '30px'
+
+
+def test_invalid_tags(screen: Screen):
+    good_tags = ['div', 'span', 'a', 'div1', 'div-', 'DIV']
+    bad_tags = ['1div', 'di v', '-div', '_div']
+    for tag in good_tags:
+        ui.element(tag)
+    for tag in bad_tags:
+        with pytest.raises(ValueError, match=f'Invalid HTML tag: {tag}'):
+            ui.element(tag)
+
+    screen.open('/')

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -266,12 +266,12 @@ def test_default_style():
 
 
 def test_invalid_tags(screen: Screen):
-    good_tags = ['div', 'span', 'a', 'div1', 'div-', 'DIV']
-    bad_tags = ['1div', 'di v', '-div', '_div']
+    good_tags = ['div', 'div-1', 'DIV', 'däv', 'div_x', '🙂']
+    bad_tags = ['<div>', 'hi hi', 'hi/ho', 'foo$bar']
     for tag in good_tags:
         ui.element(tag)
     for tag in bad_tags:
-        with pytest.raises(ValueError, match=f'Invalid HTML tag: {tag}'):
+        with pytest.raises(ValueError):
             ui.element(tag)
 
     screen.open('/')


### PR DESCRIPTION
This PR solves #1908 by checking the tag name against a regex.