### PR TITLE
Bugfix: Default validation dict shared between all instances

### DIFF
--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -17,7 +17,7 @@ class Input(ValidationElement, DisableableElement, component='input.js'):
                  password_toggle_button: bool = False,
                  on_change: Optional[Callable[..., Any]] = None,
                  autocomplete: Optional[List[str]] = None,
-                 validation: Dict[str, Callable[..., bool]] = {}) -> None:
+                 validation: Dict[str, Callable[..., bool]] = None) -> None:
         """Text Input
 
         This element is based on Quasar's `QInput <https://quasar.dev/vue-components/input>`_ component.

--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -17,7 +17,7 @@ class Input(ValidationElement, DisableableElement, component='input.js'):
                  password_toggle_button: bool = False,
                  on_change: Optional[Callable[..., Any]] = None,
                  autocomplete: Optional[List[str]] = None,
-                 validation: Dict[str, Callable[..., bool]] = None) -> None:
+                 validation: Optional[Dict[str, Callable[..., bool]]] = None) -> None:
         """Text Input
 
         This element is based on Quasar's `QInput <https://quasar.dev/vue-components/input>`_ component.
@@ -44,7 +44,7 @@ class Input(ValidationElement, DisableableElement, component='input.js'):
         :param autocomplete: optional list of strings for autocompletion
         :param validation: dictionary of validation rules, e.g. ``{'Too long!': lambda value: len(value) < 3}``
         """
-        super().__init__(value=value, on_value_change=on_change, validation=validation)
+        super().__init__(value=value, on_value_change=on_change, validation=validation or {})
         if label is not None:
             self._props['label'] = label
         if placeholder is not None:

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -7,7 +7,7 @@ class ValidationElement(ValueElement):
 
     def __init__(self, validation: Dict[str, Callable[..., bool]], **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.validation = validation
+        self.validation = validation or {}
         self._error: Optional[str] = None
 
     @property

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -7,7 +7,7 @@ class ValidationElement(ValueElement):
 
     def __init__(self, validation: Dict[str, Callable[..., bool]], **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.validation = validation or {}
+        self.validation = validation
         self._error: Optional[str] = None
 
     @property

--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -20,7 +20,7 @@ class Number(ValidationElement, DisableableElement):
                  suffix: Optional[str] = None,
                  format: Optional[str] = None,  # pylint: disable=redefined-builtin
                  on_change: Optional[Callable[..., Any]] = None,
-                 validation: Dict[str, Callable[..., bool]] = {},
+                 validation: Dict[str, Callable[..., bool]] = None,
                  ) -> None:
         """Number Input
 

--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -20,7 +20,7 @@ class Number(ValidationElement, DisableableElement):
                  suffix: Optional[str] = None,
                  format: Optional[str] = None,  # pylint: disable=redefined-builtin
                  on_change: Optional[Callable[..., Any]] = None,
-                 validation: Dict[str, Callable[..., bool]] = None,
+                 validation: Optional[Dict[str, Callable[..., bool]]] = None,
                  ) -> None:
         """Number Input
 
@@ -43,7 +43,7 @@ class Number(ValidationElement, DisableableElement):
         :param validation: dictionary of validation rules, e.g. ``{'Too large!': lambda value: value < 3}``
         """
         self.format = format
-        super().__init__(tag='q-input', value=value, on_value_change=on_change, validation=validation)
+        super().__init__(tag='q-input', value=value, on_value_change=on_change, validation=validation or {})
         self._props['type'] = 'number'
         if label is not None:
             self._props['label'] = label

--- a/nicegui/elements/textarea.py
+++ b/nicegui/elements/textarea.py
@@ -10,7 +10,7 @@ class Textarea(Input, component='input.js'):
                  placeholder: Optional[str] = None,
                  value: str = '',
                  on_change: Optional[Callable[..., Any]] = None,
-                 validation: Dict[str, Callable[..., bool]] = {},
+                 validation: Optional[Dict[str, Callable[..., bool]]] = None,
                  ) -> None:
         """Textarea
 
@@ -26,5 +26,5 @@ class Textarea(Input, component='input.js'):
         :param on_change: callback to execute when the value changes
         :param validation: dictionary of validation rules, e.g. ``{'Too long!': lambda value: len(value) < 3}``
         """
-        super().__init__(label, placeholder=placeholder, value=value, on_change=on_change, validation=validation)
+        super().__init__(label, placeholder=placeholder, value=value, on_change=on_change, validation=validation or {})
         self._props['type'] = 'textarea'


### PR DESCRIPTION
When a default value is a mutable object it's shared among all instances.

To see the problem run the following code:

```python
from nicegui import ui

input_1 = ui.input()
input_1.validation["Too short"] = lambda v: len(v) > 5

input_2 = ui.input()

print(input_1.validation)
print(input_2.validation)
```

The validation is applied to all input elements that didn't have en explicit validation dict.

See this for a more in depth explanation:
https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil