### PR TITLE
Extend ui.upload documentation with an example for large file uploads.

### DIFF
--- a/website/documentation/content/upload_documentation.py
+++ b/website/documentation/content/upload_documentation.py
@@ -36,4 +36,21 @@ def show_file_content() -> None:
     ui.upload(on_upload=handle_upload).props('accept=.md').classes('max-w-full')
 
 
+@doc.demo('Uploading large files', '''
+    Large file uploads may encounter issues due to the default file size parameter set within the underlying Starlette library. 
+    To ensure smooth uploads of larger files, it's recommended to increase the `max_file_size` parameter in Starlette's `MultiPartParser` class from the default of `1024 * 1024` (1 Mb) to a higher limit that aligns with the expected file sizes. 
+    
+    This demo increases the `max_file_size` to 5 Mb.
+    This change allows the system to handle larger files more efficiently by keeping them in RAM, thus avoiding the need to write data to temporary files on disk and preventing upload 'stuttering'. 
+    
+    However, be mindful of the potential impact on your server when allowing users to upload large files and retaining them in RAM.
+''')
+def uploading_large_files() -> None:
+    from starlette.formparsers import MultiPartParser
+
+    MultiPartParser.max_file_size = 1024 * 1024 * 5  # 5 Mb.
+
+    ui.upload(on_upload=lambda e: ui.notify(f'Uploaded {e.name}')).classes('max-w-full')
+
+
 doc.reference(ui.upload)

--- a/website/documentation/content/upload_documentation.py
+++ b/website/documentation/content/upload_documentation.py
@@ -40,7 +40,7 @@ def show_file_content() -> None:
     Large file uploads may encounter issues due to the default file size parameter set within the underlying Starlette library. 
     To ensure smooth uploads of larger files, it's recommended to increase the `max_file_size` parameter in Starlette's `MultiPartParser` class from the default of `1024 * 1024` (1 Mb) to a higher limit that aligns with the expected file sizes. 
     
-    This demo increases the `max_file_size` to 5 Mb.
+    This demo increases Starlette Multiparser's `max_file_size` to be kept in RAM to 5 Mb.
     This change allows the system to handle larger files more efficiently by keeping them in RAM, thus avoiding the need to write data to temporary files on disk and preventing upload 'stuttering'. 
     
     However, be mindful of the potential impact on your server when allowing users to upload large files and retaining them in RAM.


### PR DESCRIPTION
As discussed [here](https://github.com/zauberzeug/nicegui/discussions/3220#discussioncomment-9785621), I added an example on [ui.upload's documentation page ](https://nicegui.io/documentation/upload) that facilitates uploading of large files.