### PR TITLE
Allow draggable groups

### DIFF
--- a/nicegui/elements/lib/three/modules/DragControls.js
+++ b/nicegui/elements/lib/three/modules/DragControls.js
@@ -334,12 +334,7 @@ function onPointerDown( event ) {
 
 			// look for the outermost group in the object's upper hierarchy
 
-			_selected = findGroup( _intersections[ 0 ].object );
-
-            // Use the object itself if no group was found
-            if ( !_selected ) {
-                _selected = _intersections[ 0 ].object;
-            }
+			_selected = findGroup( _intersections[ 0 ].object ) || _intersections[ 0 ].object;
 
 		} else {
 

--- a/nicegui/elements/lib/three/modules/DragControls.js
+++ b/nicegui/elements/lib/three/modules/DragControls.js
@@ -336,6 +336,11 @@ function onPointerDown( event ) {
 
 			_selected = findGroup( _intersections[ 0 ].object );
 
+            // Use the object itself if no group was found
+            if ( !_selected ) {
+                _selected = _intersections[ 0 ].object;
+            }
+
 		} else {
 
 			_selected = _intersections[ 0 ].object;

--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -145,6 +145,7 @@ export default {
     }
     this.controls = new OrbitControls(this.camera, this.renderer.domElement);
     this.drag_controls = new DragControls(this.draggable_objects, this.camera, this.renderer.domElement);
+    this.drag_controls.transformGroup = true;
     const applyConstraint = (constraint, position) => {
       if (!constraint) return;
       const [variable, expression] = constraint.split("=").map((s) => s.trim());

--- a/npm.py
+++ b/npm.py
@@ -131,6 +131,14 @@ for key, dependency in dependencies.items():
                 content = content.replace(MSG, 'BufferGeometryUtils')
                 newfile.write_text(content)
 
+            if 'DragControls.js' in filename:
+                content = newfile.read_text()
+                MSG = '_selected = findGroup( _intersections[ 0 ].object )'
+                if MSG not in content:
+                    raise ValueError(f'Expected to find "{MSG}" in {filename}')
+                content = content.replace(MSG, MSG + ' || _intersections[ 0 ].object')
+                newfile.write_text(content)
+
             if 'mermaid.esm.min.mjs' in filename:
                 content = newfile.read_text()
                 content = re.sub(r'"\./chunks/mermaid.esm.min/(.*?)\.mjs"', r'"\1"', content)


### PR DESCRIPTION
This PR allows groups to be draggable. Currently there is no effect when we call group.draggable().

As noted in the [documentation of DragControls](https://threejs.org/docs/#examples/en/controls/DragControls.transformGroup), this only works if the scene contains a single draggable group. This might lead to some confusion but ignoring the `.draggable()` call for groups is also confusing...😅 At least setting the `transformGroup` property to true only affects the behavior for groups and not for other objects.