### PR TITLE
Warn about late returns in @ui.page builder, which were silently dropped before

### DIFF
--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -12,6 +12,7 @@ from . import background_tasks, binding, core, helpers
 from .client import Client
 from .favicon import create_favicon_route
 from .language import Language
+from .logging import log
 
 if TYPE_CHECKING:
     from .api_router import APIRouter
@@ -87,6 +88,10 @@ class page:
         core.app.remove_route(self.path)  # NOTE make sure only the latest route definition is used
         parameters_of_decorated_func = list(inspect.signature(func).parameters.keys())
 
+        def warn_about_late_returns(task: asyncio.Task) -> None:
+            if task.result():
+                log.error(f'ignoring {task.result()}; it was returned after the html was delivered to the client')
+
         async def decorated(*dec_args, **dec_kwargs) -> Response:
             request = dec_kwargs['request']
             # NOTE cleaning up the keyword args so the signature is consistent with "func" again
@@ -105,7 +110,7 @@ class page:
                     if time.time() > deadline:
                         raise TimeoutError(f'Response not ready after {self.response_timeout} seconds')
                     await asyncio.sleep(0.1)
-                result = task.result() if task.done() else None
+                result = task.result() if task.done() else task.add_done_callback(warn_about_late_returns)  # type: ignore
             if isinstance(result, Response):  # NOTE if setup returns a response, we don't need to render the page
                 return result
             binding._refresh_step()  # pylint: disable=protected-access

--- a/tests/screen.py
+++ b/tests/screen.py
@@ -204,7 +204,7 @@ class Screen:
             assert record.levelname.strip() == level, f'Expected "{level}" but got "{record.levelname}"'
 
             if isinstance(message, re.Pattern):
-                assert message.search(record.message), f'Expected "{message}" matching regex but got "{record.message}"'
+                assert message.search(record.message), f'Expected regex "{message}" but got "{record.message}"'
             else:
                 assert record.message.strip() == message, f'Expected "{message}" but got "{record.message}"'
         finally:

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -296,7 +296,7 @@ def test_warning_about_to_late_responses(screen: Screen):
 
     screen.open('/')
     screen.should_contain('NiceGUI page')
-    screen.assert_py_logger('ERROR', re.compile('it was returned after the html was delivered to the client'))
+    screen.assert_py_logger('ERROR', re.compile('it was returned after the HTML had been delivered to the client'))
 
 
 def test_reconnecting_without_page_reload(screen: Screen):

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from uuid import uuid4
 
 from fastapi.responses import PlainTextResponse
@@ -284,6 +285,18 @@ def test_returning_custom_response_async(screen: Screen):
     screen.open('/?plain=true')
     screen.should_contain('custom response')
     screen.should_not_contain('normal NiceGUI page')
+
+
+def test_warning_about_to_late_responses(screen: Screen):
+    @ui.page('/')
+    async def page(client: Client):
+        await client.connected()
+        ui.label('NiceGUI page')
+        return PlainTextResponse('custom response')
+
+    screen.open('/')
+    screen.should_contain('NiceGUI page')
+    screen.assert_py_logger('ERROR', re.compile('it was returned after the html was delivered to the client'))
 
 
 def test_reconnecting_without_page_reload(screen: Screen):


### PR DESCRIPTION
Inspired by a discussion [on Discord](https://discord.com/channels/1089836369431498784/1169342396333572211/1178909767490609192), this PR will show a warning when a return value is detected in a @ui.page decorator after the NiceGUI html has been delivered to the browser. Before we have just silently dropped any such return values.