### PR TITLE
Documentation: fix inverted validation rule

### DIFF
--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -27,7 +27,7 @@ class Number(ValidationElement, DisableableElement):
         This element is based on Quasar's `QInput <https://quasar.dev/vue-components/input>`_ component.
 
         You can use the `validation` parameter to define a dictionary of validation rules,
-        e.g. ``{'Too small!': lambda value: value < 3}``.
+        e.g. ``{'Too small!': lambda value: value > 3}``.
         The key of the first rule that fails will be displayed as an error message.
         Alternatively, you can pass a callable that returns an optional error message.
         To disable the automatic validation on every value change, you can use the `without_auto_validation` method.


### PR DESCRIPTION
Minor documentation error. 
The original `{'Too small!': lambda value: value < 3}` would return
`True` if the number is small (error),
`False` if the number is big (okay).

But `ValidationElement` expects `False` to indicate an error:
```
            for message, check in self._validation.items():
                if not check(self.value):
                    self.error = message
                    return False
```

Alternate fix would be to replace `small` -> `big`.