### PR TITLE
Update ui.number after changing its limits

### DIFF
--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -72,8 +72,11 @@ class Number(ValidationElement, DisableableElement):
 
     @min.setter
     def min(self, value: float) -> None:
+        if self._props['min'] == value:
+            return
         self._props['min'] = value
         self.sanitize()
+        self.update()
 
     @property
     def max(self) -> float:
@@ -82,8 +85,11 @@ class Number(ValidationElement, DisableableElement):
 
     @max.setter
     def max(self, value: float) -> None:
+        if self._props['max'] == value:
+            return
         self._props['max'] = value
         self.sanitize()
+        self.update()
 
     @property
     def precision(self) -> Optional[int]:

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -36,7 +36,7 @@ function runMethod(target, method_name, args) {
   if (element === null || element === undefined) return;
   if (method_name in element) {
     return element[method_name](...args);
-  } else if (method_name in element.$refs.qRef) {
+  } else if (method_name in (element.$refs.qRef || [])) {
     return element.$refs.qRef[method_name](...args);
   } else {
     return eval(method_name)(element, ...args);

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -107,3 +107,21 @@ def test_int_float_conversion_on_error2(screen: Screen):
     element.send_keys(Keys.BACKSPACE)
     screen.should_contain('Error')
     assert element.get_attribute('value') == '1.0'
+
+
+def test_changing_limits(screen: Screen):
+    number = ui.number('Number', max=0, value=0)
+    ui.button('Raise max', on_click=lambda: setattr(number, 'max', 1))
+    ui.button('Step up', on_click=lambda: number.run_method('(e) => e.getNativeElement().stepUp()'))
+
+    screen.open('/')
+    screen.should_contain_input('0')
+
+    screen.click('Step up')
+    screen.should_contain_input('0')
+
+    screen.click('Raise max')
+    screen.should_contain_input('0')
+
+    screen.click('Step up')
+    screen.should_contain_input('1')


### PR DESCRIPTION
This PR solves an issue noticed by @eddie3ruff on #2743: The stepper buttons of a `ui.number` element didn't enforce the min and max values after changing these limits. Consider the following example:

```py
number = ui.number('Number', max=0, value=0)

def raise_max():
    number.max += 1

ui.button('Raise max', on_click=raise_max)
```

After raising the max, the stepper wouldn't allow changing the value, even though it could be edited via the input field. By triggering an update at the end of the min and max property setters, this problem is solved.