### PR TITLE
Fix update of echart options when number of series changes

### DIFF
--- a/nicegui/elements/echart.js
+++ b/nicegui/elements/echart.js
@@ -17,7 +17,7 @@ export default {
   methods: {
     update_chart() {
       convertDynamicProperties(this.options, true);
-      this.chart.setOption(this.options, { notMerge: this.chart.options.series.length != this.options.series.length });
+      this.chart.setOption(this.options, { notMerge: this.chart.options?.series.length != this.options.series.length });
     },
   },
   props: {

--- a/nicegui/elements/echart.js
+++ b/nicegui/elements/echart.js
@@ -17,7 +17,7 @@ export default {
   methods: {
     update_chart() {
       convertDynamicProperties(this.options, true);
-      this.chart.setOption(this.options);
+      this.chart.setOption(this.options, { notMerge: this.chart.options.series.length != this.options.series.length });
     },
   },
   props: {


### PR DESCRIPTION
This PR results from discussion #1900 and fixes situations like this:

```py
chart = ui.echart({
    'xAxis': {'type': 'category'},
    'yAxis': {'type': 'value'},
    'series': [{'type': 'line', 'data': [0]}],
})

ui.button('Set two', on_click=lambda: (
    chart.options.update(series=[{'type': 'line', 'data': [1]}, {'type': 'line', 'data': [2]}]),
    chart.update(),
))
ui.button('Set one', on_click=lambda: (
    chart.options.update(series=[{'type': 'line', 'data': [3]}]),
    chart.update(),
))
```

With the change from this PR, we can click both buttons in turn and always get the correct number of dots.