### PR TITLE
Improve error message when client is not yet initialised

### DIFF
--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -95,7 +95,7 @@ class User:
         By default `should_see` makes three attempts to find the element before failing.
         This can be adjusted with the `retries` parameter.
         """
-        assert self.client
+        self._assert_client()
         for _ in range(retries):
             with self.client:
                 if self.notify.contains(target) or self._gather_elements(target, kind, marker, content):
@@ -130,7 +130,7 @@ class User:
                              retries: int = 3,
                              ) -> None:
         """Assert that the page does not contain an input with the given value."""
-        assert self.client
+        self._assert_client()
         for _ in range(retries):
             with self.client:
                 if not self.notify.contains(target) and not self._gather_elements(target, kind, marker, content):
@@ -175,7 +175,7 @@ class User:
              content: Union[str, List[str], None] = None,
              ) -> UserInteraction[T]:
         """Select elements for interaction."""
-        assert self.client
+        self._assert_client()
         with self.client:
             elements = self._gather_elements(target, kind, marker, content)
             if not elements:
@@ -186,8 +186,14 @@ class User:
     @property
     def current_layout(self) -> Element:
         """Return the root layout element of the current page."""
-        assert self.client
+        self._assert_client()
         return self.client.layout
+
+    def _assert_client(self) -> None:
+        if self.client is not None:
+            return
+
+        raise ValueError("This user has not opened a page yet. Did you forgot to call .open()?")
 
     def _gather_elements(self,
                          target: Union[str, Type[T], None] = None,

--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -36,6 +36,12 @@ class User:
         self.notify = UserNotify()
         self.download = UserDownload(self)
 
+    @property
+    def _client(self) -> Client:
+        if self.client is None:
+            raise ValueError('This user has not opened a page yet. Did you forgot to call .open()?')
+        return self.client
+
     def __getattribute__(self, name: str) -> Any:
         if name not in {'notify', 'navigate', 'download'}:  # NOTE: avoid infinite recursion
             ui.navigate = self.navigate
@@ -95,9 +101,8 @@ class User:
         By default `should_see` makes three attempts to find the element before failing.
         This can be adjusted with the `retries` parameter.
         """
-        self._assert_client()
         for _ in range(retries):
-            with self.client:
+            with self._client:
                 if self.notify.contains(target) or self._gather_elements(target, kind, marker, content):
                     return
                 await asyncio.sleep(0.1)
@@ -130,9 +135,8 @@ class User:
                              retries: int = 3,
                              ) -> None:
         """Assert that the page does not contain an input with the given value."""
-        self._assert_client()
         for _ in range(retries):
-            with self.client:
+            with self._client:
                 if not self.notify.contains(target) and not self._gather_elements(target, kind, marker, content):
                     return
                 await asyncio.sleep(0.05)
@@ -175,8 +179,7 @@ class User:
              content: Union[str, List[str], None] = None,
              ) -> UserInteraction[T]:
         """Select elements for interaction."""
-        self._assert_client()
-        with self.client:
+        with self._client:
             elements = self._gather_elements(target, kind, marker, content)
             if not elements:
                 raise AssertionError('expected to find at least one ' +
@@ -186,14 +189,7 @@ class User:
     @property
     def current_layout(self) -> Element:
         """Return the root layout element of the current page."""
-        self._assert_client()
-        return self.client.layout
-
-    def _assert_client(self) -> None:
-        if self.client is not None:
-            return
-
-        raise ValueError("This user has not opened a page yet. Did you forgot to call .open()?")
+        return self._client.layout
 
     def _gather_elements(self,
                          target: Union[str, Type[T], None] = None,


### PR DESCRIPTION
`User.client` is only set after `open` is called. Since having a valid `client` instance is necessary to test anything, whether `client` is set is checked in most methods. However, this is done with a simple `assert self.client`, which gives an opaque `AssertionError` if the user has indeed forgotten to call `open`. This PR improves the error message to specifically call that out.