### PR TITLE
implement static files serving without app.mount

### DIFF
--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -153,7 +153,12 @@ class App(FastAPI):
         """
         if url_path == '/':
             raise ValueError('''Path cannot be "/", because it would hide NiceGUI's internal "/_nicegui" route.''')
-        self.mount(url_path, StaticFiles(directory=str(local_directory), follow_symlink=follow_symlink))
+
+        handler = StaticFiles(directory=local_directory, follow_symlink=follow_symlink)
+
+        @self.get(url_path + '/{path:path}')
+        async def static_file(request: Request, path: str = '') -> Response:
+            return await handler.get_response(path, request.scope)
 
     def add_static_file(self, *,
                         local_file: Union[str, Path],

--- a/tests/test_serving_files.py
+++ b/tests/test_serving_files.py
@@ -1,4 +1,5 @@
 
+import re
 from pathlib import Path
 
 import httpx
@@ -51,6 +52,27 @@ def test_adding_single_media_file(screen: Screen):
 
     screen.open('/')
     assert_video_file_streaming(url_path)
+
+
+@pytest.mark.parametrize('url_path', ['/static', '/static/'])
+def test_get_from_static_files_dir(url_path: str, screen: Screen):
+    app.add_static_files(url_path, Path(TEST_DIR).parent)
+
+    screen.open('/')
+    with httpx.Client() as http_client:
+        r = http_client.get(f'http://localhost:{Screen.PORT}/static/examples/slideshow/slides/slide1.jpg')
+        assert r.status_code == 200
+
+
+def test_404_for_non_existing_static_file(screen: Screen):
+    app.add_static_files('/static', Path(TEST_DIR))
+
+    screen.open('/')
+    with httpx.Client() as http_client:
+        r = http_client.get(f'http://localhost:{Screen.PORT}/static/does_not_exist.jpg')
+        screen.assert_py_logger('WARNING', re.compile('.*does_not_exist.jpg not found'))
+        assert r.status_code == 404
+        assert 'static/_nicegui' not in r.text, 'should use root_path, see https://github.com/zauberzeug/nicegui/issues/2570'
 
 
 def test_adding_single_static_file(screen: Screen):


### PR DESCRIPTION
This pull request fixes #2570 by not using `app.mount` to serve those files. See https://github.com/zauberzeug/nicegui/issues/2570#issuecomment-2014345947 for details of why I think this is the best solution.