### PR TITLE
Add quasar's "row" class to `ui.row`

### DIFF
--- a/nicegui/elements/column.py
+++ b/nicegui/elements/column.py
@@ -14,4 +14,4 @@ class Column(Element):
         self._classes.append('nicegui-column')
 
         if wrap:
-            self._classes.append('wrap')
+            self._style['flex-wrap'] = 'wrap'

--- a/nicegui/elements/row.py
+++ b/nicegui/elements/row.py
@@ -11,7 +11,7 @@ class Row(Element):
         :param wrap: whether to wrap the content (default: `True`)
         """
         super().__init__('div')
-        self._classes.append('nicegui-row')
+        self._classes.append('nicegui-row row')  # NOTE: 'row' class for compatibility with Quasar's col-* classes
 
-        if wrap:
-            self._classes.append('wrap')
+        if not wrap:
+            self._style['flex-wrap'] = 'nowrap'


### PR DESCRIPTION
This PR tries to solve #2881 by adding Quasar's "row" class to `ui.row`. Since it only adds
```css
.column, .flex, .row {
    display: flex;
    flex-wrap: wrap;
}
```
we only need to deal with the new wrap setting. Therefore I changed
```py
if wrap:
    self._classes.append('wrap')
```
to
```py
if not wrap:
    self._style['flex-wrap'] = 'nowrap'
```
This way `wrap=False` counteracts "row"s flex-wrap setting.

For consistency I changed the wrap handling for `ui.column` from
```py
if wrap:
    self._classes.append('wrap')
```
to
```py
if wrap:
    self._style['flex-wrap'] = 'wrap'
```

But since there are no `row-*` classes in Quasar for layouting columns, there is no need to add the "column" class to `ui.column`.

I tested the new behavior with the following demo:
```py
with ui.row(wrap=False).classes('w-40 h-40 border'):
    ui.label('A').classes('border col-6')
    ui.label('B').classes('border col-6')

with ui.row(wrap=True).classes('w-40 h-40 border'):
    ui.label('A').classes('border col-6')
    ui.label('B').classes('border col-6')

with ui.column(wrap=False).classes('w-40 h-40 border'):
    ui.label('A').classes('border h-24')
    ui.label('B').classes('border h-24')

with ui.column(wrap=True).classes('w-40 h-40 border'):
    ui.label('A').classes('border h-24')
    ui.label('B').classes('border h-24')
```