### PR TITLE
Fix orbit controls of `ui.scene` after changing the camera's up vector

### DIFF
--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -85,7 +85,7 @@ export default {
     }
     this.look_at = new THREE.Vector3(0, 0, 0);
     this.camera.lookAt(this.look_at);
-    this.camera.up = new THREE.Vector3(this.camera_up[0], this.camera_up[1], this.camera_up[2]);
+    this.camera.up = new THREE.Vector3(0, 0, 1);
     this.camera.position.set(0, -3, 5);
 
     this.scene.add(new THREE.AmbientLight(0xffffff, 0.7 * Math.PI));

--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -397,6 +397,7 @@ export default {
     },
     move_camera(x, y, z, look_at_x, look_at_y, look_at_z, up_x, up_y, up_z, duration) {
       if (this.camera_tween) this.camera_tween.stop();
+      const camera_up_changed = up_x !== null || up_y !== null || up_z !== null;
       this.camera_tween = new TWEEN.Tween([
         this.camera.position.x,
         this.camera.position.y,
@@ -428,6 +429,12 @@ export default {
           this.look_at.set(p[6], p[7], p[8]);
           this.camera.lookAt(p[6], p[7], p[8]);
           this.controls.target.set(p[6], p[7], p[8]);
+        })
+        .onComplete(() => {
+          if (camera_up_changed) {
+            this.controls.dispose();
+            this.controls = new OrbitControls(this.camera, this.renderer.domElement);
+          }
         })
         .start();
     },

--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -85,7 +85,7 @@ export default {
     }
     this.look_at = new THREE.Vector3(0, 0, 0);
     this.camera.lookAt(this.look_at);
-    this.camera.up = new THREE.Vector3(0, 0, 1);
+    this.camera.up = new THREE.Vector3(this.camera_up[0], this.camera_up[1], this.camera_up[2]);
     this.camera.position.set(0, -3, 5);
 
     this.scene.add(new THREE.AmbientLight(0xffffff, 0.7 * Math.PI));

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -106,7 +106,6 @@ class Scene(Element,
         self.camera = camera or self.perspective_camera()
         self._props['camera_type'] = self.camera.type
         self._props['camera_params'] = self.camera.params
-        self._props['camera_up'] = [self.camera.up_x, self.camera.up_y, self.camera.up_z]
         self.objects: Dict[str, Object3D] = {}
         self.stack: List[Union[Object3D, SceneObject]] = [SceneObject()]
         self._click_handlers = [on_click] if on_click else []

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -106,6 +106,7 @@ class Scene(Element,
         self.camera = camera or self.perspective_camera()
         self._props['camera_type'] = self.camera.type
         self._props['camera_params'] = self.camera.params
+        self._props['camera_up'] = [self.camera.up_x, self.camera.up_y, self.camera.up_z]
         self.objects: Dict[str, Object3D] = {}
         self.stack: List[Union[Object3D, SceneObject]] = [SceneObject()]
         self._click_handlers = [on_click] if on_click else []


### PR DESCRIPTION
This PR solves the problem that scenes need to have their Z-Axis "upwards" in order to have working orbit controls. If one tries to manually move the camera with `scene.move_camera(up_z=-1)`, the orbit controls are not updated and the mouse-interaction gets weird.

PS: Thanks for creating and sharing this awesome library! 💪 