### PR TITLE
Allow awaiting the "init" event of `ui.map` and `ui.scene`

### DIFF
--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union, cast
 
@@ -73,6 +74,13 @@ class Leaflet(Element, component='leaflet.js'):
         with self.client.individual_target(e.args['socket_id']):
             for layer in self.layers:
                 self.run_method('add_layer', layer.to_dict(), layer.id)
+
+    async def initialized(self) -> None:
+        """Wait until the map is initialized."""
+        event = asyncio.Event()
+        self.on('init', event.set, [])
+        await self.client.connected()
+        await event.wait()
 
     def _handle_moveend(self, e: GenericEventArguments) -> None:
         self.center = e.args['center']

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -1,3 +1,4 @@
+import asyncio
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -116,6 +117,13 @@ class Scene(Element,
             self.move_camera(duration=0)
             for obj in self.objects.values():
                 obj.send()
+
+    async def initialized(self) -> None:
+        """Wait until the scene is initialized."""
+        event = asyncio.Event()
+        self.on('init', event.set, [])
+        await self.client.connected()
+        await event.wait()
 
     def run_method(self, name: str, *args: Any, timeout: float = 1, check_interval: float = 0.01) -> AwaitableResponse:
         if not self.is_initialized:

--- a/website/documentation/content/leaflet_documentation.py
+++ b/website/documentation/content/leaflet_documentation.py
@@ -143,4 +143,20 @@ def run_layer_methods() -> None:
     ui.button('Change icon', on_click=lambda: marker.run_method(':setIcon', icon))
 
 
+@doc.demo('Wait for Initialization', '''
+    You can wait for the map to be initialized with the `initialized` method.
+    This is necessary when you want to run methods like fitting the bounds of the map right after the map is created.
+''')
+async def wait_for_init() -> None:
+    m = ui.leaflet(zoom=5)
+    central_park = m.generic_layer(name='polygon', args=[[
+        (40.767809, -73.981249),
+        (40.800273, -73.958291),
+        (40.797011, -73.949683),
+        (40.764704, -73.973741)
+    ]])
+    await m.initialized()
+    bounds = await central_park.run_method('getBounds')
+    m.run_map_method('fitBounds', [[bounds['_southWest'], bounds['_northEast']]])
+
 doc.reference(ui.leaflet)

--- a/website/documentation/content/leaflet_documentation.py
+++ b/website/documentation/content/leaflet_documentation.py
@@ -153,7 +153,7 @@ async def wait_for_init() -> None:
         (40.767809, -73.981249),
         (40.800273, -73.958291),
         (40.797011, -73.949683),
-        (40.764704, -73.973741)
+        (40.764704, -73.973741),
     ]])
     await m.initialized()
     bounds = await central_park.run_method('getBounds')

--- a/website/documentation/content/scene_documentation.py
+++ b/website/documentation/content/scene_documentation.py
@@ -101,12 +101,13 @@ def point_clouds() -> None:
 
 @doc.demo('Wait for Initialization', '''
     You can wait for the scene to be initialized with the `initialized` method.
-    This is necessary when you want to run methods like ...
+    This demo animates a camera movement after the scene has been fully loaded.
 ''')
 async def wait_for_init() -> None:
     with ui.scene(width=285, height=220) as scene:
-        scene.box().scale(1, 1, 1).move(y=1, z=0).with_name('box')
+        scene.sphere()
         await scene.initialized()
+        scene.move_camera(x=1, y=-1, z=1.5, duration=2)
 
 
 doc.reference(ui.scene)

--- a/website/documentation/content/scene_documentation.py
+++ b/website/documentation/content/scene_documentation.py
@@ -99,4 +99,14 @@ def point_clouds() -> None:
         scene.point_cloud(points=points, colors=points, point_size=0.1)
 
 
+@doc.demo('Wait for Initialization', '''
+    You can wait for the scene to be initialized with the `initialized` method.
+    This is necessary when you want to run methods like ...
+''')
+async def wait_for_init() -> None:
+    with ui.scene(width=285, height=220) as scene:
+        scene.box().scale(1, 1, 1).move(y=1, z=0).with_name('box')
+        await scene.initialized()
+
+
 doc.reference(ui.scene)


### PR DESCRIPTION
This PR tries to solve issue https://github.com/zauberzeug/nicegui/issues/2500 by adding an awaitable `initialized` method to `ui.map` (and `ui.scene` for consistency). This way we can write something like:

```py
@ui.page('/')
async def page():
    m = ui.leaflet(zoom=7)
    polygon = m.generic_layer(name='polygon', args=[[(0, 4), (1, 2), (3, 3)]])
    await m.initialized()
    bounds = await polygon.run_method('getBounds')
    m.run_map_method('fitBounds', [[bounds['_southWest'], bounds['_northEast']]])
```