### PR TITLE
Fix Quasar's layout rules for `ui.card` that remove children's borders and shadows

### DIFF
--- a/nicegui/elements/card.py
+++ b/nicegui/elements/card.py
@@ -16,10 +16,9 @@ class Card(Element):
         It provides a container with a dropped shadow.
 
         Note:
-        There are subtle differences between the Quasar component and this element.
-        In contrast to this element, the original QCard has no padding by default and hides outer borders of nested elements.
+        In contrast to this element,
+        the original QCard has no padding by default and hides outer borders and shadows of nested elements.
         If you want the original behavior, use the `tight` method.
-        If you want the padding and borders for nested children, move the children into another container.
 
         :param align_items: alignment of the items in the card (default: `None`)
         """

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -383,3 +383,13 @@ function createApp(elements, options) {
     config: options.quasarConfig,
   }));
 }
+
+// HACK: remove Quasar's rules for divs in QCard (#2265, #2301)
+for (let sheet of document.styleSheets) {
+  if (!/\/quasar(?:\.prod)?\.css$/.test(sheet.href)) continue;
+  for (let i = sheet.cssRules.length - 1; i >= 0; i--) {
+    if (/\.q-card > div/.test(sheet.cssRules[i].selectorText)) {
+      sheet.deleteRule(i);
+    }
+  }
+}

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -386,10 +386,9 @@ function createApp(elements, options) {
 
 // HACK: remove Quasar's rules for divs in QCard (#2265, #2301)
 for (let sheet of document.styleSheets) {
-  if (!/\/quasar(?:\.prod)?\.css$/.test(sheet.href)) continue;
-  for (let i = sheet.cssRules.length - 1; i >= 0; i--) {
-    if (/\.q-card > div/.test(sheet.cssRules[i].selectorText)) {
-      sheet.deleteRule(i);
+  if (/\/quasar(?:\.prod)?\.css$/.test(sheet.href)) {
+    for (let rule of sheet.cssRules) {
+      if (/\.q-card > div/.test(rule.selectorText)) rule.selectorText = ".nicegui-card-tight" + rule.selectorText;
     }
   }
 }

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -1,0 +1,13 @@
+from nicegui import ui
+from nicegui.testing import Screen
+
+
+def test_preserve_borders(screen: Screen):
+    with ui.card():
+        ui.label('A').classes('border shadow')
+    with ui.card().tight():
+        ui.label('B').classes('border shadow')
+
+    screen.open('/')
+    assert screen.find('A').value_of_css_property('border') == '1px solid rgb(229, 231, 235)'
+    assert screen.find('B').value_of_css_property('border') == '0px none rgb(0, 0, 0)'

--- a/website/documentation/content/card_documentation.py
+++ b/website/documentation/content/card_documentation.py
@@ -14,25 +14,21 @@ def main_demo() -> None:
 @doc.demo('Card without shadow', '''
     You can remove the shadow from a card by adding the `no-shadow` class.
     The following demo shows a 1 pixel wide border instead.
+
+    Alternatively, you can use Quasar's "flat" and "bordered" props to achieve the same effect.
 ''')
 def card_without_shadow() -> None:
     with ui.card().classes('no-shadow border-[1px]'):
         ui.label('See, no shadow!')
 
+    with ui.card().props('flat bordered'):
+        ui.label('Also no shadow!')
 
-@doc.demo('The issue with nested borders', '''
-    The following example shows a table nested in a card.
-    Cards have a default padding in NiceGUI, so the table is not flush with the card's border.
-    The table has the `flat` and `bordered` props set, so it should have a border.
-    However, due to the way QCard is designed, the border is not visible (first card).
-    There are two ways to fix this:
 
-    - To get the original QCard behavior, use the `tight` method (second card).
-        It removes the padding and the table border collapses with the card border.
-
-    - To preserve the padding _and_ the table border, move the table into another container like a `ui.row` (third card).
-
-    See https://github.com/zauberzeug/nicegui/issues/726 for more information.
+@doc.demo('Tight card layout', '''
+    By default, cards have a padding.
+    You can remove the padding and gaps between nested elements by using the `tight` method.
+    This also hides outer borders and shadows of nested elements, like in an original QCard.
 ''')
 def custom_context_menu() -> None:
     columns = [{'name': 'age', 'label': 'Age', 'field': 'age'}]
@@ -44,10 +40,6 @@ def custom_context_menu() -> None:
 
         with ui.card().tight():
             ui.table(columns, rows).props('flat bordered')
-
-        with ui.card():
-            with ui.row():
-                ui.table(columns, rows).props('flat bordered')
 
 
 doc.reference(ui.card)


### PR DESCRIPTION
Quasar's QCard is the base for `ui.card`. But in the early days of NiceGUI we decided to set a default gap and padding, so that you don't need to wrap content in card sections. If you do need Quasar's original tight layout, you can call `.tight()`.

But this decision caused quite some trouble, because Quasar keeps removing borders and shadows of child elements, which makes sense for the tight layout without padding, but not with NiceGUI's default card style (#726, #1295, #2265, #2301). We already planned to introduce a new `ui.box` element to avoid confusion between both behaviors, which would have caused a _major_ breaking change.

Now I finally found a rather neat solution to change Quasar's CSS rules to apply to tight cards only. In my point of view, this is exactly what we needed. I just didn't think of the possibility to manipulate existing rules using JavaScript, which turned out to be pretty easy and powerful.

With this change, the following cards behave as expected:
```py
with ui.card():
    ui.label('Borders and shadows').classes('border shadow')
    ui.label('of child divs').classes('border shadow')
    ui.label('are preserved').classes('border shadow')

with ui.card().tight():
    ui.label('Borders and shadows').classes('border shadow')
    ui.label('of child divs').classes('border shadow')
    ui.label('are removed').classes('border shadow')
```

![Screenshot 2024-08-06 at 10 16 03](https://github.com/user-attachments/assets/9e3c6622-0103-4a36-ac47-558546c1e651)

Old behavior for reference:

![Screenshot 2024-08-06 at 10 16 57](https://github.com/user-attachments/assets/75230495-055a-4efb-94eb-886dc9344be4)

Open tasks:

- [x] add pytest to avoid regression when updating Quasar
- [x] update documentation
