### PR TITLE
Allow access to page template head and body

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -38,6 +38,12 @@ class Client:
     auto_index_client: Client
     """The client that is used to render the auto-index page."""
 
+    head_html = ''
+    """HTML to be inserted in the <head> of the page template."""
+
+    body_html = ''
+    """HTML to be inserted in the <body> of the page template."""
+
     def __init__(self, page: page, *, shared: bool = False) -> None:
         self.id = str(uuid.uuid4())
         self.created = time.time()
@@ -58,9 +64,6 @@ class Client:
                     self.content = Element('div').classes('nicegui-content')
 
         self.waiting_javascript_commands: Dict[str, Any] = {}
-
-        self.head_html = ''
-        self.body_html = ''
 
         self.page = page
 

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -38,11 +38,11 @@ class Client:
     auto_index_client: Client
     """The client that is used to render the auto-index page."""
 
-    head_html = ''
-    """HTML to be inserted in the <head> of the page template."""
+    shared_head_html = ''
+    """HTML to be inserted in the <head> of every page template."""
 
-    body_html = ''
-    """HTML to be inserted in the <body> of the page template."""
+    shared_body_html = ''
+    """HTML to be inserted in the <body> of every page template."""
 
     def __init__(self, page: page, *, shared: bool = False) -> None:
         self.id = str(uuid.uuid4())
@@ -65,6 +65,9 @@ class Client:
 
         self.waiting_javascript_commands: Dict[str, Any] = {}
 
+        self._head_html = ''
+        self._body_html = ''
+
         self.page = page
 
         self.connect_handlers: List[Union[Callable[..., Any], Awaitable]] = []
@@ -86,6 +89,16 @@ class Client:
     def has_socket_connection(self) -> bool:
         """Return True if the client is connected, False otherwise."""
         return self.environ is not None
+
+    @property
+    def head_html(self) -> str:
+        """Return the HTML code to be inserted in the <head> of the page template."""
+        return self.shared_head_html + self._head_html
+
+    @property
+    def body_html(self) -> str:
+        """Return the HTML code to be inserted in the <body> of the page template."""
+        return self.shared_body_html + self._body_html
 
     def __enter__(self):
         self.content.__enter__()

--- a/nicegui/functions/html.py
+++ b/nicegui/functions/html.py
@@ -1,11 +1,35 @@
-from .. import context
+from .. import Client, context
 
 
-def add_body_html(code: str) -> None:
-    """Add HTML code to the body of the page."""
-    context.get_client().body_html += code + '\n'
+def add_head_html(code: str, *, shared: bool = False) -> None:
+    """Add HTML code to the head of the page.
+
+    Note that this function can only be called before the page is sent to the client.
+
+    :param code: HTML code to add
+    :param shared: if True, the code is added to all pages
+    """
+    if shared:
+        Client.shared_head_html += code + '\n'
+    else:
+        client = context.get_client()
+        if client.has_socket_connection:
+            raise RuntimeError('Cannot add head HTML after the page has been sent to the client.')
+        client._head_html += code + '\n'  # pylint: disable=protected-access
 
 
-def add_head_html(code: str) -> None:
-    """Add HTML code to the head of the page."""
-    context.get_client().head_html += code + '\n'
+def add_body_html(code: str, *, shared: bool = False) -> None:
+    """Add HTML code to the body of the page.
+
+    Note that this function can only be called before the page is sent to the client.
+
+    :param code: HTML code to add
+    :param shared: if True, the code is added to all pages
+    """
+    if shared:
+        Client.shared_body_html += code + '\n'
+    else:
+        client = context.get_client()
+        if client.has_socket_connection:
+            raise RuntimeError('Cannot add body HTML after the page has been sent to the client.')
+        client._body_html += code + '\n'  # pylint: disable=protected-access


### PR DESCRIPTION
Implementation of #2126 

This just moves `head_html` and `body_html` to class attributes.

This allows for additional user customization of pages without needing to insert ui.elements() in every single page.

## Example

```py
from nicegui import Client, ui

Client.head_html = """
<style>
a {
    color: red !important;
}
</style>
"""

@ui.page("/")
def index():
    ui.link("hello", "/hello")
    ui.markdown("""[hello](/hello)""")

ui.run(title="test", port=8081, dark=True)
"""
```

![image](https://github.com/zauberzeug/nicegui/assets/18042232/dde6cfb7-9e14-405d-8705-c618ac4e28cc)
 
## Questions

Would you guys prefer some kind of wrapper instead of directly exposing the attributes like that? Maybe something like:

```py
# my app
from nicegui import add_head_html
add_head_html("<style>a { color: red !important; } </style>")

# internals
html_head_chunks = []
def add_head_html(chunk: str):
	html_head_chunks.append(chunk)

# client.py
class Client:
	def __init__(<args>):
		# <snip>
		self.head_html = '\n.join(head_html_chunks)
```
This would let you call `add_head_html()` multiple times, which might be useful for organization or conditional assembly of chunks.