### PR TITLE
Allow testing for validation texts

### DIFF
--- a/nicegui/element_filter.py
+++ b/nicegui/element_filter.py
@@ -109,6 +109,7 @@ class ElementFilter(Generic[T]):
                     element.props.get('icon'),
                     element.props.get('placeholder'),
                     element.props.get('value'),
+                    element.props.get('error-message'),
                     element.text if isinstance(element, TextElement) else None,
                     element.content if isinstance(element, ContentElement) else None,
                     element.source if isinstance(element, SourceElement) else None,

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -396,3 +396,12 @@ async def test_download_file(user: User, data: Union[str, bytes]) -> None:
     assert len(user.download.http_responses) == 1
     assert response.status_code == 200
     assert response.text == 'Hello'
+
+
+async def test_validation(user: User) -> None:
+    ui.input('Number', validation={'Not a number': lambda value: value.isnumeric()})
+
+    await user.open('/')
+    await user.should_not_see('Not a number')
+    user.find(ui.input).type('some invalid entry')
+    await user.should_see('Not a number')


### PR DESCRIPTION
This PR solves #3759 by making the `ElementFilter` aware of the `error-message` prop.