### PR TITLE
Fix #2469.

### DIFF
--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -86,7 +86,7 @@
               // ignore "Restricted" fields in Firefox (see #2469)
               if (k == 'originalTarget') {
                 try {
-                  JSON.stringify(arg[k]);
+                  arg[k].toString();
                 } catch (e) {
                   continue;
                 }

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -83,6 +83,9 @@
           }
           else {
             for (let k in arg) {
+              // we filter it out because it's supported in Firefox only and doesn't exist in other browsers. Fixes #2469.
+              if(k == 'originalTarget')
+                continue;              
               if (event_args === null || event_args[i] === null || event_args[i].includes(k)) {
                 filtered[k] = arg[k];
               }

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -83,9 +83,14 @@
           }
           else {
             for (let k in arg) {
-              // we filter it out because it's supported in Firefox only and doesn't exist in other browsers. Fixes #2469.
-              if(k == 'originalTarget')
-                continue;              
+              // ignore "Restricted" fields in Firefox (see #2469)
+              if (k == 'originalTarget') {
+                try {
+                  JSON.stringify(arg[k]);
+                } catch (e) {
+                  continue;
+                }
+              }
               if (event_args === null || event_args[i] === null || event_args[i].includes(k)) {
                 filtered[k] = arg[k];
               }


### PR DESCRIPTION
Filter out originalTarget property in the event, because it's non-standard, exists in Firefox only and causes issues with stringifying the event. See #2469.