### PR TITLE
Add method for maximizing native application

### DIFF
--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -70,6 +70,9 @@ try:
         def resize(self, width: int, height: int, fix_point: FixPoint = FixPoint.NORTH | FixPoint.WEST) -> None:
             self._send(width, height, fix_point)
 
+        def maximize(self) -> None:
+            self._send()
+
         def minimize(self) -> None:
             self._send()
 


### PR DESCRIPTION
Recently, while developing a local window program using NiceGUI, I found that I couldn't maximize the program. There is only one toggle_fullscreen method that can do something similar, but this method maximizes the interface program to cover the entire screen, not in the usual sense of maximization (Windows taskbar is not covered).

I learned from reviewing the source code that pywebview has a maximize method that can be used to correctly maximize the window, but this method is not implemented in NiceGUI's native.py. I added just two lines of code to mimic the minimize method to implement maximize, which allowed me to properly maximize the interface program through nicegui.

I'm not sure why the maximize method is missing from NiceGUI. Maybe it wasn't available in earlier versions of pywebview? Anyway, I really need this feature and hope it can be merged. Thanks!