### PR TITLE
Register plotly event handlers only once, at mount

### DIFF
--- a/nicegui/elements/plotly.vue
+++ b/nicegui/elements/plotly.vue
@@ -7,7 +7,6 @@ export default {
   async mounted() {
     await this.$nextTick();
     this.update();
-    this.set_handlers();
   },
   updated() {
     this.update();
@@ -24,6 +23,7 @@ export default {
         Plotly.react(this.$el.id, this.options.data, this.options.layout);
       } else {
         Plotly.newPlot(this.$el.id, this.options.data, this.options.layout, options.config);
+        this.set_handlers();
       }
 
       // store last options

--- a/nicegui/elements/plotly.vue
+++ b/nicegui/elements/plotly.vue
@@ -7,24 +7,13 @@ export default {
   async mounted() {
     await this.$nextTick();
     this.update();
+    this.set_handlers();
   },
   updated() {
     this.update();
   },
   methods: {
-    update() {
-      // default responsive to true
-      const options = this.options;
-      if (options.config === undefined) options.config = { responsive: true };
-      if (options.config.responsive === undefined) options.config.responsive = true;
-
-      // re-use plotly instance if config is the same
-      if (JSON.stringify(options.config) == JSON.stringify(this.last_options.config)) {
-        Plotly.react(this.$el.id, this.options.data, this.options.layout);
-      } else {
-        Plotly.newPlot(this.$el.id, this.options.data, this.options.layout, options.config);
-      }
-
+    set_handlers() {
       // forward events
       for (const name of [
         // source: https://plotly.com/javascript/plotlyjs-events/
@@ -59,6 +48,19 @@ export default {
           };
           this.$emit(name, args);
         });
+      }
+    },
+    update() {
+      // default responsive to true
+      const options = this.options;
+      if (options.config === undefined) options.config = { responsive: true };
+      if (options.config.responsive === undefined) options.config.responsive = true;
+
+      // re-use plotly instance if config is the same
+      if (JSON.stringify(options.config) == JSON.stringify(this.last_options.config)) {
+        Plotly.react(this.$el.id, this.options.data, this.options.layout);
+      } else {
+        Plotly.newPlot(this.$el.id, this.options.data, this.options.layout, options.config);
       }
 
       // store last options

--- a/nicegui/elements/plotly.vue
+++ b/nicegui/elements/plotly.vue
@@ -13,6 +13,22 @@ export default {
     this.update();
   },
   methods: {
+    update() {
+      // default responsive to true
+      const options = this.options;
+      if (options.config === undefined) options.config = { responsive: true };
+      if (options.config.responsive === undefined) options.config.responsive = true;
+
+      // re-use plotly instance if config is the same
+      if (JSON.stringify(options.config) == JSON.stringify(this.last_options.config)) {
+        Plotly.react(this.$el.id, this.options.data, this.options.layout);
+      } else {
+        Plotly.newPlot(this.$el.id, this.options.data, this.options.layout, options.config);
+      }
+
+      // store last options
+      this.last_options = options;
+    },
     set_handlers() {
       // forward events
       for (const name of [
@@ -49,22 +65,6 @@ export default {
           this.$emit(name, args);
         });
       }
-    },
-    update() {
-      // default responsive to true
-      const options = this.options;
-      if (options.config === undefined) options.config = { responsive: true };
-      if (options.config.responsive === undefined) options.config.responsive = true;
-
-      // re-use plotly instance if config is the same
-      if (JSON.stringify(options.config) == JSON.stringify(this.last_options.config)) {
-        Plotly.react(this.$el.id, this.options.data, this.options.layout);
-      } else {
-        Plotly.newPlot(this.$el.id, this.options.data, this.options.layout, options.config);
-      }
-
-      // store last options
-      this.last_options = options;
     },
   },
   data() {


### PR DESCRIPTION
All the event handlers in plotly were being registered on every update, which was causing a lot of issues.  Event handlers should only be registered once.  This PR moves the registration of the event handlers to a one-time operation in the `mounted()` function.

Fixes #2504, I think