### PR TITLE
Add demo about LaTeX formulas in `ui.markdown`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,6 +29,7 @@ ENV CHROME_BINARY_LOCATION=/usr/bin/chromium
 RUN pip install -U pip && pip install poetry==$POETRY_VERSION
 COPY pyproject.toml poetry.lock README.md ./
 RUN poetry install --all-extras --no-root
+RUN pip install latex2mathml
 
 USER $USERNAME
 

--- a/development.dockerfile
+++ b/development.dockerfile
@@ -13,4 +13,6 @@ WORKDIR /app
 COPY . .
 RUN poetry install --all-extras
 
+RUN pip install latex2mathml
+
 CMD python3 -m debugpy --listen 5678 main.py

--- a/fly.dockerfile
+++ b/fly.dockerfile
@@ -29,6 +29,8 @@ COPY pyproject.toml poetry.lock*  ./
 
 RUN poetry install --no-root --extras "plotly matplotlib highcharts sass"
 
+RUN pip install latex2mathml
+
 ADD . .
 
 # ensure unique version to not serve cached and hence potentially wrong static files

--- a/release.dockerfile
+++ b/release.dockerfile
@@ -26,6 +26,7 @@ RUN python -m pip install \
     itsdangerous \
     pytest \
     requests \
+    latex2mathml \
     selenium
 
 WORKDIR /app

--- a/website/documentation/content/markdown_documentation.py
+++ b/website/documentation/content/markdown_documentation.py
@@ -55,6 +55,18 @@ def markdown_tables():
     ''', extras=['tables'])
 
 
+@doc.demo('LaTeX formulas', '''
+    By activating the "latex" extra, you can use LaTeX formulas.
+    This requires markdown2 version >=2.5 as well as latex2mathml to be installed.
+''')
+def markdown_latex():
+    ui.markdown('''
+        Euler's identity:
+
+        $$e^{i\pi} = -1$$
+    ''', extras=['latex'])
+
+
 @doc.demo('Change Markdown content', '''
     You can change the content of a Markdown element by setting its `content` property or calling `set_content`.
 ''')

--- a/website/documentation/content/markdown_documentation.py
+++ b/website/documentation/content/markdown_documentation.py
@@ -60,7 +60,7 @@ def markdown_tables():
     This requires markdown2 version >=2.5 as well as latex2mathml to be installed.
 ''')
 def markdown_latex():
-    ui.markdown('''
+    ui.markdown(r'''
         Euler's identity:
 
         $$e^{i\pi} = -1$$


### PR DESCRIPTION
As @motorst1 noticed in https://github.com/zauberzeug/nicegui/discussions/696#discussioncomment-10909097, `ui.markdown` can display LaTeX formulas. This PR adds a demo with notes about required packages.

Open tasks:

- [x] add latex2mathml to release.dockerfile? (and somewhere else?)
- [x] raise markdown2 requirement to version >=2.5? --> No, we leave it as it is.
