### PR TITLE
Allow disabling the auto-validation on value change

### DIFF
--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -31,6 +31,7 @@ class Input(ValidationElement, DisableableElement, component='input.js'):
         e.g. ``{'Too long!': lambda value: len(value) < 3}``.
         The key of the first rule that fails will be displayed as an error message.
         Alternatively, you can pass a callable that returns an optional error message.
+        To disable the automatic validation on every value change, you can use the `without_auto_validation` method.
 
         Note about styling the input:
         Quasar's `QInput` component is a wrapper around a native `input` element.

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -7,6 +7,7 @@ class ValidationElement(ValueElement):
 
     def __init__(self, validation: Optional[Union[Callable[..., Optional[str]], Dict[str, Callable[..., bool]]]], **kwargs: Any) -> None:
         self.validation = validation if validation is not None else {}
+        self._auto_validation = True
         self._error: Optional[str] = None
         super().__init__(**kwargs)
 
@@ -45,6 +46,11 @@ class ValidationElement(ValueElement):
         self.error = None
         return True
 
+    def disable_auto_validation(self) -> None:
+        """Disable automatic validation on value change."""
+        self._auto_validation = False
+
     def _handle_value_change(self, value: Any) -> None:
         super()._handle_value_change(value)
-        self.validate()
+        if self._auto_validation:
+            self.validate()

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -46,7 +46,7 @@ class ValidationElement(ValueElement):
         self.error = None
         return True
 
-    def disable_auto_validation(self) -> None:
+    def without_auto_validation(self) -> None:
         """Disable automatic validation on value change."""
         self._auto_validation = False
 

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -1,5 +1,7 @@
 from typing import Any, Callable, Dict, Optional, Union
 
+from typing_extensions import Self
+
 from .value_element import ValueElement
 
 
@@ -46,9 +48,10 @@ class ValidationElement(ValueElement):
         self.error = None
         return True
 
-    def without_auto_validation(self) -> None:
+    def without_auto_validation(self) -> Self:
         """Disable automatic validation on value change."""
         self._auto_validation = False
+        return self
 
     def _handle_value_change(self, value: Any) -> None:
         super()._handle_value_change(value)

--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -30,6 +30,7 @@ class Number(ValidationElement, DisableableElement):
         e.g. ``{'Too small!': lambda value: value < 3}``.
         The key of the first rule that fails will be displayed as an error message.
         Alternatively, you can pass a callable that returns an optional error message.
+        To disable the automatic validation on every value change, you can use the `without_auto_validation` method.
 
         :param label: displayed name for the number input
         :param placeholder: text to show if no value is entered

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -37,6 +37,7 @@ class Select(ValidationElement, ChoiceElement, DisableableElement, component='se
         e.g. ``{'Too long!': lambda value: len(value) < 3}``.
         The key of the first rule that fails will be displayed as an error message.
         Alternatively, you can pass a callable that returns an optional error message.
+        To disable the automatic validation on every value change, you can use the `without_auto_validation` method.
 
         :param options: a list ['value1', ...] or dictionary `{'value1':'label1', ...}` specifying the options
         :param label: the label to display above the selection

--- a/nicegui/elements/textarea.py
+++ b/nicegui/elements/textarea.py
@@ -21,6 +21,7 @@ class Textarea(Input, component='input.js'):
         e.g. ``{'Too long!': lambda value: len(value) < 3}``.
         The key of the first rule that fails will be displayed as an error message.
         Alternatively, you can pass a callable that returns an optional error message.
+        To disable the automatic validation on every value change, you can use the `without_auto_validation` method.
 
         :param label: displayed name for the textarea
         :param placeholder: text to show if no value is entered

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -172,10 +172,17 @@ def test_keep_filtered_options(multiple: bool, screen: Screen):
         screen.should_contain('B2')
 
 
-def test_select_validation(screen: Screen):
-    ui.select(['A', 'BC', 'DEF'], value='A', validation={'Too long': lambda v: len(v) < 3})
+@pytest.mark.parametrize('auto_validation', [True, False])
+def test_select_validation(auto_validation: bool, screen: Screen):
+    select = ui.select(['A', 'BC', 'DEF'], value='A', validation={'Too long': lambda v: len(v) < 3})
+    if not auto_validation:
+        select.without_auto_validation()
 
     screen.open('/')
     screen.click('A')
     screen.click('DEF')
-    screen.should_contain('Too long')
+    screen.wait(0.5)
+    if auto_validation:
+        screen.should_contain('Too long')
+    else:
+        screen.should_not_contain('Too long')


### PR DESCRIPTION
This PR introduces a `.without_auto_validation()` builder method to avoid validating the value on every value change as requested in #2618:

```py
i = ui.input(validation={'Input too long': lambda value: len(value) < 3}).without_auto_validation()
ui.button('Validate', on_click=i.validate)
```