### PR TITLE
ui.json_editor has no dispose method

### DIFF
--- a/nicegui/elements/json_editor.js
+++ b/nicegui/elements/json_editor.js
@@ -28,7 +28,7 @@ export default {
     },
     destroyEditor() {
       if (this.editor) {
-        this.editor.dispose();
+        this.editor.destroy();
       }
     },
   },


### PR DESCRIPTION
This library utilizes a `destroy` method to remove the element not `dispose`.

```py
from nicegui import app, ui

with ui.column():
    je = ui.json_editor({"content": {"json":{"test":"test"}}})

ui.button("remove", on_click=lambda _: je.run_method("destroyEditor"))
ui.run()
```

The above example logs an error on the browser when clicking the remove button.