### PR TITLE
Refine type annotation for Date element 

### DIFF
--- a/nicegui/elements/date.py
+++ b/nicegui/elements/date.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from .mixins.disableable_element import DisableableElement
 from .mixins.value_element import ValueElement
@@ -7,7 +7,9 @@ from .mixins.value_element import ValueElement
 class Date(ValueElement, DisableableElement):
 
     def __init__(self,
-                 value: Optional[str] = None,
+                 value: Optional[
+                     Union[str, Dict[str, str], List[str], List[Union[str, Dict[str, str]]]]
+                 ] = None,
                  *,
                  mask: str = 'YYYY-MM-DD',
                  on_change: Optional[Callable[..., Any]] = None) -> None:


### PR DESCRIPTION
This PR refines the static type annotation for `Date` element, as the param `value` accepts different type of inputs:
```python
ui.date(value='2023-01-01', on_change=lambda e: result.set_text(e.value))
ui.date({'from': '2023-01-01', 'to': '2023-01-05'}).props('range')
ui.date(['2023-01-01', '2023-01-02', '2023-01-03']).props('multiple')
ui.date([{'from': '2023-01-01', 'to': '2023-01-05'}, '2023-01-07']).props('multiple range')
```