### PR TITLE
Provide app.storage.tab

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -58,6 +58,7 @@ class Client:
         self.shared = shared
         self.on_air = False
         self._disconnect_task: Optional[asyncio.Task] = None
+        self.tab_id: Optional[str] = None
 
         self.outbox = Outbox(self)
 

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -158,7 +158,7 @@ async def _exception_handler_500(request: Request, exception: Exception) -> Resp
 
 
 @sio.on('handshake')
-async def _on_handshake(sid: str, data: dict[str, str]) -> bool:
+async def _on_handshake(sid: str, data: Dict[str, str]) -> bool:
     client = Client.instances.get(data['client_id'])
     if not client:
         return False

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -129,6 +129,8 @@ async def _startup() -> None:
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(Client.prune_instances(), name='prune clients')
     background_tasks.create(Slot.prune_stacks(), name='prune slot stacks')
+    prune_tab_storages = core.app.storage._prune_tab_storage  # pylint: disable=protected-access
+    background_tasks.create(prune_tab_storages(), name='prune tab storages')
     air.connect()
 
 

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -129,8 +129,7 @@ async def _startup() -> None:
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(Client.prune_instances(), name='prune clients')
     background_tasks.create(Slot.prune_stacks(), name='prune slot stacks')
-    prune_tab_storages = core.app.storage._prune_tab_storage  # pylint: disable=protected-access
-    background_tasks.create(prune_tab_storages(), name='prune tab storages')
+    background_tasks.create(core.app.storage.prune_tab_storage(), name='prune tab storage')
     air.connect()
 
 

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -158,11 +158,12 @@ async def _exception_handler_500(request: Request, exception: Exception) -> Resp
 
 
 @sio.on('handshake')
-async def _on_handshake(sid: str, client_id: str) -> bool:
-    client = Client.instances.get(client_id)
+async def _on_handshake(sid: str, data: dict[str, str]) -> bool:
+    client = Client.instances.get(data['client_id'])
     if not client:
         return False
     client.environ = sio.get_environ(sid)
+    client.tab_id = data['tab_id']
     await sio.enter_room(sid, client.id)
     client.handle_handshake()
     return True

--- a/nicegui/observables.py
+++ b/nicegui/observables.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+from datetime import datetime
 from typing import Any, Callable, Collection, Dict, Iterable, List, Optional, SupportsIndex, Union
 
 from . import events
@@ -16,6 +17,7 @@ class ObservableCollection(abc.ABC):
                  ) -> None:
         super().__init__(factory() if data is None else data)  # type: ignore
         self._parent = _parent
+        self.last_modified = datetime.now()
         self._change_handlers: List[Callable] = [on_change] if on_change else []
 
     @property
@@ -27,6 +29,7 @@ class ObservableCollection(abc.ABC):
         return change_handlers
 
     def _handle_change(self) -> None:
+        self.last_modified = datetime.now()
         for handler in self.change_handlers:
             events.handle_event(handler, events.ObservableChangeEventArguments(sender=self))
 

--- a/nicegui/observables.py
+++ b/nicegui/observables.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import abc
-from datetime import datetime
+import time
 from typing import Any, Callable, Collection, Dict, Iterable, List, Optional, SupportsIndex, Union
 
 from . import events
@@ -17,7 +17,7 @@ class ObservableCollection(abc.ABC):
                  ) -> None:
         super().__init__(factory() if data is None else data)  # type: ignore
         self._parent = _parent
-        self.last_modified = datetime.now()
+        self.last_modified = time.time()
         self._change_handlers: List[Callable] = [on_change] if on_change else []
 
     @property
@@ -29,7 +29,7 @@ class ObservableCollection(abc.ABC):
         return change_handlers
 
     def _handle_change(self) -> None:
-        self.last_modified = datetime.now()
+        self.last_modified = time.time()
         for handler in self.change_handlers:
             events.handle_event(handler, events.ObservableChangeEventArguments(sender=self))
 

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -153,7 +153,7 @@ function renderRecursively(elements, id) {
       handler = (...args) => {
         const data = {
           id: id,
-          client_id: window.client_id,
+          client_id: window.clientId,
           listener_id: event.listener_id,
           args: stringifyEventArgs(args, event.args),
         };
@@ -212,7 +212,7 @@ function runJavascript(code, request_id) {
     })
     .then((result) => {
       if (request_id) {
-        window.socket.emit("javascript_response", { request_id, client_id: window.client_id, result });
+        window.socket.emit("javascript_response", { request_id, client_id: window.clientId, result });
       }
     });
 }
@@ -264,7 +264,7 @@ function createApp(elements, options) {
     },
     mounted() {
       mounted_app = this;
-      window.client_id = options.query.client_id;
+      window.clientId = options.query.client_id;
       const url = window.location.protocol === "https:" ? "wss://" : "ws://" + window.location.host;
       window.path_prefix = options.prefix;
       window.socket = io(url, {
@@ -275,9 +275,14 @@ function createApp(elements, options) {
       });
       const messageHandlers = {
         connect: () => {
-          window.socket.emit("handshake", window.client_id, (ok) => {
+          let tabId = sessionStorage.getItem("__nicegui_tab_id");
+          if (!tabId) {
+            tabId = crypto.randomUUID();
+            sessionStorage.setItem("__nicegui_tab_id", tabId);
+          }
+          window.socket.emit("handshake", { client_id: window.clientId, tab_id: tabId }, (ok) => {
             if (!ok) {
-              console.log("reloading because handshake failed for client_id " + window.client_id);
+              console.log("reloading because handshake failed for clientId " + window.clientId);
               window.location.reload();
             }
             document.getElementById("popup").style.opacity = 0;

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -164,7 +164,6 @@ class Storage:
                                'see https://nicegui.io/documentation/page#wait_for_client_connection to await it')
         tab_id = client.tab_id
         assert tab_id is not None
-        ic(tab_id)
         if tab_id not in self.tabs:
             self.tabs[tab_id] = observables.ObservableDict()
         return self.tabs[tab_id]

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -158,11 +158,9 @@ class Storage:
     @property
     def tab(self) -> Dict:
         """A volatile storage that is only kept during the current tab session."""
-        request: Optional[Request] = request_contextvar.get()
-        if request is None:
-            if self._is_in_auto_index_context():
-                raise RuntimeError('app.storage.tab can only be used with page builder functions '
-                                   '(https://nicegui.io/documentation/page)')
+        if self._is_in_auto_index_context():
+            raise RuntimeError('app.storage.tab can only be used with page builder functions '
+                               '(https://nicegui.io/documentation/page)')
         client = context.get_client()
         if not client.has_socket_connection:
             raise RuntimeError('app.storage.tab can only be used with a client connection; '

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -185,6 +185,7 @@ class Storage:
         """Clears all storage."""
         self._general.clear()
         self._users.clear()
+        self._tabs.clear()
         for filepath in self.path.glob('storage-*.json'):
             filepath.unlink()
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -204,3 +204,22 @@ def test_tab_storage_is_auto_removed(screen: Screen):
     screen.wait(1)
     screen.open('/')
     screen.should_contain('1')
+
+
+def test_clear_tab_storage(screen: Screen):
+    storage_module.PURGE_INTERVAL = timedelta(minutes=1)
+
+    @ui.page('/')
+    async def page():
+        await context.get_client().connected()
+        app.storage.tab['test'] = '123'
+        ic()
+        ui.button('clear', on_click=app.storage.clear)
+
+    screen.open('/')
+    screen.wait(1)
+    tab_storages = app.storage._tabs  # pylint: disable=protected-access
+    assert len(tab_storages.values()) == 1
+    assert list(tab_storages.values())[0]['test'] == '123'
+    screen.click('clear')
+    assert len(list(tab_storages.values())) == 0

--- a/website/documentation/content/button_documentation.py
+++ b/website/documentation/content/button_documentation.py
@@ -27,13 +27,14 @@ def icons() -> None:
 async def await_button_click() -> None:
     # @ui.page('/')
     # async def index():
-    b = ui.button('Step')
-    await b.clicked()
-    ui.label('One')
-    await b.clicked()
-    ui.label('Two')
-    await b.clicked()
-    ui.label('Three')
+    with ui.column():  # HIDE
+        b = ui.button('Step')
+        await b.clicked()
+        ui.label('One')
+        await b.clicked()
+        ui.label('Two')
+        await b.clicked()
+        ui.label('Three')
 
 
 @doc.demo('Disable button with a context manager', '''

--- a/website/documentation/content/storage_documentation.py
+++ b/website/documentation/content/storage_documentation.py
@@ -13,9 +13,14 @@ doc.title('Storage')
 
 
 @doc.demo('Storage', '''
-    NiceGUI offers a straightforward method for data persistence within your application. 
-    It features three built-in storage types:
+    NiceGUI offers a straightforward mechanism for data persistence within your application. 
+    It features four built-in storage types:
 
+    - `app.storage.tab`:
+        Stored server-side in memory, this dictionary is unique to each tab session and can hold arbitrary objects.
+        Data will be lost on restarting the server until <https://github.com/zauberzeug/nicegui/discussions/2841> is implemented.
+        This storage is only available within [page builder functions](/documentation/page) 
+        and requires an established connection, obtainable via [`await client.connected()`](/documentation/page#wait_for_client_connection).
     - `app.storage.user`:
         Stored server-side, each dictionary is associated with a unique identifier held in a browser session cookie.
         Unique to each user, this storage is accessible across all their browser tabs.
@@ -86,3 +91,19 @@ def ui_state():
     #         .classes('w-full').bind_value(app.storage.user, 'note')
     # END OF DEMO
     ui.textarea('This note is kept between visits').classes('w-full').bind_value(app.storage.user, 'note')
+
+
+@doc.demo('Storing data per browser tab', '''
+          When storing data in `app.storage.tab` a single user can open multiple tabs of the same app, each with it's own storage data. 
+          This may be beneficial in certain scenarios like search or when performing data analysis.
+          It is also more secure to use such a volatile storage for scenarios like logging into a bank account or accessing a password manager.
+          ''')
+def tab_storage():
+    from nicegui import app
+
+    # @ui.page('/')
+    # async def index(client):
+    #     await client.connected()
+    with ui.row():  # HIDE
+        app.storage.tab['count'] = app.storage.tab.get('count', 0) + 1
+        ui.label(f'Tab reloaded {app.storage.tab["count"]} times')

--- a/website/documentation/content/storage_documentation.py
+++ b/website/documentation/content/storage_documentation.py
@@ -18,7 +18,7 @@ doc.title('Storage')
 
     - `app.storage.tab`:
         Stored server-side in memory, this dictionary is unique to each tab session and can hold arbitrary objects.
-        Data will be lost on restarting the server until <https://github.com/zauberzeug/nicegui/discussions/2841> is implemented.
+        Data will be lost when restarting the server until <https://github.com/zauberzeug/nicegui/discussions/2841> is implemented.
         This storage is only available within [page builder functions](/documentation/page) 
         and requires an established connection, obtainable via [`await client.connected()`](/documentation/page#wait_for_client_connection).
     - `app.storage.user`:
@@ -94,16 +94,16 @@ def ui_state():
 
 
 @doc.demo('Storing data per browser tab', '''
-          When storing data in `app.storage.tab` a single user can open multiple tabs of the same app, each with it's own storage data. 
-          This may be beneficial in certain scenarios like search or when performing data analysis.
-          It is also more secure to use such a volatile storage for scenarios like logging into a bank account or accessing a password manager.
-          ''')
+    When storing data in `app.storage.tab`, a single user can open multiple tabs of the same app, each with its own storage data.
+    This may be beneficial in certain scenarios like search or when performing data analysis.
+    It is also more secure to use such a volatile storage for scenarios like logging into a bank account or accessing a password manager.
+''')
 def tab_storage():
     from nicegui import app
 
     # @ui.page('/')
     # async def index(client):
     #     await client.connected()
-    with ui.row():  # HIDE
+    with ui.column():  # HIDE
         app.storage.tab['count'] = app.storage.tab.get('count', 0) + 1
         ui.label(f'Tab reloaded {app.storage.tab["count"]} times')


### PR DESCRIPTION
This pull request picks up on the idea from https://github.com/zauberzeug/nicegui/pull/2820#discussion_r1554523968 and other discussion around this topic to implement `app.storage.tab`: a volatile storage which keeps a state dictionary as long as the browser tab lives. That means the data survives page reloads and switching urls.

It is implemented by storing the dictionary in the memory of the server. To decide which dictionary needs to be accessed the pull request introduces a `client.tab_id` which is automatically set when doing the websocket handshake.

### ToDos

- [x] When to delete the storage dicts? A tab could revisit the page even after a few days...
- [x] add tests
- [x] add demo