### PR TITLE
Allow pretty printing storage json

### DIFF
--- a/nicegui/json/builtin_wrapper.py
+++ b/nicegui/json/builtin_wrapper.py
@@ -11,7 +11,10 @@ except ImportError:
     has_numpy = False
 
 
-def dumps(obj: Any, sort_keys: bool = False, separators: Optional[Tuple[str, str]] = None, indent: bool = True):
+def dumps(obj: Any,
+          sort_keys: bool = False,
+          separators: Optional[Tuple[str, str]] = None, *,
+          indent: bool = True) -> str:
     """Serializes a Python object to a JSON-encoded string.
 
     This implementation uses Python's default json module, but extends it in order to support NumPy arrays.

--- a/nicegui/json/builtin_wrapper.py
+++ b/nicegui/json/builtin_wrapper.py
@@ -11,7 +11,7 @@ except ImportError:
     has_numpy = False
 
 
-def dumps(obj: Any, sort_keys: bool = False, separators: Optional[Tuple[str, str]] = None):
+def dumps(obj: Any, sort_keys: bool = False, separators: Optional[Tuple[str, str]] = None, indent: bool = True):
     """Serializes a Python object to a JSON-encoded string.
 
     This implementation uses Python's default json module, but extends it in order to support NumPy arrays.
@@ -22,7 +22,7 @@ def dumps(obj: Any, sort_keys: bool = False, separators: Optional[Tuple[str, str
         obj,
         sort_keys=sort_keys,
         separators=separators,
-        indent=None,
+        indent=2 if indent else None,
         allow_nan=False,
         ensure_ascii=False,
         cls=NumpyJsonEncoder)

--- a/nicegui/json/orjson_wrapper.py
+++ b/nicegui/json/orjson_wrapper.py
@@ -14,7 +14,10 @@ except ImportError:
 ORJSON_OPTS = orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NON_STR_KEYS
 
 
-def dumps(obj: Any, sort_keys: bool = False, separators: Optional[Tuple[str, str]] = None, indent: bool = True):
+def dumps(obj: Any,
+          sort_keys: bool = False,
+          separators: Optional[Tuple[str, str]] = None, *,
+          indent: bool = True) -> str:
     """Serializes a Python object to a JSON-encoded string.
 
     By default, this function supports serializing NumPy arrays, which Python's json module does not.
@@ -33,7 +36,7 @@ def dumps(obj: Any, sort_keys: bool = False, separators: Optional[Tuple[str, str
     if sort_keys:
         opts |= orjson.OPT_SORT_KEYS
 
-    # flag for pretty printing json
+    # flag for pretty-printing with indentation
     if indent:
         opts |= orjson.OPT_INDENT_2
 

--- a/nicegui/json/orjson_wrapper.py
+++ b/nicegui/json/orjson_wrapper.py
@@ -14,7 +14,7 @@ except ImportError:
 ORJSON_OPTS = orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NON_STR_KEYS
 
 
-def dumps(obj: Any, sort_keys: bool = False, separators: Optional[Tuple[str, str]] = None):
+def dumps(obj: Any, sort_keys: bool = False, separators: Optional[Tuple[str, str]] = None, indent: bool = True):
     """Serializes a Python object to a JSON-encoded string.
 
     By default, this function supports serializing NumPy arrays, which Python's json module does not.
@@ -32,6 +32,10 @@ def dumps(obj: Any, sort_keys: bool = False, separators: Optional[Tuple[str, str
     # flag for sorting by object keys
     if sort_keys:
         opts |= orjson.OPT_SORT_KEYS
+
+    # flag for pretty printing json
+    if indent:
+        opts |= orjson.OPT_INDENT_2
 
     return orjson.dumps(obj, option=opts, default=_orjson_converter).decode('utf-8')
 

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -49,7 +49,7 @@ class ReadOnlyDict(MutableMapping):
 
 class PersistentDict(observables.ObservableDict):
 
-    def __init__(self, filepath: Path, encoding: Optional[str] = None, *, indent: bool = True) -> None:
+    def __init__(self, filepath: Path, encoding: Optional[str] = None, *, indent: bool = False) -> None:
         self.filepath = filepath
         self.encoding = encoding
         self.indent = indent

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -49,9 +49,10 @@ class ReadOnlyDict(MutableMapping):
 
 class PersistentDict(observables.ObservableDict):
 
-    def __init__(self, filepath: Path, encoding: Optional[str] = None) -> None:
+    def __init__(self, filepath: Path, encoding: Optional[str] = None, indent: bool = True) -> None:
         self.filepath = filepath
         self.encoding = encoding
+        self.indent = indent
         try:
             data = json.loads(filepath.read_text(encoding)) if filepath.exists() else {}
         except Exception:
@@ -68,7 +69,7 @@ class PersistentDict(observables.ObservableDict):
 
         async def backup() -> None:
             async with aiofiles.open(self.filepath, 'w', encoding=self.encoding) as f:
-                await f.write(json.dumps(self))
+                await f.write(json.dumps(self, indent=self.indent))
         if core.loop:
             background_tasks.create_lazy(backup(), name=self.filepath.stem)
         else:

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -49,7 +49,7 @@ class ReadOnlyDict(MutableMapping):
 
 class PersistentDict(observables.ObservableDict):
 
-    def __init__(self, filepath: Path, encoding: Optional[str] = None, indent: bool = True) -> None:
+    def __init__(self, filepath: Path, encoding: Optional[str] = None, *, indent: bool = True) -> None:
         self.filepath = filepath
         self.encoding = encoding
         self.indent = indent

--- a/website/documentation/content/storage_documentation.py
+++ b/website/documentation/content/storage_documentation.py
@@ -152,3 +152,10 @@ def short_term_memory():
         ui.button('Update content',
                   on_click=lambda: cache.update(count=cache['count'] + 1))
         ui.button('Reload page', on_click=ui.navigate.reload)
+
+
+doc.text('Indentation', '''
+    By default, the general and user storage data is stored in JSON format without indentation.
+    You can change this to an indentation of 2 spaces by setting
+    `app.storage.general.indent = True` or `app.storage.user.indent = True`.
+''')


### PR DESCRIPTION
Added a boolean flag to `PersistentDict`, and modified the json wrappers to allow either a 2 space indent, or no indent at all.

Relevant discussion here: https://github.com/zauberzeug/nicegui/discussions/3367