### PR TITLE
Raise RuntimeError if a page layout element is nested

### DIFF
--- a/nicegui/page_layout.py
+++ b/nicegui/page_layout.py
@@ -273,4 +273,5 @@ class PageSticky(Element):
 def _check_current_slot() -> None:
     parent = context.get_slot().parent
     if parent != parent.client.content:
-        log.warning('Layout elements should not be nested but must be direct children of the page content. This will be raising an Exception in NiceGUI 1.5')  # DEPRECATED
+        log.warning('Layout elements should not be nested but must be direct children of the page content. '
+                    'This will be raising an exception in NiceGUI 1.5')  # DEPRECATED

--- a/nicegui/page_layout.py
+++ b/nicegui/page_layout.py
@@ -43,6 +43,7 @@ class Header(ValueElement):
         :param wrap: whether the header should wrap its content (default: `True`)
         :param add_scroll_padding: whether to automatically prevent link targets from being hidden behind the header (default: `True`)
         """
+        _check_current_slot()
         with context.get_client().layout:
             super().__init__(tag='q-header', value=value, on_value_change=None)
         self._classes.append('nicegui-header')
@@ -106,6 +107,7 @@ class Drawer(Element):
         :param top_corner: whether the drawer expands into the top corner (default: `False`)
         :param bottom_corner: whether the drawer expands into the bottom corner (default: `False`)
         """
+        _check_current_slot()
         with context.get_client().layout:
             super().__init__('q-drawer')
         if value is None:
@@ -224,6 +226,7 @@ class Footer(ValueElement):
         :param elevated: whether the footer should have a shadow (default: `False`)
         :param wrap: whether the footer should wrap its content (default: `True`)
         """
+        _check_current_slot()
         with context.get_client().layout:
             super().__init__(tag='q-footer', value=value, on_value_change=None)
         self.classes('nicegui-footer')
@@ -264,3 +267,9 @@ class PageSticky(Element):
         super().__init__('q-page-sticky')
         self._props['position'] = position
         self._props['offset'] = [x_offset, y_offset]
+
+
+def _check_current_slot() -> None:
+    parent = context.get_slot().parent
+    if parent != parent.client.content:
+        raise RuntimeError('Layout elements must not be nested but must be direct children of the page content.')

--- a/nicegui/page_layout.py
+++ b/nicegui/page_layout.py
@@ -4,6 +4,7 @@ from . import context
 from .element import Element
 from .elements.mixins.value_element import ValueElement
 from .functions.html import add_body_html
+from .logging import log
 
 DrawerSides = Literal['left', 'right']
 
@@ -272,4 +273,4 @@ class PageSticky(Element):
 def _check_current_slot() -> None:
     parent = context.get_slot().parent
     if parent != parent.client.content:
-        raise RuntimeError('Layout elements must not be nested but must be direct children of the page content.')
+        log.warning('Layout elements should not be nested but must be direct children of the page content. This will be raising an Exception in NiceGUI 1.5')  # DEPRECATED


### PR DESCRIPTION
This PR tries to avoid the confusion from #1953 where a `ui.header` was placed inside a refreshable UI container.

**But** I'm not 100% sure if it is too harsh to exit with an exception just because the element is created from the wrong spot. This might break existing code where it works perfectly fine to call `ui.header` from anywhere. Should we print a warning instead? Or is it a reasonable requirement to create such elements from the top-most slot?