### PR TITLE
fix: fix 404 page bug when accessing wrong static files.

### DIFF
--- a/nicegui/app/app_config.py
+++ b/nicegui/app/app_config.py
@@ -36,6 +36,7 @@ class AppConfig:
     prod_js: bool = field(init=False)
     show_welcome_message: bool = field(init=False)
     _has_run_config: bool = False
+    root_path: str = field(init=False)
 
     def add_run_config(self,
                        *,
@@ -50,6 +51,7 @@ class AppConfig:
                        tailwind: bool,
                        prod_js: bool,
                        show_welcome_message: bool,
+                       root_path: str,
                        ) -> None:
         """Add the run config to the app config."""
         self.reload = reload
@@ -64,6 +66,7 @@ class AppConfig:
         self.prod_js = prod_js
         self.show_welcome_message = show_welcome_message
         self._has_run_config = True
+        self.root_path = root_path
 
     @property
     def has_run_config(self) -> bool:

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -144,6 +144,7 @@ async def _shutdown() -> None:
 @app.exception_handler(404)
 async def _exception_handler_404(request: Request, exception: Exception) -> Response:
     log.warning(f'{request.url} not found')
+    request.scope['root_path'] = ''
     with Client(page('')) as client:
         error_content(404, exception)
     return client.build_response(request, 404)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -144,7 +144,7 @@ async def _shutdown() -> None:
 @app.exception_handler(404)
 async def _exception_handler_404(request: Request, exception: Exception) -> Response:
     log.warning(f'{request.url} not found')
-    request.scope['root_path'] = ''
+    request.scope['root_path'] = core.app.config.root_path
     with Client(page('')) as client:
         error_content(404, exception)
     return client.build_response(request, 404)

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -92,6 +92,7 @@ def run(*,
         tailwind=tailwind,
         prod_js=prod_js,
         show_welcome_message=show_welcome_message,
+        root_path=""
     )
     core.app.config.endpoint_documentation = endpoint_documentation
 

--- a/nicegui/ui_run_with.py
+++ b/nicegui/ui_run_with.py
@@ -55,6 +55,7 @@ def run_with(
         tailwind=tailwind,
         prod_js=prod_js,
         show_welcome_message=show_welcome_message,
+        root_path=mount_path
     )
 
     storage.set_storage_secret(storage_secret)

--- a/tests/test_404page.py
+++ b/tests/test_404page.py
@@ -1,0 +1,14 @@
+from nicegui import app
+from nicegui.testing import Screen
+
+
+def test_404page_for_static_files(screen: Screen):
+    app.add_static_files('/static', '.')
+
+    screen.open('/static')
+    screen.should_contain('This page doesn\'t exist.')
+    screen.assert_py_logger('WARNING',f'http://localhost:{screen.PORT}/static/ not found')
+
+    screen.open('/static/_____')
+    screen.should_contain('This page doesn\'t exist.')
+    screen.assert_py_logger('WARNING',f'http://localhost:{screen.PORT}/static/_____ not found')

--- a/tests/test_404page.py
+++ b/tests/test_404page.py
@@ -12,3 +12,5 @@ def test_404page_for_static_files(screen: Screen):
     screen.open('/static/_____')
     screen.should_contain('This page doesn\'t exist.')
     screen.assert_py_logger('WARNING',f'http://localhost:{screen.PORT}/static/_____ not found')
+
+    app.remove_route('/static')


### PR DESCRIPTION
This #2570 issue is because starlette modify `request.route['root_path']` when routing static files mount.  I just reset this field when handling 404 page request. 
I'm a beginner in nicegui and may miss something. On my machine, all test passed and the bug is fixed.
I also add a test for 404 page.