### PR TITLE
Multicasting of page-scoped content

### DIFF
--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -5,7 +5,7 @@ import signal
 import urllib
 from enum import Enum
 from pathlib import Path
-from typing import Any, Awaitable, Callable, List, Optional, Union
+from typing import Any, Awaitable, Callable, List, Optional, Union, Iterator
 
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import FileResponse
@@ -258,3 +258,16 @@ class App(FastAPI):
         self._connect_handlers.clear()
         self._disconnect_handlers.clear()
         self._exception_handlers[:] = [log.exception]
+
+    @staticmethod
+    def clients(path: str) -> Iterator[Client]:
+        """Iterate over all connected clients and return only those instances that match a path.
+
+        When using `@ui.page("/path")` each client gets a private view of this page. Updates must be
+        sent to each client individually, which this iterator simplifies.
+
+        :param path: string to filter clients by
+        """
+        for client in Client.instances.values():
+            if client.page.path == path:
+                yield client

--- a/nicegui/testing/plugin.py
+++ b/nicegui/testing/plugin.py
@@ -1,4 +1,4 @@
 # pylint: disable=unused-import
 from .general_fixtures import nicegui_reset_globals, pytest_configure  # noqa: F401
-from .screen_plugin import nicegui_chrome_options, nicegui_driver, nicegui_remove_all_screenshots, screen  # noqa: F401
+from .screen_plugin import nicegui_chrome_options, nicegui_driver, nicegui_remove_all_screenshots, screen, screen2  # noqa: F401
 from .user_plugin import create_user, prepare_simulated_auto_index_client, user  # noqa: F401

--- a/nicegui/testing/screen_plugin.py
+++ b/nicegui/testing/screen_plugin.py
@@ -83,3 +83,24 @@ def screen(nicegui_reset_globals,  # noqa: F811, pylint: disable=unused-argument
         shutil.rmtree(DOWNLOAD_DIR)
     if logs:
         pytest.fail('There were unexpected logs. See "Captured log call" below.', pytrace=False)
+
+
+@pytest.fixture
+def screen2(nicegui_reset_globals,  # noqa: F811, pylint: disable=unused-argument
+           nicegui_remove_all_screenshots,  # pylint: disable=unused-argument
+           nicegui_driver: webdriver.Chrome,
+           request: pytest.FixtureRequest,
+           caplog: pytest.LogCaptureFixture,
+           ) -> Generator[Screen, None, None]:
+    """Create a new SeleniumScreen fixture. Used to have two parallel screens"""
+    prepare_simulation(request)
+    screen_ = Screen(nicegui_driver, caplog)
+    yield screen_
+    logs = screen_.caplog.get_records('call')
+    if screen_.is_open:
+        screen_.shot(request.node.name)
+    screen_.stop_server()
+    if DOWNLOAD_DIR.exists():
+        shutil.rmtree(DOWNLOAD_DIR)
+    if logs:
+        pytest.fail('There were unexpected logs. See "Captured log call" below.', pytrace=False)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from fastapi.responses import PlainTextResponse
 from selenium.webdriver.common.by import By
 
-from nicegui import background_tasks, ui
+from nicegui import background_tasks, ui, app
 from nicegui.testing import Screen
 
 
@@ -322,3 +322,20 @@ def test_ip(screen: Screen):
 
     screen.open('/')
     screen.should_contain('127.0.0.1')
+
+
+def test_multicast(screen: Screen, screen2: Screen):
+    def update():
+        for client in app.clients('/'):
+            with client:
+                ui.label('added')
+
+    @ui.page('/')
+    def page():
+        ui.button('add label', on_click=update)
+
+    screen.open("/")
+    screen2.open("/")
+    screen.click('add label')
+    screen.should_contain('added')
+    screen2.should_contain('added')

--- a/website/documentation/content/element_filter_documentation.py
+++ b/website/documentation/content/element_filter_documentation.py
@@ -38,6 +38,45 @@ def text_element() -> None:
     ui.label(', '.join(b.text for b in ElementFilter(kind=TextElement, local_scope=True)))
 
 
+@doc.demo('Local updates', '''
+    The content on a page is private to the client and has its own local element context. 
+    If you have a global background process, like a websocket-based chat handler or a notification system, and you want 
+    to send updates to pages instead of the global context, you need to filter for each client connected to that page.
+
+    Here, you can use the `app.client(path="/some-path")` iterator to return all applicable clients and use their 
+    context to apply updates.
+''')
+def local_updates():
+    import time
+    import asyncio
+    from nicegui import ui, app, ElementFilter
+
+    @ui.page("/time")
+    def make_page():
+        ui.label("Current time")
+        ui.label(time.strftime('%H:%M:%S')).mark('clock')
+
+    async def run_clock():
+        """Background activity to update the label value every second."""
+
+        def update_clock():
+            # Apply updates to clients currently connected to `/time`
+            for client in app.clients("/time"):
+                # Enter the client content context to look-up elements by their mark and apply the update.
+                # If you try to update this element without the client.content the element filter will not be able
+                # to find it, since the element is local to the page context.
+                with client.content:
+                    for element in ElementFilter(kind=ui.label, marker='clock'):
+                        element.text = time.strftime('%H:%M:%S')
+
+        while True:
+            update_clock()
+            await asyncio.sleep(1)
+
+    app.on_startup(run_clock)
+    ui.run()
+
+
 @doc.demo('Markers', '''
     Markers are a simple way to tag elements with a string which can be queried by an `ElementFilter`.
 ''')

--- a/website/documentation/content/page_documentation.py
+++ b/website/documentation/content/page_documentation.py
@@ -52,6 +52,43 @@ def wait_for_connected_demo():
     ui.link('wait for connection', wait_for_connection)
 
 
+@doc.demo('Multicasting', '''
+    The content on a page is private to the client and has its own local element context. 
+    If you have a global background process, like a websocket-based chat handler or a notification system, and you want 
+    to send updates to pages instead of the global context, you need to filter for each client connected to that page.
+    
+    Here, you can use the `app.client(path="/some-path")` iterator to return all applicable clients and use their 
+    context to apply updates.
+''')
+def multicasting():
+    import time
+    import asyncio
+    from nicegui import ui, app, ElementFilter
+
+    @ui.page("/time")
+    def make_page():
+        ui.label("Current time")
+        ui.label(time.strftime('%H:%M:%S')).mark('clock')
+
+    async def run_clock():
+        """Background activity to update the label value every second."""
+        def update_clock():
+            # Apply updates to clients currently connected to `/time`
+            for client in app.clients("/time"):
+                # Enter the client content context to look-up elements by their mark and apply the update.
+                # If you try to update this element without the client.content the element filter will not be able
+                # to find it, since the element is local to the page context.
+                with client.content:
+                    for element in ElementFilter(kind=ui.label, marker='clock'):
+                        element.text = time.strftime('%H:%M:%S')
+        while True:
+            update_clock()
+            await asyncio.sleep(1)
+
+    app.on_startup(run_clock)
+    ui.run()
+
+
 @doc.demo('Modularize with APIRouter', '''
     You can use the NiceGUI specialization of
     [FastAPI's APIRouter](https://fastapi.tiangolo.com/tutorial/bigger-applications/?h=apirouter#apirouter)


### PR DESCRIPTION
PR for https://github.com/zauberzeug/nicegui/discussions/3828

As discussed there added an iterator to `app` for yielding clients based on path. Also added documentation (at Page and ElementFilter since it kinda applies to both of them). Added a test.

I was also experimenting a bit with adding a wrapper or context manager as in my initial example, but I think @falkoschindler is right: an iterator is cleaner and then the developer can just do what they want with it.

E.g., in my original example
```python
    def update_clock():
        def _update():
            for element in ElementFilter(kind=ui.label, marker='clock'):
                element.text = time.strftime('%H:%M:%S')
        with_clients(OTHER_PAGE_ROUTE, _update)
```
versus now
```python
    def update_clock():
        for client in app.clients(OTHER_PAGE_ROUTE):
            with client.content:
                for element in ElementFilter(kind=ui.label, marker='clock'):
                    element.text = time.strftime('%H:%M:%S')
```