### PR TITLE
Fix plotly event registration

### DIFF
--- a/nicegui/elements/plotly.vue
+++ b/nicegui/elements/plotly.vue
@@ -7,7 +7,6 @@ export default {
   async mounted() {
     await this.$nextTick();
     this.update();
-    this.set_handlers();
   },
   updated() {
     this.update();
@@ -21,7 +20,9 @@ export default {
 
       // Plotly.react can be used to create a new plot and to update it efficiently
       // https://plotly.com/javascript/plotlyjs-function-reference/#plotlyreact
-      Plotly.react(this.$el.id, this.options.data, this.options.layout, options.config);
+      Plotly.react(this.$el.id, this.options.data, this.options.layout, options.config).then(() => {
+        this.set_handlers();
+      });
 
       // store last options
       this.last_options = options;
@@ -47,6 +48,7 @@ export default {
         "plotly_redraw",
         "plotly_animated",
       ]) {
+        this.$el.removeAllListeners(name);
         this.$el.on(name, (event) => {
           const args = {
             ...event,


### PR DESCRIPTION
This PR solves #2519 by removing all event listeners before re-attaching them after each `Plotly.react()`.

Can be tested with
```py
fig = {'data': [{'x': [1, 2, 3], 'y': [1, 2, 3]}]}
plot = ui.plotly(fig).classes('w-96 h-96').on('plotly_click', ui.notify)
ui.checkbox('visible').bind_value(plot, 'visible')
```

After toggling the plot's visibility, click events still work as expected.