### PR TITLE
Update tooltip documentation: clarify method limitations and add upload component example

### DIFF
--- a/website/documentation/content/tooltip_documentation.py
+++ b/website/documentation/content/tooltip_documentation.py
@@ -48,7 +48,7 @@ def tooltip_on_html_and_markdown():
 
 @doc.demo('Tooltip for the upload element', '''
     Components like `ui.upload` do not support tooltips directly.
-    You can wrap them in a `ui.element()` to add tooltips and props.
+    You can wrap them in a `ui.element` to add tooltips and props.
 ''')
 def simple_upload_with_tooltip_demo():
     with ui.element():

--- a/website/documentation/content/tooltip_documentation.py
+++ b/website/documentation/content/tooltip_documentation.py
@@ -11,8 +11,9 @@ def tooltips_demo():
 
 @doc.demo('Tooltip method', '''
     Instead of nesting a tooltip element inside another element, you can also use the `tooltip` method.
-    However, it's important to note that when using the method approach, you cannot apply additional
-    properties (props) or styling directly to the tooltip.
+
+    Note that with this method you cannot apply additional properties (props) or styling directly to the tooltip.
+    If you need custom styling or properties, nest a `ui.tooltip` element instead.
 ''')
 def tooltip_method_demo():
     ui.label('Tooltips...').tooltip('...are shown on mouse over')
@@ -28,7 +29,7 @@ def tooltip_html_demo():
 
 
 @doc.demo('Tooltip with other content', '''
-    You can use HTML in tooltips.
+    Other elements like `ui.images` can also be nested inside a tooltip.
 ''')
 def tooltip_with_other_content():
     with ui.label('Mountains...'):
@@ -45,14 +46,14 @@ def tooltip_on_html_and_markdown():
         ui.html('This is <u>HTML</u>...')
 
 
-@doc.demo('Tooltip for upload component', '''
-    Components like `ui.upload()` that don't support tooltips can be wrapped in a `ui.element()`.
-    This allows you to add a tooltip and customize it with props.
+@doc.demo('Tooltip for the upload element', '''
+    Components like `ui.upload` do not support tooltips directly.
+    You can wrap them in a `ui.element()` to add tooltips and props.
 ''')
 def simple_upload_with_tooltip_demo():
     with ui.element():
-        ui.tooltip('Click or drag files to upload').props('delay=1000 transition-show="rotate" transition-hide="rotate"')
-        ui.upload(on_upload=lambda e: ui.notify(f'Uploaded {e.name}'))
+        ui.upload(on_upload=lambda e: ui.notify(f'Uploaded {e.name}')).classes('w-72')
+        ui.tooltip('Upload files').props('delay=1000 transition-show=rotate')
 
 
 doc.reference(ui.tooltip)

--- a/website/documentation/content/tooltip_documentation.py
+++ b/website/documentation/content/tooltip_documentation.py
@@ -11,6 +11,8 @@ def tooltips_demo():
 
 @doc.demo('Tooltip method', '''
     Instead of nesting a tooltip element inside another element, you can also use the `tooltip` method.
+    However, it's important to note that when using the method approach, you cannot apply additional
+    properties (props) or styling directly to the tooltip.
 ''')
 def tooltip_method_demo():
     ui.label('Tooltips...').tooltip('...are shown on mouse over')
@@ -41,6 +43,16 @@ def tooltip_with_other_content():
 def tooltip_on_html_and_markdown():
     with ui.element().tooltip('...with a tooltip!'):
         ui.html('This is <u>HTML</u>...')
+
+
+@doc.demo('Tooltip for upload component', '''
+    Components like `ui.upload()` that don't support tooltips can be wrapped in a `ui.element()`.
+    This allows you to add a tooltip and customize it with props.
+''')
+def simple_upload_with_tooltip_demo():
+    with ui.element():
+        ui.tooltip('Click or drag files to upload').props('delay=1000 transition-show="rotate" transition-hide="rotate"')
+        ui.upload(on_upload=lambda e: ui.notify(f'Uploaded {e.name}'))
 
 
 doc.reference(ui.tooltip)


### PR DESCRIPTION
1. Clarifies limitations of the tooltip method approach:
   - Adds a note explaining that the method approach doesn't support additional properties (props) or direct styling.
   - [Issue#3322](https://github.com/zauberzeug/nicegui/issues/3322)

2. Introduces a new example for components that don't natively support tooltips:
   - Demonstrates how to use `ui.element()` as a wrapper for `ui.upload()` to add a customizable tooltip.
   - Shows the application of tooltip props for delay and transition effects.
   - [Issue#3331](https://github.com/zauberzeug/nicegui/issues/3331)

These updates aim to provide users with a clearer understanding of tooltip usage in different scenarios and offer solutions for components with tooltip limitations. The new example also showcases advanced tooltip customization options.