### PR TITLE
integer argument for ui.number

### DIFF
--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -93,18 +93,12 @@ class Number(ValidationElement, DisableableElement):
         value = float(self.value or 0)
         value = max(value, self.min)
         value = min(value, self.max)
-        if self.integer:
-            self.set_value(int(math.floor(value)))
-        else:
-            self.set_value(float(self.format % value) if self.format else value)
+        self.set_value(float(self.format % value) if self.format else value)
 
     def _event_args_to_value(self, e: GenericEventArguments) -> Any:
         if not e.args:
             return None
-        if self.integer:
-            return int(math.floor(float(e.args)))
-        else:
-            return float(e.args)
+        return float(e.args)
 
     def _value_to_model_value(self, value: Any) -> Any:
         if value is None:
@@ -113,10 +107,13 @@ class Number(ValidationElement, DisableableElement):
             return str(value)
         if value == '':
             return 0
-        return self.format % float(value)
+        model_value = self.format % float(value)
+        if self.integer:
+            model_value = str(int(math.floor(float(model_value))))
+        return model_value
 
     def _value_to_event_value(self, value: Any) -> Any:
+        event_value = float(value) if value else 0
         if self.integer:
-            return int(math.floor(value)) if value else 0
-        else:
-            return float(value) if value else 0
+            event_value = int(math.floor(event_value))
+        return event_value

--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -14,7 +14,7 @@ class Number(ValidationElement, DisableableElement):
                  value: Optional[float] = None,
                  min: Optional[float] = None,  # pylint: disable=redefined-builtin
                  max: Optional[float] = None,  # pylint: disable=redefined-builtin
-                 digits: Optional[int] = None,
+                 precision: Optional[int] = None,
                  step: Optional[float] = None,
                  prefix: Optional[str] = None,
                  suffix: Optional[str] = None,
@@ -34,7 +34,7 @@ class Number(ValidationElement, DisableableElement):
         :param value: the initial value of the field
         :param min: the minimum value allowed
         :param max: the maximum value allowed
-        :param digits: the number of digits allowed (default: no limit, negative: decimal places before the dot)
+        :param precision: the number of decimal places allowed (default: no limit, negative: decimal places before the dot)
         :param step: the step size for the stepper buttons
         :param prefix: a prefix to prepend to the displayed value
         :param suffix: a suffix to append to the displayed value
@@ -53,7 +53,7 @@ class Number(ValidationElement, DisableableElement):
             self._props['min'] = min
         if max is not None:
             self._props['max'] = max
-        self._digits = digits
+        self._precision = precision
         if step is not None:
             self._props['step'] = step
         if prefix is not None:
@@ -83,13 +83,13 @@ class Number(ValidationElement, DisableableElement):
         self.sanitize()
 
     @property
-    def digits(self) -> Optional[int]:
-        """The number of digits allowed (default: no limit, negative: decimal places before the dot)."""
-        return self._digits
+    def precision(self) -> Optional[int]:
+        """The number of decimal places allowed (default: no limit, negative: decimal places before the dot)."""
+        return self._precision
 
-    @digits.setter
-    def digits(self, value: Optional[int]) -> None:
-        self._digits = value
+    @precision.setter
+    def precision(self, value: Optional[int]) -> None:
+        self._precision = value
         self.sanitize()
 
     @property
@@ -104,8 +104,8 @@ class Number(ValidationElement, DisableableElement):
         value = float(self.value)
         value = max(value, self.min)
         value = min(value, self.max)
-        if self.digits is not None:
-            value = float(round(value, self.digits))
+        if self.precision is not None:
+            value = float(round(value, self.precision))
         self.set_value(float(self.format % value) if self.format else value)
 
     def _event_args_to_value(self, e: GenericEventArguments) -> Any:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -53,3 +53,24 @@ def test_out_of_limits(screen: Screen):
 
     number.max = 15
     screen.should_contain('out_of_limits: False')
+
+
+def test_integer(screen: Screen):
+    event_values = []
+    number = ui.number('Number', integer=True, value=5, on_change=lambda e: event_values.append(e.value))
+    ui.label().bind_text_from(number, 'value', lambda value: f'value: {value}, type: {type(value)}')
+
+    screen.open('/')
+    screen.should_contain("value: 5, type: <class 'int'>")
+
+    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
+    element.send_keys('67.89')
+    screen.should_contain("value: 567, type: <class 'int'>")
+
+    number.set_value(1.23)
+    screen.should_contain("value: 1, type: <class 'int'>")
+
+    number.value = 4.56
+    screen.should_contain("value: 4, type: <class 'int'>")
+
+    assert event_values == [56, 567, 0, 567, 1, 4]

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -59,9 +59,9 @@ def test_out_of_limits(screen: Screen):
     screen.should_contain('out_of_limits: False')
 
 
-@pytest.mark.parametrize('digits', [None, 1, -1])
-def test_rounding(digits: int, screen: Screen):
-    number = ui.number('Number', value=12, digits=digits)
+@pytest.mark.parametrize('precision', [None, 1, -1])
+def test_rounding(precision: int, screen: Screen):
+    number = ui.number('Number', value=12, precision=precision)
     ui.label().bind_text_from(number, 'value', lambda value: f'number=_{value}_')
 
     screen.open('/')
@@ -70,9 +70,9 @@ def test_rounding(digits: int, screen: Screen):
     element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
     element.send_keys('.345')
     screen.click('number=')  # blur the number input
-    if digits is None:
+    if precision is None:
         screen.should_contain('number=_12.345_')
-    elif digits == 1:
+    elif precision == 1:
         screen.should_contain('number=_12.3_')
-    elif digits == -1:
+    elif precision == -1:
         screen.should_contain('number=_10.0_')

--- a/website/more_documentation/number_documentation.py
+++ b/website/more_documentation/number_documentation.py
@@ -17,3 +17,10 @@ def more() -> None:
     def clearable():
         i = ui.number(value=42).props('clearable')
         ui.label().bind_text_from(i, 'value')
+
+    @text_demo('Integer', '''
+       Coerce the returned value to be integer instead of the default float.    
+    ''')
+    def integer():
+        i = ui.number(value=38)
+        ui.button('Check number type', on_click=lambda: ui.notify(f'{i.value=} is of type {type(i.value)}'))

--- a/website/more_documentation/number_documentation.py
+++ b/website/more_documentation/number_documentation.py
@@ -17,13 +17,13 @@ def more() -> None:
         i = ui.number(value=42).props('clearable')
         ui.label().bind_text_from(i, 'value')
 
-    @text_demo('Number of digits', '''
-        You can specify the number of digits using the `digits` parameter.
+    @text_demo('Number of decimal places', '''
+        You can specify the number of decimal places using the `precision` parameter.
         A negative value means decimal places before the dot.
         The rounding takes place when the input loses focus,
-        when sanitization parameters like min, max or digits change,
+        when sanitization parameters like min, max or precision change,
         or when `sanitize()` is called manually.
     ''')
     def integer():
-        n = ui.number(value=3.14159265359, digits=5)
+        n = ui.number(value=3.14159265359, precision=5)
         n.sanitize()

--- a/website/more_documentation/number_documentation.py
+++ b/website/more_documentation/number_documentation.py
@@ -10,7 +10,6 @@ def main_demo() -> None:
 
 
 def more() -> None:
-
     @text_demo('Clearable', '''
         The `clearable` prop from [Quasar](https://quasar.dev/) adds a button to the input that clears the text.    
     ''')
@@ -18,10 +17,13 @@ def more() -> None:
         i = ui.number(value=42).props('clearable')
         ui.label().bind_text_from(i, 'value')
 
-    @text_demo('Integer', '''
-        You can coerce an integer value instead of the default float using the `integer` parameter.
+    @text_demo('Number of digits', '''
+        You can specify the number of digits using the `digits` parameter.
+        A negative value means decimal places before the dot.
+        The rounding takes place when the input loses focus,
+        when sanitization parameters like min, max or digits change,
+        or when `sanitize()` is called manually.
     ''')
     def integer():
-        i = ui.number(value=38)
-        ui.button('Check number type',
-                  on_click=lambda: ui.notify(f'{i.value=} is of type {type(i.value)}'))
+        n = ui.number(value=3.14159265359, digits=5)
+        n.sanitize()

--- a/website/more_documentation/number_documentation.py
+++ b/website/more_documentation/number_documentation.py
@@ -19,8 +19,9 @@ def more() -> None:
         ui.label().bind_text_from(i, 'value')
 
     @text_demo('Integer', '''
-       Coerce the returned value to be integer instead of the default float.    
+        You can coerce an integer value instead of the default float using the `integer` parameter.
     ''')
     def integer():
         i = ui.number(value=38)
-        ui.button('Check number type', on_click=lambda: ui.notify(f'{i.value=} is of type {type(i.value)}'))
+        ui.button('Check number type',
+                  on_click=lambda: ui.notify(f'{i.value=} is of type {type(i.value)}'))


### PR DESCRIPTION
Feature to allow for an integer to be the returned type of ui.number instead of the default float. Example provided as well.

Feature request: #1921