### PR TITLE
Fix docker cache in github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,8 +86,8 @@ jobs:
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           build-args: VERSION=${{ steps.prep.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ steps.prep.outputs.docker_image }}:buildcache
+          cache-to: type=registry,ref=${{ steps.prep.outputs.docker_image }}:buildcache,mode=max
 
       # Uploading the README.md is not a core feature of docker/build-push-action yet
       - name: Update README

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,13 +77,6 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -93,15 +86,8 @@ jobs:
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           build-args: VERSION=${{ steps.prep.outputs.version }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Uploading the README.md is not a core feature of docker/build-push-action yet
       - name: Update README


### PR DESCRIPTION
If this [RoSys PR](https://github.com/zauberzeug/rosys/pull/217) works, we fix the Docker cache here as well by not confining the cache to a commit.