### PR TITLE
Add tooltips to the search and theme buttons.

### DIFF
--- a/website/header.py
+++ b/website/header.py
@@ -49,7 +49,7 @@ def add_header(menu: Optional[ui.left_drawer] = None) -> None:
         search = Search()
         search.create_button()
 
-        with ui.element().classes('max-[420px]:hidden'):
+        with ui.element().classes('max-[420px]:hidden').tooltip('Cycle theme mode through dark, light, and system/auto.'):
             ui.button(icon='dark_mode', on_click=lambda: dark_mode.set_value(None)) \
                 .props('flat fab-mini color=white').bind_visibility_from(dark_mode, 'value', value=True)
             ui.button(icon='light_mode', on_click=lambda: dark_mode.set_value(True)) \

--- a/website/search.py
+++ b/website/search.py
@@ -39,7 +39,7 @@ class Search:
         ui.keyboard(self.handle_keypress)
 
     def create_button(self) -> ui.button:
-        return ui.button(on_click=self.dialog.open, icon='search').props('flat color=white')
+        return ui.button(on_click=self.dialog.open, icon='search').props('flat color=white').tooltip('Press Ctrl+K or Ctrl+/ to search the documentation')
 
     def handle_keypress(self, e: events.KeyEventArguments) -> None:
         if not e.action.keydown:


### PR DESCRIPTION
This PR is small and simple, it just adds tooltips to the search and theme buttons on the website. The tooltip for the theme button explains that you can cycles through the `dark`, `light`, and `system/auto` theme modes while the tooltip for the search button explains that pressing `Ctrl+K` or `Ctrl+/` opens the documentation search dialog.