### PR TITLE
Avoid importing pandas if not needed

### DIFF
--- a/nicegui/elements/aggrid.py
+++ b/nicegui/elements/aggrid.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Optional, cast
+import importlib.util
+from typing import TYPE_CHECKING, Dict, List, Optional, cast
 
 from typing_extensions import Self
 
@@ -6,11 +7,10 @@ from .. import optional_features
 from ..awaitable_response import AwaitableResponse
 from ..element import Element
 
-try:
-    import pandas as pd
+if importlib.util.find_spec('pandas'):
     optional_features.register('pandas')
-except ImportError:
-    pass
+    if TYPE_CHECKING:
+        import pandas as pd
 
 
 class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-community.min.js']):
@@ -59,6 +59,8 @@ class AgGrid(Element, component='aggrid.js', libraries=['lib/aggrid/ag-grid-comm
         :param options: dictionary of additional AG Grid options
         :return: AG Grid element
         """
+        import pandas as pd  # pylint: disable=import-outside-toplevel
+
         def is_special_dtype(dtype):
             return (pd.api.types.is_datetime64_any_dtype(dtype) or
                     pd.api.types.is_timedelta64_dtype(dtype) or

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Dict, List, Literal, Optional, Union
+import importlib.util
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Union
 
 from typing_extensions import Self
 
@@ -7,11 +8,10 @@ from ..element import Element
 from ..events import GenericEventArguments, TableSelectionEventArguments, ValueChangeEventArguments, handle_event
 from .mixins.filter_element import FilterElement
 
-try:
-    import pandas as pd
+if importlib.util.find_spec('pandas'):
     optional_features.register('pandas')
-except ImportError:
-    pass
+    if TYPE_CHECKING:
+        import pandas as pd
 
 
 class Table(FilterElement, component='table.js'):
@@ -110,6 +110,8 @@ class Table(FilterElement, component='table.js'):
         :param on_select: callback which is invoked when the selection changes
         :return: table element
         """
+        import pandas as pd  # pylint: disable=import-outside-toplevel
+
         def is_special_dtype(dtype):
             return (pd.api.types.is_datetime64_any_dtype(dtype) or
                     pd.api.types.is_timedelta64_dtype(dtype) or


### PR DESCRIPTION
This PR implements a suggestion from https://github.com/zauberzeug/nicegui/discussions/3533#discussioncomment-10394288 to only import pandas if typechecking or actually creating a table or AG Grid from a pandas dataframe.

The improvement can be tested running the following command:

```bash
python3 -X importtime -c 'import nicegui' 2>&1 | grep "nicegui.elements.table\|nicegui.elements.aggrid" 
```

The numbers are in microseconds. The cumulative time is reduced from around 150ms down to 3ms on my machine.

Because pandas must have been already imported when calling `from_pandas`, the nested import statement shouldn't add (almost) no extra cost.