### PR TITLE
Add ui.input trigger autocomplete trigger capability

### DIFF
--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, Set, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Generic, List, Set, Type, TypeVar, Union
 
 from typing_extensions import Self
 
@@ -37,12 +37,11 @@ class UserInteraction(Generic[T]):
         with self.user.client:
             for element in self.elements:
                 if isinstance(element, ui.input) and event == 'keydown.tab':
-                    for option in element.props.get('_autocomplete'):
+                    autocomplete: List[str] = element.props['_autocomplete']
+                    for option in autocomplete:
                         if option.startswith(element.value):
                             element.value = option
                             break
-
-                    return self
 
                 for listener in element._event_listeners.values():  # pylint: disable=protected-access
                     if listener.type != event:

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -36,6 +36,17 @@ class UserInteraction(Generic[T]):
         assert self.user.client
         with self.user.client:
             for element in self.elements:
+                if isinstance(element, ui.input) and event == 'keydown.tab':
+                    autocomplete_list = element.props.get('_autocomplete')
+                    typed_string = element.value
+
+                    for elem in autocomplete_list:
+                        if typed_string in elem:
+                            element.value = elem
+                            break
+
+                    return self
+
                 for listener in element._event_listeners.values():  # pylint: disable=protected-access
                     if listener.type != event:
                         continue

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -37,12 +37,9 @@ class UserInteraction(Generic[T]):
         with self.user.client:
             for element in self.elements:
                 if isinstance(element, ui.input) and event == 'keydown.tab':
-                    autocomplete_list = element.props.get('_autocomplete')
-                    typed_string = element.value
-
-                    for elem in autocomplete_list:
-                        if typed_string in elem:
-                            element.value = elem
+                    for option in element.props.get('_autocomplete'):
+                        if option.startswith(element.value):
+                            element.value = option
                             break
 
                     return self

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -410,3 +410,13 @@ async def test_validation(user: User) -> None:
     await user.should_not_see('Not a number')
     user.find(ui.input).type('some invalid entry')
     await user.should_see('Not a number')
+
+async def test_trigger_autocomplete(user: User) -> None:
+    options = ['AutoComplete', 'NiceGUI', 'Awesome']
+    ui.input(label='Text', placeholder='start typing', autocomplete=options)
+
+    await user.open('/')
+
+    await user.should_not_see('AutoComplete')
+    user.find('Text').type('Auto').trigger('keydown.tab')
+    await user.should_see('AutoComplete')

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -411,12 +411,11 @@ async def test_validation(user: User) -> None:
     user.find(ui.input).type('some invalid entry')
     await user.should_see('Not a number')
 
+
 async def test_trigger_autocomplete(user: User) -> None:
-    options = ['AutoComplete', 'NiceGUI', 'Awesome']
-    ui.input(label='Text', placeholder='start typing', autocomplete=options)
+    ui.input(label='fruit', autocomplete=['apple', 'banana', 'cherry'])
 
     await user.open('/')
-
-    await user.should_not_see('AutoComplete')
-    user.find('Text').type('Auto').trigger('keydown.tab')
-    await user.should_see('AutoComplete')
+    await user.should_not_see('apple')
+    user.find('fruit').type('a').trigger('keydown.tab')
+    await user.should_see('apple')

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -39,34 +39,6 @@ def user_fixture():
     ''').classes('bold-links arrow-links')
 
 
-doc.text('Trigger Events', '''
-    The `UserInteraction` object returned by `user.find(...)` provides methods to trigger events on the found elements.
-    This applies for not only for click or pushing "Enter" events, but also for other keyboard actions.
-    For example, it is not sufficient to just type text into an input field for the autocomplete to work.
-    Instead, you need to trigger a `keydown` event with the `keydown.tab` key.
-''')
-
-
-@doc.ui
-def trigger_events():
-    with python_window(classes='w-[500px]', title='trigger autocomplete'):
-        ui.markdown('''
-            ```python
-            options = ['AutoComplete', 'NiceGUI', 'Awesome']
-            ui.input(
-                label='Text',
-                placeholder='start typing',
-                autocomplete=options
-            )
-
-            await user.open('/')
-            await user.should_not_see('AutoComplete')
-            user.find('Text').type('Auto').trigger('keydown.tab')
-            await user.should_see('AutoComplete')
-            ```
-        ''')
-
-
 @doc.part('Async execution')
 def async_execution():
     ui.markdown('''
@@ -180,6 +152,32 @@ def upload_table():
                     {'name': 'Alice', 'age': '30'},
                     {'name': 'Bob', 'age': '28'},
                 ]
+                ```
+            ''')
+
+
+doc.text('Autocomplete', '''
+    The `UserInteraction` object returned by `user.find(...)` provides methods to trigger events on the found elements.
+    This demo shows how to trigger a "keydown.tab" event to autocomplete an input field.
+''')
+
+
+@doc.ui
+def trigger_events():
+    with ui.row().classes('gap-4 items-stretch'):
+        with python_window(classes='w-[500px]', title='some UI code'):
+            ui.markdown('''
+                ```python
+                fruits = ['apple', 'banana', 'cherry']
+                ui.input(label='fruit', autocomplete=fruits)
+                ```
+            ''')
+        with python_window(classes='w-[500px]', title='user assertions'):
+            ui.markdown('''
+                ```python
+                await user.open('/')
+                user.find('fruit').type('a').trigger('keydown.tab')
+                await user.should_see('apple')
                 ```
             ''')
 

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -39,6 +39,34 @@ def user_fixture():
     ''').classes('bold-links arrow-links')
 
 
+doc.text('Trigger Events', '''
+    The `UserInteraction` object returned by `user.find(...)` provides methods to trigger events on the found elements.
+    This applies for not only for click or pushing "Enter" events, but also for other keyboard actions.
+    For example, it is not sufficient to just type text into an input field for the autocomplete to work.
+    Instead, you need to trigger a `keydown` event with the `keydown.tab` key.
+''')
+
+
+@doc.ui
+def trigger_events():
+    with python_window(classes='w-[500px]', title='trigger autocomplete'):
+        ui.markdown('''
+            ```python
+            options = ['AutoComplete', 'NiceGUI', 'Awesome']
+            ui.input(
+                label='Text',
+                placeholder='start typing',
+                autocomplete=options
+            )
+
+            await user.open('/')
+            await user.should_not_see('AutoComplete')
+            user.find('Text').type('Auto').trigger('keydown.tab')
+            await user.should_see('AutoComplete')
+            ```
+        ''')
+
+
 @doc.part('Async execution')
 def async_execution():
     ui.markdown('''


### PR DESCRIPTION
This fixes the issue mentioned in #3886 .

The PR implements a workaround in the testing/user_interaction module by checking if a trigger event is a "tab" event and then replacing the current text value by the first element in the autocomplete list.