### PR TITLE
Use more specific page titles for individual documentation pages

### DIFF
--- a/website/documentation/rendering.py
+++ b/website/documentation/rendering.py
@@ -27,6 +27,8 @@ def render_page(documentation: DocumentationPage, *, with_menu: bool = True) -> 
     add_head_html()
     add_header(menu)
     ui.add_head_html('<style>html {scroll-behavior: auto;}</style>')
+    title = (documentation.title or '').replace('*', '')
+    ui.page_title('NiceGUI' if not title else title if title.split()[0] == 'NiceGUI' else f'{title} | NiceGUI')
 
     # content
     def render_content():


### PR DESCRIPTION
This PR addresses feature request https://github.com/zauberzeug/nicegui/discussions/2583 and adds more descriptive titles for individual documentation pages.