### PR TITLE
provide client.request and make client.ip available even before client.connected (breaking change)

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -54,6 +54,7 @@ class Client:
         self.is_waiting_for_connection: bool = False
         self.is_waiting_for_disconnect: bool = False
         self.environ: Optional[Dict[str, Any]] = None
+        self.request: Optional[Request] = None
         self.shared = shared
         self.on_air = False
         self._disconnect_task: Optional[asyncio.Task] = None
@@ -86,8 +87,9 @@ class Client:
 
     @property
     def ip(self) -> Optional[str]:
-        """Return the IP address of the client, or None if the client is not connected."""
-        return self.environ['asgi.scope']['client'][0] if self.environ else None  # pylint: disable=unsubscriptable-object
+        """Return the IP address of the client, or None if its an 
+        `auto-index page <https://nicegui.io/documentation/section_pages_routing#auto-index_page>`_."""
+        return self.request.client.host if self.request is not None else None  # mypy: ignore
 
     @property
     def has_socket_connection(self) -> bool:

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -44,7 +44,8 @@ class Client:
     shared_body_html = ''
     """HTML to be inserted in the <body> of every page template."""
 
-    def __init__(self, page: page, *, shared: bool = False) -> None:
+    def __init__(self, page: page, *, request: Optional[Request] = None) -> None:
+        self.request: Optional[Request] = request
         self.id = str(uuid.uuid4())
         self.created = time.time()
         self.instances[self.id] = self
@@ -54,8 +55,7 @@ class Client:
         self.is_waiting_for_connection: bool = False
         self.is_waiting_for_disconnect: bool = False
         self.environ: Optional[Dict[str, Any]] = None
-        self.request: Optional[Request] = None
-        self.shared = shared
+        self.shared = request is None
         self.on_air = False
         self._disconnect_task: Optional[asyncio.Task] = None
 

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -44,7 +44,7 @@ class Client:
     shared_body_html = ''
     """HTML to be inserted in the <body> of every page template."""
 
-    def __init__(self, page: page, *, request: Optional[Request] = None) -> None:
+    def __init__(self, page: page, *, request: Optional[Request]) -> None:
         self.request: Optional[Request] = request
         self.id = str(uuid.uuid4())
         self.created = time.time()
@@ -87,9 +87,9 @@ class Client:
 
     @property
     def ip(self) -> Optional[str]:
-        """Return the IP address of the client, or None if its an 
+        """Return the IP address of the client, or None if it is an
         `auto-index page <https://nicegui.io/documentation/section_pages_routing#auto-index_page>`_."""
-        return self.request.client.host if self.request is not None else None  # mypy: ignore
+        return self.request.client.host if self.request is not None and self.request.client is not None else None
 
     @property
     def has_socket_connection(self) -> bool:

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -48,7 +48,7 @@ static_files = StaticFiles(
 )
 app.mount(f'/_nicegui/{__version__}/static', static_files, name='static')
 
-Client.auto_index_client = Client(page('/')).__enter__()  # pylint: disable=unnecessary-dunder-call
+Client.auto_index_client = Client(page('/'), request=None).__enter__()  # pylint: disable=unnecessary-dunder-call
 
 
 @app.get('/')
@@ -130,7 +130,7 @@ async def _shutdown() -> None:
 @app.exception_handler(404)
 async def _exception_handler_404(request: Request, exception: Exception) -> Response:
     log.warning(f'{request.url} not found')
-    with Client(page('')) as client:
+    with Client(page(''), request=request) as client:
         error_content(404, exception)
     return client.build_response(request, 404)
 
@@ -138,7 +138,7 @@ async def _exception_handler_404(request: Request, exception: Exception) -> Resp
 @app.exception_handler(Exception)
 async def _exception_handler_500(request: Request, exception: Exception) -> Response:
     log.exception(exception)
-    with Client(page('')) as client:
+    with Client(page(''), request=request) as client:
         error_content(500, exception)
     return client.build_response(request, 500)
 

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -48,7 +48,7 @@ static_files = StaticFiles(
 )
 app.mount(f'/_nicegui/{__version__}/static', static_files, name='static')
 
-Client.auto_index_client = Client(page('/'), shared=True).__enter__()  # pylint: disable=unnecessary-dunder-call
+Client.auto_index_client = Client(page('/')).__enter__()  # pylint: disable=unnecessary-dunder-call
 
 
 @app.get('/')

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -97,6 +97,7 @@ class page:
             # NOTE cleaning up the keyword args so the signature is consistent with "func" again
             dec_kwargs = {k: v for k, v in dec_kwargs.items() if k in parameters_of_decorated_func}
             with Client(self) as client:
+                client.request = request
                 if any(p.name == 'client' for p in inspect.signature(func).parameters.values()):
                     dec_kwargs['client'] = client
                 result = func(*dec_args, **dec_kwargs)

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -96,8 +96,7 @@ class page:
             request = dec_kwargs['request']
             # NOTE cleaning up the keyword args so the signature is consistent with "func" again
             dec_kwargs = {k: v for k, v in dec_kwargs.items() if k in parameters_of_decorated_func}
-            with Client(self) as client:
-                client.request = request
+            with Client(self, request=request) as client:
                 if any(p.name == 'client' for p in inspect.signature(func).parameters.values()):
                     dec_kwargs['client'] = client
                 result = func(*dec_args, **dec_kwargs)

--- a/nicegui/testing/conftest.py
+++ b/nicegui/testing/conftest.py
@@ -70,7 +70,7 @@ def reset_globals() -> Generator[None, None, None]:
     Client.instances.clear()
     Client.page_routes.clear()
     app.reset()
-    Client.auto_index_client = Client(page('/'), shared=True).__enter__()  # pylint: disable=unnecessary-dunder-call
+    Client.auto_index_client = Client(page('/')).__enter__()  # pylint: disable=unnecessary-dunder-call
     # NOTE we need to re-add the auto index route because we removed all routes above
     app.get('/')(Client.auto_index_client.build_response)
     binding.reset()

--- a/nicegui/testing/conftest.py
+++ b/nicegui/testing/conftest.py
@@ -70,7 +70,7 @@ def reset_globals() -> Generator[None, None, None]:
     Client.instances.clear()
     Client.page_routes.clear()
     app.reset()
-    Client.auto_index_client = Client(page('/')).__enter__()  # pylint: disable=unnecessary-dunder-call
+    Client.auto_index_client = Client(page('/'), request=None).__enter__()  # pylint: disable=unnecessary-dunder-call
     # NOTE we need to re-add the auto index route because we removed all routes above
     app.get('/')(Client.auto_index_client.build_response)
     binding.reset()

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -315,8 +315,7 @@ def test_reconnecting_without_page_reload(screen: Screen):
 def test_ip(screen: Screen):
     @ui.page('/')
     def page(client: Client):
-        ui.label(client.ip or 'no ip')
+        ui.label(client.ip or 'unknown')
 
     screen.open('/')
-    screen.should_not_contain('no ip')
     screen.should_contain('127.0.0.1')

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -310,3 +310,13 @@ def test_reconnecting_without_page_reload(screen: Screen):
     screen.wait(2.0)
     element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
     assert element.get_attribute('value') == 'hello', 'input should be preserved after reconnect (i.e. no page reload)'
+
+
+def test_ip(screen: Screen):
+    @ui.page('/')
+    def page(client: Client):
+        ui.label(client.ip or 'no ip')
+
+    screen.open('/')
+    screen.should_not_contain('no ip')
+    screen.should_contain('127.0.0.1')


### PR DESCRIPTION
This pull request makes the FastAPI Request object which caused the client to be created available to the client. With this change providing the ip address without the need to `await client.connected()` is trivial. This feature request was mentioned on #1695, #1727 to better fight against DDOS attacs.

The change is braking because in 1.4 the `client.ip` could be used as an indicator if the client websocket connection has already been established.