### PR TITLE
Hide bottom space for error message when validation is `None`

### DIFF
--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -46,7 +46,7 @@ class Input(ValidationElement, DisableableElement, component='input.js'):
         :param password_toggle_button: whether to show a button to toggle the password visibility (default: False)
         :param on_change: callback to execute when the value changes
         :param autocomplete: optional list of strings for autocompletion
-        :param validation: dictionary of validation rules or a callable that returns an optional error message
+        :param validation: dictionary of validation rules or a callable that returns an optional error message (default: None for no validation)
         """
         super().__init__(value=value, on_value_change=on_change, validation=validation)
         if label is not None:

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -8,11 +8,25 @@ from .value_element import ValueElement
 class ValidationElement(ValueElement):
 
     def __init__(self, validation: Optional[Union[Callable[..., Optional[str]], Dict[str, Callable[..., bool]]]], **kwargs: Any) -> None:
-        self.validation = validation if validation is not None else {}
+        self._validation = validation
         self._auto_validation = True
         self._error: Optional[str] = None
         super().__init__(**kwargs)
-        self._props['error'] = False  # NOTE: reserve bottom space for error message
+        self._props['error'] = None if validation is None else False  # NOTE: reserve bottom space for error message
+
+    @property
+    def validation(self) -> Optional[Union[Callable[..., Optional[str]], Dict[str, Callable[..., bool]]]]:
+        """The validation function or dictionary of validation functions."""
+        return self._validation
+
+    @validation.setter
+    def validation(self, validation: Optional[Union[Callable[..., Optional[str]], Dict[str, Callable[..., bool]]]]) -> None:
+        """Sets the validation function or dictionary of validation functions.
+
+        :param validation: validation function or dictionary of validation functions (``None`` to disable validation)
+        """
+        self._validation = validation
+        self.validate()
 
     @property
     def error(self) -> Optional[str]:
@@ -25,10 +39,11 @@ class ValidationElement(ValueElement):
 
         :param error: The optional error message
         """
-        if self._error == error:
+        new_error_prop = None if self.validation is None else (error is not None)
+        if self._error == error and self._props['error'] == new_error_prop:
             return
         self._error = error
-        self._props['error'] = error is not None
+        self._props['error'] = new_error_prop
         self._props['error-message'] = error
         self.update()
 
@@ -37,14 +52,15 @@ class ValidationElement(ValueElement):
 
         :return: True if the value is valid, False otherwise
         """
-        if callable(self.validation):
-            self.error = self.validation(self.value)
+        if callable(self._validation):
+            self.error = self._validation(self.value)
             return self.error is None
 
-        for message, check in self.validation.items():
-            if not check(self.value):
-                self.error = message
-                return False
+        if isinstance(self._validation, dict):
+            for message, check in self._validation.items():
+                if not check(self.value):
+                    self.error = message
+                    return False
 
         self.error = None
         return True

--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -43,7 +43,7 @@ class Number(ValidationElement, DisableableElement):
         :param suffix: a suffix to append to the displayed value
         :param format: a string like "%.2f" to format the displayed value
         :param on_change: callback to execute when the value changes
-        :param validation: dictionary of validation rules or a callable that returns an optional error message
+        :param validation: dictionary of validation rules or a callable that returns an optional error message (default: None for no validation)
         """
         self.format = format
         super().__init__(tag='q-input', value=value, on_value_change=on_change, validation=validation)

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -49,7 +49,7 @@ class Select(ValidationElement, ChoiceElement, DisableableElement, component='se
         :param new_value_mode: handle new values from user input (default: None, i.e. no new values)
         :param multiple: whether to allow multiple selections
         :param clearable: whether to add a button to clear the selection
-        :param validation: dictionary of validation rules or a callable that returns an optional error message
+        :param validation: dictionary of validation rules or a callable that returns an optional error message (default: None for no validation)
         :param key_generator: a callback or iterator to generate a dictionary key for new values
         """
         self.multiple = multiple

--- a/nicegui/elements/textarea.py
+++ b/nicegui/elements/textarea.py
@@ -27,7 +27,7 @@ class Textarea(Input, component='input.js'):
         :param placeholder: text to show if no value is entered
         :param value: the initial value of the field
         :param on_change: callback to execute when the value changes
-        :param validation: dictionary of validation rules or a callable that returns an optional error message
+        :param validation: dictionary of validation rules or a callable that returns an optional error message (default: None for no validation)
         """
         super().__init__(label, placeholder=placeholder, value=value, on_change=on_change, validation=validation)
         self._props['type'] = 'textarea'


### PR DESCRIPTION
PR #3446 added a bottom space for the error message of validation messages. This turned out to be unnecessary when no validation is used. This PR changes the behavior to only reserve the bottom space if the `validation` property is not `None`.

Code for experimenting with the new implementation:

```py
input_ = ui.input(value='Hello, world!').classes('border')

def add_validation():
    input_.validation = {
        'Must start with "Hello"': lambda x: x.startswith('Hello'),
        'Must end with "world!"': lambda x: x.endswith('world!')
    }

def remove_validation():
    input_.validation = None

ui.button('Add validation', on_click=add_validation)
ui.button('Remove validation', on_click=remove_validation)
```