### PR TITLE
Avoid shadows and borders of nested cards being removed

### DIFF
--- a/nicegui/elements/card.js
+++ b/nicegui/elements/card.js
@@ -1,0 +1,11 @@
+export default {
+  template: `
+    <q-card v-bind="$attrs">
+      <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
+        <div>
+          <slot :name="slot" v-bind="slotProps || {}" />
+        </div>
+      </template>
+    </q-card>
+  `,
+};

--- a/nicegui/elements/card.py
+++ b/nicegui/elements/card.py
@@ -3,7 +3,7 @@ from typing_extensions import Self
 from ..element import Element
 
 
-class Card(Element):
+class Card(Element, component='card.js'):
 
     def __init__(self) -> None:
         """Card
@@ -17,7 +17,7 @@ class Card(Element):
         If you want the original behavior, use the `tight` method.
         If you want the padding and borders for nested children, move the children into another container.
         """
-        super().__init__('q-card')
+        super().__init__()
         self._classes.append('nicegui-card')
 
     def tight(self) -> Self:

--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -16,7 +16,7 @@
 .nicegui-footer,
 .nicegui-drawer,
 .nicegui-tab-panel,
-.nicegui-card,
+.nicegui-card > div,
 .nicegui-carousel-slide,
 .nicegui-step .q-stepper__nav,
 .nicegui-step .q-stepper__step-inner,
@@ -42,7 +42,11 @@
 .nicegui-column {
   padding: 0;
 }
-.nicegui-card-tight {
+.nicegui-card > div {
+  width: 100%;
+  height: 100%;
+}
+.nicegui-card-tight > div {
   padding: 0;
   gap: 0;
 }

--- a/website/documentation/content/card_documentation.py
+++ b/website/documentation/content/card_documentation.py
@@ -20,34 +20,4 @@ def card_without_shadow() -> None:
         ui.label('See, no shadow!')
 
 
-@doc.demo('The issue with nested borders', '''
-    The following example shows a table nested in a card.
-    Cards have a default padding in NiceGUI, so the table is not flush with the card's border.
-    The table has the `flat` and `bordered` props set, so it should have a border.
-    However, due to the way QCard is designed, the border is not visible (first card).
-    There are two ways to fix this:
-
-    - To get the original QCard behavior, use the `tight` method (second card).
-        It removes the padding and the table border collapses with the card border.
-    
-    - To preserve the padding _and_ the table border, move the table into another container like a `ui.row` (third card).
-
-    See https://github.com/zauberzeug/nicegui/issues/726 for more information.
-''')
-def custom_context_menu() -> None:
-    columns = [{'name': 'age', 'label': 'Age', 'field': 'age'}]
-    rows = [{'age': '16'}, {'age': '18'}, {'age': '21'}]
-
-    with ui.row():
-        with ui.card():
-            ui.table(columns, rows).props('flat bordered')
-
-        with ui.card().tight():
-            ui.table(columns, rows).props('flat bordered')
-
-        with ui.card():
-            with ui.row():
-                ui.table(columns, rows).props('flat bordered')
-
-
 doc.reference(ui.card)


### PR DESCRIPTION
This PR tries to avoid the confusion discussed in #726, #1295, #2265, where child elements of `ui.card` loose shadow and borders. This happens due to Quasar's CSS definitions, which are optimized for "tight" cards. NiceGUI adds some padding and gap by default, so shadow and borders seem to be missing for no obvious reason.

Unfortunately we can't undo Quasar's CSS setting. But I found a way to make them ineffective by inserting another div layer, catching Quasar's CSS setting, while the actual card content isn't affected.

I tested with the following scenarios:
```py
with ui.card().classes('bg-blue-100'):
    with ui.card().classes('bg-green-100'):
        ui.label('Hello world!')

with ui.card().classes('no-shadow border-[1px]'):
    ui.label('See, no shadow!')

with ui.card().tight():
    ui.image('https://picsum.photos/id/684/640/360')
    with ui.card_section():
        ui.label('Lorem ipsum dolor sit amet, consectetur adipiscing elit, ...')

with ui.card():
    ui.table(
        [{'name': 'age', 'label': 'Age', 'field': 'age'}],
        [{'age': '16'}, {'age': '18'}, {'age': '21'}],
    ).props('flat bordered')
```
<img width="412" alt="Screenshot 2024-01-06 at 14 37 20" src="https://github.com/zauberzeug/nicegui/assets/5767091/450b57f3-5cda-4280-8c6e-e7f396ba759f">

Only when working with "tight" cards, the result is suboptimal. But I guess it's more intuitive to remove unwanted borders in this case than to wonder why they magically disappear.

```py
with ui.card().tight():
    with ui.card().classes('border'):
        ui.label('Hello world!')
    with ui.card().classes('border'):
        ui.label('Hello world!')
```

<img width="131" alt="Screenshot 2024-01-06 at 14 37 37" src="https://github.com/zauberzeug/nicegui/assets/5767091/e4515557-95e7-4cd7-8ea6-b3456f141903">
