### PR TITLE
Improve startup tests

### DIFF
--- a/test_startup.sh
+++ b/test_startup.sh
@@ -19,14 +19,21 @@ run() {
 check() {
     echo "Checking $1 ----------"
     pushd "$(dirname "$1")" >/dev/null
-    if run "$(basename "$1")" "${@:2}"; then
-        echo "OK --------"
-        popd > /dev/null
-    else
-        echo "FAILED -------"
-        popd > /dev/null
-        return 1
-    fi
+
+    max_attempts=3
+    for attempt in $(seq 1 $max_attempts); do
+        if run "$(basename "$1")" "${@:2}"; then
+            echo "OK --------"
+            popd > /dev/null
+            return 0
+        elif [ $attempt -eq $max_attempts ]; then
+            echo "FAILED after $max_attempts attempts -------"
+            popd > /dev/null
+            return 1
+        else
+            echo "Attempt $attempt failed. Retrying..."
+        fi
+    done
 }
 
 check main.py || exit 1

--- a/test_startup.sh
+++ b/test_startup.sh
@@ -32,13 +32,8 @@ error=0
 check main.py || error=1
 for path in examples/*
 do
-    # skip if python is 3.11 and if path is examples/sqlite_database
-    if test $(python3 --version | cut -d' ' -f2 | cut -d'.' -f1,2) = "3.11" && test $path = "examples/sqlite_database"; then
-        continue # until https://github.com/omnilib/aiosqlite/issues/241 is fixed
-    fi
-
-    # skip if python is 3.12 and if path is examples/sqlite_database
-    if test $(python3 --version | cut -d' ' -f2 | cut -d'.' -f1,2) = "3.12" && test $path = "examples/sqlite_database"; then
+    # Skip examples/sqlite_database for Python 3.11 and 3.12
+    if [[ $(python3 --version | cut -d' ' -f2 | cut -d'.' -f1,2) =~ ^3.1[12]$ ]] && [[ $path == "examples/sqlite_database" ]]; then
         continue # until https://github.com/omnilib/aiosqlite/issues/241 is fixed
     fi
 

--- a/test_startup.sh
+++ b/test_startup.sh
@@ -28,8 +28,7 @@ check() {
     fi
 }
 
-error=0
-check main.py || error=1
+check main.py || exit 1
 for path in examples/*
 do
     # Skip examples/sqlite_database for Python 3.11 and 3.12
@@ -44,20 +43,21 @@ do
 
     # install all requirements except nicegui
     if test -f $path/requirements.txt; then
-        sed '/^nicegui/d' $path/requirements.txt > $path/requirements.tmp.txt || error=1 # remove nicegui from requirements.txt
-        python3 -m pip install -r $path/requirements.tmp.txt || error=1
-        rm $path/requirements.tmp.txt || error=1
+        sed '/^nicegui/d' $path/requirements.txt > $path/requirements.tmp.txt || exit 1 # remove nicegui from requirements.txt
+        python3 -m pip install -r $path/requirements.tmp.txt || exit 1
+        rm $path/requirements.tmp.txt || exit 1
     fi
 
     # run start.sh or main.py
     if test -f $path/start.sh; then
-        check $path/start.sh dev || error=1
+        check $path/start.sh dev || exit 1
     elif test -f $path/main.py; then
-        check $path/main.py || error=1
+        check $path/main.py || exit 1
     fi
     if pytest -q --collect-only $path >/dev/null 2>&1; then
         echo "running tests for $path"
-        pytest $path || error=1
+        pytest $path || exit 1
     fi
 done
-test $error -eq 0
+
+exit 0


### PR DESCRIPTION
This PR improves the script that checks if main.py and our examples are able to start.

- Most important change: We exit as soon as one test fails. We rarely get any insights from continued startup test execution if one of them failed already.
- We repeat individual startup tests up to three times. Sometimes some font cache is being built or the test fails due to some timing issue. By directly checking it again we don't need to wait for the whole workflow to fail.
- Some minor code improvements have been suggested by Copilot.
