### PR TITLE
Allow client to download raw data from server

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -192,13 +192,9 @@ class Client:
         path = target if isinstance(target, str) else self.page_routes[target]
         outbox.enqueue_message('open', {'path': path, 'new_tab': new_tab}, self.id)
 
-    def download(self, url: str, filename: Optional[str] = None) -> None:
-        """Download a file from the given URL."""
-        outbox.enqueue_message('download', {'url': url, 'filename': filename}, self.id)
-
-    def download_bytes(self, data: bytes, filename: Optional[str] = None) -> None:
-        """Download a file from the given bytes."""
-        outbox.enqueue_message('download_bytes', {'data': data, 'filename': filename}, self.id)
+    def download(self, src: Union[str, bytes], filename: Optional[str] = None) -> None:
+        """Download a file from a given URL or raw bytes."""
+        outbox.enqueue_message('download', {'src': src, 'filename': filename}, self.id)
 
     def on_connect(self, handler: Union[Callable[..., Any], Awaitable]) -> None:
         """Register a callback to be called when the client connects."""

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -196,6 +196,10 @@ class Client:
         """Download a file from the given URL."""
         outbox.enqueue_message('download', {'url': url, 'filename': filename}, self.id)
 
+    def download_bytes(self, data: bytes, filename: Optional[str] = None) -> None:
+        """Download a file from the given bytes."""
+        outbox.enqueue_message('download_bytes', {'data': data, 'filename': filename}, self.id)
+
     def on_connect(self, handler: Union[Callable[..., Any], Awaitable]) -> None:
         """Register a callback to be called when the client connects."""
         self.connect_handlers.append(handler)

--- a/nicegui/functions/download.py
+++ b/nicegui/functions/download.py
@@ -4,27 +4,17 @@ from typing import Optional, Union
 from .. import context, core, helpers
 
 
-def download(src: Union[str, Path], filename: Optional[str] = None) -> None:
+def download(src: Union[str, Path, bytes], filename: Optional[str] = None) -> None:
     """Download
 
-    Function to trigger the download of a file.
+    Function to trigger the download of a file, URL or bytes.
 
-    :param src: target URL or local path of the file which should be downloaded
+    :param src: target URL, local path of a file or raw data which should be downloaded
     :param filename: name of the file to download (default: name of the file on the server)
     """
-    if helpers.is_file(src):
-        src = core.app.add_static_file(local_file=src, single_use=True)
-    else:
-        src = str(src)
+    if not isinstance(src, bytes):
+        if helpers.is_file(src):
+            src = core.app.add_static_file(local_file=src, single_use=True)
+        else:
+            src = str(src)
     context.get_client().download(src, filename)
-
-
-def download_raw(data: bytes, filename: Optional[str] = None) -> None:
-    """Download
-
-    Function to trigger the download of a file from raw data.
-
-    :param data: raw data of a file which should be downloaded
-    :param filename: name of the file to download (default: browser generated name)
-    """
-    context.get_client().download_bytes(data, filename)

--- a/nicegui/functions/download.py
+++ b/nicegui/functions/download.py
@@ -17,3 +17,14 @@ def download(src: Union[str, Path], filename: Optional[str] = None) -> None:
     else:
         src = str(src)
     context.get_client().download(src, filename)
+
+
+def download_raw(data: bytes, filename: Optional[str] = None) -> None:
+    """Download
+
+    Function to trigger the download of a file from raw data.
+
+    :param data: raw data of a file which should be downloaded
+    :param filename: name of the file to download (default: browser generated name)
+    """
+    context.get_client().download_bytes(data, filename)

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -218,6 +218,18 @@
         document.body.removeChild(anchor);
       }
 
+      function download_bytes(data, filename) {
+        const anchor = document.createElement("a");
+        const url = URL.createObjectURL(new Blob([data]));
+        anchor.href = url;
+        anchor.target = "_blank";
+        anchor.download = filename || "";
+        document.body.appendChild(anchor);
+        anchor.click();
+        document.body.removeChild(anchor);
+        URL.revokeObjectURL(url);
+      }
+
       async function loadDependencies(element) {
         if (element.component) {
           const {name, key, tag} = element.component;
@@ -298,6 +310,7 @@
               window.open(url, target);
             },
             download: (msg) => download(msg.url, msg.filename),
+            download_bytes: (msg) => download_bytes(msg.data, msg.filename),
             notify: (msg) => Quasar.Notify.create(msg),
           };
           const socketMessageQueue = [];

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -208,26 +208,17 @@
         });
       }
 
-      function download(url, filename) {
+      function download(src, filename) {
         const anchor = document.createElement("a");
-        anchor.href = url;
+        anchor.href = typeof src === "string" ? src : URL.createObjectURL(new Blob([src]));
         anchor.target = "_blank";
         anchor.download = filename || "";
         document.body.appendChild(anchor);
         anchor.click();
         document.body.removeChild(anchor);
-      }
-
-      function download_bytes(data, filename) {
-        const anchor = document.createElement("a");
-        const url = URL.createObjectURL(new Blob([data]));
-        anchor.href = url;
-        anchor.target = "_blank";
-        anchor.download = filename || "";
-        document.body.appendChild(anchor);
-        anchor.click();
-        document.body.removeChild(anchor);
-        URL.revokeObjectURL(url);
+        if (typeof src !== "string") {
+          URL.revokeObjectURL(url);
+        }
       }
 
       async function loadDependencies(element) {
@@ -309,8 +300,7 @@
               const target = msg.new_tab ? '_blank' : '_self';
               window.open(url, target);
             },
-            download: (msg) => download(msg.url, msg.filename),
-            download_bytes: (msg) => download_bytes(msg.data, msg.filename),
+            download: (msg) => download(msg.src, msg.filename),
             notify: (msg) => Quasar.Notify.create(msg),
           };
           const socketMessageQueue = [];

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -181,7 +181,7 @@ from .elements.tooltip import Tooltip as tooltip
 from .elements.tree import Tree as tree
 from .elements.upload import Upload as upload
 from .elements.video import Video as video
-from .functions.download import download, download_raw
+from .functions.download import download
 from .functions.html import add_body_html, add_head_html
 from .functions.javascript import run_javascript
 from .functions.notify import notify

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -181,7 +181,7 @@ from .elements.tooltip import Tooltip as tooltip
 from .elements.tree import Tree as tree
 from .elements.upload import Upload as upload
 from .elements.video import Video as video
-from .functions.download import download
+from .functions.download import download, download_raw
 from .functions.html import add_body_html, add_head_html
 from .functions.javascript import run_javascript
 from .functions.notify import notify

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -43,7 +43,7 @@ def test_downloading_local_file_as_src(screen: Screen):
 
 
 def test_download_raw_data(screen: Screen):
-    ui.button('download', on_click=lambda: ui.download_raw(b'test', 'test.txt'))
+    ui.button('download', on_click=lambda: ui.download(b'test', 'test.txt'))
 
     screen.open('/')
     screen.click('download')

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -40,3 +40,12 @@ def test_downloading_local_file_as_src(screen: Screen):
     screen.wait(0.5)
     assert (DOWNLOAD_DIR / 'slide1.jpg').exists()
     assert len(app.routes) == route_count_before_download
+
+
+def test_download_raw_data(screen: Screen):
+    ui.button('download', on_click=lambda: ui.download_raw(b'test', 'test.txt'))
+
+    screen.open('/')
+    screen.click('download')
+    screen.wait(0.5)
+    assert (DOWNLOAD_DIR / 'test.txt').read_text() == 'test'


### PR DESCRIPTION
I'm doing some in-memory conversion of uploaded files and I wanted the new data to be downloaded by the client without saving it to the disk on the server first and using ui.download.

This PR creates a new method & message 'download_raw' that accepts bytes instead of a local or remote file path. On the JS side, it constructs a local blob and object URL from the incoming data. Although similar to ui.download, I went with a separate method since ui.download expects a URL.