### PR TITLE
More elegant way to terminate On Air connection

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -162,9 +162,6 @@ class Air:
 
     async def connect(self) -> None:
         """Connect to the NiceGUI On Air server."""
-        # ensure that the connection is closed when the process is terminated
-        signal.signal(signal.SIGINT, lambda signum, frame: disconnect())
-        signal.signal(signal.SIGTERM, lambda signum, frame: disconnect())
         if self.connecting:
             return
         self.connecting = True
@@ -192,6 +189,7 @@ class Air:
 
     async def disconnect(self) -> None:
         """Disconnect from the NiceGUI On Air server."""
+        await self.relay.disconnect()
         for stream in self.streams.values():
             await stream.response.aclose()
         self.streams.clear()


### PR DESCRIPTION
This pull-request get's rid of hacky signal handler registration to terminate the On Air connection. This also fixes issues with auto-reload when On Air is active.