### PR TITLE
Only update tailwind.config.darkMode if value has changed

### DIFF
--- a/nicegui/elements/dark_mode.js
+++ b/nicegui/elements/dark_mode.js
@@ -9,7 +9,8 @@ export default {
     update() {
       Quasar.Dark.set(this.value === null ? "auto" : this.value);
       if (window.tailwind) {
-        tailwind.config.darkMode = this.value === null ? "media" : "class";
+        const mode = this.value === null ? "media" : "class";
+        if (mode !== tailwind.config.darkMode) tailwind.config.darkMode = mode;
         if (this.value) document.body.classList.add("dark");
         else document.body.classList.remove("dark");
       }


### PR DESCRIPTION
In #2446 it was observed that the usage of `ui.dark_mode()` in combination with a lot of elements introduces a significant delay until the website becomes responsive. This pull request fixes this by only setting the `tailwind.config.darkMode` if it has changed.