### PR TITLE
Reserve bottom space for error message

### DIFF
--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -12,6 +12,7 @@ class ValidationElement(ValueElement):
         self._auto_validation = True
         self._error: Optional[str] = None
         super().__init__(**kwargs)
+        self._props['error'] = False  # NOTE: reserve bottom space for error message
 
     @property
     def error(self) -> Optional[str]:


### PR DESCRIPTION
This PR follows the previous discussions in #2484, #2492, #2738, and #3013 to initialize the "error" prop of validation elements to avoid them to resize when error messages appear while typing.

Demonstration:
```py
ui.input('Name', validation={'Too short': lambda value: len(value) >= 3}).classes('border')
```
The bottom space is right there when loading the page.
