### PR TITLE
Introduce `ui.page_title`

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -63,6 +63,8 @@ class Client:
 
         self.waiting_javascript_commands: Dict[str, Any] = {}
 
+        self.title: Optional[str] = None
+
         self._head_html = ''
         self._body_html = ''
 
@@ -127,7 +129,7 @@ class Client:
             'imports': json.dumps(imports),
             'js_imports': '\n'.join(js_imports),
             'quasar_config': json.dumps(core.app.config.quasar_config),
-            'title': self.page.resolve_title(),
+            'title': self.page.resolve_title() if self.title is None else self.title,
             'viewport': self.page.resolve_viewport(),
             'favicon_url': get_favicon_url(self.page, prefix),
             'dark': str(self.page.resolve_dark()),

--- a/nicegui/functions/page_title.py
+++ b/nicegui/functions/page_title.py
@@ -1,0 +1,12 @@
+from .. import context, json
+
+
+def page_title(title: str) -> None:
+    """Set the page title for the current client.
+
+    :param title: page title
+    """
+    client = context.get_client()
+    client.title = title
+    if client.has_socket_connection:
+        client.run_javascript(f'document.title = {json.dumps(title)}')

--- a/nicegui/functions/page_title.py
+++ b/nicegui/functions/page_title.py
@@ -2,7 +2,9 @@ from .. import context, json
 
 
 def page_title(title: str) -> None:
-    """Set the page title for the current client.
+    """Page title
+
+    Set the page title for the current client.
 
     :param title: page title
     """

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -87,6 +87,7 @@ __all__ = [
     'run_javascript',
     'notify',
     'open',
+    'page_title',
     'refreshable',
     'state',
     'update',
@@ -188,6 +189,7 @@ from .functions.html import add_body_html, add_head_html
 from .functions.javascript import run_javascript
 from .functions.notify import notify
 from .functions.open import open  # pylint: disable=redefined-builtin
+from .functions.page_title import page_title
 from .functions.refreshable import refreshable, state
 from .functions.update import update
 from .page import page

--- a/tests/test_page_title.py
+++ b/tests/test_page_title.py
@@ -1,0 +1,21 @@
+from nicegui import ui
+
+from .screen import Screen
+
+
+def test_page_title(screen: Screen):
+    ui.page_title('Initial title')
+    ui.button('Change title', on_click=lambda: ui.page_title('"New title"'))
+
+    @ui.page('/{title}')
+    def page(title: str):
+        ui.page_title(f'Title: {title}')
+
+    screen.open('/')
+    screen.should_contain('Initial title')
+
+    screen.click('Change title')
+    screen.should_contain('"New title"')
+
+    screen.open('/test')
+    screen.should_contain('Title: test')

--- a/website/documentation/content/page_title_documentation.py
+++ b/website/documentation/content/page_title_documentation.py
@@ -1,0 +1,8 @@
+from nicegui import ui
+
+from . import doc
+
+
+@doc.demo(ui.page_title)
+def main_demo() -> None:
+    ui.button('Change page title', on_click=lambda: ui.page_title('New Title'))

--- a/website/documentation/content/section_pages_routing.py
+++ b/website/documentation/content/section_pages_routing.py
@@ -2,7 +2,7 @@ import uuid
 
 from nicegui import app, ui
 
-from . import doc, download_documentation, open_documentation, page_documentation
+from . import doc, download_documentation, open_documentation, page_documentation, page_title_documentation
 
 CONSTANT_UUID = str(uuid.uuid4())
 
@@ -79,6 +79,7 @@ def parameter_demo():
     ui.link('Water', '/icon/water_drop?amount=3')
 
 
+doc.intro(page_title_documentation)
 doc.intro(open_documentation)
 doc.intro(download_documentation)
 


### PR DESCRIPTION
This PR follows up on discussion #1436 where we noticed that it's hard to set the page title dynamically. Therefore we introduce a function `ui.page_title` to set the title before or after a socket connection is established.

Usage examples:
```py
ui.page_title('Initial title')
ui.button('Change title', on_click=lambda: ui.page_title('"New title"'))

@ui.page('/{title}')
def page(title: str):
    ui.page_title(f'Title: {title}')
    ui.label(f'Title: {title}')
```
