### PR TITLE
Disallow typing to disabled UI elements in `UserInteraction.type`

### DIFF
--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -6,6 +6,7 @@ from typing_extensions import Self
 
 from nicegui import background_tasks, events, ui
 from nicegui.element import Element
+from nicegui.elements.mixins.disableable_element import DisableableElement
 from nicegui.elements.mixins.value_element import ValueElement
 
 if TYPE_CHECKING:
@@ -58,6 +59,8 @@ class UserInteraction(Generic[T]):
         assert self.user.client
         with self.user.client:
             for element in self.elements:
+                if isinstance(element, DisableableElement) and not element.enabled:
+                    continue
                 assert isinstance(element, (ui.input, ui.editor, ui.codemirror))
                 element.value = (element.value or '') + text
         return self

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -465,3 +465,16 @@ q-layout
     Label [text=Visible]
     Label [text=Hidden, visible=False]
 '''.strip()
+
+async def test_typing_to_disabled_element(user: User) -> None:
+    initial_value = 'Hello first'
+    given_new_input = 'Hello second'
+    target = ui.input(value=initial_value)
+    target.disable()
+
+    await user.open('/')
+    user.find(initial_value).type(given_new_input)
+
+    assert target.value == initial_value
+    await user.should_see(initial_value)
+    await user.should_not_see(given_new_input)


### PR DESCRIPTION
The `UserInteraction` method `type` allows typing to a disabled element. This should be disallowed. This commit fixes that by skipping typing to elements that have the 'disable' property set to `True`.

Resolves #4080 