### PR TITLE
Enable new_value_mode="add" for dict options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
     "--disable=R0913", // Too many arguments
     "--disable=R0914", // Too many local variables
     "--disable=R0915", // Too many statements
+    "--disable=R1705", // Unnecessary "else" after "return"
     "--disable=W0102", // Dangerous default value as argument
     "--disable=W0718", // Catching too general exception
     "--disable=W1203", // Use % formatting in logging functions

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -114,9 +114,9 @@ class Select(ValidationElement, ChoiceElement, DisableableElement, component='se
                 return None
 
     def _new_value(self) -> Any:
-        if self.new_value_generator:
-            return next(self.new_value_generator) if isinstance(self.new_value_generator,
-                                                                collections.abc.Iterable) else self.new_value_generator()
+        if self.new_value_id_generator:
+            return next(self.new_value_id_generator) if isinstance(self.new_value_id_generator,
+                                                                   collections.abc.Iterable) else self.new_value_id_generator()
         return None
 
 

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -143,7 +143,7 @@ class Select(ValidationElement, ChoiceElement, DisableableElement, component='se
         else:
             key = value
             if mode in 'add-unique':
-                if value not in self.options.values():
+                if mode == 'add' or value not in self.options.values():
                     key = self._new_id(value) or value
                     self.options[key] = value
             elif mode == 'toggle':

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -61,8 +61,8 @@ class Select(ValidationElement, ChoiceElement, DisableableElement, component='se
             self._props['label'] = label
         self.new_value_id_generator = new_value_id_generator
         if new_value_mode is not None:
-            if isinstance(options, dict) and new_value_mode == 'add':
-                raise ValueError('new_value_mode "add" is not supported for dict options')
+            if isinstance(options, dict) and new_value_mode == 'add' and new_value_id_generator is None:
+                raise ValueError('new_value_mode "add" is not supported for dict options without new_value_id_generator')
             self._props['new-value-mode'] = new_value_mode
             with_input = True
         if with_input:

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -142,7 +142,7 @@ class Select(ValidationElement, ChoiceElement, DisableableElement, component='se
             return value
         else:
             key = value
-            if mode in 'add-unique':
+            if mode in {'add', 'add-unique'}:
                 if mode == 'add' or value not in self.options.values():
                     key = self._new_id(value) or value
                     self.options[key] = value

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -141,6 +141,18 @@ def test_add_new_values(screen:  Screen, option_dict: bool, multiple: bool, new_
                                   "options = ['a', 'b', 'c']")
 
 
+def test_id_generator(screen: Screen):
+    options = {'a': 'A', 'b': 'B', 'c': 'C'}
+    select = ui.select(options, value='b', new_value_mode='add', new_id_generator=lambda _: len(options))
+    ui.label().bind_text_from(select, 'options', lambda v: f'options = {v}')
+
+    screen.open('/')
+    screen.find_by_tag('input').send_keys(Keys.BACKSPACE + 'd')
+    screen.wait(0.5)
+    screen.find_by_tag('input').send_keys(Keys.ENTER)
+    screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 3: 'd'}")
+
+
 @pytest.mark.parametrize('multiple', [False, True])
 def test_keep_filtered_options(multiple: bool, screen: Screen):
     ui.select(options=['A1', 'A2', 'B1', 'B2'], with_input=True, multiple=multiple)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -143,7 +143,7 @@ def test_add_new_values(screen:  Screen, option_dict: bool, multiple: bool, new_
 
 def test_id_generator(screen: Screen):
     options = {'a': 'A', 'b': 'B', 'c': 'C'}
-    select = ui.select(options, value='b', new_value_mode='add', new_id_generator=lambda _: len(options))
+    select = ui.select(options, value='b', new_value_mode='add', key_generator=lambda _: len(options))
     ui.label().bind_text_from(select, 'options', lambda v: f'options = {v}')
 
     screen.open('/')


### PR DESCRIPTION
This pull request enables using new_value_mode="add" when options are dict.
My use case is displaying a list of people, allowing user to enter a new name. Naturally, there can be duplicates because people may have same name. But their internal ids are different.

This feature requires new_value_id_generator (a new parameter) to be not None. If it's None, previous behavior is retained.

---

See feature request #2462.