### PR TITLE
docs: say browser session cookie is "signed", not "encrypted"

### DIFF
--- a/website/documentation/content/storage_documentation.py
+++ b/website/documentation/content/storage_documentation.py
@@ -41,7 +41,7 @@ doc.title('Storage')
 
     The user storage and browser storage are only available within `page builder functions </documentation/page>`_
     because they are accessing the underlying `Request` object from FastAPI.
-    Additionally these two types require the `storage_secret` parameter in`ui.run()` to encrypt the browser session cookie.
+    Additionally these two types require the `storage_secret` parameter in`ui.run()` to sign the browser session cookie.
 
     | Storage type                | `tab`  | `client` | `user` | `general` | `browser` |
     |-----------------------------|--------|----------|--------|-----------|-----------|


### PR DESCRIPTION
Trying to be more precise to head off confusion from https://www.reddit.com/r/nicegui/comments/1dub9iw/nicegui_appstorage_is_not_encrypted/