### PR TITLE
Add pre-commit hook for code formatting and style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,38 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-builtin-literals
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+
+  - repo: https://github.com/hhatto/autopep8
+    rev: "v2.0.4"
+    hooks:
+      - id: autopep8
+        args: [--max-line-length=120, --experimental, --in-place, --recursive, .]
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.2.1
+    hooks:
+      - id: ruff
+        args: [--select=I, --fix] # isort
+      - id: ruff-format
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: "v3.15.0"
+    hooks:
+      - id: pyupgrade
+        args: [--py38-plus]
+
+  - repo: https://github.com/ikamensh/flynt/
+    rev: "1.0.1"
+    hooks:
+      - id: flynt


### PR DESCRIPTION
This `pre-commit` config comes with the following hooks:
- [check-added-large-files](https://github.com/pre-commit/pre-commit-hooks#check-added-large-files)
- [check-ast](https://github.com/pre-commit/pre-commit-hooks#check-ast)
- [check-builtin-literals](https://github.com/pre-commit/pre-commit-hooks#check-builtin-literals)
- [check-merge-conflict](https://github.com/pre-commit/pre-commit-hooks#check-merge-conflict)
- [check-toml](https://github.com/pre-commit/pre-commit-hooks#check-toml)
- [check-yaml](https://github.com/pre-commit/pre-commit-hooks#check-yaml)
- [detect-private-key](https://github.com/pre-commit/pre-commit-hooks#detect-private-key)
- [end-of-file-fixer](https://github.com/pre-commit/pre-commit-hooks#end-of-file-fixer)
- [mixed-line-ending](https://github.com/pre-commit/pre-commit-hooks#mixed-line-ending)
- [trailing-whitespace](https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace)
- autopep8 with `args: [--max-line-length=120, --experimental, --in-place, --recursive, .]` as mentioned in the `CONTRIBUTING.md`
- [ruff](https://github.com/astral-sh/ruff) with `args: [--select=I, --fix]`, basically does the same as `isort` and other things but faster.
- [ruff-format](https://docs.astral.sh/ruff/formatter/): Drop-in replacement for Black.
- [pyupgrade](https://github.com/asottile/pyupgrade): automatically upgrade syntax for newer versions of the language to avoid using syntax that is too old and could stop us from using a newer version of it.
- [flynt](https://github.com/ikamensh/flynt/): automatically convert Python code from old `"%-formatted"` and `.format(...)` strings into Python 3.6+'s `"f-strings"`. Same as `pyupgrade` it will allow us to not get stuck in an old python version.

I will also add some of these to a Github Action workflow I plan to add later in another PR to make sure all the tests are running and passing when a PR is made.