### PR TITLE
Create reminder.yml

### DIFF
--- a/.github/workflows/reminder.yml
+++ b/.github/workflows/reminder.yml
@@ -1,0 +1,16 @@
+name: 'check reminders 🔔'
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check reminders and notify
+        uses: agrc/reminder-action@v1.0.12


### PR DESCRIPTION
I have added reminders to the project. Now contributors can schedule reminders.
Use the `/remind` slash command to set a reminder on any comment box on GitHub and you'll get a ping about it again when the reminder is due.

Use any form of /remind me [what] [when], such as:

`/remind me to deploy on Oct 10`
`/remind me next Monday to review the requirements`
`/remind me that the specs on the rotary girder need checked in 6 months`