### PR TITLE
Introduce ui.navigate.reload()

### DIFF
--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -31,6 +31,15 @@ class Navigate:
         run_javascript('history.forward()')
 
     @staticmethod
+    def reload() -> None:
+        """ui.navigate.reload
+
+        Navigates 0 step in the browser history (i.e reload the current page).
+        It is equivalent to clicking the reload button in the browser.
+        """
+        run_javascript('history.go(0)')
+
+    @staticmethod
     def to(target: Union[Callable[..., Any], str, Element], new_tab: bool = False) -> None:
         """ui.navigate.to (formerly ui.open)
 

--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -34,7 +34,7 @@ class Navigate:
     def reload() -> None:
         """ui.navigate.reload
 
-        Navigates 0 step in the browser history (i.e reload the current page).
+        Reload the current page.
         It is equivalent to clicking the reload button in the browser.
         """
         run_javascript('history.go(0)')


### PR DESCRIPTION
Following the ui.navigate introduction, reload() seems to be a nice addition.
history.go(0) reloads the page.

While ui.refreshable could cover most use-cases, handling many of these in a complex page could be a huge hassle. This avoids using ui.navigate.to(<current_page>).