### PR TITLE
Improve performance of 3D scenes by initializing all objects at once

### DIFF
--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -435,15 +435,35 @@ export default {
       }
       this.camera.updateProjectionMatrix();
     },
-    init(type, id, parent_id, args, name, color, opacity, side, x, y, z, R, sx, sy, sz, visible, draggable) {
-      this.create(type, id, parent_id, ...args);
-      this.name(id, name);
-      this.material(id, color, opacity, side);
-      this.move(id, x, y, z);
-      this.rotate(id, R);
-      this.scale(id, sx, sy, sz);
-      this.visible(id, visible);
-      this.draggable(id, draggable);
+    init_objects(data) {
+      for (const [
+        type,
+        id,
+        parent_id,
+        args,
+        name,
+        color,
+        opacity,
+        side,
+        x,
+        y,
+        z,
+        R,
+        sx,
+        sy,
+        sz,
+        visible,
+        draggable,
+      ] of data) {
+        this.create(type, id, parent_id, ...args);
+        this.name(id, name);
+        this.material(id, color, opacity, side);
+        this.move(id, x, y, z);
+        this.rotate(id, R);
+        this.scale(id, sx, sy, sz);
+        this.visible(id, visible);
+        this.draggable(id, draggable);
+      }
     },
   },
 

--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -435,6 +435,16 @@ export default {
       }
       this.camera.updateProjectionMatrix();
     },
+    init(type, id, parent_id, args, name, color, opacity, side, x, y, z, R, sx, sy, sz, visible, draggable) {
+      this.create(type, id, parent_id, ...args);
+      this.name(id, name);
+      this.material(id, color, opacity, side);
+      this.move(id, x, y, z);
+      this.rotate(id, R);
+      this.scale(id, sx, sy, sz);
+      this.visible(id, visible);
+      this.draggable(id, draggable);
+    },
   },
 
   props: {

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -170,8 +170,7 @@ class Scene(Element,
         self.is_initialized = True
         with self.client.individual_target(e.args['socket_id']):
             self.move_camera(duration=0)
-            for obj in self.objects.values():
-                obj.send()
+            self.run_method('init_objects', [obj.data for obj in self.objects.values()])
 
     async def initialized(self) -> None:
         """Wait until the scene is initialized."""

--- a/nicegui/elements/scene_object3d.py
+++ b/nicegui/elements/scene_object3d.py
@@ -42,10 +42,10 @@ class Object3D:
         self._name()
         return self
 
-    def send(self) -> None:
-        """Send the object to the client."""
-        self.scene.run_method(
-            'init',
+    @property
+    def data(self) -> List[Any]:
+        """Data to be sent to the frontend."""
+        return [
             self.type, self.id, self.parent.id, self.args,
             self.name,
             self.color, self.opacity, self.side_,
@@ -54,7 +54,7 @@ class Object3D:
             self.sx, self.sy, self.sz,
             self.visible_,
             self.draggable_,
-        )
+        ]
 
     def __enter__(self) -> Self:
         self.scene.stack.append(self)

--- a/nicegui/elements/scene_object3d.py
+++ b/nicegui/elements/scene_object3d.py
@@ -44,14 +44,17 @@ class Object3D:
 
     def send(self) -> None:
         """Send the object to the client."""
-        self._create()
-        self._name()
-        self._material()
-        self._move()
-        self._rotate()
-        self._scale()
-        self._visible()
-        self._draggable()
+        self.scene.run_method(
+            'init',
+            self.type, self.id, self.parent.id, self.args,
+            self.name,
+            self.color, self.opacity, self.side_,
+            self.x, self.y, self.z,
+            self.R,
+            self.sx, self.sy, self.sz,
+            self.visible_,
+            self.draggable_,
+        )
 
     def __enter__(self) -> Self:
         self.scene.stack.append(self)


### PR DESCRIPTION
This PR experiments with sending a single initialization message with all 3D objects at once to reduce the time for creating complex 3D scenes like discussed in https://github.com/zauberzeug/nicegui/discussions/3009.

A demo with 10,000 boxes runs even faster than with PR #3017:
```py
with ui.scene() as scene:
    scene.move_camera(y=-6, z=7)
    for x in range(100):
        for y in range(100):
            scene.box().scale(0.09).move(x / 10 - 5, y / 10 - 5)
```

This approach not only bundles multiple commands into one message, it also cuts the payload significantly by focusing on the actual data rather the sending loads of overhead for every attribute. It could be combined with PR #3017 to improve the speed for updating existing objects.