### PR TITLE
Put .local/bin in PATH so pip installed programs like pytest are executable

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,6 +35,9 @@ fi
 if [ -d "/usr/local/share/fonts" ]; then
   chmod -R 777 /usr/local/share/fonts
 fi
+
+export PATH=/home/appuser/.local/bin:$PATH
+
 # Switch to appuser and execute the Docker CMD or passed in command-line arguments.
 # Using setpriv let's it run as PID 1 which is required for proper signal handling (similar to gosu/su-exec).
 exec setpriv --reuid=$PUID --regid=$PGID --init-groups $@


### PR DESCRIPTION
This PR makes `pytest` available after running `pip install pytest`. Before there was the message 

```
  WARNING: The scripts py.test and pytest are installed in '/home/appuser/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
```