### PR TITLE
Add more documentation for `ui.keyboard`

### DIFF
--- a/nicegui/elements/keyboard.py
+++ b/nicegui/elements/keyboard.py
@@ -28,6 +28,32 @@ class Keyboard(Element, component='keyboard.js'):
 
         Adds global keyboard event tracking.
 
+        The `on_key` callback receives a `KeyEventArguments` object with the following attributes:
+
+        - `sender`: the `Keyboard` element
+        - `client`: the client object
+        - `action`: a `KeyboardAction` object with the following attributes:
+            - `keydown`: whether the key was pressed
+            - `keyup`: whether the key was released
+            - `repeat`: whether the key event was a repeat
+        - `key`: a `KeyboardKey` object with the following attributes:
+            - `name`: the name of the key (e.g. 'a', 'Enter')
+            - `code`: the code of the key (e.g. 'KeyA', 'Enter')
+            - `location`: the location of the key (0 for standard keys, 1 for left keys, 2 for right keys, 3 for numpad keys)
+        - `modifiers`: a `KeyboardModifiers` object with the following attributes:
+            - `alt`: whether the alt key was pressed
+            - `ctrl`: whether the ctrl key was pressed
+            - `meta`: whether the meta key was pressed
+            - `shift`: whether the shift key was pressed
+
+        For convenience, the `KeyboardKey` object also has the following properties:
+            - `is_cursorkey`: whether the key is a cursor (arrow) key
+            - `number`: the integer value of a number key (0-9, `None` for other keys)
+            - `backspace`, `tab`, `enter`, `shift`, `control`, `alt`, `pause`, `caps_lock`, `escape`, `space`,
+              `page_up`, `page_down`, `end`, `home`, `arrow_left`, `arrow_up`, `arrow_right`, `arrow_down`,
+              `print_screen`, `insert`, `delete`, `meta`,
+              `f1`, `f2`, `f3`, `f4`, `f5`, `f6`, `f7`, `f8`, `f9`, `f10`, `f11`, `f12`: whether the key is the respective key
+
         :param on_key: callback to be executed when keyboard events occur.
         :param active: boolean flag indicating whether the callback should be executed or not (default: `True`)
         :param repeating: boolean flag indicating whether held keys should be sent repeatedly (default: `True`)


### PR DESCRIPTION
As requested in #2974, this PR adds some more documentation about `ui.keyboard` and its event arguments.