### PR TITLE
Introduce `align_items` parameter for `ui.row`, `ui.column` and `ui.card`

### DIFF
--- a/nicegui/elements/card.py
+++ b/nicegui/elements/card.py
@@ -1,3 +1,5 @@
+from typing import Literal, Optional
+
 from typing_extensions import Self
 
 from ..element import Element
@@ -5,7 +7,9 @@ from ..element import Element
 
 class Card(Element):
 
-    def __init__(self) -> None:
+    def __init__(self, *,
+                 align_items: Optional[Literal['start', 'end', 'center', 'baseline', 'stretch']] = None,
+                 ) -> None:
         """Card
 
         This element is based on Quasar's `QCard <https://quasar.dev/vue-components/card>`_ component.
@@ -16,9 +20,13 @@ class Card(Element):
         In contrast to this element, the original QCard has no padding by default and hides outer borders of nested elements.
         If you want the original behavior, use the `tight` method.
         If you want the padding and borders for nested children, move the children into another container.
+
+        :param align_items: alignment of the items in the card (default: `None`)
         """
         super().__init__('q-card')
         self._classes.append('nicegui-card')
+        if align_items:
+            self._classes.append(f'items-{align_items}')
 
     def tight(self) -> Self:
         """Remove padding and gaps between nested elements."""

--- a/nicegui/elements/column.py
+++ b/nicegui/elements/column.py
@@ -1,17 +1,25 @@
+from typing import Literal, Optional
+
 from ..element import Element
 
 
 class Column(Element):
 
-    def __init__(self, *, wrap: bool = False) -> None:
+    def __init__(self, *,
+                 wrap: bool = False,
+                 align_items: Optional[Literal['start', 'end', 'center', 'baseline', 'stretch']] = None,
+                 ) -> None:
         """Column Element
 
         Provides a container which arranges its child in a column.
 
         :param wrap: whether to wrap the content (default: `False`)
+        :param align_items: alignment of the items in the column (default: `None`)
         """
         super().__init__('div')
         self._classes.append('nicegui-column')
+        if align_items:
+            self._classes.append(f'items-{align_items}')
 
         if wrap:
             self._style['flex-wrap'] = 'wrap'

--- a/nicegui/elements/row.py
+++ b/nicegui/elements/row.py
@@ -1,18 +1,26 @@
+from typing import Literal, Optional
+
 from ..element import Element
 
 
 class Row(Element):
 
-    def __init__(self, *, wrap: bool = True) -> None:
+    def __init__(self, *,
+                 wrap: bool = True,
+                 align_items: Optional[Literal['start', 'end', 'center', 'baseline', 'stretch']] = None,
+                 ) -> None:
         """Row Element
 
         Provides a container which arranges its child in a row.
 
         :param wrap: whether to wrap the content (default: `True`)
+        :param align_items: alignment of the items in the row (default: `None`)
         """
         super().__init__('div')
         self._classes.append('nicegui-row')
         self._classes.append('row')  # NOTE: for compatibility with Quasar's col-* classes
+        if align_items:
+            self._classes.append(f'items-{align_items}')
 
         if not wrap:
             self._style['flex-wrap'] = 'nowrap'

--- a/nicegui/elements/row.py
+++ b/nicegui/elements/row.py
@@ -11,7 +11,8 @@ class Row(Element):
         :param wrap: whether to wrap the content (default: `True`)
         """
         super().__init__('div')
-        self._classes.append('nicegui-row row')  # NOTE: 'row' class for compatibility with Quasar's col-* classes
+        self._classes.append('nicegui-row')
+        self._classes.append('row')  # NOTE: for compatibility with Quasar's col-* classes
 
         if not wrap:
             self._style['flex-wrap'] = 'nowrap'


### PR DESCRIPTION
Inspired by question #3174, this PR introduces a parameter to control how items are aligned within common layout elements. It is based on Tailwind's ["Align Items"](https://tailwindcss.com/docs/align-items) classes.

```py
with ui.row(align_items='center'):
    ui.button('Button')
    ui.label('Label')

with ui.column(align_items='center'):
    ui.button('Button')
    ui.label('Label')

with ui.card(align_items='center'):
    ui.button('Button')
    ui.label('Label')
```