### PR TITLE
Support named slots in Element.move

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -498,19 +498,36 @@ class Element(Visibility):
             slot.children.clear()
         self.update()
 
-    def move(self, target_container: Optional[Element] = None, target_index: int = -1) -> None:
+    def move(self, target_container: Optional[Element] = None, target_index: int = -1, target_slot: Optional[str] = None) -> None:
         """Move the element to another container.
 
         :param target_container: container to move the element to (default: the parent container)
         :param target_index: index within the target slot (default: append to the end)
+        :param target_slot: slot within the target container (default: the parent slot or the default slot of the target container)
         """
         assert self.parent_slot is not None
         self.parent_slot.children.remove(self)
         self.parent_slot.parent.update()
         target_container = target_container or self.parent_slot.parent
-        target_index = target_index if target_index >= 0 else len(target_container.default_slot.children)
-        target_container.default_slot.children.insert(target_index, self)
-        self.parent_slot = target_container.default_slot
+
+        if target_slot is None:
+            if self.parent_slot is not None and target_container == self.parent_slot.parent:
+                parent_slot = self.parent_slot
+            else:
+                parent_slot = target_container.default_slot
+        else:
+            try:
+                parent_slot = target_container.slots[target_slot] if target_slot else target_container.default_slot
+            except KeyError:
+                raise ValueError(
+                    f'Slot "{target_slot}" does not exitst in the target container. Add it first using `add_slot("{target_slot}")`.')
+        if parent_slot is None:
+            raise ValueError('Target slot could not be determined.')
+
+        target_index = target_index if target_index >= 0 else len(parent_slot.children)
+        parent_slot.children.insert(target_index, self)
+
+        self.parent_slot = parent_slot
         target_container.update()
 
     def remove(self, element: Union[Element, int]) -> None:

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -134,53 +134,48 @@ def test_move(screen: Screen):
 
     screen.open('/')
     assert screen.find('A').location['y'] < screen.find('X').location['y'] < screen.find('B').location['y']
+
     screen.click('Move X to B')
     screen.wait(0.5)
     assert screen.find('A').location['y'] < screen.find('B').location['y'] < screen.find('X').location['y']
+
     screen.click('Move X to A')
     screen.wait(0.5)
     assert screen.find('A').location['y'] < screen.find('X').location['y'] < screen.find('B').location['y']
+
     screen.click('Move X to top')
     screen.wait(0.5)
     assert screen.find('X').location['y'] < screen.find('A').location['y'] < screen.find('B').location['y']
 
 
 def test_move_slots(screen: Screen):
-    a = ui.expansion(value=True)
-    with a.add_slot('header'):
-        ui.label('A')
-    with a:
+    with ui.expansion(value=True) as a:
+        with a.add_slot('header'):
+            ui.label('A')
         x = ui.label('X')
 
-    b = ui.expansion(value=True)
-    with b.add_slot('header'):
-        ui.label('B')
+    with ui.expansion(value=True) as b:
+        with b.add_slot('header'):
+            ui.label('B')
 
     ui.button('Move X to header', on_click=lambda: x.move(target_slot='header'))
-
     ui.button('Move X to B', on_click=lambda: x.move(b))
     ui.button('Move X to top', on_click=lambda: x.move(target_index=0))
 
     screen.open('/')
+    assert screen.find('A').location['y'] < screen.find('X').location['y'], 'X is in A.default'
 
-    def x_is_in_header_of(container: str) -> bool:
-        return screen.find(container).location['y'] == screen.find('X').location['y']
-
-    def x_is_in_default_of(container: str) -> bool:
-        return screen.find(container).location['y'] < screen.find('X').location['y']
-
-    assert x_is_in_default_of('A')
     screen.click('Move X to header')
     screen.wait(0.5)
-    assert x_is_in_header_of('A')
-    assert screen.find('A').location['x'] < screen.find('X').location['x']
+    assert screen.find('A').location['y'] == screen.find('X').location['y'], 'X is in A.header'
+
     screen.click('Move X to top')
     screen.wait(0.5)
-    assert x_is_in_header_of('A')
-    assert screen.find('X').location['x'] < screen.find('A').location['x']
+    assert screen.find('A').location['y'] < screen.find('X').location['y'], 'X is in A.default'
+
     screen.click('Move X to B')
     screen.wait(0.5)
-    assert x_is_in_default_of('B')
+    assert screen.find('B').location['y'] < screen.find('X').location['y'], 'X is in B.default'
 
 
 def test_xss(screen: Screen):

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -145,6 +145,44 @@ def test_move(screen: Screen):
     assert screen.find('X').location['y'] < screen.find('A').location['y'] < screen.find('B').location['y']
 
 
+def test_move_slots(screen: Screen):
+    a = ui.expansion(value=True)
+    with a.add_slot('header'):
+        ui.label('A')
+    with a:
+        x = ui.label('X')
+
+    b = ui.expansion(value=True)
+    with b.add_slot('header'):
+        ui.label('B')
+
+    ui.button('Move X to header', on_click=lambda: x.move(target_slot='header'))
+
+    ui.button('Move X to B', on_click=lambda: x.move(b))
+    ui.button('Move X to top', on_click=lambda: x.move(target_index=0))
+
+    screen.open('/')
+
+    def x_is_in_header_of(container: str) -> bool:
+        return screen.find(container).location['y'] == screen.find('X').location['y']
+
+    def x_is_in_default_of(container: str) -> bool:
+        return screen.find(container).location['y'] < screen.find('X').location['y']
+
+    assert x_is_in_default_of('A')
+    screen.click('Move X to header')
+    screen.wait(0.5)
+    assert x_is_in_header_of('A')
+    assert screen.find('A').location['x'] < screen.find('X').location['x']
+    screen.click('Move X to top')
+    screen.wait(0.5)
+    assert x_is_in_header_of('A')
+    assert screen.find('X').location['x'] < screen.find('A').location['x']
+    screen.click('Move X to B')
+    screen.wait(0.5)
+    assert x_is_in_default_of('B')
+
+
 def test_xss(screen: Screen):
     ui.label('</script><script>alert(1)</script>')
     ui.label('<b>Bold 1</b>, `code`, copy&paste, multi\nline')

--- a/website/documentation/content/element_documentation.py
+++ b/website/documentation/content/element_documentation.py
@@ -29,22 +29,13 @@ def move_elements() -> None:
     This demo shows how to move elements between slots within an element.
 ''')
 def move_elements_to_slots() -> None:
-    a = ui.expansion(value=True)
-    with a.add_slot('header'):
-        ui.label('A')
-    with a:
-        x = ui.label('X')
+    with ui.card() as card:
+        name = ui.input('Name', value='Paul')
+        name.add_slot('append')
+        icon = ui.icon('face')
 
-    b = ui.expansion(value=True)
-    with b.add_slot('header'):
-        ui.label('B')
-
-    ui.button('Move X to header', on_click=lambda: x.move(target_slot='header'))
-    ui.button('Move X to default', on_click=lambda: x.move(target_slot='default'))
-
-    ui.button('Move X to A', on_click=lambda: x.move(a))
-    ui.button('Move X to B', on_click=lambda: x.move(b))
-    ui.button('Move X to top', on_click=lambda: x.move(target_index=0))
+    ui.button('Move into input', on_click=lambda: icon.move(name, target_slot='append'))
+    ui.button('Move out of input', on_click=lambda: icon.move(card))
 
 
 @doc.demo('Default props', '''

--- a/website/documentation/content/element_documentation.py
+++ b/website/documentation/content/element_documentation.py
@@ -25,6 +25,28 @@ def move_elements() -> None:
     ui.button('Move X to top', on_click=lambda: x.move(target_index=0))
 
 
+@doc.demo('Move elements to slots', '''
+    This demo shows how to move elements between slots within an element.
+''')
+def move_elements_to_slots() -> None:
+    a = ui.expansion(value=True)
+    with a.add_slot('header'):
+        ui.label('A')
+    with a:
+        x = ui.label('X')
+
+    b = ui.expansion(value=True)
+    with b.add_slot('header'):
+        ui.label('B')
+
+    ui.button('Move X to header', on_click=lambda: x.move(target_slot='header'))
+    ui.button('Move X to default', on_click=lambda: x.move(target_slot='default'))
+
+    ui.button('Move X to A', on_click=lambda: x.move(a))
+    ui.button('Move X to B', on_click=lambda: x.move(b))
+    ui.button('Move X to top', on_click=lambda: x.move(target_index=0))
+
+
 @doc.demo('Default props', '''
     You can set default props for all elements of a certain class.
     This way you can avoid repeating the same props over and over again.


### PR DESCRIPTION
This adds support for named slots in Element.move()

Most importantly `Element.move(index)` will now keep the current slot rather than moving into the default slot.

The new parameter `target_slot` can be used to move an element into a specific slot of the current parent element or the specified `target_element`.

Some special cases:
- Moving into a new `target_element` without specifying a `target_slot` will use the default slot.
- Moving into the current parent element without specifying a `target_slot` will keep the current slot.

I would like some opinions on the last point. If `target_element` is specified while `target_slot` is `None` should we always use the default slot to mimic the first case (i.e. even if the target is the current parent)?
