### PR TITLE
Clear storage dir after test completion

### DIFF
--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -212,3 +212,5 @@ class Storage:
         self._tabs.clear()
         for filepath in self.path.glob('storage-*.json'):
             filepath.unlink()
+        if self.path.exists():
+            self.path.rmdir()

--- a/nicegui/testing/general_fixtures.py
+++ b/nicegui/testing/general_fixtures.py
@@ -52,6 +52,7 @@ def nicegui_reset_globals() -> Generator[None, None, None]:
     app.get('/')(Client.auto_index_client.build_response)
     binding.reset()
     yield
+    app.reset()
 
 
 def prepare_simulation(request: pytest.FixtureRequest) -> None:


### PR DESCRIPTION
This PR addresses the cleanup of our tests as raised in #3649. The storage dir (and all app cleanup) is now properly called in test teardown.