### PR TITLE
Introduce proper download simulation for the user fixture

### DIFF
--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -40,7 +40,7 @@ class User:
             ui.notify = self.notify
         return super().__getattribute__(name)
 
-    async def open(self, path: str, *, clear_forward_history: bool = True) -> None:
+    async def open(self, path: str, *, clear_forward_history: bool = True) -> Client:
         """Open the given path."""
         response = await self.http_client.get(path, follow_redirects=True)
         assert response.status_code == 200, f'Expected status code 200, got {response.status_code}'
@@ -56,6 +56,7 @@ class User:
         self.back_history.append(path)
         if clear_forward_history:
             self.forward_history.clear()
+        return self.client
 
     @overload
     async def should_see(self,

--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -12,6 +12,7 @@ from nicegui import Client, ElementFilter, ui
 from nicegui.element import Element
 from nicegui.nicegui import _on_handshake
 
+from .user_download import UserDownload
 from .user_interaction import UserInteraction
 from .user_navigate import UserNavigate
 from .user_notify import UserNotify
@@ -33,18 +34,18 @@ class User:
         self.forward_history: List[str] = []
         self.navigate = UserNavigate(self)
         self.notify = UserNotify()
-        self.http_responses: List[httpx.Response] = []
+        self.download = UserDownload(self)
 
     def __getattribute__(self, name: str) -> Any:
-        if name not in {'notify', 'navigate'}:  # NOTE: avoid infinite recursion
+        if name not in {'notify', 'navigate', 'download'}:  # NOTE: avoid infinite recursion
             ui.navigate = self.navigate
             ui.notify = self.notify
+            ui.download = self.download
         return super().__getattribute__(name)
 
     async def open(self, path: str, *, clear_forward_history: bool = True) -> Client:
         """Open the given path."""
         response = await self.http_client.get(path, follow_redirects=True)
-        self.http_responses.append(response)
         assert response.status_code == 200, f'Expected status code 200, got {response.status_code}'
         if response.headers.get('X-Nicegui-Content') != 'page':
             raise ValueError(f'Expected a page response, got {response.text}')
@@ -53,7 +54,6 @@ class User:
         assert match is not None
         client_id = match.group(1)
         self.client = Client.instances[client_id]
-        self.client.outbox._emit = self._on_emit  # type: ignore # NOTE: monkey-patch the outbox
         self.sio.on('connect')
         await _on_handshake(f'test-{uuid4()}', {'client_id': self.client.id, 'tab_id': str(uuid4())})
         self.back_history.append(path)
@@ -189,18 +189,6 @@ class User:
         assert self.client
         return self.client.layout
 
-    async def new_http_response(self) -> httpx.Response:
-        """Wait for a new http response to happen.
-
-        For example when a download is triggered by the user.
-
-        :returns: the response"""
-        assert self.client
-        downloads = len(self.http_responses)
-        while len(self.http_responses) < downloads + 1:
-            await asyncio.sleep(0.1)
-        return self.http_responses[-1]
-
     def _gather_elements(self,
                          target: Union[str, Type[T], None] = None,
                          kind: Optional[Type[T]] = None,
@@ -230,8 +218,3 @@ class User:
             return f'element of type {kind.__name__} with {marker=} and {content=} on the page:\n{self.current_layout}'
         else:
             return f'element with {marker=} and {content=} on the page:\n{self.current_layout}'
-
-    async def _on_emit(self, message_type: str, data: Any, target_id: str) -> None:
-        if message_type == 'download':
-            if isinstance(data['src'], str):
-                self.http_responses.append(await self.http_client.get(data['src']))

--- a/nicegui/testing/user_download.py
+++ b/nicegui/testing/user_download.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, List, Optional, Union
+
+import httpx
+
+from .. import background_tasks
+
+if TYPE_CHECKING:
+    from .user import User
+
+
+class UserDownload:
+
+    def __init__(self, user: User) -> None:
+        self.http_responses: List[httpx.Response] = []
+        self.user = user
+
+    def __call__(self, src: Union[str, Path, bytes], filename: Optional[str] = None, media_type: str = '') -> Any:
+        background_tasks.create(self._get(src))
+
+    async def _get(self,  src: Union[str, Path, bytes]) -> None:
+        if isinstance(src, bytes):
+            await asyncio.sleep(0)
+            response = httpx.Response(200, content=src)
+        else:
+            response = await self.user.http_client.get(str(src))
+        self.http_responses.append(response)
+
+    async def new(self) -> httpx.Response:
+        """Wait for a new download to happen.
+
+        :returns: the http response"""
+        assert self.user.client
+        downloads = len(self.http_responses)
+        max_attempts = 10
+        while len(self.http_responses) < downloads + 1:
+            await asyncio.sleep(0.1)
+            max_attempts -= 1
+            if max_attempts == 0:
+                raise TimeoutError('Download did not happen')
+        return self.http_responses[-1]

--- a/nicegui/testing/user_download.py
+++ b/nicegui/testing/user_download.py
@@ -25,7 +25,7 @@ class UserDownload:
     async def _get(self,  src: Union[str, Path, bytes]) -> None:
         if isinstance(src, bytes):
             await asyncio.sleep(0)
-            response = httpx.Response(200, content=src)
+            response = httpx.Response(httpx.codes.OK, content=src)
         else:
             response = await self.user.http_client.get(str(src))
         self.http_responses.append(response)

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -379,7 +379,7 @@ async def test_upload_table(user: User) -> None:
     ]
 
 
-async def test_ui_download(user: User) -> None:
+async def test_download_bytes(user: User) -> None:
     @ui.page('/')
     def page():
         ui.button('Download', on_click=lambda: ui.download(b'Hello', filename='hello.txt'))
@@ -392,3 +392,22 @@ async def test_ui_download(user: User) -> None:
     assert message_type == 'download'
     assert data['src'] == b'Hello'
     assert data['filename'] == 'hello.txt'
+
+
+async def test_download_file(user: User) -> None:
+
+    @app.get('/data')
+    def get_data() -> PlainTextResponse:
+        return PlainTextResponse('Hello')
+
+    @ui.page('/')
+    def page():
+        ui.button('Download', on_click=lambda: ui.download('/data'))
+
+    await user.open('/')
+    assert len(user.http_responses) == 1
+    user.find('Download').click()
+    response = await user.new_http_response()
+    assert len(user.http_responses) == 2
+    assert response.status_code == 200
+    assert response.text == 'Hello'

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -381,7 +381,6 @@ async def test_upload_table(user: User) -> None:
 
 @pytest.mark.parametrize('data', ['/data', b'Hello'])
 async def test_download_file(user: User, data: Union[str, bytes]) -> None:
-
     @app.get('/data')
     def get_data() -> PlainTextResponse:
         return PlainTextResponse('Hello')
@@ -393,7 +392,7 @@ async def test_download_file(user: User, data: Union[str, bytes]) -> None:
     await user.open('/')
     assert len(user.download.http_responses) == 0
     user.find('Download').click()
-    response = await user.download.new()
+    response = await user.download.next()
     assert len(user.download.http_responses) == 1
     assert response.status_code == 200
     assert response.text == 'Hello'

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -377,3 +377,18 @@ async def test_upload_table(user: User) -> None:
         {'name': 'Alice', 'age': '30'},
         {'name': 'Bob', 'age': '28'},
     ]
+
+
+async def test_ui_download(user: User) -> None:
+    @ui.page('/')
+    def page():
+        ui.button('Download', on_click=lambda: ui.download(b'Hello', filename='hello.txt'))
+
+    client = await user.open('/')
+    user.find('Download').click()
+    messages = list(client.outbox.messages)
+    assert len(messages) == 1
+    target_id, message_type, data = messages[0]
+    assert message_type == 'download'
+    assert data['src'] == b'Hello'
+    assert data['filename'] == 'hello.txt'

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -156,6 +156,41 @@ def upload_table():
             ''')
 
 
+doc.text('Outbox Messages', '''
+    NiceGUI sends commands to the browser in the form of messages.
+    These messages are stored in the `outbox` attribute of the `Client` instance and can be inspected.
+''')
+
+
+@doc.ui
+def check_outbox():
+    with ui.row().classes('gap-4 items-stretch'):
+        with python_window(classes='w-[500px]', title='some UI code'):
+            ui.markdown('''
+                ```python
+
+                @ui.page('/')
+                def page():
+                    def download():
+                        ui.download(b'Hello', filename='hello.txt')
+
+                    ui.button('Download', on_click=download)
+                ```
+            ''')
+
+        with python_window(classes='w-[500px]', title='user assertions'):
+            ui.markdown('''
+                ```python
+                client = await user.open('/')
+                user.find('Download').click()
+                _, message_type, data = list(client.outbox.messages)[0]
+                assert message_type == 'download'
+                assert data['src'] == b'Hello'
+                assert data['filename'] == 'hello.txt'
+                ```
+            ''')
+
+
 doc.text('Multiple Users', '''
     Sometimes it is not enough to just interact with the UI as a single user.
     Besides the `user` fixture, we also provide the `create_user` fixture which is a factory function to create users.

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -156,9 +156,9 @@ def upload_table():
             ''')
 
 
-doc.text('Outbox Messages', '''
-    NiceGUI sends commands to the browser in the form of messages.
-    These messages are stored in the `outbox` attribute of the `Client` instance and can be inspected.
+doc.text('Test Downloads', '''
+    You can verify that a download was triggered by checking `user.downloads.http_responses`.
+    By awaiting `user.downloads.next()` you can get the next download response.
 ''')
 
 
@@ -181,12 +181,11 @@ def check_outbox():
         with python_window(classes='w-[500px]', title='user assertions'):
             ui.markdown('''
                 ```python
-                client = await user.open('/')
+                await user.open('/')
+                assert len(user.download.http_responses) == 0
                 user.find('Download').click()
-                _, message_type, data = list(client.outbox.messages)[0]
-                assert message_type == 'download'
-                assert data['src'] == b'Hello'
-                assert data['filename'] == 'hello.txt'
+                response = await user.download.new()
+                assert response.text == 'Hello'
                 ```
             ''')
 

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -168,7 +168,6 @@ def check_outbox():
         with python_window(classes='w-[500px]', title='some UI code'):
             ui.markdown('''
                 ```python
-
                 @ui.page('/')
                 def page():
                     def download():
@@ -184,7 +183,7 @@ def check_outbox():
                 await user.open('/')
                 assert len(user.download.http_responses) == 0
                 user.find('Download').click()
-                response = await user.download.new()
+                response = await user.download.next()
                 assert response.text == 'Hello'
                 ```
             ''')


### PR DESCRIPTION
Improving upon #3687 to solve #3686 this PR adds a `user.download` to access the list of performed downloads.