### PR TITLE
Remove non-existent flag from `docker compose down` command in docker.sh

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -42,7 +42,7 @@ case $cmd in
         docker compose up -d --build $cmd_args
         ;;
     d | down)
-        docker compose down -d $cmd_args
+        docker compose down $cmd_args
         ;;
     s | start)
         docker compose start $cmd_args


### PR DESCRIPTION
In the `docker.sh` file there is a subcommand `d | down` that runs `docker compose down -d $cmd_args`, but the `-d` flag does not exist for `docker compose down` , so it throws an error. This PR just removes that flag