### PR TITLE
Fixed select behavior in case of single with input

### DIFF
--- a/nicegui/elements/select.js
+++ b/nicegui/elements/select.js
@@ -20,26 +20,20 @@ export default {
   },
   methods: {
     filterFn(val, update, abort) {
-      update(() => {
-        const needle = this.$attrs.multiple
-          ? this.$el.querySelector("input[type=search]")?.value.toLocaleLowerCase()
-          : val.toLocaleLowerCase()
-        this.filteredOptions = this.findFilteredOptions(needle)
-      });
+      update(() => (this.filteredOptions = val ? this.findFilteredOptions() : this.initialOptions));
     },
-    findFilteredOptions(needle) {
+    findFilteredOptions() {
+      const needle = this.$el.querySelector("input[type=search]")?.value.toLocaleLowerCase();
       return needle
         ? this.initialOptions.filter((v) => String(v.label).toLocaleLowerCase().indexOf(needle) > -1)
         : this.initialOptions;
     },
   },
   updated() {
-    if (this.$attrs.multiple) {
-      const needle = this.$el.querySelector("input[type=search]")?.value.toLocaleLowerCase()
-      const newFilteredOptions = this.findFilteredOptions(needle)
-      if (newFilteredOptions.length !== this.filteredOptions.length) {
-        this.filteredOptions = newFilteredOptions;
-      }
+    if (!this.$attrs.multiple) return;
+    const newFilteredOptions = this.findFilteredOptions();
+    if (newFilteredOptions.length !== this.filteredOptions.length) {
+      this.filteredOptions = newFilteredOptions;
     }
   },
   watch: {

--- a/nicegui/elements/select.js
+++ b/nicegui/elements/select.js
@@ -20,19 +20,26 @@ export default {
   },
   methods: {
     filterFn(val, update, abort) {
-      update(() => (this.filteredOptions = this.findFilteredOptions()));
+      update(() => {
+        const needle = this.$attrs.multiple
+          ? this.$el.querySelector("input[type=search]")?.value.toLocaleLowerCase()
+          : val.toLocaleLowerCase()
+        this.filteredOptions = this.findFilteredOptions(needle)
+      });
     },
-    findFilteredOptions() {
-      const needle = this.$el.querySelector("input[type=search]")?.value.toLocaleLowerCase();
+    findFilteredOptions(needle) {
       return needle
         ? this.initialOptions.filter((v) => String(v.label).toLocaleLowerCase().indexOf(needle) > -1)
         : this.initialOptions;
     },
   },
   updated() {
-    const newFilteredOptions = this.findFilteredOptions();
-    if (newFilteredOptions.length !== this.filteredOptions.length) {
-      this.filteredOptions = newFilteredOptions;
+    if (this.$attrs.multiple) {
+      const needle = this.$el.querySelector("input[type=search]")?.value.toLocaleLowerCase()
+      const newFilteredOptions = this.findFilteredOptions(needle)
+      if (newFilteredOptions.length !== this.filteredOptions.length) {
+        this.filteredOptions = newFilteredOptions;
+      }
     }
   },
   watch: {

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -141,8 +141,10 @@ def test_add_new_values(screen:  Screen, option_dict: bool, multiple: bool, new_
             screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C'}" if option_dict else
                                   "options = ['a', 'b', 'c']")
 
-def test_keep_filtered_options_single(screen: Screen):
-    ui.select(options=['A1', 'A2', 'B1', 'B2'], with_input=True)
+
+@pytest.mark.parametrize('multiple', [False, True])
+def test_keep_filtered_options(multiple: bool, screen: Screen):
+    ui.select(options=['A1', 'A2', 'B1', 'B2'], with_input=True, multiple=multiple)
 
     screen.open('/')
     screen.find_by_tag('input').click()
@@ -163,29 +165,9 @@ def test_keep_filtered_options_single(screen: Screen):
     screen.find_by_tag('input').click()
     screen.should_contain('A1')
     screen.should_contain('A2')
-    screen.should_contain('B1')
-    screen.should_contain('B2')
-
-def test_keep_filtered_options_multiple(screen: Screen):
-    ui.select(options=['A1', 'A2', 'B1', 'B2'], with_input=True, multiple=True)
-
-    screen.open('/')
-    screen.find_by_tag('input').click()
-    screen.should_contain('A1')
-    screen.should_contain('A2')
-    screen.should_contain('B1')
-    screen.should_contain('B2')
-
-    screen.find_by_tag('input').send_keys('A')
-    screen.wait(0.5)
-    screen.should_contain('A1')
-    screen.should_contain('A2')
-    screen.should_not_contain('B1')
-    screen.should_not_contain('B2')
-
-    screen.click('A1')
-    screen.wait(0.5)
-    screen.should_contain('A1')
-    screen.should_contain('A2')
-    screen.should_not_contain('B1')
-    screen.should_not_contain('B2')
+    if multiple:
+        screen.should_not_contain('B1')
+        screen.should_not_contain('B2')
+    else:
+        screen.should_contain('B1')
+        screen.should_contain('B2')

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -141,8 +141,32 @@ def test_add_new_values(screen:  Screen, option_dict: bool, multiple: bool, new_
             screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C'}" if option_dict else
                                   "options = ['a', 'b', 'c']")
 
+def test_keep_filtered_options_single(screen: Screen):
+    ui.select(options=['A1', 'A2', 'B1', 'B2'], with_input=True)
 
-def test_keep_filtered_options(screen: Screen):
+    screen.open('/')
+    screen.find_by_tag('input').click()
+    screen.should_contain('A1')
+    screen.should_contain('A2')
+    screen.should_contain('B1')
+    screen.should_contain('B2')
+
+    screen.find_by_tag('input').send_keys('A')
+    screen.wait(0.5)
+    screen.should_contain('A1')
+    screen.should_contain('A2')
+    screen.should_not_contain('B1')
+    screen.should_not_contain('B2')
+
+    screen.click('A1')
+    screen.wait(0.5)
+    screen.find_by_tag('input').click()
+    screen.should_contain('A1')
+    screen.should_contain('A2')
+    screen.should_contain('B1')
+    screen.should_contain('B2')
+
+def test_keep_filtered_options_multiple(screen: Screen):
     ui.select(options=['A1', 'A2', 'B1', 'B2'], with_input=True, multiple=True)
 
     screen.open('/')


### PR DESCRIPTION
This patch fixes the behavior, when would like to use only single value select with input filtering.

Previously it automatically stored the filtering, causing that only selected value was shown to user as the only option. User must clear the value first in order to see all possible values. I believe this was not intended as the patch that caused this was meant to be for multiple value selects 