### PR TITLE
Add early exit when setting the value of `ui.state` variables

### DIFF
--- a/nicegui/functions/refreshable.py
+++ b/nicegui/functions/refreshable.py
@@ -154,6 +154,8 @@ def state(value: Any) -> Tuple[Any, Callable[[Any], None]]:
         value = target.locals[target.next_index]
 
     def set_value(new_value: Any, index=target.next_index) -> None:
+        if target.locals[index] == new_value:
+            return
         target.locals[index] = new_value
         target.refreshable.refresh()
 


### PR DESCRIPTION
This PR solves a problem described in #2921 where setting the value of a `ui.state` variable causes an infinite recursion.

Take this simple example code:
```py
@ui.refreshable
def counter():
    count, set_count = ui.state(0)
    color, set_color = ui.state('black')
    ui.number(value=count, on_change=lambda e: set_count(e.value))
    ui.select(['black', 'red', 'green', 'blue'], value=color, on_change=lambda e: set_color(e.value))
    if count == 0:
        set_color('red')

counter()
```

Whenever the `count` is zero, the `color` is set to "red", which causes the refreshable to re-run - even if the color hasn't changed. The proposed change causes an early exit to avoid the infinite recursion.