### PR TITLE
Fix events on hidden and disabled elements

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -274,7 +274,7 @@ class Client:
         """Forward an event to the corresponding element."""
         with self:
             sender = self.elements.get(msg['id'])
-            if sender is not None:
+            if sender is not None and not sender.is_ignoring_events:
                 msg['args'] = [None if arg is None else json.loads(arg) for arg in msg.get('args', [])]
                 if len(msg['args']) == 1:
                     msg['args'] = msg['args'][0]

--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -403,8 +403,6 @@ def handle_event(handler: Optional[Callable[..., Any]], arguments: EventArgument
 
         parent_slot: Union[Slot, nullcontext]
         if isinstance(arguments, UiEventArguments):
-            if arguments.sender.is_ignoring_events:
-                return
             parent_slot = arguments.sender.parent_slot or arguments.sender.client.layout.default_slot
         else:
             parent_slot = nullcontext()


### PR DESCRIPTION
This PR fixes issue #3522 by not ignoring _all_ events on hidden and disabled elements, but only those emitted from the client. This still prevents the user from manipulating the server state using the browser's developer tools, but allows handling server-side events.