### PR TITLE
Relaxe upper bounds on some dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,24 +11,24 @@ keywords = ["gui", "ui", "web", "interface", "live"]
 [tool.poetry.dependencies]
 python = "^3.8"
 typing-extensions = ">=4.0.0"
-markdown2 = ">=2.4.7,<2.4.11"
+markdown2 = ">=2.4.7,!=2.4.11"
 Pygments = ">=2.15.1,<3.0.0"
 uvicorn = {extras = ["standard"], version = ">=0.22.0"}
 fastapi = ">=0.109.0,<0.110.0"
 python-socketio = {extras = ["asyncio-client"], version = ">=5.10.0"} # version min: see https://github.com/zauberzeug/nicegui/issues/1809
 vbuild = ">=0.8.2"
-watchfiles = ">=0.18.1,<1.0.0"
+watchfiles = ">=0.18.1"
 jinja2 = "^3.1.3" # https://github.com/zauberzeug/nicegui/security/dependabot/24
-python-multipart = "^0.0.6"
+python-multipart = ">=0.0.6"
 orjson = {version = "^3.8.6", markers = "platform_machine != 'i386' and platform_machine != 'i686'"} # orjson does not support 32bit
 itsdangerous = "^2.1.2"
-aiofiles = "^23.1.0"
+aiofiles = ">=23.1.0"
 pywebview = { version = "^4.4.0", optional = true }
 plotly = { version = "^5.13.0", optional = true }
 matplotlib = { version = "^3.5.0", optional = true }
-httpx = ">=0.24.0,<1.0.0"
+httpx = ">=0.24.0"
 nicegui-highcharts = { version = "^1.0.1", optional = true }
-ifaddr = "^0.2.0"
+ifaddr = ">=0.2.0"
 aiohttp = ">=3.9.2" # https://github.com/zauberzeug/nicegui/security/dependabot/25 and 26
 
 [tool.poetry.extras]
@@ -42,13 +42,13 @@ icecream = "^2.1.0"
 autopep8 = "^1.5.7"
 debugpy = "^1.3.0"
 pytest-selenium = "^4.0.0"
-pytest-asyncio = "^0.19.0"
-pytest = "6.2.5"
+pytest-asyncio = ">=0.19.0"
+pytest = ">=6.2.5,<8"
 itsdangerous = "^2.1.2" # required by SessionMiddleware (see https://fastapi.tiangolo.com/?h=itsdangerous#optional-dependencies)
 isort = "^5.11.4"
 docutils = "^0.19"
 pandas = "^2.0.0"
-secure = "^0.3.0"
+secure = ">=0.3.0"
 webdriver-manager = "^3.8.6"
 numpy = [
     {version = "^1.24.0", python = "~3.8"},


### PR DESCRIPTION
- The "^" specifier is often too restrictive for 0.* versions so I would not recommend to use it in these cases: https://python-poetry.org/docs/dependency-specification/
- Markdown2: The issue from 2.4.11 was fixed in 2.4.12:
  - https://github.com/zauberzeug/nicegui/pull/2154
  - https://github.com/trentm/python-markdown2/issues/546
  - https://github.com/trentm/python-markdown2/blob/master/CHANGES.md#python-markdown2-2412
- Watchfiles: Doesn't look like v1 will introduce breaking changes: https://github.com/samuelcolvin/watchfiles/issues/186
- python-multipart: "^0.06" is "==0.0.6" which is too strict and at this stage, any release can potentially add breaking changes
- aiofiles: Uses CalVer and 24.0.0 is as likely to introduce breaking changes as 23.2.0.
- httpx: It does not look like 1.0.0 will introduce breaking changes (if you already fixed any deprecation warnings).  Testing against the 1.0.0beata0 is advisable, though. https://github.com/encode/httpx/pull/3069
- ifaddr: Development is rather slow, package looks quite stable. I don't think that a 0.3.0 will add breaking changes and a 1.0 is not in sight.
- pytest-asyncio: Restriction to >=0.19,<0.20 seems unwanted and updates are needed for recent pytest versions
- pytest: Has there been a reason to not support pytest7?  pytest8 currently breaks some plugins, but this should be fixed soon.

Fixes: #2485