### PR TITLE
Add loaded event which fires when source of ui.interactive_image changes

### DIFF
--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -76,6 +76,7 @@ export default {
       this.loaded_image_width = e.target.naturalWidth;
       this.loaded_image_height = e.target.naturalHeight;
       this.viewBox = `0 0 ${this.loaded_image_width} ${this.loaded_image_height}`;
+      this.$emit("loaded", { width: this.loaded_image_width, height: this.loaded_image_height, source: e.target.src });
     },
     onMouseEvent(type, e) {
       const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;

--- a/tests/test_interactive_image.py
+++ b/tests/test_interactive_image.py
@@ -1,10 +1,9 @@
-import time
 from typing import List
 
 import pytest
 from selenium.webdriver.common.action_chains import ActionChains
 
-from nicegui import Client, events, ui
+from nicegui import Client, ui
 from nicegui.testing import Screen
 
 
@@ -80,16 +79,16 @@ def test_mousemove_event(screen: Screen, cross: bool):
 
 
 def test_loaded_event(screen: Screen):
-    loaded: List[events.GenericEventArguments] = []
+    sources: List[str] = []
     ii = ui.interactive_image('https://picsum.photos/id/29/640/360')
-    ii.on('loaded', loaded.append)
-    ui.button('Change Source', on_click=lambda: ii.set_source(f'https://picsum.photos/640/360?time={time.time()}'))
+    ii.on('loaded', lambda e: sources.append(e.args['source']))
+    ui.button('Change Source', on_click=lambda: ii.set_source('https://picsum.photos/id/30/640/360'))
 
     screen.open('/')
     screen.wait(0.5)
-    assert len(loaded) == 1
+    assert len(sources) == 1
     screen.click('Change Source')
     screen.wait(1.5)
-    assert len(loaded) == 2
-    assert '?time=' in loaded[1].args['source']
-    assert screen.find_by_tag('img').get_attribute('src') == loaded[1].args['source']
+    assert len(sources) == 2
+    assert sources[1].endswith('id/30/640/360')
+    assert screen.find_by_tag('img').get_attribute('src') == sources[1]

--- a/tests/test_interactive_image.py
+++ b/tests/test_interactive_image.py
@@ -1,7 +1,10 @@
+import time
+from typing import List
+
 import pytest
 from selenium.webdriver.common.action_chains import ActionChains
 
-from nicegui import Client, ui
+from nicegui import Client, events, ui
 from nicegui.testing import Screen
 
 
@@ -74,3 +77,19 @@ def test_mousemove_event(screen: Screen, cross: bool):
         .pause(0.5) \
         .perform()
     assert counter['value'] > 0
+
+
+def test_loaded_event(screen: Screen):
+    loaded: List[events.GenericEventArguments] = []
+    ii = ui.interactive_image('https://picsum.photos/id/29/640/360')
+    ii.on('loaded', loaded.append)
+    ui.button('Change Source', on_click=lambda: ii.set_source(f'https://picsum.photos/640/360?time={time.time()}'))
+
+    screen.open('/')
+    screen.wait(0.5)
+    assert len(loaded) == 1
+    screen.click('Change Source')
+    screen.wait(0.5)
+    assert len(loaded) == 2
+    assert '?time=' in loaded[1].args['source']
+    assert screen.find_by_tag('img').get_attribute('src') == loaded[1].args['source']

--- a/tests/test_interactive_image.py
+++ b/tests/test_interactive_image.py
@@ -89,7 +89,7 @@ def test_loaded_event(screen: Screen):
     screen.wait(0.5)
     assert len(loaded) == 1
     screen.click('Change Source')
-    screen.wait(0.5)
+    screen.wait(1.5)
     assert len(loaded) == 2
     assert '?time=' in loaded[1].args['source']
     assert screen.find_by_tag('img').get_attribute('src') == loaded[1].args['source']

--- a/website/documentation/content/interactive_image_documentation.py
+++ b/website/documentation/content/interactive_image_documentation.py
@@ -52,7 +52,7 @@ def blank_canvas():
 
 
 @doc.demo('Loaded event', '''
-    You can listen to the `loaded` event to know when the image has been loaded.
+    You can listen to the "loaded" event to know when the image has been loaded.
 ''')
 def loaded_event():
     import time

--- a/website/documentation/content/interactive_image_documentation.py
+++ b/website/documentation/content/interactive_image_documentation.py
@@ -51,4 +51,15 @@ def blank_canvas():
     ).classes('w-64 bg-blue-50')
 
 
+@doc.demo('Loaded event', '''
+    You can listen to the `loaded` event to know when the image has been loaded.
+''')
+def loaded_event():
+    import time
+
+    ii = ui.interactive_image('https://picsum.photos/640/360')
+    ii.on('loaded', lambda e: ui.notify(f'loaded {e.args}'))
+    ui.button('Change Source', on_click=lambda: ii.set_source(f'https://picsum.photos/640/360?time={time.time()}'))
+
+
 doc.reference(ui.interactive_image)


### PR DESCRIPTION
This pull request adds the feature requested on [Reddit r/nicegui](https://www.reddit.com/r/nicegui/comments/19dxkz2/spinner_during_loading_image_in_interactive_image/).