### PR TITLE
Add a toggleable button demo to the docs

### DIFF
--- a/website/documentation/content/button_documentation.py
+++ b/website/documentation/content/button_documentation.py
@@ -61,4 +61,28 @@ def disable_context_manager() -> None:
     ui.button('Get slow response', on_click=lambda e: get_slow_response(e.sender))
 
 
+@doc.demo('Custom toggle button', '''
+As with all other elements you can implement your own subclass with specialized logic.
+Like this red/green toggle button with an internal boolean state.
+''')
+def toggle_button() -> None:
+    class ToggleButton(ui.button):
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._state = False
+            self.on('click', self.toggle)
+
+        def toggle(self) -> None:
+            """Toggle the button state."""
+            self._state = not self._state
+            self.update()
+
+        def update(self):
+            self.props(f'color={"green" if self._state else "red"}')
+            super().update()
+
+    ToggleButton('Toggle me')
+
+
 doc.reference(ui.button)

--- a/website/documentation/content/button_documentation.py
+++ b/website/documentation/content/button_documentation.py
@@ -62,13 +62,13 @@ def disable_context_manager() -> None:
 
 
 @doc.demo('Custom toggle button', '''
-As with all other elements you can implement your own subclass with specialized logic.
-Like this red/green toggle button with an internal boolean state.
+    As with all other elements, you can implement your own subclass with specialized logic.
+    Like this red/green toggle button with an internal boolean state.
 ''')
 def toggle_button() -> None:
     class ToggleButton(ui.button):
 
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args, **kwargs) -> None:
             super().__init__(*args, **kwargs)
             self._state = False
             self.on('click', self.toggle)
@@ -78,7 +78,7 @@ def toggle_button() -> None:
             self._state = not self._state
             self.update()
 
-        def update(self):
+        def update(self) -> None:
             self.props(f'color={"green" if self._state else "red"}')
             super().update()
 


### PR DESCRIPTION
This pull request brings the code from a [Discord question](https://discord.com/channels/1089836369431498784/1211383144234623036) into the documentation. It demos a custom (inherited) button implementation which toggles an internal state with red/green color change.