### PR TITLE
Provide access to Leaflet options

### DIFF
--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -36,7 +36,7 @@ class Leaflet(Element, component='leaflet.js'):
         self._classes.append('nicegui-leaflet')
 
         self.layers: List[Layer] = []
-        self._props['map_options'] = ObservableDict()
+        self._props['map_options'] = ObservableDict(on_change=self.update)
         self.set_location(location)
         self.set_zoom(zoom)
         self.draw_control = draw_control
@@ -65,11 +65,6 @@ class Leaflet(Element, component='leaflet.js'):
     def options(self) -> ObservableDict[str, Any]:
         """Options configuring the Leaflet map."""
         return self._props['map_options']
-
-    @options.setter
-    def options(self, value: ObservableDict[str, Any]) -> None:
-        assert isinstance(value, ObservableDict)
-        self._props['map_options'] = value
 
     def _handle_init(self, e: GenericEventArguments) -> None:
         self.is_initialized = True

--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List, Tuple, cast
 
 from typing_extensions import Self
 
+from nicegui.observables import ObservableDict
+
 from .. import binding
 from ..awaitable_response import AwaitableResponse, NullResponse
 from ..element import Element
@@ -34,7 +36,7 @@ class Leaflet(Element, component='leaflet.js'):
         self._classes.append('nicegui-leaflet')
 
         self.layers: List[Layer] = []
-        self._props['map_options'] = {}
+        self._props['map_options'] = ObservableDict()
         self.set_location(location)
         self.set_zoom(zoom)
         self.draw_control = draw_control
@@ -60,12 +62,13 @@ class Leaflet(Element, component='leaflet.js'):
         return attribute
 
     @property
-    def options(self) -> Dict[str, Any]:
+    def options(self) -> ObservableDict[str, Any]:
         """Options configuring the Leaflet map."""
         return self._props['map_options']
 
     @options.setter
-    def options(self, value: Dict[str, Any]) -> None:
+    def options(self, value: ObservableDict[str, Any]) -> None:
+        assert isinstance(value, ObservableDict)
         self._props['map_options'] = value
 
     def _handle_init(self, e: GenericEventArguments) -> None:

--- a/website/documentation/content/leaflet_documentation.py
+++ b/website/documentation/content/leaflet_documentation.py
@@ -61,12 +61,7 @@ def vector_layers() -> None:
 def map_options() -> None:
     m = ui.leaflet(location=(51.505, -0.09)).classes('h-32')
     m.options['zoomControl'] = False
-    m.update()
-
-    def keyboard_zoom(value: bool) -> None:
-        m.options['keyboard'] = value
-        m.update()
-    ui.switch('allow keyboard zoom', value=True, on_change=lambda e: keyboard_zoom(e.value))
+    ui.switch('keyboard zoom', on_change=lambda e: m.options.update({'keyboard': e.value}))
 
 
 doc.reference(ui.leaflet)

--- a/website/documentation/content/leaflet_documentation.py
+++ b/website/documentation/content/leaflet_documentation.py
@@ -53,4 +53,20 @@ def vector_layers() -> None:
                     args=[[51.505, -0.09], {'color': 'red', 'radius': 300}])
 
 
+@doc.demo('Changing Map Options', '''
+    You can change the map options with the `options` property.
+    See the [Leaflet documentation](https://leafletjs.com/reference.html#map) for a list of available options.
+    This demo hides the zoom controls and allows toggles weather the map is draggable and whether the zoom control is shown.
+''')
+def map_options() -> None:
+    m = ui.leaflet(location=(51.505, -0.09)).classes('h-32')
+    m.options['zoomControl'] = False
+    m.update()
+
+    def keyboard_zoom(value: bool) -> None:
+        m.options['keyboard'] = value
+        m.update()
+    ui.switch('allow keyboard zoom', value=True, on_change=lambda e: keyboard_zoom(e.value))
+
+
 doc.reference(ui.leaflet)


### PR DESCRIPTION
This PR should allow the manipulation of Leaflet options. Instead of building the options dict internally it is exposed but will require a `update()` call to be send to the client.

ToDos

- [ ] fix toggling of zoom controls in demo (no idea why it's not working)
- [x] could we use an observable dict for the options so the `update()` call is not needed?