### PR TITLE
Check value of choice elements against options

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,13 +8,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     ignore:
-      - dependency-name: "ruff"
-        update-types: ["patch"]
-    groups:
-      fastapi:
-        patterns:
-          - "fastapi"
-        schedule:
-          interval: "daily"
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]

--- a/nicegui/elements/choice_element.py
+++ b/nicegui/elements/choice_element.py
@@ -16,7 +16,7 @@ class ChoiceElement(ValueElement):
         self._values: List[str] = []
         self._labels: List[str] = []
         self._update_values_and_labels()
-        if not isinstance(value, list) and value not in self._values:
+        if not isinstance(value, list) and value is not None and value not in self._values:
             raise ValueError(f'Invalid value: {value}')
         super().__init__(tag=tag, value=value, on_value_change=on_change)
         self._update_options()

--- a/nicegui/elements/choice_element.py
+++ b/nicegui/elements/choice_element.py
@@ -16,6 +16,8 @@ class ChoiceElement(ValueElement):
         self._values: List[str] = []
         self._labels: List[str] = []
         self._update_values_and_labels()
+        if not isinstance(value, list) and value not in self._values:
+            raise ValueError(f'Invalid value: {value}')
         super().__init__(tag=tag, value=value, on_value_change=on_change)
         self._update_options()
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -198,3 +198,10 @@ def test_select_validation(auto_validation: bool, screen: Screen):
         screen.should_contain('Too long')
     else:
         screen.should_not_contain('Too long')
+
+
+def test_invalid_value(screen: Screen):
+    with pytest.raises(ValueError, match='Invalid value: X'):
+        ui.select(['A', 'B', 'C'], value='X')
+
+    screen.open('/')


### PR DESCRIPTION
This PR raises a more readable exception when initializing a choice element with an invalid value, as discussed in #3809:
```py
ui.select(['Apple', 'Banana'], value='Cherry')
```

- [x] fix tests
- [x] add test for new behavior