### PR TITLE
Ignore `CancelledError` in `check_for_late_return_value`

### DIFF
--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -94,8 +94,12 @@ class page:
         parameters_of_decorated_func = list(inspect.signature(func).parameters.keys())
 
         def check_for_late_return_value(task: asyncio.Task) -> None:
-            if task.result() is not None:
-                log.error(f'ignoring {task.result()}; it was returned after the HTML had been delivered to the client')
+            try:
+                if task.result() is not None:
+                    log.error(f'ignoring {task.result()}; '
+                              'it was returned after the HTML had been delivered to the client')
+            except asyncio.CancelledError:
+                pass
 
         @wraps(func)
         async def decorated(*dec_args, **dec_kwargs) -> Response:

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -24,7 +24,7 @@ async def _run(executor: Any, callback: Callable[P, R], *args: P.args, **kwargs:
     except RuntimeError as e:
         if 'cannot schedule new futures after shutdown' not in str(e):
             raise
-    except asyncio.exceptions.CancelledError:
+    except asyncio.CancelledError:
         pass
     return  # type: ignore  # the assumption is that the user's code no longer cares about this value
 


### PR DESCRIPTION
This PR tries to solve #3268 where a `CancelledError` pops up in the terminal when terminating an app with a page function still awaiting a result:
```py
@ui.page('/')
async def page():
    await ui.context.client.connected()
    await asyncio.sleep(10)
```

ChatGPT:

> The issue arises because the task is being cancelled when the app terminates. When the app shuts down, all pending tasks are cancelled, and `asyncio.sleep` raises a `CancelledError`. The `CancelledError` is then propagated to the `done_callback`, causing the exception in your callback.

Since we only want to warn the user that a `Response` might have not been sent to the client because it was generated too late, I think it is safe to ignore the `CancelledError` in this case, like we do in several other places.