### PR TITLE
Allow commas in unquoted prop strings

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -42,7 +42,7 @@ PROPS_PATTERN = re.compile(r'''
             '       # Match the closing quote
         )
         |           # Or
-        ([\w\-.%:\/]+)  # Capture group 4: Value without quotes
+        ([\w\-.,%:\/]+)  # Capture group 4: Value without quotes
     )
 )?                  # End of optional non-capturing group for value
 (?:$|\s)            # Match end of string or whitespace

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -50,6 +50,7 @@ def test_props_parsing():
     assert ui.element._parse_props('href=http://192.168.42.100/') == {'href': 'http://192.168.42.100/'}
     assert ui.element._parse_props('hint="Your \\"given\\" name"') == {'hint': 'Your "given" name'}
     assert ui.element._parse_props('input-style="{ color: #ff0000 }"') == {'input-style': '{ color: #ff0000 }'}
+    assert ui.element._parse_props('accept=.jpeg,.jpg,.png') == {'accept': '.jpeg,.jpg,.png'}
 
     assert ui.element._parse_props('empty=""') == {'empty': ''}
     assert ui.element._parse_props("empty=''") == {'empty': ''}


### PR DESCRIPTION
As noticed in discussion #3128, adding props like
```py
.props('accept=.jpeg,.jpg,.png')
```
didn't work, because commas in a prop string required it to be wrapped in quotes:
```py
.props('accept=".jpeg,.jpg,.png"')
```

But since I don't see a reason why dots are recognized as a value character but commas aren't, I added it to the `PROPS_PATTERN`.