### PR TITLE
Update `ui.number` after sanitization

### DIFF
--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -116,6 +116,7 @@ class Number(ValidationElement, DisableableElement):
         if self.precision is not None:
             value = float(round(value, self.precision))
         self.set_value(float(self.format % value) if self.format else value)
+        self.update()
 
     def _event_args_to_value(self, e: GenericEventArguments) -> Any:
         if not e.args:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -30,6 +30,11 @@ def test_apply_format_on_blur(screen: Screen):
     screen.click('Button')
     screen.should_contain_input('3.1417')
 
+    element.click()
+    element.send_keys(Keys.BACKSPACE * 10 + '2')
+    screen.click('Button')
+    screen.should_contain_input('2.0000')
+
 
 def test_max_value(screen: Screen):
     ui.number('Number', min=0, max=10, value=5)


### PR DESCRIPTION
This PR solves #3324 by updating the number element after sanitization on blur. This is necessary, because calling `set_value` not always updates the client. E.g. an input value "10" equals the formatted value "10.000", so an explicit `update()` is necessary.