### PR TITLE
New style of joystick

### DIFF
--- a/nicegui/elements/joystick.vue
+++ b/nicegui/elements/joystick.vue
@@ -1,5 +1,5 @@
 <template>
-  <div><div></div></div>
+  <div class="nicegui-joystick"><div></div></div>
 </template>
 
 <script>
@@ -23,9 +23,8 @@ export default {
 
 <style scoped>
 :scope > div {
-  background-color: AliceBlue;
-  width: 10em;
-  height: 10em;
+  width: 100%;
+  height: 100%;
   position: relative;
 }
 </style>

--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -296,3 +296,7 @@ h6.q-timeline__title {
   position: absolute;
   left: 1.5em;
 }
+.nicegui-joystick {
+  width: 10em;
+  height: 10em;
+}

--- a/website/documentation/content/joystick_documentation.py
+++ b/website/documentation/content/joystick_documentation.py
@@ -7,7 +7,8 @@ from . import doc
 def main_demo() -> None:
     ui.joystick(color='blue', size=50,
                 on_move=lambda e: coordinates.set_text(f'{e.x:.3f}, {e.y:.3f}'),
-                on_end=lambda _: coordinates.set_text('0, 0'))
+                on_end=lambda _: coordinates.set_text('0, 0')
+                ).classes('bg-slate-400')
     coordinates = ui.label('0, 0')
 
 


### PR DESCRIPTION
Inspired by https://github.com/zauberzeug/nicegui/discussions/3531
Make styling joystick more easier.
We can customize the size and the dark mode background color of joystick by this way:
```python3
ui.joystick(color="red", size=50, mode="static").classes(
    "w-96 h-96 bg-red-100 dark:bg-green-100"
)
```
light mode:
<img width="240" src="https://github.com/user-attachments/assets/6b989b4d-3ddf-4171-8546-a7ef28cd5c82">
dark mode:
<img width="240" src="https://github.com/user-attachments/assets/efb33630-d1b5-4088-92ab-420884987e5d">

Note:
After this change, joystick will lose default background color. If you use it without any parameter or additional style, it is transparent.