### PR TITLE
Replace check_interval for JavaScript requests with asyncio event

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -477,7 +477,6 @@ class Element(Visibility):
         :param name: name of the method
         :param args: arguments to pass to the method
         :param timeout: maximum time to wait for a response (default: 1 second)
-        :param check_interval: time between checks for a response (default: 0.01 seconds)
         """
         if not core.loop:
             return NullResponse()

--- a/nicegui/elements/aggrid.py
+++ b/nicegui/elements/aggrid.py
@@ -105,7 +105,6 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
         :param name: name of the method
         :param args: arguments to pass to the method
         :param timeout: timeout in seconds (default: 1 second)
-        :param check_interval: interval in seconds to check for a response (default: 0.01 seconds)
 
         :return: AwaitableResponse that can be awaited to get the result of the method call
         """
@@ -127,7 +126,6 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
         :param name: name of the method
         :param args: arguments to pass to the method
         :param timeout: timeout in seconds (default: 1 second)
-        :param check_interval: interval in seconds to check for a response (default: 0.01 seconds)
 
         :return: AwaitableResponse that can be awaited to get the result of the method call
         """
@@ -146,7 +144,6 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
         :param name: name of the method
         :param args: arguments to pass to the method
         :param timeout: timeout in seconds (default: 1 second)
-        :param check_interval: interval in seconds to check for a response (default: 0.01 seconds)
 
         :return: AwaitableResponse that can be awaited to get the result of the method call
         """
@@ -185,7 +182,7 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
         This does not happen when the cell loses focus, unless ``stopEditingWhenCellsLoseFocus: True`` is set.
 
         :param timeout: timeout in seconds (default: 1 second)
-        :param check_interval: interval in seconds to check for a response (default: 0.01 seconds)
+
         :return: list of row data
         """
         result = await self.client.run_javascript(f'''

--- a/nicegui/elements/echart.py
+++ b/nicegui/elements/echart.py
@@ -109,7 +109,6 @@ class EChart(Element, component='echart.js', libraries=['lib/echarts/echarts.min
         :param name: name of the method (a prefix ":" indicates that the arguments are JavaScript expressions)
         :param args: arguments to pass to the method (Python objects or JavaScript expressions)
         :param timeout: timeout in seconds (default: 1 second)
-        :param check_interval: interval in seconds to check for a response (default: 0.01 seconds)
 
         :return: AwaitableResponse that can be awaited to get the result of the method call
         """

--- a/nicegui/elements/json_editor.py
+++ b/nicegui/elements/json_editor.py
@@ -68,7 +68,6 @@ class JsonEditor(Element, component='json_editor.js', exposed_libraries=['lib/va
         :param name: name of the method (a prefix ":" indicates that the arguments are JavaScript expressions)
         :param args: arguments to pass to the method (Python objects or JavaScript expressions)
         :param timeout: timeout in seconds (default: 1 second)
-        :param check_interval: interval in seconds to check for a response (default: 0.01 seconds)
 
         :return: AwaitableResponse that can be awaited to get the result of the method call
         """

--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -128,7 +128,6 @@ class Leaflet(Element, component='leaflet.js'):
         :param name: name of the method (a prefix ":" indicates that the arguments are JavaScript expressions)
         :param args: arguments to pass to the method
         :param timeout: timeout in seconds (default: 1 second)
-        :param check_interval: interval in seconds to check for a response (default: 0.01 seconds)
 
         :return: AwaitableResponse that can be awaited to get the result of the method call
         """
@@ -144,7 +143,6 @@ class Leaflet(Element, component='leaflet.js'):
         :param name: name of the method (a prefix ":" indicates that the arguments are JavaScript expressions)
         :param args: arguments to pass to the method
         :param timeout: timeout in seconds (default: 1 second)
-        :param check_interval: interval in seconds to check for a response (default: 0.01 seconds)
 
         :return: AwaitableResponse that can be awaited to get the result of the method call
         """

--- a/nicegui/elements/leaflet_layer.py
+++ b/nicegui/elements/leaflet_layer.py
@@ -38,7 +38,6 @@ class Layer:
         :param name: name of the method (a prefix ":" indicates that the arguments are JavaScript expressions)
         :param args: arguments to pass to the method
         :param timeout: timeout in seconds (default: 1 second)
-        :param check_interval: interval in seconds to check for a response (default: 0.01 seconds)
 
         :return: AwaitableResponse that can be awaited to get the result of the method call
         """

--- a/nicegui/functions/javascript.py
+++ b/nicegui/functions/javascript.py
@@ -2,11 +2,10 @@ from typing import Optional
 
 from .. import context
 from ..awaitable_response import AwaitableResponse
-from ..logging import log
 
 
 def run_javascript(code: str, *,
-                   respond: Optional[bool] = None,  # DEPRECATED
+                   respond: Optional[bool] = None,
                    timeout: float = 1.0, check_interval: float = 0.01) -> AwaitableResponse:
     """Run JavaScript
 
@@ -19,17 +18,7 @@ def run_javascript(code: str, *,
 
     :param code: JavaScript code to run
     :param timeout: timeout in seconds (default: `1.0`)
-    :param check_interval: interval in seconds to check for a response (default: `0.01`)
 
     :return: AwaitableResponse that can be awaited to get the result of the JavaScript code
     """
-    if respond is True:
-        log.warning('The "respond" argument of run_javascript() has been removed. '
-                    'Now the function always returns an AwaitableResponse that can be awaited. '
-                    'Please remove the "respond=True" argument.')
-    if respond is False:
-        raise ValueError('The "respond" argument of run_javascript() has been removed. '
-                         'Now the function always returns an AwaitableResponse that can be awaited. '
-                         'Please remove the "respond=False" argument and call the function without awaiting.')
-
-    return context.get_client().run_javascript(code, timeout=timeout, check_interval=check_interval)
+    return context.get_client().run_javascript(code, respond=respond, timeout=timeout, check_interval=check_interval)

--- a/nicegui/javascript_request.py
+++ b/nicegui/javascript_request.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+
+
+class JavaScriptRequest:
+    _instances: Dict[str, JavaScriptRequest] = {}
+
+    def __init__(self, request_id: str, *, timeout: float) -> None:
+        self.request_id = request_id
+        self._instances[request_id] = self
+        self.timeout = timeout
+        self._event = asyncio.Event()
+        self._result: Any = None
+
+    @classmethod
+    def resolve(cls, request_id: str, result: Any) -> None:
+        """Store the result of a JavaScript request and unblock the awaiter."""
+        request = cls._instances[request_id]
+        request._result = result  # pylint: disable=protected-access
+        request._event.set()  # pylint: disable=protected-access
+
+    def __await__(self) -> Any:
+        try:
+            yield from asyncio.wait_for(self._event.wait(), self.timeout).__await__()
+        except asyncio.TimeoutError as e:
+            raise TimeoutError(f'JavaScript did not respond within {self.timeout:.1f} s') from e
+        else:
+            return self._result
+        finally:
+            self._instances.pop(self.request_id)


### PR DESCRIPTION
This PR solves one aspect of issue #2482 by replacing the 0.01s loop with asyncio events.

To verify everything is still working, I experimented with the following demo code:
```py
def alert():
    ui.run_javascript('alert("Hello!")')

async def get_date():
    time = await ui.run_javascript('Date()')
    ui.notify(f'Browser time: {time}')

async def fail():
    await ui.run_javascript('fail()')

ui.button('fire and forget', on_click=alert)
ui.button('receive result', on_click=get_date)
ui.button('timeout', on_click=fail)
```

Note that I didn't mark every single method parameter as DEPRECATED. I only marked the root implementation, which is called by all derived methods. Similarly, I only added a warning once. I even removed a duplicate marker and a warning for the deprecated `respond` parameter.