### PR TITLE
Update date_documentation.py: remove auto-close on menu

### DIFF
--- a/website/documentation/content/date_documentation.py
+++ b/website/documentation/content/date_documentation.py
@@ -21,7 +21,7 @@ def date():
     with ui.input('Date') as date:
         with date.add_slot('append'):
             ui.icon('edit_calendar').on('click', lambda: menu.open()).classes('cursor-pointer')
-        with ui.menu() as menu:
+        with ui.menu().props(remove="auto-close") as menu:
             ui.date().bind_value(date)
 
 


### PR DESCRIPTION
Thanks for the great project!

For me, the menu closes on every interaction, e.g. going forward one month.
This seems to come from the `auto-close` property being set on `menu` by default.
Removing that property resolved the issue for me.
It might be helpful to have this in the documentation.