### PR TITLE
Use newer langchain package

### DIFF
--- a/examples/chat_with_ai/requirements.txt
+++ b/examples/chat_with_ai/requirements.txt
@@ -1,3 +1,4 @@
-langchain>=0.0.142
+langchain>=0.2
+langchain-community
 langchain_openai
 nicegui


### PR DESCRIPTION
This fixes a dependency error where newest langchain packages do not have the langchain-community package build in.