### PR TITLE
Let SVG of `ui.pyplot` fill its container

### DIFF
--- a/nicegui/elements/pyplot.py
+++ b/nicegui/elements/pyplot.py
@@ -47,6 +47,7 @@ class Pyplot(Element):
             raise ImportError('Matplotlib is not installed. Please run "pip install matplotlib".')
 
         super().__init__('div')
+        self._classes.append('nicegui-pyplot')
         self.close = close
         self.fig = plt.figure(**kwargs)
         self._convert_to_html()

--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -246,6 +246,10 @@ h6.q-timeline__title {
 .nicegui-code .codehilite {
   padding: 0 0.5rem;
 }
+.nicegui-pyplot > svg {
+  width: 100%;
+  height: 100%;
+}
 
 /* CodeMirror */
 .nicegui-codemirror .cm-editor.cm-focused {


### PR DESCRIPTION
This PR resolves discussion #3277 by setting the width and height of an SVG element to 100% of its parent container, which is the `ui.pyplot` element itself. This way the following plot stays inside the `ui.card`, which wasn't the case before:
```py
with ui.card().classes('w-[400px]'):
    with ui.pyplot() as plot:
        plot.fig.gca().plot()
```