### PR TITLE
Fix camera looking back to the origin after calling `move_camera()`

### DIFF
--- a/nicegui/elements/scene.js
+++ b/nicegui/elements/scene.js
@@ -452,6 +452,8 @@ export default {
           if (camera_up_changed) {
             this.controls.dispose();
             this.controls = new OrbitControls(this.camera, this.renderer.domElement);
+            this.controls.target.copy(this.look_at);
+            this.camera.lookAt(this.look_at);
           }
         })
         .start();


### PR DESCRIPTION
This PR fixes a problem introduced by PR #3544: The camera kept looking at the origin when calling `move_camera()` with given `look_at_*` coordinates.

The fix can be verified with the following snippet. Moving back and forth between the spheres should not point the camera back to the origin, an the orbit controls should orbit around the sphere which is currently looked at:
```py
with ui.scene() as scene:
    scene.sphere().move(1, 2, 0).material('blue')
    scene.sphere().move(4, 5, 0).material('red')

ui.button('blue', on_click=lambda: scene.move_camera(*(1, 2, 3), *(1, 2, 0), *(0, 1, 0), duration=1))
ui.button('red', on_click=lambda: scene.move_camera(*(4, 5, 6), *(4, 5, 0), *(0, 1, 0), duration=0))
```