### PR TITLE
run io_bound and cpu_bound maintain type signatures of their callbacks

### DIFF
--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -2,7 +2,7 @@ import asyncio
 import sys
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from functools import partial
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, Callable, TypeVar
 
 from typing_extensions import ParamSpec
 


### PR DESCRIPTION
This is a pretty simple way for `nicegui` to not 'drop' the types of callbacks that need to get run in the background for whatever reason. I know `mypy` supports this, and I'm pretty sure other type checkers do too. It's an official part of the type system.

For this code:

<img width="452" alt="Screenshot 2024-03-20 at 11 08 40 AM" src="https://github.com/zauberzeug/nicegui/assets/549720/615ad8a1-b90e-463b-aba7-9feb14c44dd1">

we go from 

<img width="435" alt="Screenshot 2024-03-20 at 11 09 13 AM" src="https://github.com/zauberzeug/nicegui/assets/549720/0c90af00-a327-4e7c-81bb-1412f263d33c">

to 

<img width="1049" alt="Screenshot 2024-03-20 at 11 10 00 AM" src="https://github.com/zauberzeug/nicegui/assets/549720/e23cd148-e5d8-4c11-b327-b9d2f020f572">


And (although i have no accompanying screenshots) you would also get type checking on your inputs to the function.