### PR TITLE
Add support for calling AG Grid row methods

### DIFF
--- a/nicegui/elements/aggrid.js
+++ b/nicegui/elements/aggrid.js
@@ -53,6 +53,9 @@ export default {
     run_column_method(name, ...args) {
       return this.gridOptions.columnApi[name](...args);
     },
+    run_row_method(row_id, name, ...args) {
+      return this.gridOptions.api.getRowNode(row_id)[name](...args);
+    },
     handle_event(type, args) {
       this.$emit(type, {
         value: args.value,

--- a/nicegui/elements/aggrid.py
+++ b/nicegui/elements/aggrid.py
@@ -143,7 +143,7 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
         If the function is awaited, the result of the method call is returned.
         Otherwise, the method is executed without waiting for a response.
 
-        :param row_id: id of the row
+        :param row_id: id of the row (as defined by the ``getRowId`` option)
         :param name: name of the method
         :param args: arguments to pass to the method
         :param timeout: timeout in seconds (default: 1 second)

--- a/nicegui/elements/aggrid.py
+++ b/nicegui/elements/aggrid.py
@@ -134,6 +134,25 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
         """
         return self.run_method('run_column_method', name, *args, timeout=timeout, check_interval=check_interval)
 
+    def run_row_method(self, row_id: str, name: str, *args,
+                       timeout: float = 1, check_interval: float = 0.01) -> AwaitableResponse:
+        """Run an AG Grid API method on a specific row.
+
+        See `AG Grid Row Reference <https://www.ag-grid.com/javascript-data-grid/row-object/>`_ for a list of methods.
+
+        If the function is awaited, the result of the method call is returned.
+        Otherwise, the method is executed without waiting for a response.
+
+        :param row_id: id of the row
+        :param name: name of the method
+        :param args: arguments to pass to the method
+        :param timeout: timeout in seconds (default: 1 second)
+        :param check_interval: interval in seconds to check for a response (default: 0.01 seconds)
+
+        :return: AwaitableResponse that can be awaited to get the result of the method call
+        """
+        return self.run_method('run_row_method', row_id, name, *args, timeout=timeout, check_interval=check_interval)
+
     async def get_selected_rows(self) -> List[Dict]:
         """Get the currently selected rows.
 

--- a/tests/test_aggrid.py
+++ b/tests/test_aggrid.py
@@ -212,3 +212,19 @@ def test_problematic_datatypes(screen: Screen):
     screen.should_contain('5 days')
     screen.should_contain('(1+2j)')
     screen.should_contain('2021-01')
+
+
+def test_run_row_method(screen: Screen):
+    grid = ui.aggrid({
+        'columnDefs': [{'field': 'name'}, {'field': 'age'}],
+        'rowData': [{'id': 'alice', 'name': 'Alice', 'age': 18}],
+    })
+    ui.button('Update', on_click=lambda: grid.run_row_method('alice', 'setDataValue', 'age', 42))
+
+    screen.open('/')
+    screen.should_contain('Alice')
+    screen.should_contain('18')
+
+    screen.click('Update')
+    screen.should_contain('Alice')
+    screen.should_contain('42')

--- a/tests/test_aggrid.py
+++ b/tests/test_aggrid.py
@@ -217,9 +217,10 @@ def test_problematic_datatypes(screen: Screen):
 def test_run_row_method(screen: Screen):
     grid = ui.aggrid({
         'columnDefs': [{'field': 'name'}, {'field': 'age'}],
-        'rowData': [{'id': 'alice', 'name': 'Alice', 'age': 18}],
+        'rowData': [{'name': 'Alice', 'age': 18}],
+        ':getRowId': '(params) => params.data.name',
     })
-    ui.button('Update', on_click=lambda: grid.run_row_method('alice', 'setDataValue', 'age', 42))
+    ui.button('Update', on_click=lambda: grid.run_row_method('Alice', 'setDataValue', 'age', 42))
 
     screen.open('/')
     screen.should_contain('Alice')

--- a/website/documentation/content/aggrid_documentation.py
+++ b/website/documentation/content/aggrid_documentation.py
@@ -195,4 +195,30 @@ def aggrid_with_dynamic_row_height():
     }).classes('max-h-40')
 
 
+@doc.demo('Run row methods', '''
+    You can run methods on individual rows by using the `run_row_method` method.
+    This method takes the row ID, the method name and the method arguments as arguments.
+    The row ID is either the row index (as a string) or the value of the `getRowId` function.
+
+    The following demo shows how to use it to update cell values.
+    Note that the row selection is preserved when the value is updated.
+    This would not be the case if the grid was updated using the `update` method.
+''')
+def aggrid_run_row_method():
+    grid = ui.aggrid({
+        'columnDefs': [
+            {'field': 'name', 'checkboxSelection': True},
+            {'field': 'age'},
+        ],
+        'rowData': [
+            {'name': 'Alice', 'age': 18},
+            {'name': 'Bob', 'age': 21},
+            {'name': 'Carol', 'age': 42},
+        ],
+        ':getRowId': '(params) => params.data.name',
+    })
+    ui.button('Update',
+              on_click=lambda: grid.run_row_method('Alice', 'setDataValue', 'age', 99))
+
+
 doc.reference(ui.aggrid)


### PR DESCRIPTION
This PR implements AG Grid row methods for feature request #2357. Similar to `run_method`, `run_grid_method` and `run_column_method` there's now also a `run_row_method` method:

```py
grid = ui.aggrid({
    'columnDefs': [
        {'field': 'name', 'checkboxSelection': True},
        {'field': 'age'},
    ],
    'rowData': [
        {'name': 'Alice', 'age': 18},
        {'name': 'Bob', 'age': 21},
        {'name': 'Carol', 'age': 42},
    ],
    ':getRowId': '(params) => params.data.name',
})
ui.button('Update', on_click=lambda: grid.run_row_method('Alice', 'setDataValue', 'age', 99))
```