### PR TITLE
Only ignore specific missing imports with mypy

### DIFF
--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, cast
+from typing import Any, Callable, List, Optional, cast
 
 from typing_extensions import Self
 
@@ -33,7 +33,7 @@ class ValueElement(Element):
         self.set_value(value)
         self._props[self.VALUE_PROP] = self._value_to_model_value(value)
         self._props['loopback'] = self.LOOPBACK
-        self._change_handlers: list[Callable[..., Any]] = [on_value_change] if on_value_change else []
+        self._change_handlers: List[Callable[..., Any]] = [on_value_change] if on_value_change else []
 
         def handle_change(e: GenericEventArguments) -> None:
             self._send_update_on_value_change = self.LOOPBACK is True

--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -179,7 +179,7 @@ class KeyboardKey:
     @property
     def number(self) -> Optional[int]:
         """Integer value of a number key."""
-        return int(self.code.removeprefix('Digit')) if self.code.startswith('Digit') else None
+        return int(self.code[len('Digit'):]) if self.code.startswith('Digit') else None
 
     @property
     def backspace(self) -> bool:

--- a/nicegui/observables.py
+++ b/nicegui/observables.py
@@ -115,10 +115,10 @@ class ObservableDict(ObservableCollection, dict):
         self._handle_change()
 
     def __or__(self, other: Any) -> Any:
-        return super().__or__(other)
+        return ObservableDict({**self, **other})  # NOTE: Use super().__or__(other) when switching to Python 3.9
 
     def __ior__(self, other: Any) -> Any:
-        super().__ior__(self._observe(dict(other)))
+        self.update(self._observe(dict(other)))  # NOTE: Use super().__ior__(other) when switching to Python 3.9
         self._handle_change()
         return self
 

--- a/nicegui/observables.py
+++ b/nicegui/observables.py
@@ -115,10 +115,17 @@ class ObservableDict(ObservableCollection, dict):
         self._handle_change()
 
     def __or__(self, other: Any) -> Any:
-        return ObservableDict({**self, **other})  # NOTE: Use super().__or__(other) when switching to Python 3.9
+        try:
+            return super().__or__(other)  # type: ignore # pylint: disable=no-member
+        except TypeError:
+            return ObservableDict({**self, **other})  # NOTE: remove this when switching to Python 3.9
 
     def __ior__(self, other: Any) -> Any:
-        self.update(self._observe(dict(other)))  # NOTE: Use super().__ior__(other) when switching to Python 3.9
+        other_dict = self._observe(dict(other))
+        try:
+            super().__ior__(other_dict)  # type: ignore # pylint: disable=no-member
+        except TypeError:
+            self.update(other_dict)  # NOTE: remove this when switching to Python 3.9
         self._handle_change()
         return self
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,21 @@ addopts = "--driver Chrome"
 asyncio_mode = "auto"
 
 [tool.mypy]
+python_version = "3.8"
+
+[[tool.mypy.overrides]]
+module = [
+    "icecream",
+    "markdown2",
+    "matplotlib.*",
+    "nicegui_highcharts",
+    "plotly.*",
+    "pyecharts.*",
+    "sass",
+    "socketio.*",
+    "vbuild",
+    "webview.*", # can be removed with next pywebview release
+]
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/website/documentation/content/audio_documentation.py
+++ b/website/documentation/content/audio_documentation.py
@@ -23,7 +23,7 @@ def control_demo() -> None:
 
 
 @doc.demo('Event subscription', '''
-    This demo shows how to subscribe to some of the [available events](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#events).  
+    This demo shows how to subscribe to some of the [available events](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#events).
 ''')
 def event_demo() -> None:
     a = ui.audio('https://cdn.pixabay.com/download/audio/2022/02/22/audio_d1718ab41b.mp3')


### PR DESCRIPTION
This PR updates the mypy configuration in the `pyproject.toml` to only ignore missing imports for some specific modules. It also fixes some small python3.8 compatibility issues.

- [x] `__or__` and `__ior__` python3.8 compatibility in [`observables.py`](https://github.com/zauberzeug/nicegui/blob/2d69785c3654fcebd7947d873bc286eba59ab374/nicegui/observables.py#L117)