### PR TITLE
Allow handling Mermaid errors on the server

### DIFF
--- a/nicegui/elements/mermaid.js
+++ b/nicegui/elements/mermaid.js
@@ -21,7 +21,12 @@ export default {
       if (is_running) return;
       is_running = true;
       while (queue.length) {
-        await mermaid.run({ nodes: [queue.shift()] });
+        try {
+          await mermaid.run({ nodes: [queue.shift()] });
+        } catch (error) {
+          console.error(error);
+          this.$emit("error", error);
+        }
       }
       is_running = false;
     },

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -63,3 +63,15 @@ def test_create_dynamically(screen: Screen):
     screen.open('/')
     screen.click('Create')
     screen.should_contain('Node')
+
+
+def test_error(screen: Screen):
+    ui.mermaid('''
+    graph LR;
+        A --> B;
+        A -> C;
+    ''').on('error', lambda e: ui.label(e.args['message']))
+
+    screen.open('/')
+    screen.should_contain('Syntax error in text')
+    screen.should_contain('Parse error on line 3')

--- a/website/documentation/content/mermaid_documentation.py
+++ b/website/documentation/content/mermaid_documentation.py
@@ -12,4 +12,16 @@ def main_demo() -> None:
     ''')
 
 
+@doc.demo('Handle errors', '''
+    You can handle errors by listening to the `error` event.
+    The event `args` contain the properties `hash`, `message`, `str` and an `error` object with additional information.
+''')
+def error_demo() -> None:
+    ui.mermaid('''
+    graph LR;
+        A --> B;
+        A -> C;
+    ''').on('error', lambda e: print(e.args['message']))
+
+
 doc.reference(ui.mermaid)


### PR DESCRIPTION
As discussed in #2390, this PR allows to subscribe to Mermaid errors.

```py
ui.mermaid('''
graph LR;
    A --> B;
    A -> C;
''').on('error', lambda e: ui.label(e.args['message']))
```

![Screenshot 2024-01-18 at 10 03 51](https://github.com/zauberzeug/nicegui/assets/5767091/241c9fe8-8f5c-465f-ae9d-f7e0be2be012)
