### PR TITLE
Fix `app.storage.tab` for NiceGUI On Air

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -122,6 +122,7 @@ class Air:
                 return False
             client = Client.instances[client_id]
             client.environ = data['environ']
+            client.tab_id = data['tab_id']
             client.on_air = True
             client.handle_handshake()
             return True


### PR DESCRIPTION
This pull request allows to use the new `app.storage.tab` in On Air connections by correctly processing the `tab_id` in "On Air" handshakes.