### PR TITLE
Run dynamic argument conversion when using run_grid_method / run_row_method

### DIFF
--- a/nicegui/elements/aggrid.js
+++ b/nicegui/elements/aggrid.js
@@ -46,9 +46,11 @@ export default {
       this.api.addGlobalListener(this.handle_event);
     },
     run_grid_method(name, ...args) {
+      convertDynamicProperties(args, true);
       return runMethod(this.api, name, args);
     },
     run_row_method(row_id, name, ...args) {
+      convertDynamicProperties(args, true);
       return runMethod(this.api.getRowNode(row_id), name, args);
     },
     handle_event(type, args) {


### PR DESCRIPTION
Following up with https://github.com/zauberzeug/nicegui/pull/3757

Do dynamic property conversion when using `run_grid_method` / `run_row_method`, so you can dynamically add / change callbacks and other things using properties with `:` prefix.

