### PR TITLE
Leaflet.js & .py: fixed layer events and run_layer_method

### DIFF
--- a/nicegui/elements/leaflet.js
+++ b/nicegui/elements/leaflet.js
@@ -76,11 +76,8 @@ export default {
     for (const type of ["layeradd", "layerremove"]) {
       this.map.on(type, (e) => {
         this.$emit(`map-${type}`, {
-            originalEvent: undefined,
-            target: undefined,
-            sourceTarget: undefined,
-            id: e.layer.id ? e.layer.id : undefined,
-            leaflet_id: e.layer._leaflet_id,
+          id: e.layer.id,
+          leaflet_id: e.layer._leaflet_id,
         });
       });
     }
@@ -122,9 +119,6 @@ export default {
       l.id = id;
       l.addTo(this.map);
     },
-    remove_map() {
-      this.map.remove();
-    },
     remove_layer(id) {
       this.map.eachLayer((layer) => layer.id === id && this.map.removeLayer(layer));
     },
@@ -139,17 +133,16 @@ export default {
       return this.map[name](...args);
     },
     run_layer_method(id, name, ...args) {
-      var res = null;
+      let result = null;
       this.map.eachLayer((layer) => {
-        if (layer.id == id) {
-          if (name.startsWith(":")) {
-            name = name.slice(1);
-            args = args.map((arg) => new Function("return " + arg)());
-          }
-          res = layer[name](...args);
+        if (layer.id !== id) return;
+        if (name.startsWith(":")) {
+          name = name.slice(1);
+          args = args.map((arg) => new Function("return " + arg)());
         }
+        result = layer[name](...args);
       });
-      return res;
+      return result;
     },
   },
 };

--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -143,6 +143,5 @@ class Leaflet(Element, component='leaflet.js'):
         return self.run_method('run_layer_method', layer_id, name, *args, timeout=timeout, check_interval=check_interval)
 
     def _handle_delete(self) -> None:
-        # self.run_method('remove_map')
         binding.remove(self.layers)
         super().delete()

--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -143,5 +143,6 @@ class Leaflet(Element, component='leaflet.js'):
         return self.run_method('run_layer_method', layer_id, name, *args, timeout=timeout, check_interval=check_interval)
 
     def _handle_delete(self) -> None:
+        self.run_method('remove_map')
         binding.remove(self.layers)
         super().delete()

--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -143,6 +143,6 @@ class Leaflet(Element, component='leaflet.js'):
         return self.run_method('run_layer_method', layer_id, name, *args, timeout=timeout, check_interval=check_interval)
 
     def _handle_delete(self) -> None:
-        self.run_method('remove_map')
+        # self.run_method('remove_map')
         binding.remove(self.layers)
         super().delete()


### PR DESCRIPTION
See [2500](https://github.com/zauberzeug/nicegui/issues/2500#issuecomment-1945904046):

1. In the event handlers. The 'layeradd' and 'layerremove' events don't work properly because they have a different target. So we need to give them a separate handler.
2. In run_layer_method. The leaflet .eachLayer function always iterates over all layers. The current code seems to assume that it can break out with a 'return', but the result will be overridden by the next iteration. Solve by adding a 'res' variable outside the loop.

[ #removed in e2afe91:
#3. Deleting a ui.leaflet element doesn't currently remove the LeafletJS map. Added this in .py (_handle_delete) #and .js (remove_map). ]
