### PR TITLE
outbox: RuntimeError: dictionary changed size during iteration

### DIFF
--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -51,7 +51,7 @@ async def loop(air: Optional[Air]) -> None:
             for client_id, elements in update_queue.items():
                 data = {
                     element_id: None if element is None else element._to_dict()  # pylint: disable=protected-access
-                    for element_id, element in elements.items()
+                    for element_id, element in list(elements.items())
                 }
                 coros.append(emit('update', data, client_id))
             update_queue.clear()


### PR DESCRIPTION
This should fix the issue tested. Before issue show up few times per hour not happen any more.

Reproducing very difficult,  comes side effect. 

list take copy of items therefore dictionary size cannot change during iteration anymore.

```
Error message:
dictionary changed size during iteration
Traceback (most recent call last):
  File "/home/hsyrja/.local/lib/python3.10/site-packages/nicegui/outbox.py", line 49, in loop
    data = {
  File "/home/hsyrja/.local/lib/python3.10/site-packages/nicegui/outbox.py", line 49, in <dictcomp>
    data = {
RuntimeError: dictionary changed size during iteration
```