### PR TITLE
Fix binding removal for non-hashable objects

### DIFF
--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -155,32 +155,27 @@ class BindableProperty:
             self._change_handler(owner, value)
 
 
-def remove(objects: Iterable[Any], type_: Type) -> None:
+def remove(objects: Iterable[Any]) -> None:
     """Remove all bindings that involve the given objects.
 
-    The ``type_`` argument is as a quick pre-filter.
-
     :param objects: The objects to remove.
-    :param type_: The type of the objects to remove.
     """
-    object_set = set(objects)
+    object_ids = set(map(id, objects))
     active_links[:] = [
         (source_obj, source_name, target_obj, target_name, transform)
         for source_obj, source_name, target_obj, target_name, transform in active_links
-        if not (isinstance(source_obj, type_) and source_obj in object_set or
-                isinstance(target_obj, type_) and target_obj in object_set)
+        if id(source_obj) not in object_ids and id(target_obj) not in object_ids
     ]
     for key, binding_list in list(bindings.items()):
         binding_list[:] = [
             (source_obj, target_obj, target_name, transform)
             for source_obj, target_obj, target_name, transform in binding_list
-            if not (isinstance(source_obj, type_) and source_obj in object_set or
-                    isinstance(target_obj, type_) and target_obj in object_set)
+            if id(source_obj) not in object_ids and id(target_obj) not in object_ids
         ]
         if not binding_list:
             del bindings[key]
     for (obj_id, name), obj in list(bindable_properties.items()):
-        if isinstance(obj, type_) and obj in object_set:
+        if id(obj) in object_ids:
             del bindable_properties[(obj_id, name)]
 
 

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -292,7 +292,7 @@ class Client:
 
     def remove_elements(self, elements: Iterable[Element]) -> None:
         """Remove the given elements from the client."""
-        binding.remove(elements, Element)
+        binding.remove(elements)
         element_ids = [element.id for element in elements]
         for element_id in element_ids:
             del self.elements[element_id]

--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -143,5 +143,5 @@ class Leaflet(Element, component='leaflet.js'):
         return self.run_method('run_layer_method', layer_id, name, *args, timeout=timeout, check_interval=check_interval)
 
     def _handle_delete(self) -> None:
-        binding.remove(self.layers, Layer)
+        binding.remove(self.layers)
         super().delete()

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -199,7 +199,7 @@ class Scene(Element,
                         self.camera.up_x, self.camera.up_y, self.camera.up_z, duration)
 
     def _handle_delete(self) -> None:
-        binding.remove(list(self.objects.values()), Object3D)
+        binding.remove(list(self.objects.values()))
         super()._handle_delete()
 
     def delete_objects(self, predicate: Callable[[Object3D], bool] = lambda _: True) -> None:


### PR DESCRIPTION
In PR #2374 we introduced a bug that causes an exception when removing binding for an non-hashable object, as described in #2540. This PR replaces the set of objects `set(objects)` with a set of object IDs `set(map(id, objects))`. This should be more accurate, even a bit faster and doesn't require hash functions. And we don't need the `_type` parameter anymore, which served as a cheap pre-filter.

I experimented with the following code to verify that the `remove` function is equally fast (0.015s for 10,000 objects) and doesn't break for a non-hashable `dict`:

```py
import time
from nicegui import app, binding, ui

NUM = 10000
data: dict = {}

@ui.page('/')
def home_page():
    with ui.card() as card:
        for i in range(NUM):
            ui.label().bind_text_from(data, f'text{i}')

    t0 = time.perf_counter()
    card.clear()
    t1 = time.perf_counter()
    print(f'{NUM} elements deleted in {t1-t0:.3f} seconds')

    ui.button('Remove binding', on_click=lambda: binding.remove([data]))
```