### PR TITLE
shutdown with SIGINT  if autoreload is enabled

### DIFF
--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -127,17 +127,11 @@ class App(FastAPI):
         """Shut down NiceGUI.
 
         This will programmatically stop the server.
-        When auto-reload is enabled, this will only work on Linux and MacOS.
         """
         if self.native.main_window:
             self.native.main_window.destroy()
         if self.config.reload:
-            parent_pid = os.getppid()
-            if platform.system() == 'Darwin' or platform.system() == 'Linux':
-                os.kill(parent_pid, signal.SIGINT)
-            else:
-                raise NotImplementedError(
-                    'Shutting down the server with auto-reload enabled is only supported on Linux and MacOS.')
+            os.kill(os.getppid(), getattr(signal, 'CTRL_C_EVENT' if platform.system() == 'Windows' else 'SIGINT'))
         else:
             Server.instance.should_exit = True
 


### PR DESCRIPTION
This adds the ability to fully shutdown the app even if `reload=True`.

It was inspired by encode/uvicorn#1103 (more specifically [this comment](https://github.com/encode/uvicorn/discussions/1103#discussioncomment-5359710))

This is currently missing Windows support.
According to ChatGPT, the following might work, though:
```py
parent_process = psutil.Process(parent_pid)
parent_process.send_signal(signal.CTRL_C_EVENT)
 ```
 
 Could someone test this?