### PR TITLE
Warn about communication attempts with disconnected clients

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -59,6 +59,7 @@ class Client:
         self.shared = shared
         self.on_air = False
         self._disconnect_task: Optional[asyncio.Task] = None
+        self._deleted = False
         self.tab_id: Optional[str] = None
 
         self.outbox = Outbox(self)
@@ -318,6 +319,12 @@ class Client:
         self.remove_all_elements()
         self.outbox.stop()
         del Client.instances[self.id]
+        self._deleted = True
+
+    def check_existence(self) -> None:
+        """Check if the client still exists and print a warning if it doesn't."""
+        if self._deleted:
+            log.warning('Client has been deleted but is still being used. This is a bug in the application code.')
 
     @contextmanager
     def individual_target(self, socket_id: str) -> Iterator[None]:

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -205,17 +205,15 @@ class Client:
                         'Now the method automatically returns when receiving a response without checking regularly in an interval. '
                         'Please remove the "check_interval" argument.')
 
-        request_id = str(uuid.uuid4())
-        target_id = self._temporary_socket_id or self.id
-
         def send_and_forget():
-            self.outbox.enqueue_message('run_javascript', {'code': code}, target_id)
+            self.outbox.enqueue_message('run_javascript', {'code': code})
 
         async def send_and_wait():
             if self is self.auto_index_client:
                 raise RuntimeError('Cannot await JavaScript responses on the auto-index page. '
                                    'There could be multiple clients connected and it is not clear which one to wait for.')
-            self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id}, target_id)
+            request_id = str(uuid.uuid4())
+            self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id})
             return await JavaScriptRequest(request_id, timeout=timeout)
 
         return AwaitableResponse(send_and_forget, send_and_wait)
@@ -223,11 +221,11 @@ class Client:
     def open(self, target: Union[Callable[..., Any], str], new_tab: bool = False) -> None:
         """Open a new page in the client."""
         path = target if isinstance(target, str) else self.page_routes[target]
-        self.outbox.enqueue_message('open', {'path': path, 'new_tab': new_tab}, self.id)
+        self.outbox.enqueue_message('open', {'path': path, 'new_tab': new_tab})
 
     def download(self, src: Union[str, bytes], filename: Optional[str] = None, media_type: str = '') -> None:
         """Download a file from a given URL or raw bytes."""
-        self.outbox.enqueue_message('download', {'src': src, 'filename': filename, 'media_type': media_type}, self.id)
+        self.outbox.enqueue_message('download', {'src': src, 'filename': filename, 'media_type': media_type})
 
     def on_connect(self, handler: Union[Callable[..., Any], Awaitable]) -> None:
         """Add a callback to be invoked when the client connects."""

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -60,6 +60,7 @@ class Client:
         self.on_air = False
         self._disconnect_task: Optional[asyncio.Task] = None
         self._deleted = False
+        self._has_warned_about_deleted_client = False
         self.tab_id: Optional[str] = None
 
         self.outbox = Outbox(self)
@@ -325,8 +326,11 @@ class Client:
 
     def check_existence(self) -> None:
         """Check if the client still exists and print a warning if it doesn't."""
-        if self._deleted:
-            log.warning('Client has been deleted but is still being used. This is a bug in the application code.')
+        if self._deleted and not self._has_warned_about_deleted_client:
+            log.warning('Client has been deleted but is still being used. This is most likely a bug in your application code. '
+                        'See https://github.com/zauberzeug/nicegui/issues/3028 for more information.',
+                        stack_info=True)
+            self._has_warned_about_deleted_client = True
 
     @contextmanager
     def individual_target(self, socket_id: str) -> Iterator[None]:

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -206,15 +206,17 @@ class Client:
                         'Now the method automatically returns when receiving a response without checking regularly in an interval. '
                         'Please remove the "check_interval" argument.')
 
+        request_id = str(uuid.uuid4())
+        target_id = self._temporary_socket_id or self.id
+
         def send_and_forget():
-            self.outbox.enqueue_message('run_javascript', {'code': code})
+            self.outbox.enqueue_message('run_javascript', {'code': code}, target_id)
 
         async def send_and_wait():
             if self is self.auto_index_client:
                 raise RuntimeError('Cannot await JavaScript responses on the auto-index page. '
                                    'There could be multiple clients connected and it is not clear which one to wait for.')
-            request_id = str(uuid.uuid4())
-            self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id})
+            self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id}, target_id)
             return await JavaScriptRequest(request_id, timeout=timeout)
 
         return AwaitableResponse(send_and_forget, send_and_wait)
@@ -222,11 +224,11 @@ class Client:
     def open(self, target: Union[Callable[..., Any], str], new_tab: bool = False) -> None:
         """Open a new page in the client."""
         path = target if isinstance(target, str) else self.page_routes[target]
-        self.outbox.enqueue_message('open', {'path': path, 'new_tab': new_tab})
+        self.outbox.enqueue_message('open', {'path': path, 'new_tab': new_tab}, self.id)
 
     def download(self, src: Union[str, bytes], filename: Optional[str] = None, media_type: str = '') -> None:
         """Download a file from a given URL or raw bytes."""
-        self.outbox.enqueue_message('download', {'src': src, 'filename': filename, 'media_type': media_type})
+        self.outbox.enqueue_message('download', {'src': src, 'filename': filename, 'media_type': media_type}, self.id)
 
     def on_connect(self, handler: Union[Callable[..., Any], Awaitable]) -> None:
         """Add a callback to be invoked when the client connects."""

--- a/nicegui/functions/notify.py
+++ b/nicegui/functions/notify.py
@@ -49,4 +49,5 @@ def notify(message: Any, *,
     options = {ARG_MAP.get(key, key): value for key, value in locals().items() if key != 'kwargs' and value is not None}
     options['message'] = str(message)
     options.update(kwargs)
-    context.client.outbox.enqueue_message('notify', options)
+    client = context.client
+    client.outbox.enqueue_message('notify', options, client.id)

--- a/nicegui/functions/notify.py
+++ b/nicegui/functions/notify.py
@@ -49,5 +49,4 @@ def notify(message: Any, *,
     options = {ARG_MAP.get(key, key): value for key, value in locals().items() if key != 'kwargs' and value is not None}
     options['message'] = str(message)
     options.update(kwargs)
-    client = context.client
-    client.outbox.enqueue_message('notify', options, client.id)
+    context.client.outbox.enqueue_message('notify', options)

--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -46,10 +46,9 @@ class Outbox:
         self.updates[element.id] = None
         self._set_enqueue_event()
 
-    def enqueue_message(self, message_type: MessageType, data: Any) -> None:
+    def enqueue_message(self, message_type: MessageType, data: Any, target_id: ClientId) -> None:
         """Enqueue a message for the given client."""
         self.client.check_existence()
-        target_id = self.client._temporary_socket_id or self.client.id  # pylint: disable=protected-access
         self.messages.append((target_id, message_type, data))
         self._set_enqueue_event()
 

--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -44,8 +44,9 @@ class Outbox:
         self.updates[element.id] = None
         self._set_enqueue_event()
 
-    def enqueue_message(self, message_type: MessageType, data: Any, target_id: ClientId) -> None:
+    def enqueue_message(self, message_type: MessageType, data: Any) -> None:
         """Enqueue a message for the given client."""
+        target_id = self.client._temporary_socket_id or self.client.id  # pylint: disable=protected-access
         self.messages.append((target_id, message_type, data))
         self._set_enqueue_event()
 

--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -36,16 +36,19 @@ class Outbox:
 
     def enqueue_update(self, element: Element) -> None:
         """Enqueue an update for the given element."""
+        self.client.check_existence()
         self.updates[element.id] = element
         self._set_enqueue_event()
 
     def enqueue_delete(self, element: Element) -> None:
         """Enqueue a deletion for the given element."""
+        self.client.check_existence()
         self.updates[element.id] = None
         self._set_enqueue_event()
 
     def enqueue_message(self, message_type: MessageType, data: Any) -> None:
         """Enqueue a message for the given client."""
+        self.client.check_existence()
         target_id = self.client._temporary_socket_id or self.client.id  # pylint: disable=protected-access
         self.messages.append((target_id, message_type, data))
         self._set_enqueue_event()


### PR DESCRIPTION
This PR tries to solve issue #3028 where a memory leak in the application code only becomes apparent when trying to delete a UI element. To warn the user about a deleted client that is still in use, this PR checks the client whenever a message is enqueued in the outbox.

I tested with the following demo:
```py
import asyncio
import time
from nicegui import app, ui

handlers = []

async def loop():
    while True:
        for handler in handlers:
            handler()
        await asyncio.sleep(1)

app.on_startup(loop)

@ui.page('/')
def page():
    log = ui.log(max_lines=10)
    handlers.append(lambda: log.push(f'Hello at {time.time()}'))
```

When closing a client and waiting a few seconds, a warning appears that a deleted client is used. Without this PR, we need to wait until elements are deleted from the overflowing log element, which causes a KeyError.