### PR TITLE
Improve conversion of dynamic props

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -158,7 +158,11 @@ function renderRecursively(elements, id) {
   Object.entries(props).forEach(([key, value]) => {
     if (key.startsWith(":")) {
       try {
-        props[key.substring(1)] = eval(value);
+        try {
+          props[key.substring(1)] = new Function(`return (${value})`)();
+        } catch (e) {
+          props[key.substring(1)] = eval(value);
+        }
         delete props[key];
       } catch (e) {
         console.error(`Error while converting ${key} attribute to function:`, e);

--- a/nicegui/static/utils/dynamic_properties.js
+++ b/nicegui/static/utils/dynamic_properties.js
@@ -11,7 +11,11 @@ export function convertDynamicProperties(obj, recursive) {
   for (const [attr, value] of Object.entries(obj)) {
     if (attr.startsWith(":")) {
       try {
-        obj[attr.slice(1)] = new Function(`return (${value})`)();
+        try {
+          obj[attr.slice(1)] = new Function(`return (${value})`)();
+        } catch (e) {
+          obj[attr.slice(1)] = eval(value);
+        }
         delete obj[attr];
       } catch (e) {
         console.error(`Error while converting ${attr} attribute to function:`, e);


### PR DESCRIPTION
This PR combines `eval` and `new Function` to convert different kind of dynamic props:

```py
# plain value, single vs. multiple statements
ui.button('This should be red').props(''' :color="'red'" ''')
ui.button('This should be red').props(''' :color="{const c = 'red'; c}" ''')

# dictionary value, with and without additional brackets
ui.input('This should be red').props(''' :input-style="({background: 'red'})" ''')
ui.input('This should be red').props(''' :input-style="{background: 'red'}" ''')

# "thumb-style" prop, which expects an object
with ui.scroll_area().props(''' :thumb-style="({background: 'red'})" ''').classes('w-60 h-20'):
    ui.label('The thumb should be red').classes('h-32')
with ui.scroll_area().props(''' :thumb-style="{background: 'red'}" ''').classes('w-60 h-20'):
    ui.label('The thumb should be red').classes('h-32')

# EChart options, which use dynamic_properties.js for recursive conversion
ui.echart({
    ':xAxis': "{type: 'value'}",
    'yAxis': {'type': 'value'},
    'series': [{'type': 'bar', 'data': [1, 2]}],
})
ui.echart({
    ':xAxis': "{const t = 'value'; ({ type: t }); }",
    'yAxis': {'type': 'value'},
    'series': [{'type': 'bar', 'data': [1, 2]}],
})
```