### PR TITLE
Add option to loosen security to allow click to trigger javascript

### DIFF
--- a/nicegui/elements/mermaid.js
+++ b/nicegui/elements/mermaid.js
@@ -30,6 +30,9 @@ export default {
       }
       is_running = false;
     },
+    initialize() {
+      mermaid.initialize({securityLevel: 'loose' });
+    }
   },
   props: {
     content: String,

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -75,3 +75,29 @@ def test_error(screen: Screen):
     screen.open('/')
     screen.should_contain('Syntax error in text')
     screen.should_contain('Parse error on line 3')
+
+
+def test_click_mermaid_node(screen: Screen):
+
+    ui.add_head_html('''
+            <script>
+                var _mermaidClickHandler = function (e) {
+                        emitEvent("mermaidNodeEvent",e);
+                        };
+            </script>
+            ''')
+
+    ui.on('mermaidNodeEvent',ui.label("Success"))
+
+    ui.mermaid('''
+    graph LR;
+        A --> B;
+        click A href "javascript:_mermaidClickHandler('x')"
+    ''').on('error', lambda e: ui.label(e.args['message']))
+
+    screen.open('/')
+    screen.click('A')
+    screen.should_contain('Success')
+
+
+


### PR DESCRIPTION
Added a second function to the mermaid.js interface to initialize the securityLevel to be 'loose'

This allows triggers of the form

click <nodeid> href "javascript:<function_name>()" to be triggered.

A proof of concept demo (work in progress) can be seen at 

[https://github.com/kyloe/nicegui_mermaid_demo/tree/main](https://github.com/kyloe/nicegui_mermaid_demo/tree/main)

