### PR TITLE
Update Markdown elements even if invisible (e.g. inside tooltip or tab)

### DIFF
--- a/nicegui/elements/markdown.js
+++ b/nicegui/elements/markdown.js
@@ -4,7 +4,7 @@ export default {
     this.ensure_codehilite_css();
     if (this.use_mermaid) {
       this.mermaid = (await import("mermaid")).default;
-      this.update(this.$el.innerHTML);
+      this.renderMermaid();
     }
   },
   data() {
@@ -12,9 +12,11 @@ export default {
       mermaid: null,
     };
   },
+  updated() {
+    this.renderMermaid();
+  },
   methods: {
-    update(content) {
-      this.$el.innerHTML = content;
+    renderMermaid() {
       this.$el.querySelectorAll(".mermaid-pre").forEach(async (pre, i) => {
         await this.mermaid.run({ nodes: [pre.children[0]] });
       });

--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -35,7 +35,6 @@ class Markdown(ContentElement, component='markdown.js'):
         if self._props.get('innerHTML') != html:
             self._props['innerHTML'] = html
             self.update()
-            self.run_method('update', html)
 
 
 @lru_cache(maxsize=int(os.environ.get('MARKDOWN_CONTENT_CACHE_SIZE', '1000')))

--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -34,6 +34,7 @@ class Markdown(ContentElement, component='markdown.js'):
         html = prepare_content(content, extras=' '.join(self.extras))
         if self._props.get('innerHTML') != html:
             self._props['innerHTML'] = html
+            self.update()
             self.run_method('update', html)
 
 

--- a/nicegui/elements/restructured_text.py
+++ b/nicegui/elements/restructured_text.py
@@ -21,7 +21,7 @@ class ReStructuredText(Markdown):
         html = prepare_content(content)
         if self._props.get('innerHTML') != html:
             self._props['innerHTML'] = html
-            self.run_method('update', html)
+            self.update()
 
 
 @lru_cache(maxsize=int(os.environ.get('RST_CONTENT_CACHE_SIZE', '1000')))


### PR DESCRIPTION
This is an attempt to fix #2779. It seems to make Markdown elements update correctly but breaks Mermaid diagrams in Markdown elements, not sure why.
Additional changes are welcome.