### PR TITLE
Introduce camera parameters for `ui.scene`

### DIFF
--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -65,13 +65,24 @@ export default {
 
     window["scene_" + this.$el.id] = this.scene; // NOTE: for selenium tests only
 
-    this.look_at = new THREE.Vector3(0, 0, 0);
-    const aspect = this.width / this.height;
     if (this.camera_type === "perspective") {
-      this.camera = new THREE.PerspectiveCamera(75, aspect, 0.1, 1000);
+      this.camera = new THREE.PerspectiveCamera(
+        this.camera_params.fov,
+        this.width / this.height,
+        this.camera_params.near,
+        this.camera_params.far
+      );
     } else {
-      this.camera = new THREE.OrthographicCamera(-aspect, aspect, 1, -1, 0.1, 1000);
+      this.camera = new THREE.OrthographicCamera(
+        (-this.camera_params.size / 2) * (this.width / this.height),
+        (this.camera_params.size / 2) * (this.width / this.height),
+        this.camera_params.size / 2,
+        -this.camera_params.size / 2,
+        this.camera_params.near,
+        this.camera_params.far
+      );
     }
+    this.look_at = new THREE.Vector3(0, 0, 0);
     this.camera.lookAt(this.look_at);
     this.camera.up = new THREE.Vector3(0, 0, 1);
     this.camera.position.set(0, -3, 5);
@@ -416,8 +427,8 @@ export default {
       this.text3d_renderer.setSize(clientWidth, clientHeight);
       this.camera.aspect = clientWidth / clientHeight;
       if (this.camera_type === "orthographic") {
-        this.camera.left = -this.camera.aspect;
-        this.camera.right = this.camera.aspect;
+        this.camera.left = (-this.camera.aspect * this.camera_params.size) / 2;
+        this.camera.right = (this.camera.aspect * this.camera_params.size) / 2;
       }
       this.camera.updateProjectionMatrix();
     },
@@ -428,6 +439,7 @@ export default {
     height: Number,
     grid: Boolean,
     camera_type: String,
+    camera_params: Object,
     drag_constraints: String,
   },
 };

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -89,7 +89,7 @@ class Scene(Element,
         :param width: width of the canvas
         :param height: height of the canvas
         :param grid: whether to display a grid
-        :param camera: camera definition, either ``ui.scene.perspective_camera`` (default) or ``ui.scene.orthographic_camera``
+        :param camera: camera definition, either instance of ``ui.scene.perspective_camera`` (default) or ``ui.scene.orthographic_camera``
         :param on_click: callback to execute when a 3D object is clicked
         :param on_drag_start: callback to execute when a 3D object is dragged
         :param on_drag_end: callback to execute when a 3D object is dropped
@@ -140,7 +140,7 @@ class Scene(Element,
         return SceneCamera(type='perspective', params={'fov': fov, 'near': near, 'far': far})
 
     @staticmethod
-    def orthographic_camera(*, size: float = 10.0, near: float = 0.1, far: float = 1000) -> SceneCamera:
+    def orthographic_camera(*, size: float = 10, near: float = 0.1, far: float = 1000) -> SceneCamera:
         """Create a orthographic camera.
 
         The size defines the vertical size of the view volume, i.e. the distance between the top and bottom clipping planes.

--- a/website/documentation/content/scene_documentation.py
+++ b/website/documentation/content/scene_documentation.py
@@ -113,11 +113,13 @@ async def wait_for_init() -> None:
         scene.move_camera(x=1, y=-1, z=1.5, duration=2)
 
 
-@doc.demo('Orthographic Camera', '''
-    You can use the `camera_type` argument to `ui.scene` to use an orthographic instead of a perspective camera.
+@doc.demo('Camera Parameters', '''
+    You can use the `camera` argument to `ui.scene` to use a custom camera.
+    This allows you to set the field of view of a perspective camera or the size of an orthographic camera.
 ''')
 def orthographic_camera() -> None:
-    with ui.scene(camera=ui.scene.orthographic_camera()).classes('w-full h-64') as scene:
+    with ui.scene(camera=ui.scene.orthographic_camera(size=2)) \
+            .classes('w-full h-64') as scene:
         scene.box()
 
 

--- a/website/documentation/content/scene_documentation.py
+++ b/website/documentation/content/scene_documentation.py
@@ -113,12 +113,12 @@ async def wait_for_init() -> None:
         scene.move_camera(x=1, y=-1, z=1.5, duration=2)
 
 
-# @doc.demo('Orthographic Camera', '''
-#     You can use the `camera_type` argument to `ui.scene` to use an orthographic instead of a perspective camera.
-# ''')
-# def orthographic_camera() -> None:
-#     with ui.scene(camera_type='orthographic').classes('w-full h-64') as scene:
-#         scene.box()
+@doc.demo('Orthographic Camera', '''
+    You can use the `camera_type` argument to `ui.scene` to use an orthographic instead of a perspective camera.
+''')
+def orthographic_camera() -> None:
+    with ui.scene(camera=ui.scene.orthographic_camera()).classes('w-full h-64') as scene:
+        scene.box()
 
 
 doc.reference(ui.scene)


### PR DESCRIPTION
As an extension to PR #2890, this PR makes perspective and orthographic cameras configurable, such that field-of-view (for perspective cameras) as well as the volume size (for orthographic cameras) can  be configured:

```py
with ui.scene(camera=ui.scene.perspective_camera(fov=50)) as scene:
    scene.box()
with ui.scene(camera=ui.scene.orthographic_camera(size=5)) as scene:
    scene.box()
```

![Screenshot 2024-04-15 at 14 32 26](https://github.com/zauberzeug/nicegui/assets/5767091/fd3abf25-2a1e-4341-acfc-458d341ca6f0)
