### PR TITLE
fix: fix nginx_subpath example by add proxy_redirect

### DIFF
--- a/examples/nginx_subpath/nginx.conf
+++ b/examples/nginx_subpath/nginx.conf
@@ -51,6 +51,7 @@ http {
 
             proxy_pass http://app:8080/$1?$args;
             proxy_set_header X-Forwarded-Prefix /nicegui;
+            proxy_redirect http://app:8080/ /nicegui/;
         }
     }
 }


### PR DESCRIPTION
#2977 issue is solved in this PR. 
This problem is because starlette operating path which has `/` in the end by redirect to a new url+path without `/`. 
But when proxy by Nginx, this url in docker is not the real url outside the proxy.
Nginx provide `proxy_redirect` to modify this url when proxy the redirect response.