### PR TITLE
Implement __copy__ for observable collections (fixes #3023)

### DIFF
--- a/nicegui/observables.py
+++ b/nicegui/observables.py
@@ -63,7 +63,7 @@ class ObservableCollection(abc.ABC):  # noqa: B024
 
     def __deepcopy__(self, memo: Dict) -> Self:
         if isinstance(self, dict):
-            return ObservableDict({key: deepcopy(value) for key, value in self}, _parent=self._parent)
+            return ObservableDict({key: deepcopy(self[key]) for key in self}, _parent=self._parent)
         if isinstance(self, list):
             return ObservableList([deepcopy(item) for item in self], _parent=self._parent)
         if isinstance(self, set):

--- a/nicegui/observables.py
+++ b/nicegui/observables.py
@@ -4,6 +4,8 @@ import abc
 import time
 from typing import Any, Callable, Collection, Dict, Iterable, List, Optional, Set, SupportsIndex, Union
 
+from typing_extensions import Self
+
 from . import events
 
 
@@ -45,6 +47,18 @@ class ObservableCollection(abc.ABC):  # noqa: B024
         if isinstance(data, set):
             return ObservableSet(data, _parent=self)
         return data
+
+    def __copy__(self) -> Self:
+        if isinstance(self, dict):
+            return ObservableDict(self, _parent=self)
+        if isinstance(self, list):
+            return ObservableList(self, _parent=self)
+        if isinstance(self, set):
+            return ObservableSet(self, _parent=self)
+        raise NotImplementedError(f'ObservableCollection.__copy__ not implemented for {type(self)}')
+
+    def __deepcopy__(self, memo: Dict) -> Self:
+        return self.__copy__()
 
 
 class ObservableDict(ObservableCollection, dict):

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import sys
 
 from nicegui import ui
@@ -153,3 +154,15 @@ def test_setting_change_handler():
     data.on_change(increment_counter)
     data.append(2)
     assert count == 1
+
+
+def test_copy():
+    a = ObservableList([[1, 2, 3], [4, 5, 6]])
+    b = copy.copy(a)
+    c = copy.deepcopy(a)
+    a.append([7, 8, 9])
+    a[0][0] = 0
+
+    assert a == [[0, 2, 3], [4, 5, 6], [7, 8, 9]]
+    assert b == [[0, 2, 3], [4, 5, 6]]
+    assert c == [[1, 2, 3], [4, 5, 6]]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 from pathlib import Path
 
 import httpx
@@ -263,3 +264,17 @@ def test_clear_client_storage(screen: Screen):
         assert app.storage.client == {}
 
     screen.open('/')
+
+
+def test_deepcopy(screen: Screen):
+    # https://github.com/zauberzeug/nicegui/issues/3023
+    @ui.page('/')
+    def page():
+        app.storage.general['a'] = {'b': 0}
+        copy.deepcopy(app.storage.general['a'])
+        ui.label('Loaded')
+
+    screen.open('/')
+    screen.should_contain('Loaded')
+    screen.wait(0.5)
+    assert Path('.nicegui', 'storage-general.json').read_text('utf-8') == '{"a":{"b":0}}'


### PR DESCRIPTION
This PR solves issue #3023 by implementing `__copy__` and `__deepcopy__` for observable collections.