### PR TITLE
Strip root_path to make ASGIServer from socketio compatible with mounting as sub-app

### DIFF
--- a/examples/fastapi/frontend.py
+++ b/examples/fastapi/frontend.py
@@ -4,7 +4,7 @@ from nicegui import app, ui
 
 
 def init(fastapi_app: FastAPI) -> None:
-    @ui.page('/show')
+    @ui.page('/')
     def show():
         ui.label('Hello, FastAPI!')
 
@@ -14,5 +14,6 @@ def init(fastapi_app: FastAPI) -> None:
 
     ui.run_with(
         fastapi_app,
+        mount_path='/gui',  # NOTE this can be omitted if you want the paths passed to @ui.page to be at the root
         storage_secret='pick your private secret here',  # NOTE setting a secret is optional but allows for persistent storage per user
     )

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -30,10 +30,23 @@ async def _lifespan(_: App):
     yield
     await _shutdown()
 
+
+class SocketIOASGIApp(socketio.ASGIApp):
+    """Custom ASGI app to handle root_path.
+
+    This is a workaround for https://github.com/miguelgrinberg/python-engineio/pull/345
+    """
+
+    async def __call__(self, scope, receive, send):
+        if 'root_path' in scope and scope['path'].startswith(scope['root_path']):
+            scope['path'] = scope['path'][len(scope['root_path']):]
+        return await super().__call__(scope, receive, send)
+
+
 core.app = app = App(default_response_class=NiceGUIJSONResponse, lifespan=_lifespan)
 # NOTE we use custom json module which wraps orjson
 core.sio = sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*', json=json)
-sio_app = socketio.ASGIApp(socketio_server=sio, socketio_path='/_nicegui_ws/socket.io')
+sio_app = SocketIOASGIApp(socketio_server=sio, socketio_path='/socket.io')
 app.mount('/_nicegui_ws/', sio_app)
 
 


### PR DESCRIPTION
This pull request is a workaround for https://github.com/miguelgrinberg/python-engineio/pull/345 and fixes #2468 and #2515. By deriving a custom ASGIServer from socketio we can strip the `root_path` from `path` which allows for modular and ASGI compliant usage until python-engineio (and thereby python-socketio) may provide this feature upstream sometime in the future.