### PR TITLE
Remove ui.timer objects from hierarchy

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -311,8 +311,7 @@ class Client:
             element._handle_delete()  # pylint: disable=protected-access
             element._deleted = True  # pylint: disable=protected-access
             self.outbox.enqueue_delete(element)
-            if element.id in self.elements:
-                del self.elements[element.id]
+            self.elements.pop(element.id, None)
 
     def remove_all_elements(self) -> None:
         """Remove all elements from the client."""

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -311,7 +311,8 @@ class Client:
             element._handle_delete()  # pylint: disable=protected-access
             element._deleted = True  # pylint: disable=protected-access
             self.outbox.enqueue_delete(element)
-            del self.elements[element.id]
+            if element.id in self.elements:
+                del self.elements[element.id]
 
     def remove_all_elements(self) -> None:
         """Remove all elements from the client."""

--- a/nicegui/elements/timer.py
+++ b/nicegui/elements/timer.py
@@ -126,4 +126,5 @@ class Timer(Element, component='timer.js'):
     def _cleanup(self) -> None:
         self.callback = None
         assert self.parent_slot
-        self.parent_slot.parent.remove(self)
+        if not self.client._deleted:  # pylint: disable=protected-access
+            self.parent_slot.parent.remove(self)

--- a/nicegui/elements/timer.py
+++ b/nicegui/elements/timer.py
@@ -125,3 +125,5 @@ class Timer(Element, component='timer.js'):
 
     def _cleanup(self) -> None:
         self.callback = None
+        assert self.parent_slot
+        self.parent_slot.parent.remove(self)

--- a/nicegui/elements/timer.py
+++ b/nicegui/elements/timer.py
@@ -125,6 +125,6 @@ class Timer(Element, component='timer.js'):
 
     def _cleanup(self) -> None:
         self.callback = None
-        assert self.parent_slot
         if not self.client._deleted:  # pylint: disable=protected-access
+            assert self.parent_slot
             self.parent_slot.parent.remove(self)


### PR DESCRIPTION
In #3626 @fwerner reported a memory leak with `ui.timer`. Here is a reproduction with output of memory and growing number of `Timer` objects:

```py
import gc
import os
import psutil
from nicegui import ui

def update():
    ui.timer(0.1, update, once=True)
ui.timer(0, update, once=True)

def update_status():
    process = psutil.Process(os.getpid())
    memory_usage = process.memory_info().rss / 1024 / 1024
    timer_count = sum(1 for obj in gc.get_objects() if isinstance(obj, ui.timer))
    print(f'Memory usage: {memory_usage: .2f} MB | Timer count: {timer_count}')
ui.timer(2, update_status)

ui.run()
```

The `Timer._cleanup` already deregistered the callback. This PR now removes the element from its parent so the garbage collector can do it's work.
Also a change to `Client.remove_elements` was necessary, because the cleanup does not know it the parent has already been removed from the hierarchy.