### PR TITLE
Persistence should handle issues when json data is broken

### DIFF
--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -13,6 +13,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from . import background_tasks, context, core, json, observables
+from .logging import log
 
 request_contextvar: contextvars.ContextVar[Optional[Request]] = contextvars.ContextVar('request_var', default=None)
 
@@ -46,6 +47,7 @@ class PersistentDict(observables.ObservableDict):
         try:
             data = json.loads(filepath.read_text()) if filepath.exists() else {}
         except Exception:
+            log.warning(f'Could not load storage file {filepath}')
             data = {}
         super().__init__(data, on_change=self.backup)
 

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -43,7 +43,10 @@ class PersistentDict(observables.ObservableDict):
 
     def __init__(self, filepath: Path) -> None:
         self.filepath = filepath
-        data = json.loads(filepath.read_text()) if filepath.exists() else {}
+        try:
+            data = json.loads(filepath.read_text()) if filepath.exists() else {}
+        except Exception:
+            data = {}
         super().__init__(data, on_change=self.backup)
 
     def backup(self) -> None:


### PR DESCRIPTION
This PR request ensures we properly handle broken json data when loading from persistence. A good example how this could happen was made on [Discord](https://discord.com/channels/1089836369431498784/1182377878650880020). NiceGUI breaks if non-serializable data is written to storage but later on can not load the empty file.