### PR TITLE
add debug logs for on air reconnects

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -178,8 +178,8 @@ class Air:
             self.log.debug('Already connecting.')
             return
         if self.relay.connected:
-            self.log.debug('Already connected.')
             return
+        self.log.debug('Going to connect...')
         self.connecting = True
         backoff_time = 1
         try:

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -186,7 +186,7 @@ class Air:
             while True:
                 try:
                     if self.relay.connected:
-                        await asyncio.wait_for(self.relay.disconnect, timeout=5)
+                        await asyncio.wait_for(self.disconnect(), timeout=5)
                     self.log.debug('Connecting...')
                     await self.relay.connect(
                         f'{RELAY_HOST}?device_token={self.token}',

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import gzip
 import json
+import logging
 import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, Optional
@@ -34,6 +35,7 @@ class Air:
     def __init__(self, token: str) -> None:
         import httpx  # pylint: disable=import-outside-toplevel
 
+        self.log = logging.getLogger('nicegui.air')
         self.token = token
         self.relay = socketio.AsyncClient()
         self.client = httpx.AsyncClient(app=core.app)
@@ -172,7 +174,11 @@ class Air:
 
     async def connect(self) -> None:
         """Connect to the NiceGUI On Air server."""
-        if self.connecting or self.relay.connected:
+        if self.connecting:
+            self.log.debug('Already connecting.')
+            return
+        if self.relay.connected:
+            self.log.debug('Already connected.')
             return
         self.connecting = True
         backoff_time = 1
@@ -180,20 +186,23 @@ class Air:
             while True:
                 try:
                     if self.relay.connected:
-                        await self.relay.disconnect()
+                        await asyncio.wait_for(self.relay.disconnect, timeout=5)
+                    self.log.debug('Connecting...')
                     await self.relay.connect(
                         f'{RELAY_HOST}?device_token={self.token}',
                         socketio_path='/on_air/socket.io',
                         transports=['websocket', 'polling'],  # favor websocket over polling
                     )
+                    self.log.debug('Connected.')
                     break
                 except socketio.exceptions.ConnectionError:
-                    pass
+                    self.log.debug('Connection error.', stack_info=True)
                 except ValueError:  # NOTE this sometimes happens when the internal socketio client is not yet ready
-                    pass
+                    self.log.debug('ValueError while connecting.', stack_info=True)
                 except Exception:
                     log.exception('Could not connect to NiceGUI On Air server.')
 
+                self.log.debug(f'Retrying in {backoff_time} seconds...')
                 await asyncio.sleep(backoff_time)
                 backoff_time = min(backoff_time * 2, 32)
         finally:
@@ -201,11 +210,13 @@ class Air:
 
     async def disconnect(self) -> None:
         """Disconnect from the NiceGUI On Air server."""
+        self.log.debug('Disconnecting...')
         if self.relay.connected:
             await self.relay.disconnect()
         for stream in self.streams.values():
             await stream.response.aclose()
         self.streams.clear()
+        self.log.debug('Disconnected.')
 
     async def emit(self, message_type: str, data: Dict[str, Any], room: str) -> None:
         """Emit a message to the NiceGUI On Air server."""


### PR DESCRIPTION
We saw sporadic problems with reconnects to the On Air server. This PR adds some debug logging to better see what is going on. It also ensure we disconnect from all streams and sets a disconnect timeout so we do not get stuck there.