### PR TITLE
Add pointer events to interactive image

### DIFF
--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -111,16 +111,6 @@ export default {
       const image_x = event.offsetX * zoom_factor;
       const image_y = event.offsetY * zoom_factor;
 
-      if (event_type == "pointerdown") {
-        console.log(event_type);
-        const svgNS = this.$refs.svg.namespaceURI;
-        const circle = document.createElementNS(svgNS, "circle");
-        circle.setAttribute("cx", image_x);
-        circle.setAttribute("cy", image_y);
-        circle.setAttribute("r", 5);
-        circle.setAttribute("fill", "red");
-        this.$refs.svg.appendChild(circle);
-      }
       this.$emit(`svg:${event_type}`, {
         type: event_type,
         image_x: image_x,

--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -110,6 +110,7 @@ export default {
       const imageHeight = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
       this.$emit(`svg:${type}`, {
         type: type,
+        element_id: e.target.id,
         image_x: (e.offsetX * imageWidth) / this.$refs.svg.clientWidth,
         image_y: (e.offsetY * imageHeight) / this.$refs.svg.clientHeight,
       });

--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -10,7 +10,18 @@ export default {
         v-on="onUserEvents"
         draggable="false"
       />
-      <svg style="position:absolute;top:0;left:0;pointer-events:none" :viewBox="viewBox">
+      <svg 
+        style="position:absolute;top:0;left:0;pointer-events:none" 
+        :viewBox="viewBox"
+        @pointermove="onPointerMove"
+        @pointerdown="onPointerDown"
+        @pointerup="onPointerUp"
+        @pointerover="onPointerOver"
+        @pointerout="onPointerOut"
+        @pointerenter="onPointerEnter"
+        @pointerleave="onPointerLeave"
+        @pointercancel="onPointerCancel"
+      >
         <g v-if="cross" :style="{ display: showCross ? 'block' : 'none' }">
           <line :x1="x" y1="0" :x2="x" y2="100%" :stroke="cross === true ? 'black' : cross" />
           <line x1="0" :y1="y" x2="100%" :y2="y" :stroke="cross === true ? 'black' : cross" />
@@ -20,6 +31,7 @@ export default {
       <slot></slot>
     </div>
   `,
+
   data() {
     return {
       viewBox: "0 0 0 0",
@@ -91,6 +103,78 @@ export default {
         ctrlKey: e.ctrlKey,
         metaKey: e.metaKey,
         shiftKey: e.shiftKey,
+      });
+    },
+    onPointerMove(event) {
+      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
+      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
+
+      this.$emit("pointer", {
+        type: "mousemove",
+        image_x: (event.offsetX * width) / event.x,
+        image_y: (event.offsetY * height) / event.x,
+      });
+    },
+    onPointerDown(event) {
+      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
+      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
+      this.$emit("pointer", {
+        type: "mousedown",
+        image_x: (event.offsetX * width) / event.x,
+        image_y: (event.offsetY * height) / event.x,
+      });
+    },
+    onPointerUp(event) {
+      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
+      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
+      this.$emit("pointer", {
+        type: "mouseup",
+        image_x: (event.offsetX * width) / event.x,
+        image_y: (event.offsetY * height) / event.x,
+      });
+    },
+    onPointerOver(event) {
+      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
+      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
+      this.$emit("pointer", {
+        image_x: (event.offsetX * width) / event.x,
+        image_y: (event.offsetY * height) / event.x,
+      });
+    },
+    onPointerOut(event) {
+      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
+      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
+      this.$emit("pointer", {
+        type: "mouseout",
+        image_x: (event.offsetX * width) / event.x,
+        image_y: (event.offsetY * height) / event.x,
+      });
+    },
+    onPointerEnter(event) {
+      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
+      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
+      this.$emit("pointer", {
+        type: "mouseenter",
+        image_x: (event.offsetX * width) / event.x,
+        image_y: (event.offsetY * height) / event.x,
+      });
+    },
+    onPointerLeave(event) {
+      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
+      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
+      this.$emit("pointer", {
+        type: "mouseleave",
+        image_x: (event.offsetX * width) / event.x,
+        image_y: (event.offsetY * height) / event.x,
+      });
+    },
+    onPointerCancel(event) {
+      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
+      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
+      this.$emit("pointer", {
+        type: "mousecancel",
+        image_x: (event.offsetX * width) / event.x,
+        image_y: (event.offsetY * height) / event.x,
       });
     },
   },

--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -13,14 +13,7 @@ export default {
       <svg 
         style="position:absolute;top:0;left:0;pointer-events:none" 
         :viewBox="viewBox"
-        @pointermove="onPointerMove"
-        @pointerdown="onPointerDown"
-        @pointerup="onPointerUp"
-        @pointerover="onPointerOver"
-        @pointerout="onPointerOut"
-        @pointerenter="onPointerEnter"
-        @pointerleave="onPointerLeave"
-        @pointercancel="onPointerCancel"
+
       >
         <g v-if="cross" :style="{ display: showCross ? 'block' : 'none' }">
           <line :x1="x" y1="0" :x2="x" y2="100%" :stroke="cross === true ? 'black' : cross" />
@@ -57,6 +50,18 @@ export default {
     };
     this.$refs.img.addEventListener("load", handle_completion);
     this.$refs.img.addEventListener("error", handle_completion);
+    for (const event of [
+      "pointermove",
+      "pointerdown",
+      "pointerup",
+      "pointerover",
+      "pointerout",
+      "pointerenter",
+      "pointerleave",
+      "pointercancel",
+    ]) {
+      // make it so that it calls onPointerEvent with the event type if there is an SVG event
+    }
   },
   updated() {
     this.compute_src();
@@ -105,74 +110,12 @@ export default {
         shiftKey: e.shiftKey,
       });
     },
-    onPointerMove(event) {
-      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
-      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
 
-      this.$emit("pointer", {
-        type: "mousemove",
-        image_x: (event.offsetX * width) / event.x,
-        image_y: (event.offsetY * height) / event.x,
-      });
-    },
-    onPointerDown(event) {
+    onPointerEvent(event_type, event) {
       const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
       const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
-      this.$emit("pointer", {
-        type: "mousedown",
-        image_x: (event.offsetX * width) / event.x,
-        image_y: (event.offsetY * height) / event.x,
-      });
-    },
-    onPointerUp(event) {
-      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
-      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
-      this.$emit("pointer", {
-        type: "mouseup",
-        image_x: (event.offsetX * width) / event.x,
-        image_y: (event.offsetY * height) / event.x,
-      });
-    },
-    onPointerOver(event) {
-      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
-      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
-      this.$emit("pointer", {
-        image_x: (event.offsetX * width) / event.x,
-        image_y: (event.offsetY * height) / event.x,
-      });
-    },
-    onPointerOut(event) {
-      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
-      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
-      this.$emit("pointer", {
-        type: "mouseout",
-        image_x: (event.offsetX * width) / event.x,
-        image_y: (event.offsetY * height) / event.x,
-      });
-    },
-    onPointerEnter(event) {
-      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
-      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
-      this.$emit("pointer", {
-        type: "mouseenter",
-        image_x: (event.offsetX * width) / event.x,
-        image_y: (event.offsetY * height) / event.x,
-      });
-    },
-    onPointerLeave(event) {
-      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
-      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
-      this.$emit("pointer", {
-        type: "mouseleave",
-        image_x: (event.offsetX * width) / event.x,
-        image_y: (event.offsetY * height) / event.x,
-      });
-    },
-    onPointerCancel(event) {
-      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
-      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
-      this.$emit("pointer", {
-        type: "mousecancel",
+      this.$emit(`svg:${event}`, {
+        type: event_type,
         image_x: (event.offsetX * width) / event.x,
         image_y: (event.offsetY * height) / event.x,
       });

--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -106,12 +106,25 @@ export default {
       });
     },
     onPointerEvent(event_type, event) {
-      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
-      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
+      const svgRect = this.$refs.svg.getBoundingClientRect();
+      const zoom_factor = this.loaded_image_width / svgRect.width;
+      const image_x = event.offsetX * zoom_factor;
+      const image_y = event.offsetY * zoom_factor;
+
+      if (event_type == "pointerdown") {
+        console.log(event_type);
+        const svgNS = this.$refs.svg.namespaceURI;
+        const circle = document.createElementNS(svgNS, "circle");
+        circle.setAttribute("cx", image_x);
+        circle.setAttribute("cy", image_y);
+        circle.setAttribute("r", 5);
+        circle.setAttribute("fill", "red");
+        this.$refs.svg.appendChild(circle);
+      }
       this.$emit(`svg:${event_type}`, {
         type: event_type,
-        image_x: (event.offsetX * width) / event.x,
-        image_y: (event.offsetY * height) / event.x,
+        image_x: image_x,
+        image_y: image_y,
       });
     },
   },

--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -91,12 +91,12 @@ export default {
       this.$emit("loaded", { width: this.loaded_image_width, height: this.loaded_image_height, source: e.target.src });
     },
     onMouseEvent(type, e) {
-      const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
-      const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
+      const imageWidth = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
+      const imageHeight = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
       this.$emit("mouse", {
         mouse_event_type: type,
-        image_x: (e.offsetX * width) / e.target.clientWidth,
-        image_y: (e.offsetY * height) / e.target.clientHeight,
+        image_x: (e.offsetX * imageWidth) / this.$refs.img.clientWidth,
+        image_y: (e.offsetY * imageHeight) / this.$refs.img.clientHeight,
         button: e.button,
         buttons: e.buttons,
         altKey: e.altKey,
@@ -105,16 +105,13 @@ export default {
         shiftKey: e.shiftKey,
       });
     },
-    onPointerEvent(event_type, event) {
-      const svgRect = this.$refs.svg.getBoundingClientRect();
-      const zoom_factor = this.loaded_image_width / svgRect.width;
-      const image_x = event.offsetX * zoom_factor;
-      const image_y = event.offsetY * zoom_factor;
-
-      this.$emit(`svg:${event_type}`, {
-        type: event_type,
-        image_x: image_x,
-        image_y: image_y,
+    onPointerEvent(type, e) {
+      const imageWidth = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
+      const imageHeight = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
+      this.$emit(`svg:${type}`, {
+        type: type,
+        image_x: (e.offsetX * imageWidth) / this.$refs.svg.clientWidth,
+        image_y: (e.offsetY * imageHeight) / this.$refs.svg.clientHeight,
       });
     },
   },

--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -10,11 +10,7 @@ export default {
         v-on="onUserEvents"
         draggable="false"
       />
-      <svg 
-        style="position:absolute;top:0;left:0;pointer-events:none" 
-        :viewBox="viewBox"
-
-      >
+      <svg ref="svg" style="position:absolute;top:0;left:0;pointer-events:none" :viewBox="viewBox">
         <g v-if="cross" :style="{ display: showCross ? 'block' : 'none' }">
           <line :x1="x" y1="0" :x2="x" y2="100%" :stroke="cross === true ? 'black' : cross" />
           <line x1="0" :y1="y" x2="100%" :y2="y" :stroke="cross === true ? 'black' : cross" />
@@ -24,7 +20,6 @@ export default {
       <slot></slot>
     </div>
   `,
-
   data() {
     return {
       viewBox: "0 0 0 0",
@@ -60,7 +55,7 @@ export default {
       "pointerleave",
       "pointercancel",
     ]) {
-      // make it so that it calls onPointerEvent with the event type if there is an SVG event
+      this.$refs.svg.addEventListener(event, (e) => this.onPointerEvent(event, e));
     }
   },
   updated() {
@@ -110,7 +105,6 @@ export default {
         shiftKey: e.shiftKey,
       });
     },
-
     onPointerEvent(event_type, event) {
       const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
       const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;

--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -108,7 +108,7 @@ export default {
     onPointerEvent(event_type, event) {
       const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
       const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
-      this.$emit(`svg:${event}`, {
+      this.$emit(`svg:${event_type}`, {
         type: event_type,
         image_x: (event.offsetX * width) / event.x,
         image_y: (event.offsetY * height) / event.x,

--- a/nicegui/elements/interactive_image.py
+++ b/nicegui/elements/interactive_image.py
@@ -28,7 +28,6 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
                  on_mouse: Optional[Callable[..., Any]] = None,
                  events: List[str] = ['click'],
                  cross: Union[bool, str] = False,
-                 on_pointer : Optional[Callable[..., Any]] = None,
                  ) -> None:
         """Interactive Image
 
@@ -79,26 +78,7 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
                 shift=args.get('shiftKey', False),
             )
             handle_event(on_mouse, arguments)
-        
-        def handle_move(e) -> None:
-            args = cast(dict, e.args)
-            arguments =  MouseEventArguments(
-                sender=self,
-                client=self.client,
-                type= args.get('type', ''), 
-                image_x = args.get('image_x', 0.0),
-                image_y=  args.get('image_y', 0.0),
-                button =0,
-                buttons = 0,
-                alt=args.get('altKey', False),
-                ctrl=args.get('ctrlKey', False),
-                meta=args.get('metaKey', False),
-                shift=args.get('shiftKey', False),
-            )
-            
-            handle_event(on_pointer, arguments)
-
-        self.on('pointer', handle_move)
+                    
         self.on('mouse', handle_mouse)
 
 

--- a/nicegui/elements/interactive_image.py
+++ b/nicegui/elements/interactive_image.py
@@ -28,6 +28,7 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
                  on_mouse: Optional[Callable[..., Any]] = None,
                  events: List[str] = ['click'],
                  cross: Union[bool, str] = False,
+                 on_pointer : Optional[Callable[..., Any]] = None,
                  ) -> None:
         """Interactive Image
 
@@ -53,6 +54,7 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
         :param on_mouse: callback for mouse events (contains image coordinates `image_x` and `image_y` in pixels)
         :param events: list of JavaScript events to subscribe to (default: `['click']`)
         :param cross: whether to show crosshairs or a color string (default: `False`)
+        :param on_pointer: callback for pointer events (contains image coordinates `image_x` and `image_y` in pixels, and `type` of the event)
         """
         super().__init__(source=source, content=content)
         self._props['events'] = events
@@ -77,7 +79,28 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
                 shift=args.get('shiftKey', False),
             )
             handle_event(on_mouse, arguments)
+        
+        def handle_move(e) -> None:
+            args = cast(dict, e.args)
+            arguments =  MouseEventArguments(
+                sender=self,
+                client=self.client,
+                type= args.get('type', ''), 
+                image_x = args.get('image_x', 0.0),
+                image_y=  args.get('image_y', 0.0),
+                button =0,
+                buttons = 0,
+                alt=args.get('altKey', False),
+                ctrl=args.get('ctrlKey', False),
+                meta=args.get('metaKey', False),
+                shift=args.get('shiftKey', False),
+            )
+            
+            handle_event(on_pointer, arguments)
+
+        self.on('pointer', handle_move)
         self.on('mouse', handle_mouse)
+
 
     def _set_props(self, source: Union[str, Path, 'PIL_Image']) -> None:
         if optional_features.has('pillow') and isinstance(source, PIL_Image):

--- a/nicegui/elements/interactive_image.py
+++ b/nicegui/elements/interactive_image.py
@@ -78,9 +78,7 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
                 shift=args.get('shiftKey', False),
             )
             handle_event(on_mouse, arguments)
-                    
         self.on('mouse', handle_mouse)
-
 
     def _set_props(self, source: Union[str, Path, 'PIL_Image']) -> None:
         if optional_features.has('pillow') and isinstance(source, PIL_Image):

--- a/tests/test_serving_files.py
+++ b/tests/test_serving_files.py
@@ -81,10 +81,13 @@ def test_auto_serving_file_from_video_source(screen: Screen):
 
     screen.open('/')
     video = screen.find_by_tag('video')
-    assert '/_nicegui/auto/media/' in video.get_attribute('src')
-    screen.wait(1.0)
-    assert_video_file_streaming(video.get_attribute('src'))
-    screen.wait(1.0)
+    src = video.get_attribute('src')
+    assert src is not None
+    ic()
+    assert '/_nicegui/auto/media/' in src
+    ic()
+    assert_video_file_streaming(src)
+    ic()
 
 
 def test_mimetypes_of_static_files(screen: Screen):

--- a/website/documentation/content/interactive_image_documentation.py
+++ b/website/documentation/content/interactive_image_documentation.py
@@ -77,7 +77,7 @@ def crosshairs():
           ''')
 def svg_content():
     image = ui.interactive_image(
-        size=(800, 600), cross=True, on_pointer=lambda e : ui.notify(e)).classes('w-64 bg-blue-50')
+        size=(800, 600), cross=True).classes('w-64 bg-blue-50').on('pointer:mousemove'  , lambda e: ui.notify(f'mousemove at ({e.image_x:.1f}, {e.image_y:.1f})'))
     image.content = '''
                     <circle cx="125" cy="80" r="50" fill="black" pointer-events="all" />
                     <circle cx="250" cy="80" r="50" fill="black" pointer-events="all" />

--- a/website/documentation/content/interactive_image_documentation.py
+++ b/website/documentation/content/interactive_image_documentation.py
@@ -70,17 +70,26 @@ def crosshairs():
     ui.interactive_image('https://picsum.photos/id/565/640/360', cross='red')
 
 
-@doc.demo('SVG content', '''
-    You can overlay SVG content on top of the image.
-    The SVG content is positioned absolutely with respect to the image.
-    You can also access SVG events by passing a callback to `on_pointer`.
-          ''')
+@doc.demo('SVG events', '''
+    You can subscribe to events of the SVG elements by using the `on` method with an "svg:" prefix.
+    Make sure to set `pointer-events="all"` for the SVG elements you want to receive events from.
+
+    Currently the following SVG events are supported:
+
+    - pointermove
+    - pointerdown
+    - pointerup
+    - pointerover
+    - pointerout
+    - pointerenter
+    - pointerleave
+    - pointercancel
+''')
 def svg_content():
-    image = ui.interactive_image(
-        size=(800, 600), cross=True).classes('w-64 bg-blue-50').on('svg:pointermove'  , lambda e : ui.notify("Mouse move!"))
-    image.content = '''
-                    <circle cx="125" cy="80" r="50" fill="black" pointer-events="all" />
-                    <circle cx="250" cy="80" r="50" fill="black" pointer-events="all" />
-                    '''
+    ui.interactive_image('https://picsum.photos/id/565/640/360', cross=True, content='''
+        <rect x="85" y="70" width="80" height="60" fill="none" stroke="red" pointer-events="all" cursor="pointer" />
+        <rect x="180" y="70" width="80" height="60" fill="none" stroke="red" pointer-events="all" cursor="pointer" />
+    ''').on('svg:pointerdown', lambda e: ui.notify(f'SVG clicked: {e.args}'))
+
 
 doc.reference(ui.interactive_image)

--- a/website/documentation/content/interactive_image_documentation.py
+++ b/website/documentation/content/interactive_image_documentation.py
@@ -70,4 +70,17 @@ def crosshairs():
     ui.interactive_image('https://picsum.photos/id/565/640/360', cross='red')
 
 
+@doc.demo('SVG content', '''
+    You can overlay SVG content on top of the image.
+    The SVG content is positioned absolutely with respect to the image.
+    You can also access SVG events by passing a callback to `on_pointer`.
+          ''')
+def svg_content():
+    image = ui.interactive_image(
+        size=(800, 600), cross=True, on_pointer=lambda e : ui.notify(e)).classes('w-64 bg-blue-50')
+    image.content = '''
+                    <circle cx="125" cy="80" r="50" fill="black" pointer-events="all" />
+                    <circle cx="250" cy="80" r="50" fill="black" pointer-events="all" />
+                    '''
+
 doc.reference(ui.interactive_image)

--- a/website/documentation/content/interactive_image_documentation.py
+++ b/website/documentation/content/interactive_image_documentation.py
@@ -87,8 +87,8 @@ def crosshairs():
 ''')
 def svg_content():
     ui.interactive_image('https://picsum.photos/id/565/640/360', cross=True, content='''
-        <rect x="85" y="70" width="80" height="60" fill="none" stroke="red" pointer-events="all" cursor="pointer" />
-        <rect x="180" y="70" width="80" height="60" fill="none" stroke="red" pointer-events="all" cursor="pointer" />
+        <rect id="A" x="85" y="70" width="80" height="60" fill="none" stroke="red" pointer-events="all" cursor="pointer" />
+        <rect id="B" x="180" y="70" width="80" height="60" fill="none" stroke="red" pointer-events="all" cursor="pointer" />
     ''').on('svg:pointerdown', lambda e: ui.notify(f'SVG clicked: {e.args}'))
 
 

--- a/website/documentation/content/interactive_image_documentation.py
+++ b/website/documentation/content/interactive_image_documentation.py
@@ -77,7 +77,7 @@ def crosshairs():
           ''')
 def svg_content():
     image = ui.interactive_image(
-        size=(800, 600), cross=True).classes('w-64 bg-blue-50').on('pointer:mousemove'  , lambda e: ui.notify(f'mousemove at ({e.image_x:.1f}, {e.image_y:.1f})'))
+        size=(800, 600), cross=True).classes('w-64 bg-blue-50').on('svg:pointermove'  , lambda e : ui.notify("Mouse move!"))
     image.content = '''
                     <circle cx="125" cy="80" r="50" fill="black" pointer-events="all" />
                     <circle cx="250" cy="80" r="50" fill="black" pointer-events="all" />


### PR DESCRIPTION
The reason that I am submitting this pull request is that because I found a need to have access to the events that arise from what I recently learned are pointers. 
Basically, with the on_mouse you can access the position that the user clicked on. However, given my project https://github.com/frankvp11/ModelMaker, I have been trying to access what* they are clicking on when they click. I have yet to test it with my project, but from what I can tell, it doesn't break the functionality of on_mouse, and would certainly be a nice feature for those of us (albeit very few) working with the SVG side of things with the interactive images.
This can also be considered as an example for how the user can simply use SVG's inside the interactive image, since from a discord discussion we determined it wasn't too clear. 
If there are any improvements needed, please let me know.
If you don't like the idea, or have perhaps a better way of implementing this (or getting my project to work lol) it'd be much appreciated. 
When testing this, go to this route: documentation/interactive_image#svg_content and place your mouse over one of the two black circles. I apologize in advance for the immense amount of spamming that pops up - this is due to the amount of events that arise. I couldn't exactly think of a better way to deal with this while still showing off the feature. 