### PR TITLE
Allow nicegui.test to be used without selenium dependencies

### DIFF
--- a/nicegui/testing/__init__.py
+++ b/nicegui/testing/__init__.py
@@ -1,4 +1,9 @@
-from .screen import Screen
+try:
+    from .screen import Screen
+except ImportError:
+    # we simply define Screen as None if selenium is not installed
+    # this allows simpler dependency management when only using the "User" fixture
+    Screen = None  # type: ignore
 from .user import User
 from .user_interaction import UserInteraction
 

--- a/nicegui/testing/__init__.py
+++ b/nicegui/testing/__init__.py
@@ -1,14 +1,16 @@
 try:
     from .screen import Screen
-except ImportError:
+except ImportError as e:
     # we simply define Screen as None if selenium is not installed
     # this allows simpler dependency management when only using the "User" fixture
     class Screen:  # type: ignore
+        error = e
+
         def __init__(self, *args, **kwargs):
-            raise ImportError('Selenium dependencies are missing. Please install selenium to use the Screen class.')
+            raise RuntimeError('Screen is not available') from self.error
 
         def __getattr__(self, name):
-            raise ImportError('Selenium dependencies are missing. Please install selenium to use the Screen class.')
+            raise RuntimeError('Screen is not available') from self.error
 
 from .user import User
 from .user_interaction import UserInteraction

--- a/nicegui/testing/__init__.py
+++ b/nicegui/testing/__init__.py
@@ -1,16 +1,10 @@
 try:
     from .screen import Screen
-except ImportError as e:
+except ImportError:
     # we simply define Screen as None if selenium is not installed
     # this allows simpler dependency management when only using the "User" fixture
-    class Screen:  # type: ignore
-        error = e
-
-        def __init__(self, *args, **kwargs):
-            raise RuntimeError('Screen is not available') from self.error
-
-        def __getattr__(self, name):
-            raise RuntimeError('Screen is not available') from self.error
+    # (see discussion in #3510)
+    Screen = None  # type: ignore
 
 from .user import User
 from .user_interaction import UserInteraction

--- a/nicegui/testing/__init__.py
+++ b/nicegui/testing/__init__.py
@@ -3,7 +3,13 @@ try:
 except ImportError:
     # we simply define Screen as None if selenium is not installed
     # this allows simpler dependency management when only using the "User" fixture
-    Screen = None  # type: ignore
+    class Screen:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError('Selenium dependencies are missing. Please install selenium to use the Screen class.')
+
+        def __getattr__(self, name):
+            raise ImportError('Selenium dependencies are missing. Please install selenium to use the Screen class.')
+
 from .user import User
 from .user_interaction import UserInteraction
 


### PR DESCRIPTION
As a follow up to #3511 this PR tries to fix #3510 by enclosing the `Screen` import in a try/cecept.