### PR TITLE
Show warning when `ui.dark_mode` breaks Tailwind

### DIFF
--- a/nicegui/elements/dark_mode.py
+++ b/nicegui/elements/dark_mode.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from .. import background_tasks, core, helpers
+from .. import core, helpers
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.value_element import ValueElement
 
@@ -20,9 +20,14 @@ class DarkMode(ValueElement, component='dark_mode.js'):
         :param on_change: Callback that is invoked when the value changes.
         """
         super().__init__(value=value, on_value_change=on_change)
-        background_tasks.create(self._check_for_issue_3753())
 
-    async def _check_for_issue_3753(self) -> None:
+        # HACK: this is a temporary warning to inform users about issue #3753
+        if core.app.is_started:
+            self._check_for_issue_3753()
+        else:
+            core.app.on_startup(self._check_for_issue_3753)
+
+    def _check_for_issue_3753(self) -> None:
         if self.client.page.resolve_dark() is None and core.app.config.tailwind:
             helpers.warn_once(
                 '`ui.dark_mode` is not supported on pages with `dark=None` while running with `tailwind=True` (the default). '

--- a/nicegui/elements/dark_mode.py
+++ b/nicegui/elements/dark_mode.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from .. import background_tasks, core, helpers
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.value_element import ValueElement
 
@@ -19,6 +20,14 @@ class DarkMode(ValueElement, component='dark_mode.js'):
         :param on_change: Callback that is invoked when the value changes.
         """
         super().__init__(value=value, on_value_change=on_change)
+        background_tasks.create(self._check_for_issue_3753())
+
+    async def _check_for_issue_3753(self) -> None:
+        if self.client.page.resolve_dark() is None and core.app.config.tailwind:
+            helpers.warn_once(
+                '`ui.dark_mode` is not supported on pages with `dark=None` while running with `tailwind=True` (the default). '
+                'See https://github.com/zauberzeug/nicegui/issues/3753 for more information.'
+            )
 
     def enable(self) -> None:
         """Enable dark mode."""


### PR DESCRIPTION
As discussed in #3753, `ui.dark_mode` can break Tailwind styling if used on a page with `dark=None`
```py
@ui.page('/', dark=None)
def page():
    ui.dark_mode(True)
    ui.label('This should be bordered').classes('border')
```
or with `ui.run(dark=None)`.

This PR shows a warning in this situation. I won't link it with the issue because this isn't a proper fix.