### PR TITLE
Prevent `ui.leaflet` from flickering after calling `flyTo()`

### DIFF
--- a/nicegui/elements/leaflet.js
+++ b/nicegui/elements/leaflet.js
@@ -62,7 +62,8 @@ export default {
       "preclick",
       "zoomanim",
     ]) {
-      this.map.on(type, (e) => {
+      this.map.on(type, async (e) => {
+        await this.$nextTick(); // NOTE: allow zoom and center to both be updated
         this.$emit(`map-${type}`, {
           ...e,
           originalEvent: undefined,

--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -82,10 +82,12 @@ class Leaflet(Element, component='leaflet.js'):
         await self.client.connected()
         await event.wait()
 
-    def _handle_moveend(self, e: GenericEventArguments) -> None:
+    async def _handle_moveend(self, e: GenericEventArguments) -> None:
+        await asyncio.sleep(0.02)  # NOTE: wait for zoom to be updated as well
         self.center = e.args['center']
 
-    def _handle_zoomend(self, e: GenericEventArguments) -> None:
+    async def _handle_zoomend(self, e: GenericEventArguments) -> None:
+        await asyncio.sleep(0.02)  # NOTE: wait for center to be updated as well
         self.zoom = e.args['zoom']
 
     def run_method(self, name: str, *args: Any, timeout: float = 1, check_interval: float = 0.01) -> AwaitableResponse:


### PR DESCRIPTION
This PR attempts to solve #3035 by adding a short delay on client and server to allow both zoom and center to update without jumping back and forth. The delay of 0.02s is deliberately chosen above the lower bound of 0.016s for Windows. I hope it isn't too dependent on processor and network speed.

Can be tested with this  code:
```py
m = ui.leaflet(center=(48.1, 11.6), zoom=10)
m.on('map-moveend', lambda e: print(e.args['center'], e.args['zoom']))
ui.button('Berlin', on_click=lambda: m.run_map_method('flyTo', [52.5, 13.4], 9, {'duration': 1.0}))
```

There might still be glitches with multiple tabs connected to the auto-index page. But maybe it's good enough for now.