### PR TITLE
Add class methods to documentation

### DIFF
--- a/nicegui/elements/aggrid.py
+++ b/nicegui/elements/aggrid.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 from typing import Dict, List, Optional, cast
+
+from typing_extensions import Self
 
 from .. import optional_features
 from ..awaitable_response import AwaitableResponse
@@ -39,11 +39,12 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
         self._classes.append('nicegui-aggrid')
         self._classes.append(f'ag-theme-{theme}')
 
-    @staticmethod
-    def from_pandas(df: pd.DataFrame, *,
+    @classmethod
+    def from_pandas(cls,
+                    df: pd.DataFrame, *,
                     theme: str = 'balham',
                     auto_size_columns: bool = True,
-                    options: Dict = {}) -> AgGrid:
+                    options: Dict = {}) -> Self:
         """Create an AG Grid from a Pandas DataFrame.
 
         Note:
@@ -69,7 +70,7 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
             df[complex_cols] = df[complex_cols].astype(str)
             df[period_cols] = df[period_cols].astype(str)
 
-        return AgGrid({
+        return cls({
             'columnDefs': [{'field': str(col)} for col in df.columns],
             'rowData': df.to_dict('records'),
             'suppressDotNotation': True,

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
+
+from typing_extensions import Self
 
 from .. import optional_features
 from ..element import Element
@@ -72,13 +72,14 @@ class Table(FilterElement, component='table.js'):
             handle_event(on_pagination_change, arguments)
         self.on('update:pagination', handle_pagination_change)
 
-    @staticmethod
-    def from_pandas(df: pd.DataFrame,
+    @classmethod
+    def from_pandas(cls,
+                    df: pd.DataFrame,
                     row_key: str = 'id',
                     title: Optional[str] = None,
                     selection: Optional[Literal['single', 'multiple']] = None,
                     pagination: Optional[Union[int, dict]] = None,
-                    on_select: Optional[Callable[..., Any]] = None) -> Table:
+                    on_select: Optional[Callable[..., Any]] = None) -> Self:
         """Create a table from a Pandas DataFrame.
 
         Note:
@@ -106,7 +107,7 @@ class Table(FilterElement, component='table.js'):
             df[complex_cols] = df[complex_cols].astype(str)
             df[period_cols] = df[period_cols].astype(str)
 
-        return Table(
+        return cls(
             columns=[{'name': col, 'label': col, 'field': col} for col in df.columns],
             rows=df.to_dict('records'),
             row_key=row_key,

--- a/website/documentation/reference.py
+++ b/website/documentation/reference.py
@@ -45,7 +45,12 @@ def _is_method_or_property(cls: type, attribute_name: str) -> bool:
     return (
         inspect.isfunction(attribute) or
         inspect.ismethod(attribute) or
-        isinstance(attribute, (property, binding.BindableProperty))
+        isinstance(attribute, (
+            staticmethod,
+            classmethod,
+            property,
+            binding.BindableProperty,
+        ))
     )
 
 

--- a/website/documentation/reference.py
+++ b/website/documentation/reference.py
@@ -32,7 +32,12 @@ def generate_class_doc(class_obj: type) -> None:
         subheading('Methods')
         with ui.column().classes('gap-2'):
             for name, method in sorted(methods.items()):
-                ui.markdown(f'**`{name}`**`{_generate_method_signature_description(method)}`')
+                decorator = ''
+                if isinstance(class_obj.__dict__.get(name), staticmethod):
+                    decorator += '`@staticmethod`<br />'
+                if isinstance(class_obj.__dict__.get(name), classmethod):
+                    decorator += '`@classmethod`<br />'
+                ui.markdown(f'{decorator}**`{name}`**`{_generate_method_signature_description(method)}`')
                 if method.__doc__:
                     _render_docstring(method.__doc__).classes('ml-8')
     if ancestors:


### PR DESCRIPTION
This PR adds `ui.aggrid.from_pandas` and `ui.table.from_pandas` to the documentation.
It also shows a decorator above the signature to indicate the nature of such methods.

While working on the documentation for these methods, I noticed that they should be class methods instead of static methods: When inheriting a `CustomTable`, its `from_pandas` method should return a `CustomTable`, not a `ui.table`. Therefore its not a static method, but depending on `cls`.