### PR TITLE
Add support for additional echart events

### DIFF
--- a/nicegui/elements/echart.js
+++ b/nicegui/elements/echart.js
@@ -5,6 +5,48 @@ export default {
   mounted() {
     this.chart = echarts.init(this.$el);
     this.chart.on("click", (e) => this.$emit("pointClick", e));
+    for (const event of [
+      "click",
+      "dblclick",
+      "mousedown",
+      "mousemove",
+      "mouseup",
+      "mouseover",
+      "mouseout",
+      "globalout",
+      "contextmenu",
+      "highlight",
+      "downplay",
+      "selectchanged",
+      "legendselectchanged",
+      "legendselected",
+      "legendunselected",
+      "legendselectall",
+      "legendinverseselect",
+      "legendscroll",
+      "datazoom",
+      "datarangeselected",
+      "graphroam",
+      "georoam",
+      "treeroam",
+      "timelinechanged",
+      "timelineplaychanged",
+      "restore",
+      "dataviewchanged",
+      "magictypechanged",
+      "geoselectchanged",
+      "geoselected",
+      "geounselected",
+      "axisareaselected",
+      "brush",
+      "brushEnd",
+      "brushselected",
+      "globalcursortaken",
+      "rendered",
+      "finished",
+    ]) {
+      this.chart.on(event, (e) => this.$emit(`chart:${event}`, e));
+    }
     this.update_chart();
     new ResizeObserver(this.chart.resize).observe(this.$el);
   },

--- a/tests/test_echart.py
+++ b/tests/test_echart.py
@@ -103,3 +103,14 @@ def test_create_from_pyecharts(screen: Screen):
         const y = chart.getOption().yAxis[0].axisLabel.formatter;
         return [typeof x, x.toString(), typeof y, y.toString()];
     ''') == ['function', X_AXIS_FORMATTER, 'function', Y_AXIS_FORMATTER]
+
+
+def test_chart_events(screen: Screen):
+    ui.echart({
+        'xAxis': {'type': 'category'},
+        'yAxis': {'type': 'value'},
+        'series': [{'type': 'line', 'data': [1, 2, 3]}],
+    }).on('chart:rendered', lambda: ui.label('Chart rendered.'))
+
+    screen.open('/')
+    screen.should_contain('Chart rendered.')

--- a/website/documentation/content/echart_documentation.py
+++ b/website/documentation/content/echart_documentation.py
@@ -100,4 +100,21 @@ def methods_demo() -> None:
     ))
 
 
+@doc.demo('Arbitrary chart events', '''
+    You can register arbitrary event listeners for the chart using the `on` method and a "chart:" prefix.
+    This demo shows how to register a callback for the "selectchanged" event which is triggered when the user selects a point.
+''')
+def events_demo() -> None:
+    ui.echart({
+        'toolbox': {'feature': {'brush': {'type': ['rect']}}},
+        'brush': {},
+        'xAxis': {'type': 'category'},
+        'yAxis': {'type': 'value'},
+        'series': [{'type': 'line', 'data': [1, 2, 3]}],
+    }).on('chart:selectchanged', lambda e: label.set_text(
+        f'Selected point {e.args["fromActionPayload"]["dataIndexInside"]}'
+    ))
+    label = ui.label()
+
+
 doc.reference(ui.echart)


### PR DESCRIPTION
This PR tries to solve feature request #2679 by adding support for additional chart events. They can be accessed using the "chart:" prefix like this:

```py
ui.echart({
    "brush": {},
    "xAxis": [{"type": "value"}],
    "yAxis": [{"type": "value"}],
    "series": [{"type": "scatter", "data": [[1, 2], [3, 4]]}],
}).on('chart:brush', lambda e: print(e))
```

This example prints the current selection when using the rectangle or box selection.

Open tasks:

- [x] documentation
- [x] pytest