### PR TITLE
Support creating background tasks from awaitables

### DIFF
--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -19,7 +19,7 @@ def create(coroutine: Awaitable, *, name: str = 'unnamed task') -> asyncio.Task:
     See https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task.
     """
     assert core.loop is not None
-    assert asyncio.iscoroutine(coroutine)
+    coroutine = coroutine if asyncio.iscoroutine(coroutine) else asyncio.wait_for(coroutine, None)
     task: asyncio.Task = core.loop.create_task(coroutine, name=name)
     task.add_done_callback(_handle_task_result)
     running_tasks.add(task)


### PR DESCRIPTION
In https://github.com/zauberzeug/rosys/pull/178 we noticed that `background_tasks.create` doesn't accept awaitables as promised by the type annotation:

```py
class MyAwaitable:
    def __await__(self):
        yield
        print('Awaiting...')

my_awaitable = MyAwaitable()

ui.button('Run', on_click=lambda: background_tasks.create(my_awaitable))
```

This PR replaces the assertion `asyncio.iscoroutine(coroutine)` and applies `asyncio.wait_for` as a wrapper if needed.