### PR TITLE
make log.js autoscroll to bottom when page is loaded

### DIFF
--- a/nicegui/elements/log.js
+++ b/nicegui/elements/log.js
@@ -11,6 +11,7 @@ export default {
     this.$el.innerHTML = text;
     this.num_lines = text ? text.split("\n").length : 0;
     this.total_count = this.num_lines;
+    this.$el.scrollTop = this.$el.scrollHeight;
   },
   methods: {
     push(line, total_count) {


### PR DESCRIPTION
Set log element `scrollTop` property to `scrollHeight` by default when it is initialized in `mounted()`, as in log.js `push()` method.
This makes log to scroll to its bottom when it is loaded