### PR TITLE
Custom colors prop support

### DIFF
--- a/nicegui/elements/colors.js
+++ b/nicegui/elements/colors.js
@@ -1,6 +1,20 @@
 export default {
   mounted() {
     for (let name in this.$props) {
+      if (name === "customColors") {
+        let customCSS = "";
+        for (let customColor in this.customColors) {
+          const colorName = customColor.replaceAll("_", "-");
+          const colorVar = "--q-" + colorName;
+          document.body.style.setProperty(colorVar, this.customColors[customColor]);
+          customCSS += `.text-${colorName} { color: var(${colorVar}) !important; }\n`;
+          customCSS += `.bg-${colorName} { background-color: var(${colorVar}) !important; }\n`;
+        }
+        const style = document.createElement("style");
+        style.innerHTML = customCSS;
+        document.getElementsByTagName('head')[0].appendChild(style);
+        continue;
+      }
       document.body.style.setProperty("--q-" + name.replace("_", "-"), this.$props[name]);
     }
   },
@@ -14,5 +28,6 @@ export default {
     negative: String,
     info: String,
     warning: String,
+    customColors: Object,
   },
 };

--- a/nicegui/elements/colors.js
+++ b/nicegui/elements/colors.js
@@ -1,21 +1,23 @@
 export default {
   mounted() {
     for (let name in this.$props) {
-      if (name === "customColors") {
-        let customCSS = "";
-        for (let customColor in this.customColors) {
-          const colorName = customColor.replaceAll("_", "-");
-          const colorVar = "--q-" + colorName;
-          document.body.style.setProperty(colorVar, this.customColors[customColor]);
-          customCSS += `.text-${colorName} { color: var(${colorVar}) !important; }\n`;
-          customCSS += `.bg-${colorName} { background-color: var(${colorVar}) !important; }\n`;
-        }
-        const style = document.createElement("style");
-        style.innerHTML = customCSS;
-        document.getElementsByTagName('head')[0].appendChild(style);
-        continue;
-      }
+      if (name === "customColors") continue;
       document.body.style.setProperty("--q-" + name.replace("_", "-"), this.$props[name]);
+    }
+    if (this.customColors) {
+      let customCSS = "";
+      for (let customColor in this.customColors) {
+        const colorName = customColor.replaceAll("_", "-");
+        const colorVar = "--q-" + colorName;
+        document.body.style.setProperty(colorVar, this.customColors[customColor]);
+        customCSS += `.text-${colorName} { color: var(${colorVar}) !important; }\n`;
+        customCSS += `.bg-${colorName} { background-color: var(${colorVar}) !important; }\n`;
+      }
+      const style = document.createElement("style");
+      style.innerHTML = customCSS;
+      style.dataset.niceguiCustomColors = "";
+      document.head.querySelectorAll("[data-nicegui-custom-colors]").forEach((el) => el.remove());
+      document.getElementsByTagName("head")[0].appendChild(style);
     }
   },
   props: {

--- a/nicegui/elements/colors.py
+++ b/nicegui/elements/colors.py
@@ -14,7 +14,7 @@ class Colors(Element, component='colors.js'):
                  negative: str = '#c10015',
                  info: str = '#31ccec',
                  warning: str = '#f2c037',
-                 **custom_colors) -> None:
+                 **custom_colors: str) -> None:
         """Color Theming
 
         Sets the main colors (primary, secondary, accent, ...) used by `Quasar <https://quasar.dev/style/theme-builder>`_.

--- a/nicegui/elements/colors.py
+++ b/nicegui/elements/colors.py
@@ -1,4 +1,5 @@
 from ..element import Element
+from .mixins.color_elements import QUASAR_COLORS
 
 
 class Colors(Element, component='colors.js'):
@@ -12,7 +13,8 @@ class Colors(Element, component='colors.js'):
                  positive: str = '#21ba45',
                  negative: str = '#c10015',
                  info: str = '#31ccec',
-                 warning: str = '#f2c037') -> None:
+                 warning: str = '#f2c037',
+                 **custom_colors) -> None:
         """Color Theming
 
         Sets the main colors (primary, secondary, accent, ...) used by `Quasar <https://quasar.dev/style/theme-builder>`_.
@@ -37,4 +39,6 @@ class Colors(Element, component='colors.js'):
         self._props['negative'] = negative
         self._props['info'] = info
         self._props['warning'] = warning
+        self._props['customColors'] = custom_colors
+        QUASAR_COLORS.update({name.replace('_', '-') for name in custom_colors.keys()})
         self.update()

--- a/nicegui/elements/colors.py
+++ b/nicegui/elements/colors.py
@@ -28,6 +28,7 @@ class Colors(Element, component='colors.js'):
         :param negative: Negative color (default: "#c10015")
         :param info: Info color (default: "#31ccec")
         :param warning: Warning color (default: "#f2c037")
+        :param custom_colors: Custom color definitions for branding (needs ``ui.colors`` to be called before custom color is ever used)
         """
         super().__init__()
         self._props['primary'] = primary
@@ -40,5 +41,5 @@ class Colors(Element, component='colors.js'):
         self._props['info'] = info
         self._props['warning'] = warning
         self._props['customColors'] = custom_colors
-        QUASAR_COLORS.update({name.replace('_', '-') for name in custom_colors.keys()})
+        QUASAR_COLORS.update({name.replace('_', '-') for name in custom_colors})
         self.update()

--- a/website/documentation/content/colors_documentation.py
+++ b/website/documentation/content/colors_documentation.py
@@ -12,4 +12,22 @@ def main_demo() -> None:
     b2 = ui.button('Gray', on_click=lambda: [b.classes(replace='!bg-[#555]') for b in [b1, b2]])
 
 
+@doc.demo('Custom colors', '''
+    You can add custom color definitions for branding. In this case, `ui.colors` must be called before the
+    custom color is ever used.
+''')
+def custom_color_demo() -> None:
+    import random
+
+    def random_color():
+        return f'#{random.randint(0, 0xffffff):06x}'
+
+    ui.colors(my_custom_color=random_color())
+    ui.button(
+        'Random color',
+        color='my-custom-color',
+        on_click=lambda: ui.colors(my_custom_color=random_color())
+    )
+
+
 doc.reference(ui.colors)

--- a/website/documentation/content/colors_documentation.py
+++ b/website/documentation/content/colors_documentation.py
@@ -13,21 +13,16 @@ def main_demo() -> None:
 
 
 @doc.demo('Custom colors', '''
-    You can add custom color definitions for branding. In this case, `ui.colors` must be called before the
-    custom color is ever used.
+    You can add custom color definitions for branding.
+    In this case, `ui.colors` must be called before the custom color is ever used.
 ''')
 def custom_color_demo() -> None:
-    import random
+    from random import randint
 
-    def random_color():
-        return f'#{random.randint(0, 0xffffff):06x}'
-
-    ui.colors(my_custom_color=random_color())
-    ui.button(
-        'Random color',
-        color='my-custom-color',
-        on_click=lambda: ui.colors(my_custom_color=random_color())
-    )
+    ui.colors(brand='#424242')
+    ui.label('This is your custom brand color').classes('text-brand')
+    ui.button('Randomize', color='brand',
+              on_click=lambda: ui.colors(brand=f'#{randint(0, 0xffffff):06x}'))
 
 
 doc.reference(ui.colors)


### PR DESCRIPTION
Implements a feature I just suggested [here](https://github.com/zauberzeug/nicegui/discussions/3707#discussion-7163211).

It allows to add custom colors definition for branding/theming using the `ui.colors` function. It can be used as follows:

```python
from nicegui import ui

ui.colors(my_custom_color='#ff0')
ui.button('Custom color', color='my-custom-color')

ui.run()
```

The javascript added to make this work probably isn't optimal, but it works as intended, so that's probably what needs to be reviewed the most