### PR TITLE
Reduce payload

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -182,8 +182,12 @@ class Element(Visibility):
 
     def _collect_slot_dict(self) -> Dict[str, Any]:
         return {
-            name: {'template': slot.template, 'ids': [child.id for child in slot]}
+            name: {
+                'ids': [child.id for child in slot],
+                **({'template': slot.template} if slot.template is not None else {}),
+            }
             for name, slot in self.slots.items()
+            if slot != self.default_slot
         }
 
     def _to_dict(self) -> Dict[str, Any]:
@@ -198,6 +202,7 @@ class Element(Visibility):
                     'style': self._style,
                     'props': self._props,
                     'slots': self._collect_slot_dict(),
+                    'children': [child.id for child in self.default_slot.children],
                     'events': [listener.to_dict() for listener in self._event_listeners.values()],
                     'component': {
                         'key': self.component.key,

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -82,7 +82,7 @@ class Element(Visibility):
         self._classes.extend(self._default_classes)
         self._style: Dict[str, str] = {}
         self._style.update(self._default_style)
-        self._props: Dict[str, Any] = {'key': self.id}  # HACK: workaround for #600 and #898
+        self._props: Dict[str, Any] = {}
         self._props.update(self._default_props)
         self._event_listeners: Dict[str, EventListener] = {}
         self._text: Optional[str] = None

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -192,7 +192,6 @@ class Element(Visibility):
 
     def _to_dict(self) -> Dict[str, Any]:
         return {
-            'id': self.id,
             'tag': self.tag,
             **({'text': self._text} if self._text is not None else {}),
             **{

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -190,13 +190,13 @@ class Element(Visibility):
         return {
             'id': self.id,
             'tag': self.tag,
+            **({'text': self._text} if self._text is not None else {}),
             **{
                 key: value
                 for key, value in {
                     'class': self._classes,
                     'style': self._style,
                     'props': self._props,
-                    'text': self._text,
                     'slots': self._collect_slot_dict(),
                     'events': [listener.to_dict() for listener in self._event_listeners.values()],
                     'component': {

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -190,23 +190,29 @@ class Element(Visibility):
         return {
             'id': self.id,
             'tag': self.tag,
-            'class': self._classes,
-            'style': self._style,
-            'props': self._props,
-            'text': self._text,
-            'slots': self._collect_slot_dict(),
-            'events': [listener.to_dict() for listener in self._event_listeners.values()],
-            'component': {
-                'key': self.component.key,
-                'name': self.component.name,
-                'tag': self.component.tag
-            } if self.component else None,
-            'libraries': [
-                {
-                    'key': library.key,
-                    'name': library.name,
-                } for library in self.libraries
-            ],
+            **{
+                key: value
+                for key, value in {
+                    'class': self._classes,
+                    'style': self._style,
+                    'props': self._props,
+                    'text': self._text,
+                    'slots': self._collect_slot_dict(),
+                    'events': [listener.to_dict() for listener in self._event_listeners.values()],
+                    'component': {
+                        'key': self.component.key,
+                        'name': self.component.name,
+                        'tag': self.component.tag
+                    } if self.component else None,
+                    'libraries': [
+                        {
+                            'key': library.key,
+                            'name': library.name,
+                        } for library in self.libraries
+                    ],
+                }.items()
+                if value
+            },
         }
 
     @staticmethod

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -139,6 +139,15 @@
             return;
         }
 
+        element.class ??= [];
+        element.style ??= {};
+        element.props ??= {};
+        element.text ??= null;
+        element.slots ??= {};
+        element.events ??= [];
+        element.component ??= null;
+        element.libraries ??= [];
+
         // @todo: Try avoid this with better handling of initial page load.
         if (element.component) loaded_components.add(element.component.name);
         element.libraries.forEach((library) => loaded_libraries.add(library.name));
@@ -255,10 +264,12 @@
             loaded_components.add(name);
           }
         }
-        for (const {name, key} of element.libraries) {
-          if (loaded_libraries.has(name)) continue;
-          await import(`{{ prefix | safe }}/_nicegui/{{version}}/libraries/${key}`);
-          loaded_libraries.add(name);
+        if (element.libraries) {
+          for (const {name, key} of element.libraries) {
+            if (loaded_libraries.has(name)) continue;
+            await import(`{{ prefix | safe }}/_nicegui/{{version}}/libraries/${key}`);
+            loaded_libraries.add(name);
+          }
         }
       }
 
@@ -311,7 +322,7 @@
                   delete this.elements[id];
                   continue;
                 }
-                if (element.component || element.libraries.length > 0) {
+                if (element.component || element.libraries) {
                   await loadDependencies(element);
                 }
                 this.elements[element.id] = element;

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -153,9 +153,9 @@
         element.libraries.forEach((library) => loaded_libraries.add(library.name));
 
         const props = {
-          id: 'c' + element.id,
-          ref: 'r' + element.id,
-          key: element.id,  // HACK: workaround for #600 and #898
+          id: 'c' + id,
+          ref: 'r' + id,
+          key: id,  // HACK: workaround for #600 and #898
           class: element.class.join(' ') || undefined,
           style: Object.entries(element.style).reduce((str, [p, val]) => `${str}${p}:${val};`, '') || undefined,
           ...element.props,
@@ -182,7 +182,7 @@
           else {
             handler = (...args) => {
               const data = {
-                id: element.id,
+                id: id,
                 client_id: window.client_id,
                 listener_id: event.listener_id,
                 args: stringifyEventArgs(args, event.args),
@@ -330,7 +330,7 @@
                 if (element.component || element.libraries) {
                   await loadDependencies(element);
                 }
-                this.elements[element.id] = element;
+                this.elements[id] = element;
               }
             },
             run_javascript: (msg) => runJavascript(msg['code'], msg['request_id']),

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -204,7 +204,11 @@
           }
         });
         const slots = {};
-        Object.entries(element.slots).forEach(([name, data]) => {
+        const element_slots = {
+          default: { ids: element.children || [] },
+          ...element.slots,
+        };
+        Object.entries(element_slots).forEach(([name, data]) => {
           slots[name] = (props) => {
             const rendered = [];
             if (data.template) {

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -155,6 +155,7 @@
         const props = {
           id: 'c' + element.id,
           ref: 'r' + element.id,
+          key: element.id,  // HACK: workaround for #600 and #898
           class: element.class.join(' ') || undefined,
           style: Object.entries(element.style).reduce((str, [p, val]) => `${str}${p}:${val};`, '') || undefined,
           ...element.props,


### PR DESCRIPTION
This PR tries to reduce the websocket payload when updating elements.

- [x] exclude empty fields from the element dictionary
- [x] exclude the "key" prop
- [x] exclude the "template" field in the slot dictionaries?
- [x] reduce the default slot from
    ```
    "slots": {
      "default": {
        "template": null,
        "ids": [
          213,
          214
        ]
      }
    }
    ```
    down to
    ```
    "children": [213, 214]
    ```
- [x] remove the "id" from the dictionary values? (they are repeated as the dictionary keys)