### PR TITLE
Client ip

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -90,8 +90,9 @@ class Client:
 
     @property
     def ip(self) -> Optional[str]:
-        """Return the IP address of the client, or None if the client is not connected."""
-        return self.environ['asgi.scope']['client'][0] if self.environ else None  # pylint: disable=unsubscriptable-object
+        """Return the IP address of the client, or None if it is an
+        `auto-index page <https://nicegui.io/documentation/section_pages_routing#auto-index_page>`_."""
+        return self.request.client.host if self.request is not None and self.request.client is not None else None
 
     @property
     def has_socket_connection(self) -> bool:

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -313,3 +313,12 @@ def test_reconnecting_without_page_reload(screen: Screen):
     screen.wait(2.0)
     element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
     assert element.get_attribute('value') == 'hello', 'input should be preserved after reconnect (i.e. no page reload)'
+
+
+def test_ip(screen: Screen):
+    @ui.page('/')
+    def page():
+        ui.label(ui.context.client.ip or 'unknown')
+
+    screen.open('/')
+    screen.should_contain('127.0.0.1')

--- a/website/documentation/content/page_documentation.py
+++ b/website/documentation/content/page_documentation.py
@@ -48,7 +48,6 @@ def wait_for_connected_demo():
         await ui.context.client.connected()
         await asyncio.sleep(2)
         ui.label('This text is displayed 2 seconds after the page has been fully loaded.')
-        ui.label(f'The IP address {ui.context.client.ip} was obtained from the websocket.')
 
     ui.link('wait for connection', wait_for_connection)
 


### PR DESCRIPTION
This PR implements the proposal from #3287, getting the client's IP from `request` even before the socket connection is established. For the auto-index client, the IP is `None`.