### PR TITLE
Fix JavaScript error caused by new `ui.notify`

### DIFF
--- a/nicegui/functions/notify.py
+++ b/nicegui/functions/notify.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal, Optional, Union
 
-from ..elements.notification import Notification
+from ..context import context
 
 ARG_MAP = {
     'close_button': 'closeBtn',
@@ -49,4 +49,5 @@ def notify(message: Any, *,
     options = {ARG_MAP.get(key, key): value for key, value in locals().items() if key != 'kwargs' and value is not None}
     options['message'] = str(message)
     options.update(kwargs)
-    Notification(options=options)
+    client = context.client
+    client.outbox.enqueue_message('notify', options, client.id)

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -358,6 +358,7 @@ function createApp(elements, options) {
           window.open(url, target);
         },
         download: (msg) => download(msg.src, msg.filename, msg.media_type, options.prefix),
+        notify: (msg) => Quasar.Notify.create(msg),
       };
       const socketMessageQueue = [];
       let isProcessingSocketMessage = false;

--- a/nicegui/testing/plugin.py
+++ b/nicegui/testing/plugin.py
@@ -14,6 +14,7 @@ from starlette.routing import Route
 import nicegui.storage
 from nicegui import Client, app, binding, core, run, ui
 from nicegui.functions.navigate import Navigate
+from nicegui.functions.notify import notify
 from nicegui.page import page
 
 from .screen import Screen
@@ -143,6 +144,7 @@ async def user(nicegui_reset_globals,  # pylint: disable=unused-argument
         async with httpx.AsyncClient(app=core.app, base_url='http://test') as client:
             yield User(client)
     ui.navigate = Navigate()
+    ui.notify = notify
 
 
 @pytest.fixture
@@ -155,6 +157,7 @@ async def create_user(nicegui_reset_globals,  # pylint: disable=unused-argument
     async with core.app.router.lifespan_context(core.app):
         yield lambda: User(httpx.AsyncClient(app=core.app, base_url='http://test'))
     ui.navigate = Navigate()
+    ui.notify = notify
 
 
 @pytest.fixture()

--- a/nicegui/testing/user_notify.py
+++ b/nicegui/testing/user_notify.py
@@ -1,0 +1,14 @@
+from typing import Any, List
+
+
+class UserNotify:
+
+    def __init__(self) -> None:
+        self.messages: List[str] = []
+
+    def __call__(self, message: str, **kwargs) -> None:
+        self.messages.append(message)
+
+    def contains(self, needle: Any) -> bool:
+        """Check if any of the messages contain the given substring."""
+        return isinstance(needle, str) and any(needle in message for message in self.messages)


### PR DESCRIPTION
This PR solves the JavaScript error and memory leak reported in #3454 when using `ui.notify`, which creates a `ui.notification` elements since PR #3121.

As it turned out, there is an important difference between `ui.notify` and `ui.notification` which is why this PR reverts `ui.notify` back to calling a Quasar function instead of creating an element: `ui.notify` allows grouping of multiple identical notifications, while `ui.notification` creates new popups each time. Therefore it is impractical to replace one with another, causing errors and memory leaks.

Besides reverting `ui.notify`, this PR introduces a new `UserNotify` class to simulate notifications for `user` tests. It doesn't simulate durations or dismiss buttons - the notifications simply remain "visible" -, but that should be ok for now and can be extended later.