### PR TITLE
Remove upper bound of setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ nicegui-pack = "nicegui.scripts.pack:main"
 
 [build-system]
 requires = [
-    "setuptools>=30.3.0,<50",
+    "setuptools>=30.3.0",
     "poetry-core>=1.0.0"
 ]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
As pointed out in https://github.com/zauberzeug/nicegui/issues/2485#issuecomment-2496689056, `< 50` is to harsh.