### PR TITLE
Allow filtering nodes in `ui.tree`

### DIFF
--- a/nicegui/elements/tree.py
+++ b/nicegui/elements/tree.py
@@ -78,21 +78,19 @@ class Tree(Element):
         self._select_handlers.append(callback)
         return self
 
-    def select(self, node_key: Optional[str] = None) -> Self:
+    def select(self, node_key: Optional[str]) -> Self:
         """Select the given node.
 
-        :param node_key: node key string to select (default: do nothing)
+        :param node_key: node key to select
         """
-        if node_key:
+        if self._props['selected'] != node_key:
             self._props['selected'] = node_key
             self.update()
         return self
 
     def deselect(self) -> Self:
-        """Remove node selection if any selected."""
-        self._props['selected'] = None
-        self.update()
-        return self
+        """Remove node selection."""
+        return self.select(None)
 
     def on_expand(self, callback: Callable[..., Any]) -> Self:
         """Add a callback to be invoked when the expansion changes."""
@@ -107,7 +105,7 @@ class Tree(Element):
     def tick(self, node_keys: Optional[List[str]] = None) -> Self:
         """Tick the given nodes.
 
-        :param node_keys: list of node keys to tick (default: all nodes)
+        :param node_keys: list of node keys to tick or ``None`` to tick all nodes (default: ``None``)
         """
         self._props['ticked'][:] = self._find_node_keys(node_keys).union(self._props['ticked'])
         self.update()
@@ -116,10 +114,9 @@ class Tree(Element):
     def untick(self, node_keys: Optional[List[str]] = None) -> Self:
         """Remove tick from the given nodes.
 
-        :param node_keys: list of node keys to untick (default: none of the nodes)
+        :param node_keys: list of node keys to untick or ``None`` to untick all nodes (default: ``None``)
         """
-        self._props['ticked'][:] = set(self._props['ticked']).difference(
-            self._find_node_keys(node_keys).intersection(self._props['ticked']))
+        self._props['ticked'][:] = set(self._props['ticked']).difference(self._find_node_keys(node_keys))
         self.update()
         return self
 

--- a/nicegui/elements/tree.py
+++ b/nicegui/elements/tree.py
@@ -41,7 +41,7 @@ class Tree(Element):
         self._props['node-key'] = node_key
         self._props['label-key'] = label_key
         self._props['children-key'] = children_key
-        self._props['selected'] = []
+        self._props['selected'] = None
         self._props['expanded'] = []
         self._props['ticked'] = []
         if tick_strategy is not None:
@@ -76,6 +76,22 @@ class Tree(Element):
     def on_select(self, callback: Callable[..., Any]) -> Self:
         """Add a callback to be invoked when the selection changes."""
         self._select_handlers.append(callback)
+        return self
+
+    def select(self, node_key: Optional[str] = None) -> Self:
+        """Select the given node.
+
+        :param node_key: node key string to select (default: do nothing)
+        """
+        if node_key:
+            self._props['selected'] = node_key
+            self.update()
+        return self
+
+    def deselect(self) -> Self:
+        """Remove node selection if any selected."""
+        self._props['selected'] = None
+        self.update()
         return self
 
     def on_expand(self, callback: Callable[..., Any]) -> Self:

--- a/nicegui/elements/tree.py
+++ b/nicegui/elements/tree.py
@@ -3,11 +3,11 @@ from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Set
 from typing_extensions import Self
 
 from .. import helpers
-from ..element import Element
 from ..events import GenericEventArguments, ValueChangeEventArguments, handle_event
+from .mixins.filter_element import FilterElement
 
 
-class Tree(Element):
+class Tree(FilterElement):
 
     def __init__(self,
                  nodes: List[Dict], *,
@@ -36,7 +36,7 @@ class Tree(Element):
         :param on_tick: callback which is invoked when a node is ticked or unticked
         :param tick_strategy: whether and how to use checkboxes ("leaf", "leaf-filtered" or "strict"; default: ``None``)
         """
-        super().__init__('q-tree')
+        super().__init__(tag='q-tree', filter=None)
         self._props['nodes'] = nodes
         self._props['node-key'] = node_key
         self._props['label-key'] = label_key

--- a/nicegui/elements/tree.py
+++ b/nicegui/elements/tree.py
@@ -116,7 +116,7 @@ class Tree(Element):
     def untick(self, node_keys: Optional[List[str]] = None) -> Self:
         """Remove tick from the given nodes.
 
-        :param node_keys: list of node keys to untick (default: all nodes)
+        :param node_keys: list of node keys to untick (default: none of the nodes)
         """
         self._props['ticked'][:] = set(self._props['ticked']).difference(
             self._find_node_keys(node_keys).intersection(self._props['ticked']))

--- a/nicegui/elements/tree.py
+++ b/nicegui/elements/tree.py
@@ -104,6 +104,25 @@ class Tree(Element):
         self._tick_handlers.append(callback)
         return self
 
+    def tick(self, node_keys: Optional[List[str]] = None) -> Self:
+        """Tick the given nodes.
+
+        :param node_keys: list of node keys to tick (default: all nodes)
+        """
+        self._props['ticked'][:] = self._find_node_keys(node_keys).union(self._props['ticked'])
+        self.update()
+        return self
+
+    def untick(self, node_keys: Optional[List[str]] = None) -> Self:
+        """Remove tick from the given nodes.
+
+        :param node_keys: list of node keys to untick (default: all nodes)
+        """
+        self._props['ticked'][:] = set(self._props['ticked']).difference(
+            self._find_node_keys(node_keys).intersection(self._props['ticked']))
+        self.update()
+        return self
+
     def expand(self, node_keys: Optional[List[str]] = None) -> Self:
         """Expand the given nodes.
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -62,3 +62,20 @@ def test_expand_and_collapse_nodes(screen: Screen):
     screen.should_not_contain('2')
     screen.should_contain('A')
     screen.should_contain('B')
+
+
+def test_select_deselect_node(screen: Screen):
+    tree = ui.tree([
+        {'id': 'numbers', 'children': [{'id': '1'}, {'id': '2'}]},
+        {'id': 'letters', 'children': [{'id': 'A'}, {'id': 'B'}]},
+    ], label_key='id')
+
+    ui.button('Select number', on_click=lambda: tree.select('2'))
+    ui.button('Deselect number', on_click=lambda: tree.deselect())
+
+    screen.open('/')
+    screen.click('Select number')
+    assert tree._props['selected'] == '2'
+
+    screen.click('Deselect number')
+    assert tree._props['selected'] is None

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -108,3 +108,20 @@ def test_tick_untick_node_or_nodes(screen: Screen):
 
     screen.click('Untick all')
     screen.should_contain('Ticked: []')
+
+
+def test_filter(screen: Screen):
+    t = ui.tree([
+        {'id': 'fruits', 'children': [{'id': 'Apple'}, {'id': 'Banana'}, {'id': 'Cherry'}]},
+    ], label_key='id', tick_strategy='leaf-filtered').expand()
+    ui.button('Filter', on_click=lambda: t.set_filter('a'))
+
+    screen.open('/')
+    screen.should_contain('Apple')
+    screen.should_contain('Banana')
+    screen.should_contain('Cherry')
+
+    screen.click('Filter')
+    screen.should_contain('Apple')
+    screen.should_contain('Banana')
+    screen.should_not_contain('Cherry')

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -79,3 +79,39 @@ def test_select_deselect_node(screen: Screen):
 
     screen.click('Deselect number')
     assert tree._props['selected'] is None
+
+
+def test_tick_untick_node_or_nodes(screen: Screen):
+    tree = ui.tree([
+        {'id': 'numbers', 'children': [{'id': '1'}, {'id': '2'}]},
+        {'id': 'letters', 'children': [{'id': 'A'}, {'id': 'B'}]},
+    ], label_key='id', tick_strategy='leaf')
+
+    ui.button('Tick some', on_click=lambda: tree.tick(['1', '2', 'B']))
+    ui.button('Untick some', on_click=lambda: tree.untick(['1', 'B']))
+    ui.button('Tick all', on_click=tree.tick)
+    ui.button('Untick all', on_click=tree.untick)
+
+    screen.open('/')
+    tree.expand()
+    screen.wait(0.5)
+
+    screen.click('Tick some')
+    screen.wait(0.5)
+    assert len(tree._props['ticked']) == len(['1', '2', 'B'])
+    assert all(a == b for a, b in zip(sorted(tree._props['ticked']), sorted(['1', '2', 'B'])))
+
+    screen.click('Untick some')
+    screen.wait(0.5)
+    assert len(tree._props['ticked']) == len(['2'])
+    assert all(a == b for a, b in zip(tree._props['ticked'], ['2']))
+
+    screen.click('Tick all')
+    screen.wait(0.5)
+    assert len(tree._props['ticked']) == len(['numbers', '1', '2', 'letters', 'A', 'B'])
+    assert all(a == b for a, b in zip(sorted(tree._props['ticked']),
+               sorted(['numbers', '1', '2', 'letters', 'A', 'B'])))
+
+    screen.click('Untick all')
+    screen.wait(0.5)
+    assert len(tree._props['ticked']) == 0

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -70,15 +70,16 @@ def test_select_deselect_node(screen: Screen):
         {'id': 'letters', 'children': [{'id': 'A'}, {'id': 'B'}]},
     ], label_key='id')
 
-    ui.button('Select number', on_click=lambda: tree.select('2'))
-    ui.button('Deselect number', on_click=lambda: tree.deselect())
+    ui.button('Select', on_click=lambda: tree.select('2'))
+    ui.button('Deselect', on_click=tree.deselect)
+    ui.label().bind_text_from(tree._props, 'selected', lambda x: f'Selected: {x}')
 
     screen.open('/')
-    screen.click('Select number')
-    assert tree._props['selected'] == '2'
+    screen.click('Select')
+    screen.should_contain('Selected: 2')
 
-    screen.click('Deselect number')
-    assert tree._props['selected'] is None
+    screen.click('Deselect')
+    screen.should_contain('Selected: None')
 
 
 def test_tick_untick_node_or_nodes(screen: Screen):
@@ -91,27 +92,19 @@ def test_tick_untick_node_or_nodes(screen: Screen):
     ui.button('Untick some', on_click=lambda: tree.untick(['1', 'B']))
     ui.button('Tick all', on_click=tree.tick)
     ui.button('Untick all', on_click=tree.untick)
+    ui.label().bind_text_from(tree._props, 'ticked', lambda x: f'Ticked: {sorted(x)}')
 
     screen.open('/')
-    tree.expand()
-    screen.wait(0.5)
+    screen.should_contain('Ticked: []')
 
     screen.click('Tick some')
-    screen.wait(0.5)
-    assert len(tree._props['ticked']) == len(['1', '2', 'B'])
-    assert all(a == b for a, b in zip(sorted(tree._props['ticked']), sorted(['1', '2', 'B'])))
+    screen.should_contain("Ticked: ['1', '2', 'B']")
 
     screen.click('Untick some')
-    screen.wait(0.5)
-    assert len(tree._props['ticked']) == len(['2'])
-    assert all(a == b for a, b in zip(tree._props['ticked'], ['2']))
+    screen.should_contain("Ticked: ['2']")
 
     screen.click('Tick all')
-    screen.wait(0.5)
-    assert len(tree._props['ticked']) == len(['numbers', '1', '2', 'letters', 'A', 'B'])
-    assert all(a == b for a, b in zip(sorted(tree._props['ticked']),
-               sorted(['numbers', '1', '2', 'letters', 'A', 'B'])))
+    screen.should_contain("Ticked: ['1', '2', 'A', 'B', 'letters', 'numbers']")
 
     screen.click('Untick all')
-    screen.wait(0.5)
-    assert len(tree._props['ticked']) == 0
+    screen.should_contain('Ticked: []')

--- a/website/documentation/content/tree_documentation.py
+++ b/website/documentation/content/tree_documentation.py
@@ -69,7 +69,7 @@ def select_programmatically():
     t = ui.tree([
         {'id': 'numbers', 'children': [{'id': '1'}, {'id': '2'}]},
         {'id': 'letters', 'children': [{'id': 'A'}, {'id': 'B'}]},
-    ], label_key='id', tick_strategy='leaf').expand()
+    ], label_key='id').expand()
 
     with ui.row():
         ui.button('Select A', on_click=lambda: t.select('A'))

--- a/website/documentation/content/tree_documentation.py
+++ b/website/documentation/content/tree_documentation.py
@@ -35,7 +35,17 @@ def tree_with_custom_header_and_body():
     ''')
 
 
-@doc.demo('Expand and collapse programmatically', '''
+@doc.demo('Tree with checkboxes', '''
+    The tree can be used with checkboxes by setting the "tick-strategy" prop.
+''')
+def tree_with_checkboxes():
+    ui.tree([
+        {'id': 'A', 'children': [{'id': 'A1'}, {'id': 'A2'}]},
+        {'id': 'B', 'children': [{'id': 'B1'}, {'id': 'B2'}]},
+    ], label_key='id', tick_strategy='leaf', on_tick=lambda e: ui.notify(e.value))
+
+
+@doc.demo('Expand/collapse programmatically', '''
     The whole tree or individual nodes can be toggled programmatically using the `expand()` and `collapse()` methods.
     This even works if a node is disabled (e.g. not clickable by the user).
 ''')
@@ -52,34 +62,36 @@ def expand_programmatically():
         ui.button('- A', on_click=lambda: t.collapse(['A']))
 
 
-@doc.demo('Tree with checkboxes', '''
-    The tree can be used with checkboxes by setting the "tick-strategy" prop.
+@doc.demo('Select/deselect programmatically', '''
+    You can select or deselect nodes with the `select()` and `deselect()` methods.
 ''')
-def tree_with_checkboxes():
-    ui.tree([
-        {'id': 'A', 'children': [{'id': 'A1'}, {'id': 'A2'}]},
-        {'id': 'B', 'children': [{'id': 'B1'}, {'id': 'B2'}]},
-    ], label_key='id', tick_strategy='leaf', on_tick=lambda e: ui.notify(e.value))
+def select_programmatically():
+    t = ui.tree([
+        {'id': 'numbers', 'children': [{'id': '1'}, {'id': '2'}]},
+        {'id': 'letters', 'children': [{'id': 'A'}, {'id': 'B'}]},
+    ], label_key='id', tick_strategy='leaf').expand()
 
-
-@doc.demo('Select/deselect or tick/untick programmatically', '''
-    Node label in tree can be selected or deselected with the `select()` and `deselect()` methods.
-    If enabled with "tick-strategy" prop then nodes can be ticked or unticked with the `tick()` and `untick()` methods.
-''')
-def select_or_tick_programmatically():
-    with ui.row():
-        t = ui.tree([
-            {'id': 'numbers', 'children': [{'id': '1'}, {'id': '2'}]},
-            {'id': 'letters', 'children': [{'id': 'A'}, {'id': 'B'}]},
-        ], label_key='id', tick_strategy='leaf').expand()
-        with ui.column():
-            ui.button('Tick 1, 2 & B', on_click=lambda: t.tick(['1', '2', 'B']))
-            ui.button('Untick 2 & B', on_click=lambda: t.untick(['2', 'B']))
-            ui.button('Tick all', on_click=t.tick)
-            ui.button('Untick all', on_click=t.untick)
     with ui.row():
         ui.button('Select A', on_click=lambda: t.select('A'))
         ui.button('Deselect A', on_click=t.deselect)
+
+
+@doc.demo('Tick/untick programmatically', '''
+    After setting a `tick_strategy`, you can tick or untick nodes with the `tick()` and `untick()` methods.
+    You can either specify a list of node keys or `None` to tick or untick all nodes.
+''')
+def tick_programmatically():
+    t = ui.tree([
+        {'id': 'numbers', 'children': [{'id': '1'}, {'id': '2'}]},
+        {'id': 'letters', 'children': [{'id': 'A'}, {'id': 'B'}]},
+    ], label_key='id', tick_strategy='leaf').expand()
+
+    with ui.row():
+        ui.button('Tick 1, 2 and B', on_click=lambda: t.tick(['1', '2', 'B']))
+        ui.button('Untick 2 and B', on_click=lambda: t.untick(['2', 'B']))
+    with ui.row():
+        ui.button('Tick all', on_click=t.tick)
+        ui.button('Untick all', on_click=t.untick)
 
 
 doc.reference(ui.tree)

--- a/website/documentation/content/tree_documentation.py
+++ b/website/documentation/content/tree_documentation.py
@@ -62,4 +62,24 @@ def tree_with_checkboxes():
     ], label_key='id', tick_strategy='leaf', on_tick=lambda e: ui.notify(e.value))
 
 
+@doc.demo('Select/deselect or tick/untick programmatically', '''
+    Node label in tree can be selected or deselected with the `select()` and `deselect()` methods.
+    If enabled with "tick-strategy" prop then nodes can be ticked or unticked with the `tick()` and `untick()` methods.
+''')
+def select_or_tick_programmatically():
+    with ui.row():
+        t = ui.tree([
+            {'id': 'numbers', 'children': [{'id': '1'}, {'id': '2'}]},
+            {'id': 'letters', 'children': [{'id': 'A'}, {'id': 'B'}]},
+        ], label_key='id', tick_strategy='leaf').expand()
+        with ui.column():
+            ui.button('Tick 1, 2 & B', on_click=lambda: t.tick(['1', '2', 'B']))
+            ui.button('Untick 2 & B', on_click=lambda: t.untick(['2', 'B']))
+            ui.button('Tick all', on_click=t.tick)
+            ui.button('Untick all', on_click=t.untick)
+    with ui.row():
+        ui.button('Select A', on_click=lambda: t.select('A'))
+        ui.button('Deselect A', on_click=t.deselect)
+
+
 doc.reference(ui.tree)

--- a/website/documentation/content/tree_documentation.py
+++ b/website/documentation/content/tree_documentation.py
@@ -94,4 +94,16 @@ def tick_programmatically():
         ui.button('Untick all', on_click=t.untick)
 
 
+@doc.demo('Filter nodes', '''
+    You can filter nodes by setting the `filter` property.
+    The tree will only show nodes that match the filter.
+''')
+def filter_nodes():
+    t = ui.tree([
+        {'id': 'fruits', 'children': [{'id': 'Apple'}, {'id': 'Banana'}]},
+        {'id': 'vegetables', 'children': [{'id': 'Potato'}, {'id': 'Tomato'}]},
+    ], label_key='id').expand()
+    ui.input('filter').bind_value_to(t, 'filter')
+
+
 doc.reference(ui.tree)


### PR DESCRIPTION
Inspired by https://github.com/zauberzeug/nicegui/discussions/3436#discussioncomment-10297039, this PR adds the `FilterElement` mixin to `ui.tree`. This allows to filter nodes by name.