### PR TITLE
Implement multi-column row keys for ui.table

### DIFF
--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -67,10 +67,7 @@ class Table(FilterElement, component='table.js'):
         self._props['columns'] = self._normalize_columns(columns)
         self._props['rows'] = rows
         # if row_key is a list of columns, use the Javascript arrow function syntax, prepending row. to each key
-        if isinstance(row_key, list):
-            self._props[':row-key'] = self._row_key = f"row => {'+'.join([f'row.{col}' for col in row_key])}"
-        else:
-            self._props['row-key'] = self._row_key = row_key
+        self.row_key = row_key  # should call the property setter
         self._props['title'] = title
         self._props['hide-pagination'] = pagination is None
         self._props['pagination'] = pagination if isinstance(pagination, dict) else {'rowsPerPage': pagination or 0}
@@ -314,7 +311,8 @@ class Table(FilterElement, component='table.js'):
     @row_key.setter
     def row_key(self, value: str) -> None:
         if isinstance(value, list):
-            self._props[':row-key'] = self._row_key = f"row => {'+'.join([f'row.{col}' for col in value])}"
+            self._row_key = value
+            self._props[':row-key'] = f"row => {'+'.join([f'row.{col}' for col in value])}"
         else:
             self._props['row-key'] = self._row_key = value
         self.update()

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -309,11 +309,14 @@ class Table(FilterElement, component='table.js'):
     @property
     def row_key(self) -> str:
         """Name of the column containing unique data identifying the row."""
-        return self._props['row-key']
+        return self._row_key
 
     @row_key.setter
     def row_key(self, value: str) -> None:
-        self._props['row-key'] = self._row_key = value
+        if isinstance(value, list):
+            self._props[':row-key'] = self._row_key = f"row => {'+'.join([f'row.{col}' for col in value])}"
+        else:
+            self._props['row-key'] = self._row_key = value
         self.update()
 
     @property

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -68,9 +68,9 @@ class Table(FilterElement, component='table.js'):
         self._props['rows'] = rows
         # if row_key is a list of columns, use the Javascript arrow function syntax, prepending row. to each key
         if isinstance(row_key, list):
-            self._props[':row-key'] = f"row => {'+'.join([f'row.{col}' for col in row_key])}"
+            self._props[':row-key'] = self._row_key = f"row => {'+'.join([f'row.{col}' for col in row_key])}"
         else:
-            self._props['row-key'] = row_key
+            self._props['row-key'] = self._row_key = row_key
         self._props['title'] = title
         self._props['hide-pagination'] = pagination is None
         self._props['pagination'] = pagination if isinstance(pagination, dict) else {'rowsPerPage': pagination or 0}
@@ -87,10 +87,10 @@ class Table(FilterElement, component='table.js'):
                 self.selected.extend(e.args['rows'])
             else:
                 # if row_key is a list of columns, calculate the row_key for each row in the selected list
-                if isinstance(row_key, list):
-                    self.selected = [row for row in self.selected if ''.join([row[col] for col in row_key]) not in e.args['keys']]
+                if isinstance(self._row_key, list):
+                    self.selected = [row for row in self.selected if ''.join([row[col] for col in self._row_key]) not in e.args['keys']]
                 else:
-                    self.selected = [row for row in self.selected if row[row_key] not in e.args['keys']]
+                    self.selected = [row for row in self.selected if row[self._row_key] not in e.args['keys']]
             self.update()
             arguments = TableSelectionEventArguments(sender=self, client=self.client, selection=self.selected)
             for handler in self._selection_handlers:
@@ -313,7 +313,7 @@ class Table(FilterElement, component='table.js'):
 
     @row_key.setter
     def row_key(self, value: str) -> None:
-        self._props['row-key'] = value
+        self._props['row-key'] = self._row_key = value
         self.update()
 
     @property


### PR DESCRIPTION
It is now possible to specify a list of keys as row-key property. Example:

```py
summary_table = ui.table(
    columns=summary_columns,
    rows=summary_rows,
    row_key=['date', 'name']
    pagination=10,
    selection='single'  # Enable single row selection
)
```

In the current version, it's possible to work with multiple columns as composite table key as:
```py
ui.table(...).props(':row-key="row => row.date+row.name"')
```

but it doesn't handle deselection properly, as row_key is still equal to 'id' if not specified in the arguments list...