### PR TITLE
fix ui.input value loss

### DIFF
--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -8,7 +8,6 @@ from .mixins.validation_element import ValidationDict, ValidationElement, Valida
 
 class Input(ValidationElement, DisableableElement, component='input.js'):
     VALUE_PROP: str = 'value'
-    LOOPBACK = False
 
     def __init__(self,
                  label: Optional[str] = None, *,


### PR DESCRIPTION
I noticed that the ui.input does not keep its displayed value when a dialog is closed and opened again.
Even more confusingly it keeps the value that was last set by the nicegui server (either by setting input.value or just connecting the client while it had a value).

As far as I managed to understand it, the issue is with the value prop is not being set properly when the user changes the input (though input.value does change correctly). Setting LOOPBACK back to `True` seems to solve this.

I do not understand this setting enough to answer the following questions:
What does it change?
Why was it set to False in the first place?
