### PR TITLE
Fix for ChoiceElement duplicate `self.update()` calls and basic ChoiceElement unit testing

### DIFF
--- a/tests/test_choice_element.py
+++ b/tests/test_choice_element.py
@@ -1,4 +1,4 @@
-from nicegui import ui
+from nicegui import events, ui
 from nicegui.testing import Screen
 
 
@@ -70,5 +70,18 @@ def test_radio_set_options_value(screen: Screen):
     screen.open('/')
     r.set_options(['D', 'E', 'F'], value='E')
     assert r.value == 'E'
+
+# - When using `set_options` with the value argument set and the `on_change` callback active on the element,
+# `on_change` should never pass `None` through, even if the old value is not within the new list of element options
+
+def test_radio_set_options_value_callback(screen: Screen):
+
+    def check_change_is_not_none(e: events.ValueChangeEventArguments):
+        assert e.value is not None
+
+    r = ui.radio(['A', 'B', 'C'], on_change=check_change_is_not_none)
+
+    screen.open('/')
+    r.set_options(['D', 'E', 'F'], value='F')
 
 ###

--- a/tests/test_choice_element.py
+++ b/tests/test_choice_element.py
@@ -1,0 +1,74 @@
+from nicegui import ui
+from nicegui.testing import Screen
+
+
+###
+
+# Tests Needed:
+
+# - Radio options should be clickable, and the value should be set to the clicked option
+
+def test_radio_click(screen: Screen):
+    r = ui.radio(['A', 'B', 'C'])
+
+    screen.open('/')
+    screen.click('A')
+    assert r.value == 'A'
+    screen.click('B')
+    assert r.value == 'B'
+
+# - Clicking an option that is already selectable should do nothing
+
+def test_radio_click_already_selected(screen: Screen):
+    r = ui.radio(['A', 'B', 'C'], value='B')
+
+    screen.open('/')
+    screen.click('B')
+    assert r.value == 'B'
+
+# - Element value should be settable by invoking `set_value`
+
+def test_radio_set_value(screen: Screen):
+    r = ui.radio(['A', 'B', 'C'])
+
+    screen.open('/')
+    r.set_value('B')
+    assert r.value == 'B'
+
+# - Element options should be settable by invoking `set_options`
+
+def test_radio_set_options(screen: Screen):
+    r = ui.radio(['A', 'B', 'C'])
+
+    screen.open('/')
+    r.set_options(['D', 'E', 'F'])
+    assert r.options == ['D', 'E', 'F']
+
+# - When using `set_options`, the new value should still be what the old value was if the old value is within the new list of element options
+
+def test_radio_set_options_value_still_valid(screen: Screen):
+    r = ui.radio(['A', 'B', 'C'], value='C')
+
+    screen.open('/')
+    r.set_options(['C', 'D', 'E'])
+    assert r.value == 'C'
+
+# - When using `set_options`, the new value should be set to `None` if the old value is not within the new list of element options
+
+def test_radio_set_options_value_none(screen: Screen):
+    r = ui.radio(['A', 'B', 'C'], value='C')
+
+    screen.open('/')
+    r.set_options(['D', 'E', 'F'])
+    assert r.value is None
+
+# - When using `set_options` with the value argument set, the new value should be properly set
+
+def test_radio_set_options_value(screen: Screen):
+    r = ui.radio(['A', 'B', 'C'])
+
+    screen.open('/')
+    r.set_options(['D', 'E', 'F'], value='E')
+    assert r.value == 'E'
+
+###

--- a/tests/test_radio_element.py
+++ b/tests/test_radio_element.py
@@ -1,13 +1,6 @@
 from nicegui import events, ui
 from nicegui.testing import Screen
 
-
-###
-
-# Tests Needed:
-
-# - Radio options should be clickable, and the value should be set to the clicked option
-
 def test_radio_click(screen: Screen):
     r = ui.radio(['A', 'B', 'C'])
 
@@ -17,16 +10,12 @@ def test_radio_click(screen: Screen):
     screen.click('B')
     assert r.value == 'B'
 
-# - Clicking an option that is already selectable should do nothing
-
 def test_radio_click_already_selected(screen: Screen):
     r = ui.radio(['A', 'B', 'C'], value='B')
 
     screen.open('/')
     screen.click('B')
     assert r.value == 'B'
-
-# - Element value should be settable by invoking `set_value`
 
 def test_radio_set_value(screen: Screen):
     r = ui.radio(['A', 'B', 'C'])
@@ -35,16 +24,12 @@ def test_radio_set_value(screen: Screen):
     r.set_value('B')
     assert r.value == 'B'
 
-# - Element options should be settable by invoking `set_options`
-
 def test_radio_set_options(screen: Screen):
     r = ui.radio(['A', 'B', 'C'])
 
     screen.open('/')
     r.set_options(['D', 'E', 'F'])
     assert r.options == ['D', 'E', 'F']
-
-# - When using `set_options`, the new value should still be what the old value was if the old value is within the new list of element options
 
 def test_radio_set_options_value_still_valid(screen: Screen):
     r = ui.radio(['A', 'B', 'C'], value='C')
@@ -53,16 +38,12 @@ def test_radio_set_options_value_still_valid(screen: Screen):
     r.set_options(['C', 'D', 'E'])
     assert r.value == 'C'
 
-# - When using `set_options`, the new value should be set to `None` if the old value is not within the new list of element options
-
 def test_radio_set_options_value_none(screen: Screen):
     r = ui.radio(['A', 'B', 'C'], value='C')
 
     screen.open('/')
     r.set_options(['D', 'E', 'F'])
     assert r.value is None
-
-# - When using `set_options` with the value argument set, the new value should be properly set
 
 def test_radio_set_options_value(screen: Screen):
     r = ui.radio(['A', 'B', 'C'])
@@ -71,10 +52,12 @@ def test_radio_set_options_value(screen: Screen):
     r.set_options(['D', 'E', 'F'], value='E')
     assert r.value == 'E'
 
-# - When using `set_options` with the value argument set and the `on_change` callback active on the element,
-# `on_change` should never pass `None` through, even if the old value is not within the new list of element options
-
 def test_radio_set_options_value_callback(screen: Screen):
+    """Fix for https://github.com/zauberzeug/nicegui/issues/3733.
+
+    When using `set_options` with the value argument set and the `on_change` callback active on the element,
+    `on_change` should never pass `None` through, even if the old value is not within the new list of element options.
+    """
 
     def check_change_is_not_none(e: events.ValueChangeEventArguments):
         assert e.value is not None
@@ -83,5 +66,3 @@ def test_radio_set_options_value_callback(screen: Screen):
 
     screen.open('/')
     r.set_options(['D', 'E', 'F'], value='F')
-
-###


### PR DESCRIPTION
Resolves #3733

Added unit testing as requested. Wasn't sure how ham to go exactly, but I just went ahead and added tests for all the functionality that I've used with the `ui.radio()` element before.