### PR TITLE
Handle type error when navigating

### DIFF
--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -60,6 +60,8 @@ class Navigate:
             path = f'#c{target.id}'
         elif callable(target):
             path = Client.page_routes[target]
+        else:
+            raise TypeError(f"Expected a str path, an Element, or a page builder, but got {target}")
         context.client.open(path, new_tab)
 
 

--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -61,7 +61,7 @@ class Navigate:
         elif callable(target):
             path = Client.page_routes[target]
         else:
-            raise TypeError(f"Expected a str path, an Element, or a page builder, but got {target}")
+            raise TypeError(f'Invalid target type: {type(target)}')
         context.client.open(path, new_tab)
 
 


### PR DESCRIPTION
In the event that `target` does not satisfy the type hint for `to`, the user will get an `UnboundLocalError` for `path`, which is confusing. This PR explicitly handles the case where `to` gets an input of an unexpected type.