### PR TITLE
Expose additional PyInstaller arguments

### DIFF
--- a/nicegui/scripts/pack.py
+++ b/nicegui/scripts/pack.py
@@ -42,8 +42,8 @@ def main() -> None:
         f'{Path(nicegui.__file__).parent}{os.pathsep}nicegui',
     ], help='Include additional data.')
     parser.add_argument('--icon', type=str, help='Path to an icon file.')
-    parser.add_argument('--osx-bundle-identifier', type=str, help='OSX bundle identifier.')
-    parser.add_argument('--dry-run', action='store_true', help='Dry run', default=False)
+    parser.add_argument('--osx-bundle-identifier', type=str, help='Mac OS .app bundle identifier.')
+    parser.add_argument('--dry-run', action='store_true', help='Dry run.', default=False)
     parser.add_argument('main', default='main.py', help='Main file which calls `ui.run()`.')
     args = parser.parse_args()
 

--- a/nicegui/scripts/pack.py
+++ b/nicegui/scripts/pack.py
@@ -41,6 +41,8 @@ def main() -> None:
     parser.add_argument('--add-data', type=str, action='append', default=[
         f'{Path(nicegui.__file__).parent}{os.pathsep}nicegui',
     ], help='Include additional data.')
+    parser.add_argument('--icon', type=str, help='Path to an icon file.')
+    parser.add_argument('--osx-bundle-identifier', type=str, help='OSX bundle identifier.')
     parser.add_argument('--dry-run', action='store_true', help='Dry run', default=False)
     parser.add_argument('main', default='main.py', help='Main file which calls `ui.run()`.')
     args = parser.parse_args()
@@ -57,6 +59,11 @@ def main() -> None:
         command.append('--onefile')
     for data in args.add_data:
         command.extend(['--add-data', data])
+    if args.icon:
+        command.extend(['--icon', args.icon])
+    if args.osx_bundle_identifier:
+        command.extend(['--osx-bundle-identifier', args.osx_bundle_identifier])
+
     command.extend([args.main])
 
     print('PyInstaller command:')


### PR DESCRIPTION
The optional added arguments are useful for building on OSX.

It would probably make sense to expose all arguments of PyInstaller as far as they don't conflict, although this would require manually respecifying them all.

(Alternatively, you could also provide documentation on how to package with PyInstaller if the user prefers not to use the wrapper.)