### PR TITLE
fixes #2524

### DIFF
--- a/examples/editable_table/main.py
+++ b/examples/editable_table/main.py
@@ -13,7 +13,7 @@ rows = [
 
 
 def add_row() -> None:
-    new_id = max(dx['id'] for dx in rows) + 1
+    new_id = max((dx['id'] for dx in rows), default=-1) + 1
     rows.append({'id': new_id, 'name': 'New guy', 'age': 21})
     ui.notify(f'Added new row with ID {new_id}')
     table.update()


### PR DESCRIPTION
With the addition of `default=-1`, an entry in `rows` can be created with `id` being 0 when it's empty.