### PR TITLE
Simplify clearing of values in pytests with simulated user interaction

### DIFF
--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -6,6 +6,7 @@ from typing_extensions import Self
 
 from nicegui import background_tasks, events, ui
 from nicegui.element import Element
+from nicegui.elements.mixins.value_element import ValueElement
 
 if TYPE_CHECKING:
     from .user import User
@@ -43,7 +44,9 @@ class UserInteraction(Generic[T]):
         return self
 
     def type(self, text: str) -> Self:
-        """Type the given text into the selected elements."""
+        """Type the given text into the selected elements.
+
+        Note: All elements must have a ``value`` attribute."""
         assert self.user.client
         with self.user.client:
             for element in self.elements:
@@ -74,4 +77,15 @@ class UserInteraction(Generic[T]):
                         args = not element.value
                     event_arguments = events.GenericEventArguments(sender=element, client=self.user.client, args=args)
                     events.handle_event(listener.handler, event_arguments)
+        return self
+
+    def clear(self) -> Self:
+        """Clear the selected elements.
+
+        Note: All elements must have a ``value`` attribute)."""
+        assert self.user.client
+        with self.user.client:
+            for element in self.elements:
+                assert isinstance(element, (ValueElement))
+                element.value = ''
         return self

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -89,5 +89,5 @@ class UserInteraction(Generic[T]):
         with self.user.client:
             for element in self.elements:
                 assert isinstance(element, ValueElement)
-                element.value = ''
+                element.value = None
         return self

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -46,7 +46,8 @@ class UserInteraction(Generic[T]):
     def type(self, text: str) -> Self:
         """Type the given text into the selected elements.
 
-        Note: All elements must have a ``value`` attribute."""
+        Note: All elements must have a ``value`` attribute.
+        """
         assert self.user.client
         with self.user.client:
             for element in self.elements:
@@ -82,10 +83,11 @@ class UserInteraction(Generic[T]):
     def clear(self) -> Self:
         """Clear the selected elements.
 
-        Note: All elements must have a ``value`` attribute)."""
+        Note: All elements must have a ``value`` attribute).
+        """
         assert self.user.client
         with self.user.client:
             for element in self.elements:
-                assert isinstance(element, (ValueElement))
+                assert isinstance(element, ValueElement)
                 element.value = ''
         return self

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -207,6 +207,11 @@ async def test_input(user: User, kind: Type) -> None:
     await user.should_see('Value: Hello World')
     await user.should_see('Changed: Hello World')
 
+    user.find(kind).clear()
+    user.find(kind).type('Test')
+    await user.should_see('Value: Test')
+    await user.should_see('Changed: Test')
+
 
 async def test_should_not_see(user: User) -> None:
     @ui.page('/')


### PR DESCRIPTION
This PR implement the feature request from #3747 by introducing a `clear` method for the `UserInteraction` class. Usage:

```py
user.find(ui.input).clear() # empties the content of an input element
```