### PR TITLE
update Github Action to cache docker to different locations for each platform

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,10 @@ jobs:
   docker:
     needs: pypi
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [{ platform: linux/amd64, cache: buildcache-amd64 }, { platform: linux/arm64, cache: buildcache-arm64 }]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare
@@ -82,13 +86,18 @@ jobs:
         with:
           context: .
           file: ./release.dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.build.platform }}
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           build-args: VERSION=${{ steps.prep.outputs.version }}
-          cache-from: type=registry,ref=${{ steps.prep.outputs.docker_image }}:buildcache
-          cache-to: type=registry,ref=${{ steps.prep.outputs.docker_image }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ steps.prep.outputs.docker_image }}:${{ matrix.build.cache }}
+          cache-to: type=registry,ref=${{ steps.prep.outputs.docker_image }}:${{ matrix.build.cache }},mode=max
 
+  readme:
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - uses: actions/checkout@v4
       # Uploading the README.md is not a core feature of docker/build-push-action yet
       - name: Update README
         uses: christian-korneck/update-container-description-action@v1


### PR DESCRIPTION
Since the docker caching in the GitHub actions still isn't working properly, this attempts to fix it. As described in [this PR](https://github.com/zauberzeug/rosys/pull/232) in RoSys the issue is the multi platform setup in our docker build and push action. This PR attempts to fix this by using different build caches for each platform.