### PR TITLE
Add `return_exclusions` to `runJavascript()`

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -459,7 +459,8 @@ class Element(Visibility):
             return
         self.client.outbox.enqueue_update(self)
 
-    def run_method(self, name: str, *args: Any, timeout: float = 1, check_interval: float = 0.01) -> AwaitableResponse:
+    def run_method(self, name: str, *args: Any, timeout: float = 1, check_interval: float = 0.01,
+                   return_exclusions: list[str] | None = None) -> AwaitableResponse:
         """Run a method on the client side.
 
         If the function is awaited, the result of the method call is returned.
@@ -469,11 +470,13 @@ class Element(Visibility):
         :param args: arguments to pass to the method
         :param timeout: maximum time to wait for a response (default: 1 second)
         :param check_interval: time between checks for a response (default: 0.01 seconds)
+        :param return_exclusions: list of dotted paths to exclude from the result (default: `[]`)
         """
         if not core.loop:
             return NullResponse()
         return self.client.run_javascript(f'return runMethod({self.id}, "{name}", {json.dumps(args)})',
-                                          timeout=timeout, check_interval=check_interval)
+                                          timeout=timeout, check_interval=check_interval,
+                                          return_exclusions=return_exclusions)
 
     def _collect_descendants(self, *, include_self: bool = False) -> List[Element]:
         elements: List[Element] = [self] if include_self else []

--- a/nicegui/elements/aggrid.py
+++ b/nicegui/elements/aggrid.py
@@ -95,7 +95,8 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
         """DEPRECATED: Use `run_grid_method` instead."""
         return self.run_grid_method(name, *args, timeout=timeout, check_interval=check_interval)
 
-    def run_grid_method(self, name: str, *args, timeout: float = 1, check_interval: float = 0.01) -> AwaitableResponse:
+    def run_grid_method(self, name: str, *args, timeout: float = 1, check_interval: float = 0.01,
+                        return_exclusions: list[str] | None = None) -> AwaitableResponse:
         """Run an AG Grid API method.
 
         See `AG Grid API <https://www.ag-grid.com/javascript-data-grid/grid-api/>`_ for a list of methods.
@@ -107,10 +108,12 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
         :param args: arguments to pass to the method
         :param timeout: timeout in seconds (default: 1 second)
         :param check_interval: interval in seconds to check for a response (default: 0.01 seconds)
+        :param return_exclusions: list of dotted paths to exclude from the result (default: `[]`)
 
         :return: AwaitableResponse that can be awaited to get the result of the method call
         """
-        return self.run_method('run_grid_method', name, *args, timeout=timeout, check_interval=check_interval)
+        return self.run_method('run_grid_method', name, *args, timeout=timeout, check_interval=check_interval,
+                               return_exclusions=return_exclusions)
 
     def call_column_method(self, name: str, *args, timeout: float = 1, check_interval: float = 0.01) -> AwaitableResponse:
         """DEPRECATED: Use `run_column_method` instead."""

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -215,7 +215,25 @@
         return Vue.h(Vue.resolveComponent(element.tag), props, slots);
       }
 
-      function runJavascript(code, request_id) {
+      function cloneWithExclusions(source, exclusions) {
+          const exclusionSet = new Set(exclusions);
+
+          const isExcluded = (path) => exclusionSet.has(path);
+
+          function cloneObject(obj, currentPath = '') {
+            if (typeof obj !== 'object' || obj === null) return obj;
+            return Object.entries(obj).reduce((acc, [key, value]) => {
+              const newPath = currentPath ? `${currentPath}.${key}` : key;
+              if (isExcluded(newPath)) return acc;
+              acc[key] = cloneObject(value, newPath);
+              return acc;
+            }, Array.isArray(obj) ? [] : {});
+          }
+
+          return cloneObject(source);
+      }
+
+      function runJavascript(code, request_id, return_exclusions = []) {
         (new Promise((resolve) =>resolve(eval(code)))).catch((reason) => {
           if(reason instanceof SyntaxError)
             return eval(`(async() => {${code}})()`);
@@ -223,6 +241,7 @@
             throw reason;
         }).then((result) => {
           if (request_id) {
+            if (return_exclusions.length > 0) result = cloneWithExclusions(result, return_exclusions);
             window.socket.emit("javascript_response", {request_id, client_id: window.client_id, result});
           }
         });
@@ -317,7 +336,7 @@
                 this.elements[element.id] = element;
               }
             },
-            run_javascript: (msg) => runJavascript(msg['code'], msg['request_id']),
+            run_javascript: (msg) => runJavascript(msg['code'], msg['request_id'], msg['return_exclusions']),
             open: (msg) => {
               const url = msg.path.startsWith('/') ? "{{ prefix | safe }}" + msg.path : msg.path;
               const target = msg.new_tab ? '_blank' : '_self';


### PR DESCRIPTION
Due to potential recursion in the objects returned by runJavascript, it is necessary to remove parts of the tree without modifying the objects in place. Added an optional argument that allows the exclusion of data from the return value in a dotted-path notation.