### PR TITLE
Delay events before handshake

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -174,13 +174,13 @@ function renderRecursively(elements, id) {
       handler = eval(event.js_handler);
     } else {
       handler = (...args) => {
-        const data = {
-          id: id,
-          client_id: window.clientId,
-          listener_id: event.listener_id,
-          args: stringifyEventArgs(args, event.args),
-        };
-        const emitter = () => window.socket?.emit("event", data);
+        const emitter = () =>
+          window.socket?.emit("event", {
+            id: id,
+            client_id: window.clientId,
+            listener_id: event.listener_id,
+            args: stringifyEventArgs(args, event.args),
+          });
         const delayed_emitter = () => {
           if (window.did_handshake) emitter();
           else setTimeout(emitter, 10);


### PR DESCRIPTION
In https://github.com/zauberzeug/nicegui/discussions/3530#discussioncomment-10369711 we noticed that Firefox auto-fills input fields before the websocket handshake happens, so that the information is lost and the server doesn't update its state. In this example the notification shows empty credentials although Firefox shows filled out input fields:
```py
username = ui.input('Username')
password = ui.input('Password', password=True, password_toggle_button=True)
ui.button('Login', on_click=lambda: ui.notify(f'{username.value}:{password.value}'))
```

This PR fixes this problem by waiting before emitting events until the handshake happens.

Technically there's a new possibility for messing up the state:
If the server sends an value update right after the handshake happens, the client might still be holding back the change event, causing server and client getting out of sync again. But by using a very short interval of 10ms this problem seems very unlikely.
```py
@ui.page('/')
async def page():
    username = ui.input('Username')
    password = ui.input('Password', password=True, password_toggle_button=True)
    ui.button('Login', on_click=lambda: ui.notify(f'{username.value}:{password.value}'))
    await ui.context.client.connected()
    username.value = 'foo'
```

Open tasks:

- [x] fix table pytests
- [ ] review