### PR TITLE
Reduce the CSS specificity for ui.link to simplify overriding its style

### DIFF
--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -195,8 +195,7 @@
   display: grid;
   gap: var(--nicegui-default-gap);
 }
-.nicegui-link:link,
-.nicegui-link:visited {
+.nicegui-link {
   text-decoration-line: underline;
   color: rgb(59 130 246);
 }


### PR DESCRIPTION
This PR follows up on discussion #2134, where @frankhuurman noticed the difficulty of removing the underline of `ui.link`:
```py
ui.link('Link', target='#').classes('no-underline')
```

Because NiceGUI's default CSS definition for `.nicegui-link:link` and `.nicegui-link:visited` has higher specificity than Tailwind's `.no-underline`, you need to use the "important" prefix:
```py
ui.link('Link', target='#').classes('!no-underline')
```

But we can simply remove the link states in this case, making it easier to apply Tailwind classes to `ui.link`.