### PR TITLE
Implement ui.navigate functionality

### DIFF
--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -1,0 +1,51 @@
+from typing import Any, Callable, Union
+
+from .. import context
+from ..client import Client
+from ..element import Element
+from .javascript import run_javascript
+
+
+def back():
+    """ui.navigate.back
+
+    Navigates back in the browser history.
+    It is equivalent to clicking the back button in the browser.
+
+    """
+    run_javascript("history.back()")
+
+
+def forward():
+    """ui.navigate.forward
+
+    Navigates forward in the browser history.
+    It is equivalent to clicking the forward button in the browser.
+
+    """
+    run_javascript("history.forward()")
+
+
+def to(target: Union[Callable[..., Any], str, Element], new_tab: bool = False) -> None:  # pylint: disable=redefined-builtin
+    """ui.navigate.to
+
+    Can be used to programmatically trigger redirects for a specific client.
+
+    When using the `new_tab` parameter, the browser might block the new tab.
+    This is a browser setting and cannot be changed by the application.
+    You might want to use `ui.link` and its `new_tab` parameter instead.
+
+    Note: When using an `auto-index page </documentation/section_pages_routing#auto-index_page>`_ (e.g. no `@page` decorator), 
+    all clients (i.e. browsers) connected to the page will open the target URL unless a socket is specified.
+    User events like button clicks provide such a socket.
+
+    :param target: page function, NiceGUI element on the same page or string that is a an absolute URL or relative path from base URL
+    :param new_tab: whether to open the target in a new tab (might be blocked by the browser)
+    """
+    if isinstance(target, str):
+        path = target
+    elif isinstance(target, Element):
+        path = f'#c{target.id}'
+    elif callable(target):
+        path = Client.page_routes[target]
+    context.get_client().open(path, new_tab)

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -50,6 +50,7 @@ __all__ = [
     'menu',
     'menu_item',
     'mermaid',
+    'navigate',
     'notification',
     'number',
     'pagination',
@@ -200,6 +201,7 @@ from .elements.tooltip import Tooltip as tooltip
 from .elements.tree import Tree as tree
 from .elements.upload import Upload as upload
 from .elements.video import Video as video
+from .functions import navigate
 from .functions.download import download
 from .functions.html import add_body_html, add_head_html
 from .functions.javascript import run_javascript


### PR DESCRIPTION
This PR adds the `ui.navigate` module, which includes the `ui.navigate.back()`, `ui.navigate.forward()`, and `ui.navigate.to()` methods. These methods allow for programmatic navigation within the browser history and redirecting to specific URLs or page functions.