### PR TITLE
Restrict access to all routes (except /_nicegui)

### DIFF
--- a/examples/authentication/main.py
+++ b/examples/authentication/main.py
@@ -11,7 +11,7 @@ from fastapi import Request
 from fastapi.responses import RedirectResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from nicegui import Client, app, ui
+from nicegui import app, ui
 
 # in reality users passwords would obviously need to be hashed
 passwords = {'user1': 'pass1', 'user2': 'pass2'}
@@ -27,7 +27,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         if not app.storage.user.get('authenticated', False):
-            if request.url.path in Client.page_routes.values() and request.url.path not in unrestricted_page_routes:
+            if not request.url.path.startswith('/_nicegui') and request.url.path not in unrestricted_page_routes:
                 app.storage.user['referrer_path'] = request.url.path  # remember where the user wanted to go
                 return RedirectResponse('/login')
         return await call_next(request)


### PR DESCRIPTION
This PR is inspired by #3403 and implements a more restricted behaviour for the authentication middleware.