### PR TITLE
Fix bug when opening/closing `ui.select` on air

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -140,10 +140,11 @@ class Air:
             if client_id not in Client.instances:
                 return
             client = Client.instances[client_id]
-            if data['msg']['args'] and data['msg']['args'][0].startswith('{"socket_id":'):
-                args = json.loads(data['msg']['args'][0])
-                args['socket_id'] = client_id  # HACK: translate socket_id of ui.scene's init event
-                data['msg']['args'][0] = json.dumps(args)
+            args = data['msg']['args']
+            if args and isinstance(args[0], str) and args[0].startswith('{"socket_id":'):
+                arg0 = json.loads(args[0])
+                arg0['socket_id'] = client_id  # HACK: translate socket_id of ui.scene's init event
+                args[0] = json.dumps(arg0)
             client.handle_event(data['msg'])
 
         @self.relay.on('javascript_response')

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -81,8 +81,8 @@ class Select(ValidationElement, ChoiceElement, DisableableElement, component='se
         self._props['clearable'] = clearable
 
         self._is_showing_popup = False
-        self.on('popup-show', lambda e: setattr(e.sender, '_is_showing_popup', True), args=[])
-        self.on('popup-hide', lambda e: setattr(e.sender, '_is_showing_popup', False), args=[])
+        self.on('popup-show', lambda e: setattr(e.sender, '_is_showing_popup', True))
+        self.on('popup-hide', lambda e: setattr(e.sender, '_is_showing_popup', False))
 
     @property
     def is_showing_popup(self) -> bool:

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -81,8 +81,8 @@ class Select(ValidationElement, ChoiceElement, DisableableElement, component='se
         self._props['clearable'] = clearable
 
         self._is_showing_popup = False
-        self.on('popup-show', lambda e: setattr(e.sender, '_is_showing_popup', True))
-        self.on('popup-hide', lambda e: setattr(e.sender, '_is_showing_popup', False))
+        self.on('popup-show', lambda e: setattr(e.sender, '_is_showing_popup', True), args=[])
+        self.on('popup-hide', lambda e: setattr(e.sender, '_is_showing_popup', False), args=[])
 
     @property
     def is_showing_popup(self) -> bool:


### PR DESCRIPTION
This PR fixes a bug unveiled by PR #3487 which registered for the "popup-show" and "popup-hide" events. Apparently, a check in air.py assumed the first argument to be a string, which it isn't. This PR checks for the correct type and, while at it, removes the arguments for the popup events altogether, because they are not needed.