### PR TITLE
Add demos for using `ui.refreshable` with local scope

### DIFF
--- a/website/documentation/content/refreshable_documentation.py
+++ b/website/documentation/content/refreshable_documentation.py
@@ -94,42 +94,43 @@ def reactive_state():
 @doc.demo('Global scope', '''
     When defining a refreshable function in the global scope,
     every refreshable UI that is created by calling this function will share the same state.
-    In this demo, `hello()` will show the name entered in the input field.
-    When opening the page with a second browser or in incognito mode,
-    both browsers will continue to show the same name, even if it is changed in one of them.
+    In this demo, `time()` will show the current date and time.
+    When opening the page in a new tab, _both_ tabs will be updated simultaneously when clicking the "Refresh" button.
+
     See the "local scope" demos below for a way to create independent refreshable UIs instead.
 ''')
 def global_scope():
-    from nicegui import app
+    from datetime import datetime
 
     @ui.refreshable
-    def hello():
-        ui.label(f'Hello {app.storage.user.get("name")}')
+    def time():
+        ui.label(f'Time: {datetime.now()}')
 
     @ui.page('/global_refreshable')
     def demo():
-        ui.input('Name', on_change=hello.refresh).bind_value(app.storage.user, 'name')
-        hello()
+        time()
+        ui.button('Refresh', on_click=time.refresh)
 
     ui.link('Open demo', demo)
 
 
 @doc.demo('Local scope (1/3)', '''
     When defining a refreshable function in a local scope,
-    refreshable UI that is created by calling this function will have independent state.
-    In contrast to the "global scope" demo, the name entered in the input field will only be shown to the same user.
+    refreshable UI that is created by calling this function will refresh independently.
+    In contrast to the "global scope" demo,
+    the time will be updated only in the tab where the "Refresh" button was clicked.
 ''')
 def local_scope_1():
-    from nicegui import app
+    from datetime import datetime
 
     @ui.page('/local_refreshable_1')
     def demo():
         @ui.refreshable
-        def hello():
-            ui.label(f'Hello {app.storage.user.get("name")}')
+        def time():
+            ui.label(f'Time: {datetime.now()}')
 
-        ui.input('Name', on_change=hello.refresh).bind_value(app.storage.user, 'name')
-        hello()
+        time()
+        ui.button('Refresh', on_click=time.refresh)
 
     ui.link('Open demo', demo)
 
@@ -141,19 +142,18 @@ def local_scope_1():
     because the `ui.refreshable` decorator acts on the class instance rather than the class itself.
 ''')
 def local_scope_2():
-    from nicegui import app
+    from datetime import datetime
 
-    class Greeting:
+    class Clock:
         @ui.refreshable
-        def hello(self):
-            ui.label(f'Hello {app.storage.user.get("name")}')
+        def time(self):
+            ui.label(f'Time: {datetime.now()}')
 
     @ui.page('/local_refreshable_2')
     def demo():
-        greeting = Greeting()
-        ui.input('Name', on_change=greeting.hello.refresh) \
-            .bind_value(app.storage.user, 'name')
-        greeting.hello()
+        clock = Clock()
+        clock.time()
+        ui.button('Refresh', on_click=clock.time.refresh)
 
     ui.link('Open demo', demo)
 
@@ -161,20 +161,19 @@ def local_scope_2():
 @doc.demo('Local scope (3/3)', '''
     As an alternative to the class definition shown above, you can also define the UI function in global scope,
     but apply the `ui.refreshable` decorator inside the page function.
-    This way the refreshable UI will have independent state.
+    This way the refreshable UI will refresh independently.
 ''')
 def local_scope_3():
-    from nicegui import app
+    from datetime import datetime
 
-    def hello():
-        ui.label(f'Hello {app.storage.user.get("name")}')
+    def time():
+        ui.label(f'Time: {datetime.now()}')
 
     @ui.page('/local_refreshable_3')
     def demo():
-        refreshable_hello = ui.refreshable(hello)
-        ui.input('Name', on_change=refreshable_hello.refresh) \
-            .bind_value(app.storage.user, 'name')
-        refreshable_hello()
+        refreshable_time = ui.refreshable(time)
+        refreshable_time()
+        ui.button('Refresh', on_click=refreshable_time.refresh)
 
     ui.link('Open demo', demo)
 

--- a/website/documentation/content/refreshable_documentation.py
+++ b/website/documentation/content/refreshable_documentation.py
@@ -91,4 +91,92 @@ def reactive_state():
         counter('B')
 
 
+@doc.demo('Global scope', '''
+    When defining a refreshable function in the global scope,
+    every refreshable UI that is created by calling this function will share the same state.
+    In this demo, `hello()` will show the name entered in the input field.
+    When opening the page with a second browser or in incognito mode,
+    both browsers will continue to show the same name, even if it is changed in one of them.
+    See the "local scope" demos below for a way to create independent refreshable UIs instead.
+''')
+def global_scope():
+    from nicegui import app
+
+    @ui.refreshable
+    def hello():
+        ui.label(f'Hello {app.storage.user.get("name")}')
+
+    @ui.page('/global_refreshable')
+    def demo():
+        ui.input('Name', on_change=hello.refresh).bind_value(app.storage.user, 'name')
+        hello()
+
+    ui.link('Open demo', demo)
+
+
+@doc.demo('Local scope (1/3)', '''
+    When defining a refreshable function in a local scope,
+    refreshable UI that is created by calling this function will have independent state.
+    In contrast to the "global scope" demo, the name entered in the input field will only be shown to the same user.
+''')
+def local_scope_1():
+    from nicegui import app
+
+    @ui.page('/local_refreshable_1')
+    def demo():
+        @ui.refreshable
+        def hello():
+            ui.label(f'Hello {app.storage.user.get("name")}')
+
+        ui.input('Name', on_change=hello.refresh).bind_value(app.storage.user, 'name')
+        hello()
+
+    ui.link('Open demo', demo)
+
+
+@doc.demo('Local scope (2/3)', '''
+    In order to define refreshable UIs with local state outside of page functions,
+    you can, e.g., define a class with a refreshable method.
+    This way, you can create multiple instances of the class with independent state,
+    because the `ui.refreshable` decorator acts on the class instance rather than the class itself.
+''')
+def local_scope_2():
+    from nicegui import app
+
+    class Greeting:
+        @ui.refreshable
+        def hello(self):
+            ui.label(f'Hello {app.storage.user.get("name")}')
+
+    @ui.page('/local_refreshable_2')
+    def demo():
+        greeting = Greeting()
+        ui.input('Name', on_change=greeting.hello.refresh) \
+            .bind_value(app.storage.user, 'name')
+        greeting.hello()
+
+    ui.link('Open demo', demo)
+
+
+@doc.demo('Local scope (3/3)', '''
+    As an alternative to the class definition shown above, you can also define the UI function in global scope,
+    but apply the `ui.refreshable` decorator inside the page function.
+    This way the refreshable UI will have independent state.
+''')
+def local_scope_3():
+    from nicegui import app
+
+    def hello():
+        ui.label(f'Hello {app.storage.user.get("name")}')
+
+    @ui.page('/local_refreshable_3')
+    def demo():
+        refreshable_hello = ui.refreshable(hello)
+        ui.input('Name', on_change=refreshable_hello.refresh) \
+            .bind_value(app.storage.user, 'name')
+        refreshable_hello()
+
+    ui.link('Open demo', demo)
+
+
 doc.reference(ui.refreshable)

--- a/website/documentation/content/refreshable_documentation.py
+++ b/website/documentation/content/refreshable_documentation.py
@@ -114,16 +114,16 @@ def global_scope():
     ui.link('Open demo', demo)
 
 
-@doc.demo('Local scope (1/3)', '''
+@doc.demo('Local scope (variant A)', '''
     When defining a refreshable function in a local scope,
     refreshable UI that is created by calling this function will refresh independently.
     In contrast to the "global scope" demo,
     the time will be updated only in the tab where the "Refresh" button was clicked.
 ''')
-def local_scope_1():
+def local_scope_a():
     from datetime import datetime
 
-    @ui.page('/local_refreshable_1')
+    @ui.page('/local_refreshable_a')
     def demo():
         @ui.refreshable
         def time():
@@ -135,13 +135,13 @@ def local_scope_1():
     ui.link('Open demo', demo)
 
 
-@doc.demo('Local scope (2/3)', '''
+@doc.demo('Local scope (variant B)', '''
     In order to define refreshable UIs with local state outside of page functions,
     you can, e.g., define a class with a refreshable method.
     This way, you can create multiple instances of the class with independent state,
     because the `ui.refreshable` decorator acts on the class instance rather than the class itself.
 ''')
-def local_scope_2():
+def local_scope_b():
     from datetime import datetime
 
     class Clock:
@@ -149,7 +149,7 @@ def local_scope_2():
         def time(self):
             ui.label(f'Time: {datetime.now()}')
 
-    @ui.page('/local_refreshable_2')
+    @ui.page('/local_refreshable_b')
     def demo():
         clock = Clock()
         clock.time()
@@ -158,18 +158,18 @@ def local_scope_2():
     ui.link('Open demo', demo)
 
 
-@doc.demo('Local scope (3/3)', '''
+@doc.demo('Local scope (variant C)', '''
     As an alternative to the class definition shown above, you can also define the UI function in global scope,
     but apply the `ui.refreshable` decorator inside the page function.
     This way the refreshable UI will refresh independently.
 ''')
-def local_scope_3():
+def local_scope_c():
     from datetime import datetime
 
     def time():
         ui.label(f'Time: {datetime.now()}')
 
-    @ui.page('/local_refreshable_3')
+    @ui.page('/local_refreshable_c')
     def demo():
         refreshable_time = ui.refreshable(time)
         refreshable_time()


### PR DESCRIPTION
Inspired by #2535 and #3233, this PR adds 4 demos showing how to use `ui.refreshable` with different scope.