### PR TITLE
Dynamically hide `ui.code`'s copy button

### DIFF
--- a/nicegui/elements/code.py
+++ b/nicegui/elements/code.py
@@ -1,11 +1,13 @@
 import asyncio
+import time
 from typing import Optional
 
 from ..element import Element
-from ..elements.button import Button as button
-from ..elements.markdown import Markdown as markdown
-from ..elements.markdown import remove_indentation
 from ..functions.javascript import run_javascript
+from .button import Button as button
+from .markdown import Markdown as markdown
+from .markdown import remove_indentation
+from .timer import Timer as timer
 
 
 class Code(Element):
@@ -28,9 +30,19 @@ class Code(Element):
             self.copy_button = button(icon='content_copy', on_click=self.copy_to_clipboard) \
                 .props('round flat size=sm').classes('absolute right-2 top-2 opacity-20 hover:opacity-80')
 
+        self._last_scroll: float = 0.0
+        self.markdown.on('scroll', self._handle_scroll)
+        timer(0.1, self._update_copy_button)
+
     async def copy_to_clipboard(self) -> None:
         """Copy the code to the clipboard."""
         run_javascript('navigator.clipboard.writeText(`' + self.content + '`)')
         self.copy_button.props('icon=check')
         await asyncio.sleep(3.0)
         self.copy_button.props('icon=content_copy')
+
+    def _handle_scroll(self) -> None:
+        self._last_scroll = time.time()
+
+    def _update_copy_button(self) -> None:
+        self.copy_button.set_visibility(time.time() > self._last_scroll + 1.0)


### PR DESCRIPTION
Inspired by GitHub's code blocks, this PR hides the copy button of `ui.code` when scrolling. A timer is used to show the button after 1 second of inactivity.

Can be tested with something like
```py
ui.code('print("This is a very long line.")').classes('w-32')
```