### PR TITLE
Use correct version for citation file

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Update Citation.cff
         env:
           ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
-        run: python .github/workflows/update_citation.py
+        run: python .github/workflows/update_citation.py $(echo ${GITHUB_REF/refs\/tags\//})
 
       - name: Update version in pyproject.toml
         run: python .github/workflows/update_pyproject.py $(echo ${GITHUB_REF/refs\/tags\//})

--- a/.github/workflows/update_citation.py
+++ b/.github/workflows/update_citation.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import sys
 from pathlib import Path
@@ -7,7 +8,7 @@ import requests
 import yaml
 
 
-def get_infos() -> Tuple[str, str, str]:
+def get_infos() -> Tuple[str,  str]:
     headers = {
         'Accept': 'application/json',
     }
@@ -26,11 +27,12 @@ def get_infos() -> Tuple[str, str, str]:
         sys.exit(1)
     data = response.json()
     metadata = data['hits']['hits'][0]['metadata']
-    return str(metadata['doi']), str(metadata['version']), str(metadata['publication_date'])
+    return str(metadata['doi']), str(metadata['publication_date'])
 
 
 if __name__ == '__main__':
     path = Path('CITATION.cff')
     citation = yaml.safe_load(path.read_text())
-    citation['doi'], citation['version'], citation['date-released'] = get_infos()
+    citation['doi'], citation['date-released'] = get_infos()
+    citation['version'] = sys.argv[1].removeprefix('v')
     path.write_text(yaml.dump(citation, sort_keys=False, default_flow_style=False))


### PR DESCRIPTION
I noticed that our CITATION.cff file is always one version behind. Therefore this PR uses the same `GITHUB_REF` like we use for updating the pyproject file.

By the way, I wonder if
```
$(echo ${GITHUB_REF/refs\/tags\//})
```
could be simplified to
```
${GITHUB_REF/refs\/tags\//}
```
But I don't feel like risking a messed up release.