### PR TITLE
Add new example with global computation and progress bar

### DIFF
--- a/examples/global_progress/main.py
+++ b/examples/global_progress/main.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import asyncio
+import time
+from multiprocessing import Manager
+from queue import Empty, Queue
+from typing import Callable, Generator
+
+from nicegui import app, background_tasks, run, ui
+
+
+class Computer:
+
+    def __init__(self) -> None:
+        self._queue: Queue
+        self.progress: float = 0.0
+        self.is_running: bool = False
+
+        app.on_startup(self._create_queue)
+
+    async def run(self, func: Callable[..., Generator[float, None, None]]) -> None:
+        background_tasks.create(run.cpu_bound(self._run_generator, func, self._queue))
+        background_tasks.create(self._consume_queue())
+
+    @staticmethod
+    def _run_generator(func: Callable[..., Generator[float, None, None]], queue: Queue) -> None:
+        for progress in func():
+            queue.put({'progress': progress})
+        queue.put({'progress': 1.0})
+
+    def _create_queue(self) -> None:
+        self._queue = Manager().Queue()
+
+    async def _consume_queue(self) -> None:
+        self.is_running = True
+        self.progress = 0.0
+        while self.progress < 1.0:
+            try:
+                msg = self._queue.get_nowait()
+            except Empty:
+                await asyncio.sleep(0.1)
+                continue
+            self.progress = msg['progress']
+        self.is_running = False
+
+
+def heavy_computation() -> Generator[float, None, None]:
+    n = 50
+    for i in range(n):
+        time.sleep(0.1)
+        yield i / n
+
+
+computer = Computer()
+
+
+@ui.page('/')
+def main_page():
+    ui.button('compute', on_click=lambda: computer.run(heavy_computation))
+    ui.linear_progress().props('instant-feedback') \
+        .bind_value_from(computer, 'progress') \
+        .bind_visibility_from(computer, 'is_running')
+
+
+ui.run()

--- a/examples/global_worker/main.py
+++ b/examples/global_worker/main.py
@@ -8,7 +8,7 @@ from typing import Callable, Generator
 from nicegui import app, background_tasks, run, ui
 
 
-class Computer:
+class Worker:
 
     def __init__(self) -> None:
         self._queue: Queue
@@ -50,15 +50,15 @@ def heavy_computation() -> Generator[float, None, None]:
         yield i / n
 
 
-computer = Computer()
+worker = Worker()
 
 
 @ui.page('/')
 def main_page():
-    ui.button('compute', on_click=lambda: computer.run(heavy_computation))
+    ui.button('compute', on_click=lambda: worker.run(heavy_computation))
     ui.linear_progress().props('instant-feedback') \
-        .bind_value_from(computer, 'progress') \
-        .bind_visibility_from(computer, 'is_running')
+        .bind_value_from(worker, 'progress') \
+        .bind_visibility_from(worker, 'is_running')
 
 
 ui.run()

--- a/website/examples.py
+++ b/website/examples.py
@@ -33,6 +33,7 @@ examples: List[Example] = [
     Example('OpenCV Webcam', 'uses OpenCV to capture images from a webcam'),
     Example('SVG Clock', 'displays an analog clock by updating an SVG with `ui.timer`'),
     Example('Progress', 'demonstrates a progress bar for heavy computations'),
+    Example('Global Worker', 'demonstrates a global worker for heavy computations with progress feedback'),
     Example('NGINX Subpath', 'shows the setup to serve an app behind a reverse proxy subpath'),
     Example('Script Executor', 'executes scripts on selection and displays the output'),
     Example('Local File Picker', 'demonstrates a dialog for selecting files locally on the server'),


### PR DESCRIPTION
Inspired by the discussion #2676, this PR adds an example with a long-running computation with a progress that can be accessed from multiple pages.

Open tasks:

- [x] better name for `Computer`
- [x] add link on main page