### PR TITLE
Explain how to work with outbox messages with the User pytest fixture

### DIFF
--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -40,7 +40,7 @@ class User:
             ui.notify = self.notify
         return super().__getattribute__(name)
 
-    async def open(self, path: str, *, clear_forward_history: bool = True) -> None:
+    async def open(self, path: str, *, clear_forward_history: bool = True) -> Client:
         """Open the given path."""
         response = await self.http_client.get(path, follow_redirects=True)
         assert response.status_code == 200, f'Expected status code 200, got {response.status_code}'
@@ -56,6 +56,7 @@ class User:
         self.back_history.append(path)
         if clear_forward_history:
             self.forward_history.clear()
+        return self.client
 
     @overload
     async def should_see(self,

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -377,3 +377,18 @@ async def test_upload_table(user: User) -> None:
         {'name': 'Alice', 'age': '30'},
         {'name': 'Bob', 'age': '28'},
     ]
+
+
+async def test_ui_download(user: User) -> None:
+    @ui.page('/')
+    def page():
+        ui.button('Download', on_click=lambda: ui.download(b'Hello', filename='hello.txt'))
+
+    client = await user.open('/')
+    user.find('Download').click()
+    messages = list(client.outbox.messages)
+    assert len(messages) == 1
+    target_id, message_type, data = messages[0]
+    assert message_type == 'download'
+    assert data['src'] == b'Hello'
+    assert data['filename'] == 'hello.txt'

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -156,6 +156,41 @@ def upload_table():
             ''')
 
 
+doc.text('Outbox Messages', '''
+    NiceGUI sends commands to the browser in the form of messages.
+    These messages are stored in the `outbox` attribute of the `Client` instance and can be inspected.
+''')
+
+
+@doc.ui
+def check_outbox():
+    with ui.row().classes('gap-4 items-stretch'):
+        with python_window(classes='w-[500px]', title='some UI code'):
+            ui.markdown('''
+                ```python
+
+                @ui.page('/')
+                def page():
+                    def download():
+                        ui.download(b'Hello', filename='hello.txt')
+
+                    ui.button('Download', on_click=download)
+                ```
+            ''')
+
+        with python_window(classes='w-[500px]', title='user assertions'):
+            ui.markdown('''
+                ```python
+                client = await user.open('/')
+                user.find('Download').click()
+                _, message_type, data = list(client.outbox.messages)[0]
+                assert message_type == 'download'
+                assert data['src'] == b'Hello'
+                assert data['filename'] == 'hello.txt'
+                ```
+            ''')
+
+
 doc.text('Multiple Users', '''
     Sometimes it is not enough to just interact with the UI as a single user.
     Besides the `user` fixture, we also provide the `create_user` fixture which is a factory function to create users.


### PR DESCRIPTION
This PR adds documentation showing how to access the outbox of the client object inside the User fixture. It also makes accessing the client more convenient, because `client.self` can be None.

This answers the question form #3686.