### PR TITLE
Avoid changing min/max limits of `ui.range` breaking the element

### DIFF
--- a/nicegui/elements/range.py
+++ b/nicegui/elements/range.py
@@ -24,6 +24,6 @@ class Range(ValueElement, DisableableElement):
         :param on_change: callback which is invoked when the user releases the range
         """
         super().__init__(tag='q-range', value=value, on_value_change=on_change, throttle=0.05)
-        self._props['min'] = min
-        self._props['max'] = max
-        self._props['step'] = step
+        self._props[':min'] = min
+        self._props[':max'] = max
+        self._props[':step'] = step

--- a/nicegui/elements/range.py
+++ b/nicegui/elements/range.py
@@ -26,4 +26,4 @@ class Range(ValueElement, DisableableElement):
         super().__init__(tag='q-range', value=value, on_value_change=on_change, throttle=0.05)
         self._props[':min'] = min
         self._props[':max'] = max
-        self._props[':step'] = step
+        self._props['step'] = step


### PR DESCRIPTION
Possible fix for #3191 