### PR TITLE
Fixed invalid initialization order

### DIFF
--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -20,10 +20,10 @@ class ValueElement(Element):
                  **kwargs: Any,
                  ) -> None:
         super().__init__(**kwargs)
+        self._send_update_on_value_change = True
         self.set_value(value)
         self._props[self.VALUE_PROP] = self._value_to_model_value(value)
         self._props['loopback'] = self.LOOPBACK
-        self._send_update_on_value_change = True
         self._change_handler = on_value_change
 
         def handle_change(e: GenericEventArguments) -> None:


### PR DESCRIPTION
This patch fixes wrong initialization order of value_element mixin.

I need to have custom class, which is build on top of `ui.select` and override `set_value` method, which needs to modify `self._send_update_on_value_change` to prevent triggering of `choice_element.update()`, which overrides the value to `None`. This doesn't work if you override the method because `self._send_update_on_value_change` is not yet initialized before initial call to `set_value()`

This is my class code:
```py
from typing import Any
from nicegui.elements.select import Select as UiSelect

class Select(UiSelect):
    def set_value(self, value: Any) -> None:
        orig_value = self._send_update_on_value_change
        self._send_update_on_value_change = False
        super().set_value(value)
        self._send_update_on_value_change = orig_value
```

Use-case behind: I have need to be able to have a dropdown field, which is able to set value regardless options, as in my case the options are being calculated and changed on the fly based on other UI fields. This is currently impossible to achieve, without having custom `Select` as in example above