### PR TITLE
make <em> italics in the documentation

### DIFF
--- a/website/documentation/rendering.py
+++ b/website/documentation/rendering.py
@@ -30,7 +30,7 @@ def render_page(documentation: DocumentationPage, *, with_menu: bool = True) -> 
             ui.markdown(f'**{documentation.heading.replace("*", "")}**').classes('mt-4')
 
     # content
-    with ui.column().classes('w-full p-8 lg:p-16 max-w-[1250px] mx-auto'):
+    with ui.column().classes('w-full p-8 lg:p-16 max-w-[1250px] mx-auto documentation'):
 
         # heading
         section_heading(documentation.subtitle or '', documentation.heading)

--- a/website/documentation/rendering.py
+++ b/website/documentation/rendering.py
@@ -30,7 +30,7 @@ def render_page(documentation: DocumentationPage, *, with_menu: bool = True) -> 
             ui.markdown(f'**{documentation.heading.replace("*", "")}**').classes('mt-4')
 
     # content
-    with ui.column().classes('w-full p-8 lg:p-16 max-w-[1250px] mx-auto documentation'):
+    with ui.column().classes('w-full p-8 lg:p-16 max-w-[1250px] mx-auto'):
 
         # heading
         section_heading(documentation.subtitle or '', documentation.heading)

--- a/website/main_page.py
+++ b/website/main_page.py
@@ -52,7 +52,7 @@ def create() -> None:
         section_heading('Installation', 'Get *started*')
         with ui.row().classes('w-full text-lg leading-tight grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-8'):
             with ui.column().classes('w-full max-w-md gap-2'):
-                ui.html('<em>1.</em>').classes('text-3xl font-bold')
+                ui.html('<em>1.</em>').classes('text-3xl font-bold fancy-em')
                 ui.markdown('Create __main.py__').classes('text-lg')
                 with documentation.python_window(classes='w-full h-52'):
                     ui.markdown('''
@@ -65,7 +65,7 @@ def create() -> None:
                         ```
                     ''')
             with ui.column().classes('w-full max-w-md gap-2'):
-                ui.html('<em>2.</em>').classes('text-3xl font-bold')
+                ui.html('<em>2.</em>').classes('text-3xl font-bold fancy-em')
                 ui.markdown('Install and launch').classes('text-lg')
                 with documentation.bash_window(classes='w-full h-52'):
                     ui.markdown('''
@@ -75,7 +75,7 @@ def create() -> None:
                         ```
                     ''')
             with ui.column().classes('w-full max-w-md gap-2'):
-                ui.html('<em>3.</em>').classes('text-3xl font-bold')
+                ui.html('<em>3.</em>').classes('text-3xl font-bold fancy-em')
                 ui.markdown('Enjoy!').classes('text-lg')
                 with documentation.browser_window(classes='w-full h-52'):
                     ui.label('Hello NiceGUI!')

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -20,7 +20,11 @@ html:not(.has-dialog) {
   font-family: "Fira Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
 }
-em:not(.browser-window *) {
+em:not(.browser-window *):not(.documentation *) {
+  font-style: normal;
+  color: #5898d4;
+}
+.documentation .title em {
   font-style: normal;
   color: #5898d4;
 }

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -20,11 +20,7 @@ html:not(.has-dialog) {
   font-family: "Fira Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
 }
-em:not(.browser-window *):not(.documentation *) {
-  font-style: normal;
-  color: #5898d4;
-}
-.documentation .title em {
+.fancy-em em {
   font-style: normal;
   color: #5898d4;
 }

--- a/website/style.py
+++ b/website/style.py
@@ -19,7 +19,7 @@ def link_target(name: str, offset: str = '0') -> ui.link_target:
 def section_heading(subtitle_: str, title_: str) -> None:
     """Render a section heading with a subtitle."""
     ui.label(subtitle_).classes('md:text-lg font-bold')
-    ui.markdown(title_).classes('text-3xl md:text-5xl font-medium mt-[-12px] title')
+    ui.markdown(title_).classes('text-3xl md:text-5xl font-medium mt-[-12px] fancy-em')
 
 
 def heading(title_: str) -> ui.markdown:
@@ -29,7 +29,7 @@ def heading(title_: str) -> ui.markdown:
 
 def title(content: str) -> ui.markdown:
     """Render a title."""
-    return ui.markdown(content).classes('text-4xl sm:text-5xl md:text-6xl font-medium')
+    return ui.markdown(content).classes('text-4xl sm:text-5xl md:text-6xl font-medium fancy-em')
 
 
 def subtitle(content: str) -> ui.markdown:

--- a/website/style.py
+++ b/website/style.py
@@ -19,7 +19,7 @@ def link_target(name: str, offset: str = '0') -> ui.link_target:
 def section_heading(subtitle_: str, title_: str) -> None:
     """Render a section heading with a subtitle."""
     ui.label(subtitle_).classes('md:text-lg font-bold')
-    ui.markdown(title_).classes('text-3xl md:text-5xl font-medium mt-[-12px]')
+    ui.markdown(title_).classes('text-3xl md:text-5xl font-medium mt-[-12px] title')
 
 
 def heading(title_: str) -> ui.markdown:


### PR DESCRIPTION
On the https://nicegui.io website the `_emphesis_` is using a blue, not italic styling. This makes writing the titles quite easy. But in the documentation it does not work well. It looks like the emphasized parts are links:

<img width="702" alt="Screenshot 2023-12-02 at 05 57 47" src="https://github.com/zauberzeug/nicegui/assets/131391/2e8b10cf-80eb-4590-88ec-faa956906a9a">

This PR changes the rendering back to italic inside the documentation as is the markdown default (see https://www.markdownguide.org/basic-syntax/#italic).