### PR TITLE
provide meta data for wrapped page-builder

### DIFF
--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import time
+from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
@@ -92,6 +93,7 @@ class page:
             if task.result() is not None:
                 log.error(f'ignoring {task.result()}; it was returned after the HTML had been delivered to the client')
 
+        @wraps(func)
         async def decorated(*dec_args, **dec_kwargs) -> Response:
             request = dec_kwargs['request']
             # NOTE cleaning up the keyword args so the signature is consistent with "func" again


### PR DESCRIPTION
This pull request adds the `@wraps` decorator to the decorated inner function of the `ui.page` builder. With this change, meta informations about the original function are preserved which for example allows to call `__wrapped__` property of the endpoint function as discovered in https://github.com/zauberzeug/nicegui/discussions/2382#discussioncomment-8195025.