### PR TITLE
fix broken target links in documentation strings

### DIFF
--- a/nicegui/api_router.py
+++ b/nicegui/api_router.py
@@ -22,7 +22,7 @@ class APIRouter(fastapi.APIRouter):
         Creates a new page at the given route.
         Each user will see a new instance of the page.
         This means it is private to the user and not shared with others
-        (as it is done `when placing elements outside of a page decorator <https://nicegui.io/documentation#auto-index_page>`_).
+        (as it is done `when placing elements outside of a page decorator <https://nicegui.io/documentation/section_pages_routing#auto-index_page>`_).
 
         :param path: route of the new page (path must start with '/')
         :param title: optional page title

--- a/nicegui/functions/open.py
+++ b/nicegui/functions/open.py
@@ -14,7 +14,7 @@ def open(target: Union[Callable[..., Any], str, Element], new_tab: bool = False)
     This is a browser setting and cannot be changed by the application.
     You might want to use `ui.link` and its `new_tab` parameter instead.
 
-    Note: When using an `auto-index page </documentation#auto-index_page>`_ (e.g. no `@page` decorator), 
+    Note: When using an `auto-index page </documentation/section_pages_routing#auto-index_page>`_ (e.g. no `@page` decorator), 
     all clients (i.e. browsers) connected to the page will open the target URL unless a socket is specified.
     User events like button clicks provide such a socket.
 

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -38,7 +38,7 @@ class page:
         This decorator marks a function to be a page builder.
         Each user accessing the given route will see a new instance of the page.
         This means it is private to the user and not shared with others 
-        (as it is done `when placing elements outside of a page decorator <https://nicegui.io/documentation#auto-index_page>`_).
+        (as it is done `when placing elements outside of a page decorator <https://nicegui.io/documentation/section_pages_routing#auto-index_page>`_).
 
         :param path: route of the new page (path must start with '/')
         :param title: optional page title

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -63,7 +63,7 @@ def run(*,
     :param binding_refresh_interval: time between binding updates (default: `0.1` seconds, bigger is more CPU friendly)
     :param reconnect_timeout: maximum time the server waits for the browser to reconnect (default: 3.0 seconds)
     :param show: automatically open the UI in a browser tab (default: `True`)
-    :param on_air: tech preview: `allows temporary remote access <https://nicegui.io/documentation#nicegui_on_air>`_ if set to `True` (default: disabled)
+    :param on_air: tech preview: `allows temporary remote access <https://nicegui.io/documentation/section_configuration_deployment#nicegui_on_air>`_ if set to `True` (default: disabled)
     :param native: open the UI in a native window of size 800x600 (default: `False`, deactivates `show`, automatically finds an open port)
     :param window_size: open the UI in a native window with the provided size (e.g. `(1024, 786)`, default: `None`, also activates `native`)
     :param fullscreen: open the UI in a fullscreen window (default: `False`, also activates `native`)


### PR DESCRIPTION
Some of the links in the docstrings that point to documentation that used to be at the top level, i.e. `documentation#<subject>` have moved, and this PR fixes the ones I found.