### PR TITLE
Make text of `ui.expansion` bindable

### DIFF
--- a/nicegui/elements/expansion.py
+++ b/nicegui/elements/expansion.py
@@ -1,10 +1,11 @@
 from typing import Any, Callable, Optional
 
 from .mixins.disableable_element import DisableableElement
+from .mixins.text_element import TextElement
 from .mixins.value_element import ValueElement
 
 
-class Expansion(ValueElement, DisableableElement):
+class Expansion(TextElement, ValueElement, DisableableElement):
 
     def __init__(self,
                  text: Optional[str] = None, *,
@@ -21,9 +22,7 @@ class Expansion(ValueElement, DisableableElement):
         :param value: whether the expansion should be opened on creation (default: `False`)
         :param on_value_change: callback to execute when value changes
         """
-        super().__init__(tag='q-expansion-item', value=value, on_value_change=on_value_change)
-        if text is not None:
-            self._props['label'] = text
+        super().__init__(tag='q-expansion-item', text=text, value=value, on_value_change=on_value_change)
         self._props['icon'] = icon
         self._classes.append('nicegui-expansion')
 
@@ -34,3 +33,6 @@ class Expansion(ValueElement, DisableableElement):
     def close(self) -> None:
         """Close the expansion."""
         self.value = False
+
+    def _text_to_model_text(self, text: str) -> None:
+        self._props['label'] = text


### PR DESCRIPTION
This PR follows up on discussion #2199 and makes `ui.expansion` a `TextElement` with a bindable `text` property.

It can be tested like this:
```py
with ui.expansion() as ex:
    ui.label('inside the expansion')

ui.input(value='Expansion').bind_value_to(ex, 'text')
```