### PR TITLE
Fix link to tabs-panel

### DIFF
--- a/website/documentation/content/tabs_documentation.py
+++ b/website/documentation/content/tabs_documentation.py
@@ -6,7 +6,7 @@ from . import doc
 @doc.demo('Tabs', '''
     The elements `ui.tabs`, `ui.tab`, `ui.tab_panels`, and `ui.tab_panel` resemble
     [Quasar's tabs](https://quasar.dev/vue-components/tabs) and
-    [tab panels](https://quasar.dev/vue-components/tab-panels>) API.
+    [tab panels](https://quasar.dev/vue-components/tab-panels) API.
 
     `ui.tabs` creates a container for the tabs. This could be placed in a `ui.header` for example.
     `ui.tab_panels` creates a container for the tab panels with the actual content.


### PR DESCRIPTION
As pointed out on [Discord](https://discord.com/channels/1089836369431498784/1258991604056723476) we had a broken link.