### PR TITLE
When searching we can now see a snippet of the content of each result.

### DIFF
--- a/website/search.py
+++ b/website/search.py
@@ -63,7 +63,7 @@ class Search:
                             with ui.element('q-item').props('clickable'):
                                 with ui.element('q-item-section'):
                                     ui.link(result['item']['title'], target=href).style('font-weight: 500')
-                                    ui.markdown(result['item']['content'][:200] + '...').classes('text-grey-1')
+                                    ui.markdown(result['item']['content'][:200] + '...').classes('text-grey')
 
         background_tasks.create_lazy(handle_input(), name='handle_search_input')
 

--- a/website/search.py
+++ b/website/search.py
@@ -1,4 +1,4 @@
-from nicegui import __version__, app, background_tasks, events, ui
+from nicegui import __version__, background_tasks, events, ui
 
 
 class Search:
@@ -58,11 +58,12 @@ class Search:
                 for result in results:
                     if result['item']['content']:
                         href: str = result['item']['url']
-                        with ui.element('q-item').props('clickable') \
+                        with ui.link(target=href).props('clickable') \
                                 .on('click', lambda href=href: self.open_url(href), []):
-                            with ui.element('q-item-section'):
-                                ui.label(result['item']['title']).style('font-weight: 500')
-                                ui.label(result['item']['content'][:200] + '...').classes('text-grey')
+                            with ui.element('q-item').props('clickable'):
+                                with ui.element('q-item-section'):
+                                    ui.link(result['item']['title'], target=href).style('font-weight: 500')
+                                    ui.markdown(result['item']['content'][:200] + '...').classes('text-grey-1')
 
         background_tasks.create_lazy(handle_input(), name='handle_search_input')
 

--- a/website/search.py
+++ b/website/search.py
@@ -60,10 +60,11 @@ class Search:
                         href: str = result['item']['url']
                         with ui.link(target=href).props('clickable') \
                                 .on('click', lambda href=href: self.open_url(href), []):
-                            with ui.element('q-item').props('clickable'):
-                                with ui.element('q-item-section'):
-                                    ui.link(result['item']['title'], target=href).style('font-weight: 500')
-                                    ui.markdown(result['item']['content'][:200] + '...').classes('text-grey')
+                            with ui.list().props('bordered separator clickable'):
+                                ui.item_label(result['item']['title']).style('font-weight: 500; padding: 0.5rem; gap: 0px').classes('text-bold')
+                                with ui.item().props('clickable').style('padding: 0.5rem; gap: 0px'):
+                                    with ui.item_section():
+                                        ui.markdown(result['item']['content'][:200] + '...').classes('text-grey')
 
         background_tasks.create_lazy(handle_input(), name='handle_search_input')
 

--- a/website/search.py
+++ b/website/search.py
@@ -1,4 +1,4 @@
-from nicegui import __version__, background_tasks, events, ui
+from nicegui import __version__, app, background_tasks, events, ui
 
 
 class Search:
@@ -53,14 +53,17 @@ class Search:
     def handle_input(self, e: events.ValueChangeEventArguments) -> None:
         async def handle_input():
             with self.results:
-                results = await ui.run_javascript(f'return window.fuse.search("{e.value}").slice(0, 50)', timeout=6)
+                results = await ui.run_javascript(f'return window.fuse.search("{e.value}").slice(0, 100)', timeout=6)
                 self.results.clear()
                 for result in results:
-                    href: str = result['item']['url']
-                    with ui.element('q-item').props('clickable') \
-                            .on('click', lambda href=href: self.open_url(href), []):
-                        with ui.element('q-item-section'):
-                            ui.label(result['item']['title'])
+                    if result['item']['content']:
+                        href: str = result['item']['url']
+                        with ui.element('q-item').props('clickable') \
+                                .on('click', lambda href=href: self.open_url(href), []):
+                            with ui.element('q-item-section'):
+                                ui.label(result['item']['title']).style('font-weight: 500')
+                                ui.label(result['item']['content'][:200] + '...').classes('text-grey')
+
         background_tasks.create_lazy(handle_input(), name='handle_search_input')
 
     def open_url(self, url: str) -> None:

--- a/website/search.py
+++ b/website/search.py
@@ -51,20 +51,20 @@ class Search:
             self.dialog.open()
 
     def handle_input(self, e: events.ValueChangeEventArguments) -> None:
-        async def handle_input():
+        async def handle_input() -> None:
             with self.results:
                 results = await ui.run_javascript(f'return window.fuse.search("{e.value}").slice(0, 100)', timeout=6)
                 self.results.clear()
-                for result in results:
-                    if result['item']['content']:
-                        href: str = result['item']['url']
-                        with ui.link(target=href).props('clickable') \
-                                .on('click', lambda href=href: self.open_url(href), []):
-                            with ui.list().props('bordered separator clickable'):
-                                ui.item_label(result['item']['title']).style('font-weight: 500; padding: 0.5rem; gap: 0px').classes('text-bold')
-                                with ui.item().props('clickable').style('padding: 0.5rem; gap: 0px'):
-                                    with ui.item_section():
-                                        ui.markdown(result['item']['content'][:200] + '...').classes('text-grey')
+                with ui.list().props('bordered separator clickable'):
+                    for result in results:
+                        if result['item']['content']:
+                            href: str = result['item']['url']
+                            with ui.item():
+                                with ui.item_section():
+                                    with ui.link(target=href):
+                                        ui.item_label(result['item']['title']).classes('text-medium')
+                                        with ui.item_label().props('caption'):
+                                            ui.markdown(result['item']['content'][:200] + '...').classes('text-grey')
 
         background_tasks.create_lazy(handle_input(), name='handle_search_input')
 


### PR DESCRIPTION
![image](https://github.com/zauberzeug/nicegui/assets/5977640/b57e2ba0-85c1-448a-8c30-6712b4491c5b)
The description and title color can be changed, so, let me know if you have any preferences on that part. Also, I tried adding the url under the title to make it so people can copy or open it on a new tab but I dont know how to get the `http://host:port` part of the url and the `result['item']['url']` only has the route without the first part of it.

I also removed those results without `content` since those were usually `References` and other anchors that we don't want to be shown in the results as the page where they belong is already part of the results. Because of this, we now have less results to show at once and they were cut by at least half so, when we do a search we increased the max number of slices from 50 to 100.
![image](https://github.com/zauberzeug/nicegui/assets/5977640/8bd668fc-c9f2-4880-a1c6-10fff1b569d7)
![image](https://github.com/zauberzeug/nicegui/assets/5977640/f02dae86-92fa-470c-844a-e8fcb438d372)