### PR TITLE
Introduce media_type parameter for `ui.download`

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -219,9 +219,9 @@ class Client:
         path = target if isinstance(target, str) else self.page_routes[target]
         self.outbox.enqueue_message('open', {'path': path, 'new_tab': new_tab}, self.id)
 
-    def download(self, src: Union[str, bytes], filename: Optional[str] = None) -> None:
+    def download(self, src: Union[str, bytes], filename: Optional[str] = None, media_type: str = '') -> None:
         """Download a file from a given URL or raw bytes."""
-        self.outbox.enqueue_message('download', {'src': src, 'filename': filename}, self.id)
+        self.outbox.enqueue_message('download', {'src': src, 'filename': filename, 'media_type': media_type}, self.id)
 
     def on_connect(self, handler: Union[Callable[..., Any], Awaitable]) -> None:
         """Register a callback to be called when the client connects."""

--- a/nicegui/functions/download.py
+++ b/nicegui/functions/download.py
@@ -4,17 +4,18 @@ from typing import Optional, Union
 from .. import context, core, helpers
 
 
-def download(src: Union[str, Path, bytes], filename: Optional[str] = None) -> None:
+def download(src: Union[str, Path, bytes], filename: Optional[str] = None, media_type: str = '') -> None:
     """Download
 
     Function to trigger the download of a file, URL or bytes.
 
     :param src: target URL, local path of a file or raw data which should be downloaded
     :param filename: name of the file to download (default: name of the file on the server)
+    :param media_type: media type of the file to download (default: "")
     """
     if not isinstance(src, bytes):
         if helpers.is_file(src):
             src = core.app.add_static_file(local_file=src, single_use=True)
         else:
             src = str(src)
-    context.get_client().download(src, filename)
+    context.get_client().download(src, filename, media_type)

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -212,13 +212,13 @@
         });
       }
 
-      function download(src, filename) {
+      function download(src, filename, mediaType) {
         const anchor = document.createElement("a");
         if (typeof src === "string") {
           anchor.href = src.startsWith("/") ? "{{ prefix | safe }}" + src : src;
         }
         else {
-          anchor.href = URL.createObjectURL(new Blob([src]))
+          anchor.href = URL.createObjectURL(new Blob([src], {type: mediaType}))
         }
         anchor.target = "_blank";
         anchor.download = filename || "";
@@ -307,7 +307,7 @@
               const target = msg.new_tab ? '_blank' : '_self';
               window.open(url, target);
             },
-            download: (msg) => download(msg.src, msg.filename),
+            download: (msg) => download(msg.src, msg.filename, msg.media_type),
             notify: (msg) => Quasar.Notify.create(msg),
           };
           const socketMessageQueue = [];


### PR DESCRIPTION
As requested in #2491, this PR allows to specify the media type when using `ui.download`.

Can be tested with the following snippet:
```py
ui.button('Text', on_click=lambda: ui.download(b'', media_type='text/plain'))
ui.button('HTML', on_click=lambda: ui.download(b'', media_type='text/html'))
```
Chrome will automatically create a random file name with the extensions "txt" and "html", respectively.