### PR TITLE
Improve interaction with Matplotlib

### DIFF
--- a/nicegui/elements/pyplot.py
+++ b/nicegui/elements/pyplot.py
@@ -1,7 +1,7 @@
 import asyncio
 import io
 import os
-from typing import Any
+from typing import Any, List
 
 from typing_extensions import Self
 
@@ -11,7 +11,7 @@ from ..element import Element
 
 try:
     if os.environ.get('MATPLOTLIB', 'true').lower() == 'true':
-        import matplotlib.pyplot as plt
+        import matplotlib.figure
         optional_features.register('matplotlib')
 except ImportError:
     pass
@@ -27,6 +27,8 @@ class Pyplot(Element):
         :param close: whether the figure should be closed after exiting the context; set to `False` if you want to update it later (default: `True`)
         :param kwargs: arguments like `figsize` which should be passed to `pyplot.figure <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.figure.html>`_
         """
+        import matplotlib.pyplot as plt
+
         if not optional_features.has('matplotlib'):
             raise ImportError('Matplotlib is not installed. Please run "pip install matplotlib".')
 
@@ -44,16 +46,70 @@ class Pyplot(Element):
             self._props['innerHTML'] = output.getvalue()
 
     def __enter__(self) -> Self:
+        import matplotlib.pyplot as plt
+
         plt.figure(self.fig)
         return self
 
     def __exit__(self, *_) -> None:
+        import matplotlib.pyplot as plt
+
         self._convert_to_html()
         if self.close:
             plt.close(self.fig)
         self.update()
 
     async def _auto_close(self) -> None:
+        import matplotlib.pyplot as plt
+
         while self.client.id in Client.instances:
             await asyncio.sleep(1.0)
         plt.close(self.fig)
+
+
+class MplFigures(Element):
+    _figs: List[matplotlib.figure.Figure]
+    _fmt: str
+
+    def __init__(self, fmt='svg') -> None:
+        """Pyplot Context
+
+        Create a context to configure a `Matplotlib <https://matplotlib.org/>`_ plot.
+
+        """
+        if not optional_features.has('matplotlib'):
+            raise ImportError('Matplotlib is not installed. Please run "pip install matplotlib".')
+
+        super().__init__('div')
+
+        if fmt not in ('svg', ):
+            raise ValueError("Only svg currently supported")
+
+        self._figs = []
+        self._fmt = fmt
+        self._convert_to_html()
+
+    def _convert_to_html(self) -> None:
+        for fig in self._figs:
+            with io.StringIO() as output:
+                self.fig.savefig(output, format=self._fmt)
+                # TODO how to actually show more than one!
+                # TODO handle case of this being png
+                self._props['innerHTML'] = output.getvalue()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_) -> None:
+        self._convert_to_html()
+        self.update()
+
+    def figure(self, **kwargs: Any):
+        """
+        Create and register a new Figure with the element
+
+        :param kwargs: arguments like `figsize` which should be passed to `pyplot.figure <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.figure.html>`_
+        """
+        fig = matplotlib.figure.Figure(**kwargs)
+        self._figs.append(fig)
+        return fig

--- a/nicegui/elements/pyplot.py
+++ b/nicegui/elements/pyplot.py
@@ -89,7 +89,7 @@ class Matplotlib(Element):
             raise ImportError('Matplotlib is not installed. Please run "pip install matplotlib".')
 
         super().__init__('div')
-        self.figure: matplotlib.figure.Figure = MatplotlibFigure(self, **kwargs)
+        self.figure = MatplotlibFigure(self, **kwargs)
         self._convert_to_html()
 
     def _convert_to_html(self) -> None:

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -47,6 +47,7 @@ __all__ = [
     'list',
     'log',
     'markdown',
+    'matplotlib',
     'menu',
     'menu_item',
     'mermaid',
@@ -167,6 +168,7 @@ from .elements.pagination import Pagination as pagination
 from .elements.plotly import Plotly as plotly
 from .elements.progress import CircularProgress as circular_progress
 from .elements.progress import LinearProgress as linear_progress
+from .elements.pyplot import Matplotlib as matplotlib
 from .elements.pyplot import Pyplot as pyplot
 from .elements.query import Query as query
 from .elements.radio import Radio as radio

--- a/website/documentation/content/matplotlib_documentation.py
+++ b/website/documentation/content/matplotlib_documentation.py
@@ -1,0 +1,17 @@
+from nicegui import ui
+
+from . import doc
+
+
+@doc.demo(ui.matplotlib)
+def main_demo() -> None:
+    import numpy as np
+
+    with ui.matplotlib(figsize=(3, 2)).figure as fig:
+        x = np.linspace(0.0, 5.0)
+        y = np.cos(2 * np.pi * x) * np.exp(-x)
+        ax = fig.gca()
+        ax.plot(x, y, '-')
+
+
+doc.reference(ui.matplotlib)

--- a/website/documentation/content/section_data_elements.py
+++ b/website/documentation/content/section_data_elements.py
@@ -2,9 +2,9 @@ from nicegui import optional_features
 
 from . import (aggrid_documentation, circular_progress_documentation, code_documentation, doc, echart_documentation,
                editor_documentation, highchart_documentation, json_editor_documentation, leaflet_documentation,
-               line_plot_documentation, linear_progress_documentation, log_documentation, plotly_documentation,
-               pyplot_documentation, scene_documentation, spinner_documentation, table_documentation,
-               tree_documentation)
+               line_plot_documentation, linear_progress_documentation, log_documentation, matplotlib_documentation,
+               plotly_documentation, pyplot_documentation, scene_documentation, spinner_documentation,
+               table_documentation, tree_documentation)
 
 doc.title('*Data* Elements')
 
@@ -15,6 +15,7 @@ if optional_features.has('highcharts'):
 doc.intro(echart_documentation)
 if optional_features.has('matplotlib'):
     doc.intro(pyplot_documentation)
+    doc.intro(matplotlib_documentation)
     doc.intro(line_plot_documentation)
 if optional_features.has('plotly'):
     doc.intro(plotly_documentation)


### PR DESCRIPTION
This PR is mostly a feature request/suggestion but it was easier to describe it via code that in text.  So here is a draft PR (rather than an issue with an inline diff).

----

This is a sketch of how to improve the interaction with Matplotlib.

The first idea is to directly create `Figure` objects rather than relying on pyplot.  This de-couples the UI from the global state that is the pyplot figure registry and ensures that you never get surprise GUI windows popping up (or a memory leak) when pyplot selects a GUI backend.

The second suggestion is to have the object return by the context manager be able to create multiple figures (not actually implemented).

The third is to support saving the figures as png instead of svg (not actually implemented).