### PR TITLE
Add reStructuredText (ui.rst) element and documentation.

### DIFF
--- a/nicegui/elements/rst.js
+++ b/nicegui/elements/rst.js
@@ -1,0 +1,39 @@
+export default {
+  template: `<div></div>`,
+  async mounted() {
+    this.ensure_codehilite_css();
+    if (this.use_mermaid) {
+      this.mermaid = (await import("mermaid")).default;
+      this.update(this.$el.innerHTML);
+    }
+  },
+  data() {
+    return {
+      mermaid: null,
+    };
+  },
+  methods: {
+    update(content) {
+      this.$el.innerHTML = content;
+      this.$el.querySelectorAll(".mermaid-pre").forEach(async (pre, i) => {
+        await this.mermaid.run({ nodes: [pre.children[0]] });
+      });
+    },
+    ensure_codehilite_css() {
+      if (!document.querySelector(`style[data-codehilite-css]`)) {
+        const style = document.createElement("style");
+        style.setAttribute("data-codehilite-css", "");
+        style.innerHTML = this.codehilite_css;
+        document.head.appendChild(style);
+      }
+    },
+  },
+  props: {
+    codehilite_css: String,
+    use_mermaid: {
+      required: false,
+      default: false,
+      type: Boolean,
+    },
+  },
+};

--- a/nicegui/elements/rst.py
+++ b/nicegui/elements/rst.py
@@ -1,48 +1,48 @@
 import os
 from functools import lru_cache
-from typing import List
 
 from docutils.core import publish_parts
 from pygments.formatters import HtmlFormatter  # pylint: disable=no-name-in-module
 
-from .mermaid import Mermaid
 from .mixins.content_element import ContentElement
 
 
 class ReStructuredText(ContentElement, component='rst.js'):
 
-    def __init__(self, content: str = '', *, extras: List[str] = ['fenced-code-blocks', 'tables']) -> None:
+    def __init__(self, content: str = '') -> None:
         """ReStructuredText
 
         Renders ReStructuredText onto the page.
 
         :param content: the ReStructuredText content to be displayed
         """
-        self.extras = extras
         super().__init__(content=content)
         self._classes.append('nicegui-markdown')
         self._props['codehilite_css'] = (
             HtmlFormatter(nobackground=True).get_style_defs('.codehilite') +
             HtmlFormatter(nobackground=True, style='github-dark').get_style_defs('.body--dark .codehilite')
         )
-        if 'mermaid' in extras:
-            self._props['use_mermaid'] = True
-            self.libraries.append(Mermaid.exposed_libraries[0])
 
     def _handle_content_change(self, content: str) -> None:
-        html = prepare_content(content, extras=' '.join(self.extras))
+        html = prepare_content(content)
         if self._props.get('innerHTML') != html:
             self._props['innerHTML'] = html
             self.run_method('update', html)
 
 
 @lru_cache(maxsize=int(os.environ.get('RST_CONTENT_CACHE_SIZE', '1000')))
-def prepare_content(content: str, extras: str) -> str:
+def prepare_content(content: str) -> str:
     """Render ReStructuredText content to HTML."""
-    return publish_parts(
+    html = publish_parts(
         remove_indentation(content),
         writer_name='html5'
-    )["whole"]
+    )
+
+    # print(html)
+
+    # for key in html:
+    #     print(key)
+    return html["html_body"]  # if not body_only else html["html_body"]
 
 
 def remove_indentation(text: str) -> str:

--- a/nicegui/elements/rst.py
+++ b/nicegui/elements/rst.py
@@ -1,0 +1,56 @@
+import os
+from functools import lru_cache
+from typing import List
+
+from docutils.core import publish_parts
+from pygments.formatters import HtmlFormatter  # pylint: disable=no-name-in-module
+
+from .mermaid import Mermaid
+from .mixins.content_element import ContentElement
+
+
+class ReStructuredText(ContentElement, component='rst.js'):
+
+    def __init__(self, content: str = '', *, extras: List[str] = ['fenced-code-blocks', 'tables']) -> None:
+        """ReStructuredText
+
+        Renders ReStructuredText onto the page.
+
+        :param content: the ReStructuredText content to be displayed
+        """
+        self.extras = extras
+        super().__init__(content=content)
+        self._classes.append('nicegui-markdown')
+        self._props['codehilite_css'] = (
+            HtmlFormatter(nobackground=True).get_style_defs('.codehilite') +
+            HtmlFormatter(nobackground=True, style='github-dark').get_style_defs('.body--dark .codehilite')
+        )
+        if 'mermaid' in extras:
+            self._props['use_mermaid'] = True
+            self.libraries.append(Mermaid.exposed_libraries[0])
+
+    def _handle_content_change(self, content: str) -> None:
+        html = prepare_content(content, extras=' '.join(self.extras))
+        if self._props.get('innerHTML') != html:
+            self._props['innerHTML'] = html
+            self.run_method('update', html)
+
+
+@lru_cache(maxsize=int(os.environ.get('RST_CONTENT_CACHE_SIZE', '1000')))
+def prepare_content(content: str, extras: str) -> str:
+    """Render ReStructuredText content to HTML."""
+    return publish_parts(
+        remove_indentation(content),
+        writer_name='html5'
+    )["whole"]
+
+
+def remove_indentation(text: str) -> str:
+    """Remove indentation from a multi-line string based on the indentation of the first non-empty line."""
+    lines = text.splitlines()
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    if not lines:
+        return ''
+    indentation = len(lines[0]) - len(lines[0].lstrip())
+    return '\n'.join(line[indentation:] for line in lines)

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -60,6 +60,7 @@ __all__ = [
     'query',
     'radio',
     'row',
+    'rst',
     'scene',
     'scroll_area',
     'select',
@@ -171,6 +172,7 @@ from .elements.pyplot import Pyplot as pyplot
 from .elements.query import Query as query
 from .elements.radio import Radio as radio
 from .elements.row import Row as row
+from .elements.rst import ReStructuredText as rst
 from .elements.scene import Scene as scene
 from .elements.scroll_area import ScrollArea as scroll_area
 from .elements.select import Select as select

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -1,8 +1,18 @@
 from nicegui import ui
 
-from . import (doc, section_action_events, section_audiovisual_elements, section_binding_properties,
-               section_configuration_deployment, section_controls, section_data_elements, section_page_layout,
-               section_pages_routing, section_styling_appearance, section_text_elements)
+from . import (
+    doc,
+    section_action_events,
+    section_audiovisual_elements,
+    section_binding_properties,
+    section_configuration_deployment,
+    section_controls,
+    section_data_elements,
+    section_page_layout,
+    section_pages_routing,
+    section_styling_appearance,
+    section_text_elements,
+)
 
 doc.title('*NiceGUI* Documentation', 'Reference, Demos and more')
 
@@ -76,7 +86,7 @@ doc.text('Customization', '''
 
 tiles = [
     (section_text_elements, '''
-        Elements like `ui.label`, `ui.markdown` and `ui.html` can be used to display text and other content.
+        Elements like `ui.label`, `ui.markdown`, `ui.rst` and `ui.html` can be used to display text and other content.
     '''),
     (section_controls, '''
         NiceGUI provides a variety of elements for user interaction, e.g. `ui.button`, `ui.slider`, `ui.inputs`, etc.

--- a/website/documentation/content/rst_documentation.py
+++ b/website/documentation/content/rst_documentation.py
@@ -1,0 +1,64 @@
+from nicegui import ui
+
+from . import doc
+
+
+@doc.demo(ui.rst)
+def main_demo() -> None:
+    ui.rst('This is **reStructuredText**.')
+
+
+@doc.demo('reStructuredText with indentation', '''
+    Common indentation is automatically stripped from the beginning of each line.
+    So you can indent reStructuredText elements, and they will still be rendered correctly.
+''')
+def rst_with_indentation():
+    ui.rst('''
+            This is an example of a reStructuredText paragraph with several indentation levels.
+
+            You can use multiple levels of indentation to structure your content.
+            Each level of indentation represents a different level of hierarchy.
+
+            - Level 1
+                - Level 2
+                    - Level 3
+                        - Level 4
+                            - Level 5
+    ''')
+
+
+@doc.demo('reStructuredText with code blocks', '''
+    You can use code blocks to show code examples.
+    If you specify the language, the code will be syntax highlighted.
+    See [this link](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingReST/Reference/Code/Codeblocks.html#writing-rest-codeblocks-available-lexers) for a list of supported languages.
+''')
+def rst_with_code_blocks():
+    ui.rst('''
+        .. code-block:: python3
+        
+            from nicegui import ui
+
+            ui.label('Hello World!')
+
+            ui.run()
+    ''')
+
+
+@doc.demo('reStructuredText tables', '''
+    reStructuredText tables.
+    See the [sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#tables).
+''')
+def rst_tables():
+    ui.rst('''
+    +------------------------+------------+----------+----------+
+    | Header row, column 1   | Header 2   | Header 3 | Header 4 |
+    | (header rows optional) |            |          |          |
+    +========================+============+==========+==========+
+    | body row 1, column 1   | column 2   | column 3 | column 4 |
+    +------------------------+------------+----------+----------+
+    | body row 2             | ...        | ...      |          |
+    +------------------------+------------+----------+----------+
+    ''')
+
+
+doc.reference(ui.rst)

--- a/website/documentation/content/section_text_elements.py
+++ b/website/documentation/content/section_text_elements.py
@@ -1,5 +1,14 @@
-from . import (chat_message_documentation, doc, element_documentation, html_documentation, label_documentation,
-               link_documentation, markdown_documentation, mermaid_documentation)
+from . import (
+    chat_message_documentation,
+    doc,
+    element_documentation,
+    html_documentation,
+    label_documentation,
+    link_documentation,
+    markdown_documentation,
+    mermaid_documentation,
+    rst_documentation,
+)
 
 doc.title('*Text* Elements')
 
@@ -8,5 +17,6 @@ doc.intro(link_documentation)
 doc.intro(chat_message_documentation)
 doc.intro(element_documentation)
 doc.intro(markdown_documentation)
+doc.intro(rst_documentation)
 doc.intro(mermaid_documentation)
 doc.intro(html_documentation)


### PR DESCRIPTION
This pull request adds a new ReStructuredText (ui.rst) element to the Public API, along with a basic documenation for it. This new element allows for rendering reStructuredText content by converting it from reStructuredText to html so we can show it in NiceGUI, for this we use `docutils.core.publish_parts`.