### PR TITLE
Add skeleton element 

### DIFF
--- a/nicegui/elements/skeleton.py
+++ b/nicegui/elements/skeleton.py
@@ -1,0 +1,17 @@
+
+from ..element import Element
+
+
+class Skeleton(Element):
+    def __init__(self, type : str):
+        """Skeleton
+
+        This element is based on Quasar's `QSkeleton <https://quasar.dev/vue-components/skeleton>`_ component.
+
+        It serves as a placeholder for loading content in cards, menus and other component containers.
+
+        :param type: the type of skeleton to display. Valid options can be found here: https://quasar.dev/vue-components/skeleton/#predefined-types
+        """
+
+        super().__init__('q-skeleton')
+        self._props['type'] = type

--- a/nicegui/elements/skeleton.py
+++ b/nicegui/elements/skeleton.py
@@ -1,17 +1,77 @@
+from typing import Literal, Optional
 
 from ..element import Element
 
 
 class Skeleton(Element):
-    def __init__(self, type : str):
+
+    def __init__(self,
+                 type: Literal[  # pylint: disable=redefined-builtin
+                     'text',
+                     'rect',
+                     'circle',
+                     'QBtn',
+                     'QBadge',
+                     'QChip',
+                     'QToolbar',
+                     'QCheckbox',
+                     'QRadio',
+                     'QToggle',
+                     'QSlider',
+                     'QRange',
+                     'QInput',
+                     'QAvatar',
+                 ] = 'rect',
+                 *,
+                 tag: str = 'div',
+                 animation: Literal[
+                     'wave',
+                     'pulse',
+                     'pulse-x',
+                     'pulse-y',
+                     'fade',
+                     'blink',
+                     'none',
+                 ] = 'wave',
+                 animation_speed: float = 1.5,
+                 square: bool = False,
+                 bordered: bool = False,
+                 size: Optional[str] = None,
+                 width: Optional[str] = None,
+                 height: Optional[str] = None,
+                 ) -> None:
         """Skeleton
 
         This element is based on Quasar's `QSkeleton <https://quasar.dev/vue-components/skeleton>`_ component.
-
         It serves as a placeholder for loading content in cards, menus and other component containers.
+        See the `Quasar documentation <https://quasar.dev/vue-components/skeleton/#predefined-types>`_ for a list of available types.
 
-        :param type: the type of skeleton to display. Valid options can be found here: https://quasar.dev/vue-components/skeleton/#predefined-types
+        :param type: type of skeleton to display (default: "rect")
+        :param tag: HTML tag to use for this element (default: "div")
+        :param animation: animation effect of the skeleton placeholder (default: "wave")
+        :param animation_speed: animation speed in seconds (default: 1.5)
+        :param square: whether to remover border-radius so borders are squared (default: ``False``)
+        :param bordered: whether to apply a default border to the component (default: ``False``)
+        :param size: size in CSS units (overrides ``width`` and ``height``)
+        :param width: width in CSS units (overridden by ``size`` if set)
+        :param height: height in CSS units (overridden by ``size`` if set)
         """
-
         super().__init__('q-skeleton')
-        self._props['type'] = type
+        if type != 'rect':
+            self._props['type'] = type
+        if tag != 'div':
+            self._props['tag'] = tag
+        if animation != 'wave':
+            self._props['animation'] = animation
+        if animation_speed != 1.5:
+            self._props['animation-speed'] = animation_speed
+        if square:
+            self._props['square'] = True
+        if bordered:
+            self._props['bordered'] = True
+        if size:
+            self._props['size'] = size
+        if width:
+            self._props['width'] = width
+        if height:
+            self._props['height'] = height

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -75,6 +75,7 @@ __all__ = [
     'scroll_area',
     'select',
     'separator',
+    'skeleton',
     'slider',
     'space',
     'spinner',
@@ -200,6 +201,7 @@ from .elements.scene_view import SceneView as scene_view
 from .elements.scroll_area import ScrollArea as scroll_area
 from .elements.select import Select as select
 from .elements.separator import Separator as separator
+from .elements.skeleton import Skeleton as skeleton
 from .elements.slider import Slider as slider
 from .elements.space import Space as space
 from .elements.spinner import Spinner as spinner

--- a/website/documentation/content/section_audiovisual_elements.py
+++ b/website/documentation/content/section_audiovisual_elements.py
@@ -8,6 +8,7 @@ from . import (
     image_documentation,
     interactive_image_documentation,
     video_documentation,
+    skeleton_documentation,
 )
 
 doc.title('*Audiovisual* Elements')
@@ -38,7 +39,7 @@ doc.intro(audio_documentation)
 doc.intro(video_documentation)
 doc.intro(icon_documentation)
 doc.intro(avatar_documentation)
-
+doc.intro(skeleton_documentation)
 
 @doc.demo('SVG', '''
     You can add Scalable Vector Graphics using the `ui.html` element.

--- a/website/documentation/content/section_audiovisual_elements.py
+++ b/website/documentation/content/section_audiovisual_elements.py
@@ -8,7 +8,6 @@ from . import (
     image_documentation,
     interactive_image_documentation,
     video_documentation,
-    skeleton_documentation,
 )
 
 doc.title('*Audiovisual* Elements')
@@ -39,7 +38,7 @@ doc.intro(audio_documentation)
 doc.intro(video_documentation)
 doc.intro(icon_documentation)
 doc.intro(avatar_documentation)
-doc.intro(skeleton_documentation)
+
 
 @doc.demo('SVG', '''
     You can add Scalable Vector Graphics using the `ui.html` element.

--- a/website/documentation/content/section_page_layout.py
+++ b/website/documentation/content/section_page_layout.py
@@ -17,6 +17,7 @@ from . import (
     row_documentation,
     scroll_area_documentation,
     separator_documentation,
+    skeleton_documentation,
     space_documentation,
     splitter_documentation,
     stepper_documentation,
@@ -86,6 +87,7 @@ doc.intro(expansion_documentation)
 doc.intro(scroll_area_documentation)
 doc.intro(separator_documentation)
 doc.intro(space_documentation)
+doc.intro(skeleton_documentation)
 doc.intro(splitter_documentation)
 doc.intro(tabs_documentation)
 doc.intro(stepper_documentation)

--- a/website/documentation/content/skeleton_documentation.py
+++ b/website/documentation/content/skeleton_documentation.py
@@ -5,37 +5,28 @@ from . import doc
 
 @doc.demo(ui.skeleton)
 def skeleton():
-    ui.skeleton('QBtn').props("bordered square").classes("bg-slate-300")
+    ui.skeleton().classes('w-full')
 
 
-@doc.demo("Animations",
-           """How to define custom animations for a skeleton.
+@doc.demo('Styling and animation', '''
+    The `square` and `bordered` parameters can be set to `True` to remove the border-radius and add a border to the skeleton.
 
-The `animation` prop can be set to any of the following values:
-
-- pulse
-- wave
-- pulse-x
-- pulse-y
-- fade
-- blink
-- none
-
-The default value is `wave`.
-            
-           """)
+    The `animation` parameter can be set to "pulse", "wave", "pulse-x", "pulse-y", "fade", "blink", or "none"
+    to change the animation effect.
+    The default value is "wave".
+''')
 def custom_animations():
-    ui.skeleton('QToolbar').props("animation='pulse'").classes("bg-slate-300 w-full")
-    
+    ui.skeleton('QToolbar', square=True, bordered=True, animation='pulse-y') \
+        .classes('w-full')
 
-@doc.demo("Youtube Skeleton", """
-          A skeleton for a Youtube video, modified to fit the NiceGUI framework.
-""")
+
+@doc.demo('YouTube Skeleton', '''
+    Here is an example skeleton for a YouTube video.
+''')
 def youtube_skeleton():
-    with ui.card().props("flat").style("width: 100%;"):
-        ui.skeleton("square").style("height: 150px; width: 100%;").classes("bg-slate-300").props("animation='fade'")
-
-        with ui.card_section().style("width: 100%;"):
-            ui.skeleton("text").classes("text-subtitle1 bg-slate-300")
-            ui.skeleton("text").classes("text-subtitle1 w-1/2 bg-slate-300")
-            ui.skeleton("text").classes("text-caption bg-slate-300")
+    with ui.card().tight().classes('w-full'):
+        ui.skeleton(square=True, animation='fade', height='150px', width='100%')
+        with ui.card_section().classes('w-full'):
+            ui.skeleton('text').classes('text-subtitle1')
+            ui.skeleton('text').classes('text-subtitle1 w-1/2')
+            ui.skeleton('text').classes('text-caption')

--- a/website/documentation/content/skeleton_documentation.py
+++ b/website/documentation/content/skeleton_documentation.py
@@ -1,0 +1,41 @@
+from nicegui import ui
+
+from . import doc
+
+
+@doc.demo(ui.skeleton)
+def skeleton():
+    ui.skeleton('QBtn').props("bordered square").classes("bg-slate-300")
+
+
+@doc.demo("Animations",
+           """How to define custom animations for a skeleton.
+
+The `animation` prop can be set to any of the following values:
+
+- pulse
+- wave
+- pulse-x
+- pulse-y
+- fade
+- blink
+- none
+
+The default value is `wave`.
+            
+           """)
+def custom_animations():
+    ui.skeleton('QToolbar').props("animation='pulse'").classes("bg-slate-300 w-full")
+    
+
+@doc.demo("Youtube Skeleton", """
+          A skeleton for a Youtube video, modified to fit the NiceGUI framework.
+""")
+def youtube_skeleton():
+    with ui.card().props("flat").style("width: 100%;"):
+        ui.skeleton("square").style("height: 150px; width: 100%;").classes("bg-slate-300").props("animation='fade'")
+
+        with ui.card_section().style("width: 100%;"):
+            ui.skeleton("text").classes("text-subtitle1 bg-slate-300")
+            ui.skeleton("text").classes("text-subtitle1 w-1/2 bg-slate-300")
+            ui.skeleton("text").classes("text-caption bg-slate-300")


### PR DESCRIPTION
The skeleton element is added to the UI module to provide a loading placeholder for content.
Inspired by #3082.
The documentation for the Skeleton Element can be found here: https://quasar.dev/vue-components/skeleton/#predefined-types
I wasn't sure of where I should place this element, as it didn't seem to really fit under styling but I don't think that it really fits in Audiovisual elements either..
Also, the API that Quasar uses (QBtn, QToolbar, etc) for defining the type might be unfamiliar to NiceGUI users, but I'm not sure if we can fix that nicely.