### PR TITLE
Introduce `ui.refreshable_method`

### DIFF
--- a/nicegui/functions/refreshable.py
+++ b/nicegui/functions/refreshable.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, ClassVar, Dict, Generic, List, Optional, Tuple, TypeVar, Union, cast
 
-from typing_extensions import ParamSpec, Self
+from typing_extensions import Concatenate, ParamSpec, Self
 
 from .. import background_tasks, core
 from ..client import Client
@@ -11,6 +11,7 @@ from ..dataclasses import KWONLY_SLOTS
 from ..element import Element
 from ..helpers import is_coroutine_function
 
+_S = TypeVar('_S')
 _T = TypeVar('_T')
 _P = ParamSpec('_P')
 
@@ -125,6 +126,17 @@ class refreshable(Generic[_P, _T]):
             for target in self.targets
             if target.container.client.id in Client.instances and target.container.id in target.container.client.elements
         ]
+
+
+class refreshable_method(Generic[_S, _P, _T], refreshable[_P, _T]):
+
+    def __init__(self, func: Callable[Concatenate[_S, _P], Union[_T, Awaitable[_T]]]) -> None:
+        """Refreshable UI methods
+
+        The `@ui.refreshable_method` decorator allows you to create methods that have a `refresh` method.
+        This method will automatically delete all elements created by the function and recreate them.
+        """
+        super().__init__(func)  # type: ignore
 
 
 def state(value: Any) -> Tuple[Any, Callable[[Any], None]]:

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -91,6 +91,7 @@ __all__ = [
     'open',
     'page_title',
     'refreshable',
+    'refreshable_method',
     'state',
     'update',
     'page',
@@ -196,7 +197,7 @@ from .functions.notify import notify
 from .functions.on import on
 from .functions.open import open  # pylint: disable=redefined-builtin
 from .functions.page_title import page_title
-from .functions.refreshable import refreshable, state
+from .functions.refreshable import refreshable, refreshable_method, state
 from .functions.update import update
 from .page import page
 from .page_layout import Drawer as drawer

--- a/tests/test_refreshable.py
+++ b/tests/test_refreshable.py
@@ -71,7 +71,7 @@ def test_multiple_targets(screen: Screen) -> None:
             self.name = name
             self.state = 1
 
-        @ui.refreshable
+        @ui.refreshable_method
         def create_ui(self) -> None:
             nonlocal count
             count += 1
@@ -164,7 +164,7 @@ def test_refresh_with_function_reference(screen: Screen):
             self.name = name
             self.ui()
 
-        @ui.refreshable
+        @ui.refreshable_method
         def ui(self):
             ui.notify(f'Refreshing {self.name}')
             ui.button(self.name, on_click=self.ui.refresh)


### PR DESCRIPTION
As discussed in #2174, the `ui.refreshable` decorator causes a mypy error when used with class methods, and there's no fix without compromises. Therefore this PR introduces a separate decorator `ui.refreshable_method` that correctly handles the `self` argument. While existing code still works with the old decorator, one can switch to the new one to fix mypy errors.

Both decorators can be tested like this:
```py
class Clock:
    @ui.refreshable_method
    def current_time(self) -> None:
        ui.label(f'Time: {datetime.now()}')

clock = Clock()
clock.current_time()
ui.timer(1.0, clock.current_time.refresh)


@ui.refreshable
def clock_function() -> None:
    ui.label(f'Time: {datetime.now()}')

clock_function()
ui.timer(1.0, clock_function.refresh)
```