### PR TITLE
Initialization animation failure in ECharts

### DIFF
--- a/nicegui/elements/echart.js
+++ b/nicegui/elements/echart.js
@@ -47,8 +47,16 @@ export default {
     ]) {
       this.chart.on(event, (e) => this.$emit(`chart:${event}`, e));
     }
+
+    // Prevent interruption of chart animations due to resize operations.
+    // Note that it's recommended to register the callbacks for such an event before setOption
+    const finishedCallback = () => {
+      new ResizeObserver(this.chart.resize).observe(this.$el);
+      this.chart.off('finished', finishedCallback);
+    }
+    this.chart.on('finished', finishedCallback);
+
     this.update_chart();
-    new ResizeObserver(this.chart.resize).observe(this.$el);
   },
   beforeDestroy() {
     this.chart.dispose();


### PR DESCRIPTION
This PR is aimed at solving the issue where ECharts charts' animations are interrupted by resize operations.

Below is a code snippet to reproduce the issue:

```python
option = {
    "xAxis": {
        "type": "category",
        "data": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
    },
    "yAxis": {"type": "value"},
    "series": [{"data": [150, 230, 224, 218, 135, 147, 260], "type": "line"}],
    "animationDuration": 5000,
}

ui.echart(option)
```


The expected behavior is that when the chart is initially displayed, the line chart should have a fade-in animation from left to right, lasting for 5 seconds.