### PR TITLE
Potential improvement uplift from grouping and sending Outbox messages at once

### DIFF
--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
 from collections import deque
 from typing import TYPE_CHECKING, Any, Deque, Dict, Optional, Tuple
 
@@ -76,8 +77,8 @@ class Outbox:
                 coros.append(self._emit('update', data, self.client.id))
                 self.updates.clear()
 
-                for target_id, message_type, data in self.messages:
-                    coros.append(self._emit(message_type, data, target_id))
+                for target_id, messages in itertools.groupby(self.messages, key=lambda x: x[0]):
+                    coros.append(self._emit('messages', [(type_, data) for _, type_, data in messages], target_id))
                 self.messages.clear()
 
                 for coro in coros:

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -325,6 +325,9 @@ function createApp(elements, options) {
         disconnect: () => {
           document.getElementById("popup").style.opacity = 1;
         },
+        messages: (msg) => {
+          msg.forEach(([type, data]) => messageHandlers[type](data));
+        },
         update: async (msg) => {
           for (const [id, element] of Object.entries(msg)) {
             if (element === null) {


### PR DESCRIPTION
This PR experiments with sending all non-update messages at once to reduce the time for creating complex 3D scenes like discussed in #3009.

A demo with 10,000 boxes still takes a while:
```py
with ui.scene() as scene:
    scene.move_camera(y=-6, z=7)
    for x in range(100):
        for y in range(100):
            scene.box().scale(0.09).move(x / 10 - 5, y / 10 - 5)
```

I'm not sure if sending tens of thousands of messages at once is a good idea or if we should create chunks. And it is unclear what the remaining bottleneck is. Should we optimize the Python code, the payload or the JavaScript code on the client? Maybe combining multiple steps for creating a 3D object (8 at the moment) into one function call would also be a reasonable improvement.