### PR TITLE
restructure main layout of documentation

### DIFF
--- a/website/documentation/content/doc/__init__.py
+++ b/website/documentation/content/doc/__init__.py
@@ -1,4 +1,4 @@
-from .api import demo, get_page, intro, reference, registry, text, title, ui
+from .api import demo, extra_column, get_page, intro, reference, registry, text, title, ui
 
 __all__ = [
     'demo',
@@ -9,4 +9,5 @@ __all__ = [
     'title',
     'ui',
     'get_page',
+    'extra_column',
 ]

--- a/website/documentation/content/doc/api.py
+++ b/website/documentation/content/doc/api.py
@@ -130,6 +130,12 @@ def reference(element: type, *,
     _get_current_page().parts.append(DocumentationPart(title=title, reference=element))
 
 
+def extra_column(function: Callable) -> Callable:
+    """Add an extra column to the current documentation page."""
+    _get_current_page().extra_column = function
+    return function
+
+
 def _find_attribute(obj: Any, name: str) -> Optional[str]:
     for attr in dir(obj):
         if attr.lower().replace('_', '') == name.lower().replace('_', ''):

--- a/website/documentation/content/doc/page.py
+++ b/website/documentation/content/doc/page.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from nicegui.dataclasses import KWONLY_SLOTS
 
@@ -13,6 +13,7 @@ class DocumentationPage:
     subtitle: Optional[str] = None
     back_link: Optional[str] = None
     parts: List[DocumentationPart] = field(default_factory=list)
+    extra_column: Optional[Callable] = None
 
     @property
     def heading(self) -> str:

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -39,6 +39,40 @@ doc.text('Basic concepts', '''
     Or if you prefer, almost anything can be styled with CSS.
 ''')
 
+doc.text('Actions', '''
+    NiceGUI runs an event loop to handle user input and other events like timers and keyboard bindings.
+    You can write asynchronous functions for long-running tasks to keep the UI responsive.
+    The _Actions_ section covers how to work with events.
+''')
+
+doc.text('Implementation', '''
+    NiceGUI is implemented with HTML components served by an HTTP server (FastAPI), even for native windows.
+    If you already know HTML, everything will feel very familiar.
+    If you don't know HTML, that's fine too!
+    NiceGUI abstracts away the details, so you can focus on creating beautiful interfaces without worrying about how they are implemented.
+''')
+
+doc.text('Running NiceGUI Apps', '''
+    There are several options for deploying NiceGUI.
+    By default, NiceGUI runs a server on localhost and runs your app as a private web page on the local machine.
+    When run this way, your app appears in a web browser window.
+    You can also run NiceGUI in a native window separate from a web browser.
+    Or you can run NiceGUI on a server that handles many clients - the website you're reading right now is served from NiceGUI.
+
+    After creating your app pages with components, you call `ui.run()` to start the NiceGUI server.
+    Optional parameters to `ui.run` set things like the network address and port the server binds to, 
+    whether the app runs in native mode, initial window size, and many other options.
+    The section _Configuration and Deployment_ covers the options to the `ui.run()` function and the FastAPI framework it is based on.
+''')
+
+doc.text('Customization', '''
+    If you want more customization in your app, you can use the underlying Tailwind classes and Quasar components
+    to control the style or behavior of your components.
+    You can also extend the available components by subclassing existing NiceGUI components or importing new ones from Quasar.
+    All of this is optional.
+    Out of the box, NiceGUI provides everything you need to make modern, stylish, responsive user interfaces.
+''')
+
 tiles = [
     (section_text_elements, '''
         Elements like `ui.label`, `ui.markdown` and `ui.html` can be used to display text and other content.
@@ -73,9 +107,9 @@ tiles = [
 ]
 
 
-@doc.ui
+@doc.extra_column
 def create_tiles():
-    with ui.grid().classes('grid-cols-[1fr] md:grid-cols-[1fr_1fr] xl:grid-cols-[1fr_1fr_1fr]'):
+    with ui.row():
         for documentation, description in tiles:
             page = doc.get_page(documentation)
             with ui.link(target=f'/documentation/{page.name}') \
@@ -84,38 +118,3 @@ def create_tiles():
                 if page.title:
                     ui.label(page.title.replace('*', '')).classes(replace='text-2xl')
                 ui.markdown(description).classes(replace='bold-links arrow-links')
-
-
-doc.text('Actions', '''
-    NiceGUI runs an event loop to handle user input and other events like timers and keyboard bindings.
-    You can write asynchronous functions for long-running tasks to keep the UI responsive.
-    The _Actions_ section covers how to work with events.
-''')
-
-doc.text('Implementation', '''
-    NiceGUI is implemented with HTML components served by an HTTP server (FastAPI), even for native windows.
-    If you already know HTML, everything will feel very familiar.
-    If you don't know HTML, that's fine too!
-    NiceGUI abstracts away the details, so you can focus on creating beautiful interfaces without worrying about how they are implemented.
-''')
-
-doc.text('Running NiceGUI Apps', '''
-    There are several options for deploying NiceGUI.
-    By default, NiceGUI runs a server on localhost and runs your app as a private web page on the local machine.
-    When run this way, your app appears in a web browser window.
-    You can also run NiceGUI in a native window separate from a web browser.
-    Or you can run NiceGUI on a server that handles many clients - the website you're reading right now is served from NiceGUI.
-
-    After creating your app pages with components, you call `ui.run()` to start the NiceGUI server.
-    Optional parameters to `ui.run` set things like the network address and port the server binds to, 
-    whether the app runs in native mode, initial window size, and many other options.
-    The section _Configuration and Deployment_ covers the options to the `ui.run()` function and the FastAPI framework it is based on.
-''')
-
-doc.text('Customization', '''
-    If you want more customization in your app, you can use the underlying Tailwind classes and Quasar components
-    to control the style or behavior of your components.
-    You can also extend the available components by subclassing existing NiceGUI components or importing new ones from Quasar.
-    All of this is optional.
-    Out of the box, NiceGUI provides everything you need to make modern, stylish, responsive user interfaces.
-''')

--- a/website/documentation/rendering.py
+++ b/website/documentation/rendering.py
@@ -32,28 +32,30 @@ def render_page(documentation: DocumentationPage, *, with_menu: bool = True) -> 
     # content
     with ui.column().classes('w-full p-8 lg:p-16 max-w-[1250px] mx-auto'):
 
-        # heading
-        section_heading(documentation.subtitle or '', documentation.heading)
-
-        # parts
-        for part in documentation.parts:
-            if part.title:
-                if part.link_target:
-                    ui.link_target(part.link_target)
-                subheading(part.title, link=part.link, major=part.reference is not None)
-            if part.description:
-                if part.description_format == 'rst':
-                    description = part.description.replace('param ', '')
-                    html = docutils.core.publish_parts(description, writer_name='html5_polyglot')['html_body']
-                    html = apply_tailwind(html)
-                    ui.html(html)
-                else:
-                    ui.markdown(part.description)
-            if part.ui:
-                part.ui()
-            if part.demo:
-                demo(part.demo.function, lazy=part.demo.lazy, tab=part.demo.tab)
-            if part.reference:
-                generate_class_doc(part.reference)
-            if part.link:
-                ui.markdown(f'See [more...]({part.link})').classes('bold-links arrow-links')
+        with ui.row():
+            with ui.column().classes('w-[65%]' if documentation.extra_column else 'w-full'):
+                section_heading(documentation.subtitle or '', documentation.heading)
+                for part in documentation.parts:
+                    if part.title:
+                        if part.link_target:
+                            ui.link_target(part.link_target)
+                        subheading(part.title, link=part.link, major=part.reference is not None)
+                    if part.description:
+                        if part.description_format == 'rst':
+                            description = part.description.replace('param ', '')
+                            html = docutils.core.publish_parts(description, writer_name='html5_polyglot')['html_body']
+                            html = apply_tailwind(html)
+                            ui.html(html)
+                        else:
+                            ui.markdown(part.description)
+                    if part.ui:
+                        part.ui()
+                    if part.demo:
+                        demo(part.demo.function, lazy=part.demo.lazy, tab=part.demo.tab)
+                    if part.reference:
+                        generate_class_doc(part.reference)
+                    if part.link:
+                        ui.markdown(f'See [more...]({part.link})').classes('bold-links arrow-links')
+            if documentation.extra_column:
+                with ui.column().classes('ml-auto w-[30%]'):
+                    documentation.extra_column()


### PR DESCRIPTION
This PR rearranges the layout of the main documentation page to show cards in an extra column to the right of the intro text:

![Screenshot 2023-12-02 at 05 36 54](https://github.com/zauberzeug/nicegui/assets/131391/0b054780-8132-4318-9e16-49ca59970bf0)
