### PR TITLE
Disable FastAPI docs by default

### DIFF
--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -32,7 +32,7 @@ class State(Enum):
 class App(FastAPI):
 
     def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
+        super().__init__(**kwargs, docs_url=None, redoc_url=None, openapi_url=None)
         self.native = NativeConfig()
         self.storage = Storage()
         self.urls = ObservableSet()

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -31,6 +31,7 @@ def run(*,
         language: Language = 'en-US',
         binding_refresh_interval: float = 0.1,
         reconnect_timeout: float = 3.0,
+        fastapi_docs: bool = False,
         show: bool = True,
         on_air: Optional[Union[str, Literal[True]]] = None,
         native: bool = False,
@@ -63,6 +64,7 @@ def run(*,
     :param language: language for Quasar elements (default: `'en-US'`)
     :param binding_refresh_interval: time between binding updates (default: `0.1` seconds, bigger is more CPU friendly)
     :param reconnect_timeout: maximum time the server waits for the browser to reconnect (default: 3.0 seconds)
+    :param fastapi_docs: whether to enable FastAPI's automatic documentation with Swagger UI, ReDoc, and OpenAPI JSON (default: `False`)
     :param show: automatically open the UI in a browser tab (default: `True`)
     :param on_air: tech preview: `allows temporary remote access <https://nicegui.io/documentation/section_configuration_deployment#nicegui_on_air>`_ if set to `True` (default: disabled)
     :param native: open the UI in a native window of size 800x600 (default: `False`, deactivates `show`, automatically finds an open port)
@@ -103,6 +105,16 @@ def run(*,
             route.include_in_schema = endpoint_documentation in {'internal', 'all'}
         if route.path == '/' or route.path in Client.page_routes.values():
             route.include_in_schema = endpoint_documentation in {'page', 'all'}
+
+    if not fastapi_docs:
+        docs = ['/docs', '/docs/oauth2-redirect', '/redoc', '/openapi.json']
+        core.app.routes[:] = [route for route in core.app.routes
+                              if hasattr(route, 'path') and route.path not in docs]
+        # Update the app's state
+        core.app.docs_url = None
+        core.app.redoc_url = None
+        core.app.openapi_url = None
+        core.app.openapi_schema = None
 
     if on_air:
         core.air = Air('' if on_air is True else on_air)

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -4,10 +4,11 @@ import sys
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Tuple, Union
 
-import __main__
 from starlette.routing import Route
 from uvicorn.main import STARTUP_FAILURE
 from uvicorn.supervisors import ChangeReload, Multiprocess
+
+import __main__
 
 from . import core, helpers
 from . import native as native_module

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -4,11 +4,10 @@ import sys
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Tuple, Union
 
+import __main__
 from starlette.routing import Route
 from uvicorn.main import STARTUP_FAILURE
 from uvicorn.supervisors import ChangeReload, Multiprocess
-
-import __main__
 
 from . import core, helpers
 from . import native as native_module
@@ -106,15 +105,14 @@ def run(*,
         if route.path == '/' or route.path in Client.page_routes.values():
             route.include_in_schema = endpoint_documentation in {'page', 'all'}
 
-    if not fastapi_docs:
-        docs = ['/docs', '/docs/oauth2-redirect', '/redoc', '/openapi.json']
-        core.app.routes[:] = [route for route in core.app.routes
-                              if hasattr(route, 'path') and route.path not in docs]
-        # Update the app's state
-        core.app.docs_url = None
-        core.app.redoc_url = None
-        core.app.openapi_url = None
-        core.app.openapi_schema = None
+    if fastapi_docs:
+        if not core.app.docs_url:
+            core.app.docs_url = '/docs'
+        if not core.app.redoc_url:
+            core.app.redoc_url = '/redoc'
+        if not core.app.openapi_url:
+            core.app.openapi_url = '/openapi.json'
+        core.app.setup()
 
     if on_air:
         core.air = Air('' if on_air is True else on_air)

--- a/tests/test_endpoint_docs.py
+++ b/tests/test_endpoint_docs.py
@@ -1,9 +1,15 @@
 from typing import Set
 
+import pytest
 import requests
 
 from nicegui import __version__
 from nicegui.testing import Screen
+
+
+@pytest.fixture(autouse=True)
+def activate_fastapi_docs(screen: Screen):
+    screen.ui_run_kwargs['fastapi_docs'] = True
 
 
 def get_openapi_paths() -> Set[str]:


### PR DESCRIPTION
This PR is inspired by #3570. While seeking a simple solution, it dawned on me that it is probably not a good idea to make the docs available by default. A normal website or UI does not need it and it might lead to unexpected outcomes (https://nicegui.io/docs for example).
So I propose to use 2.0 to introduce a breaking change and make docs only available if `fastapi_docs=True` is passed to `ui.run`.