### PR TITLE
Support raising to override messages of ValidationElement

### DIFF
--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -41,8 +41,12 @@ class ValidationElement(ValueElement):
             return self.error is None
 
         for message, check in self.validation.items():
-            if not check(self.value):
-                self.error = message
+            try:
+                if not check(self.value):
+                    self.error = message
+                    return False
+            except (ValueError, AssertionError) as error:
+                self.error = str(error)
                 return False
 
         self.error = None

--- a/website/documentation/content/input_documentation.py
+++ b/website/documentation/content/input_documentation.py
@@ -46,11 +46,21 @@ def styling():
     You can validate the input in two ways:
 
     - by passing a callable that returns an error message or `None`, or
-    - by passing a dictionary that maps error messages to callables that return `True` if the input is valid.
+    - by passing a dictionary that maps error messages to callables that return `True` if the input is valid, or raise
+    ValueError or AssertionError to take control on the message to display.
 ''')
 def validation():
     ui.input('Name', validation=lambda value: 'Too short' if len(value) < 5 else None)
-    ui.input('Name', validation={'Too short': lambda value: len(value) >= 5})
+
+    def runtime_message(s: str):
+        if len(s) > 10:
+            raise ValueError('Too long')
+        return True
+
+    ui.input('Name', validation={
+        'Too short': lambda value: len(value) >= 5,
+        'Error message delegated to function': runtime_message
+    })
 
 
 doc.reference(ui.input)


### PR DESCRIPTION
This change aims to delegate the control of the error message to the validation functions.
This change preserve backward compatibility, while allowing to share behavior between pydantic or FastAPI endpoints [1] and NiceGUI.

[1] https://docs.pydantic.dev/2.8/concepts/validators/