### PR TITLE
Support ui.select elements for user simulation tests

### DIFF
--- a/nicegui/element_filter.py
+++ b/nicegui/element_filter.py
@@ -9,6 +9,8 @@ from .element import Element
 from .elements.mixins.content_element import ContentElement
 from .elements.mixins.source_element import SourceElement
 from .elements.mixins.text_element import TextElement
+from .elements.notification import Notification
+from .elements.select import Select
 
 T = TypeVar('T', bound=Element)
 
@@ -108,11 +110,17 @@ class ElementFilter(Generic[T]):
                     element._props.get('icon'),
                     element._props.get('placeholder'),
                     element._props.get('value'),
-                    element._props.get('options', {}).get('message'),
+                    element._props.get('options', {}).get('message') if isinstance(element, Notification) else '',
                     element.text if isinstance(element, TextElement) else None,
                     element.content if isinstance(element, ContentElement) else None,
                     element.source if isinstance(element, SourceElement) else None,
                 ) if content]
+                if isinstance(element, Select):
+                    options = {o['value']: o['label'] for o in element._props.get('options', [])}
+                    if element.shows_popup:
+                        element_contents.extend(options.values())
+                    else:
+                        element_contents.append(options.get(element.value, ''))
                 if any(all(needle not in str(haystack) for haystack in element_contents) for needle in self._contents):
                     continue
                 if any(needle in str(haystack) for haystack in element_contents for needle in self._exclude_content):

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -79,6 +79,10 @@ class Select(ValidationElement, ChoiceElement, DisableableElement, component='se
             self._props['input-debounce'] = 0
         self._props['multiple'] = multiple
         self._props['clearable'] = clearable
+        self.shows_popup = False
+        """Wether the options popup is currently shown."""
+        self.on('popup-show', lambda e: setattr(e.sender, 'shows_popup', True))
+        self.on('popup-hide', lambda e: setattr(e.sender, 'shows_popup', False))
 
     def _event_args_to_value(self, e: GenericEventArguments) -> Any:
         if self.multiple:

--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -177,7 +177,7 @@ class User:
             if not elements:
                 raise AssertionError('expected to find at least one ' +
                                      self._build_error_message(target, kind, marker, content))
-        return UserInteraction(self, elements)
+        return UserInteraction(self, elements, target)
 
     @property
     def current_layout(self) -> Element:

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -333,3 +333,20 @@ async def test_typing(user: User) -> None:
     _ = user.find('World').elements  # Set[ui.element]
     _ = user.find('Hello').elements  # Set[ui.element]
     _ = user.find('!').elements  # Set[ui.element]
+
+
+async def test_select(user: User) -> None:
+    ui.select(options=['A', 'B', 'C'], on_change=lambda e: ui.notify(f'Value: {e.value}'))
+
+    await user.open('/')
+    await user.should_not_see('A')
+    await user.should_not_see('B')
+    await user.should_not_see('C')
+    user.find(ui.select).click()
+    await user.should_see('B')
+    await user.should_see('C')
+    user.find('A').click()
+    await user.should_see('Value: A')
+    await user.should_see('A')
+    await user.should_not_see('B')
+    await user.should_not_see('C')


### PR DESCRIPTION
As @marcuslimdw described in #3486, the user simulation for integration tests fails with `ui.select` elements. This PR does not only fix the exception but also improves support for `ui.select` to allow actual selection via `user.find(...).click()`.