### PR TITLE
Reset filter when opening dropdown with multiple=False

### DIFF
--- a/nicegui/elements/select.js
+++ b/nicegui/elements/select.js
@@ -1,9 +1,10 @@
 export default {
-  props: ["options"],
+  props: ["multiple", "options"],
   template: `
     <q-select
       ref="qRef"
       v-bind="$attrs"
+      :multiple="multiple"
       :options="filteredOptions"
       @filter="filterFn"
     >
@@ -20,7 +21,7 @@ export default {
   },
   methods: {
     filterFn(val, update, abort) {
-      update(() => (this.filteredOptions = this.findFilteredOptions()));
+      update(() => (this.filteredOptions = val ? this.findFilteredOptions() : this.initialOptions));
     },
     findFilteredOptions() {
       const needle = this.$el.querySelector("input[type=search]")?.value.toLocaleLowerCase();
@@ -30,6 +31,7 @@ export default {
     },
   },
   updated() {
+    if (!this.multiple) return;
     const newFilteredOptions = this.findFilteredOptions();
     if (newFilteredOptions.length !== this.filteredOptions.length) {
       this.filteredOptions = newFilteredOptions;

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -165,3 +165,17 @@ def test_keep_filtered_options(screen: Screen):
     screen.should_contain('A2')
     screen.should_not_contain('B1')
     screen.should_not_contain('B2')
+
+
+def test_do_not_keep_filtered_options(screen: Screen):
+    # https://github.com/zauberzeug/nicegui/issues/2076
+    ui.select(options=['Alice', 'Bob', 'Carol'], with_input=True)
+
+    screen.open('/')
+    screen.find_by_tag('input').click()
+    screen.click('Alice')
+
+    screen.find_by_tag('input').click()
+    screen.should_contain('Alice')
+    screen.should_contain('Bob')
+    screen.should_contain('Carol')


### PR DESCRIPTION
This PR tries to solve issue #2076, where a single-select dropdown unexpectedly remains in a filtered state even though it has been closed and re-opened. Luckily the fix only involves a few changes:

- Change `filterFn` to use the initial options if `val` is not set. This is the case when the dropdown is re-opened without typing anything in the input field.
- Don't update the filtered options when updating a multi-select element. This avoid getting back into issue #2015.

All tests are green. I hope the PR doesn't introduce another follow-up issue.