### PR TITLE
Add reference for `ui.menu_item`

### DIFF
--- a/website/documentation/content/menu_documentation.py
+++ b/website/documentation/content/menu_documentation.py
@@ -46,4 +46,5 @@ def submenus():
                     ui.menu_item('Sub-option 3')
 
 
-doc.reference(ui.menu)
+doc.reference(ui.menu, title='Reference for ui.menu')
+doc.reference(ui.menu_item, title='Reference for ui.menu_item')

--- a/website/documentation/reference.py
+++ b/website/documentation/reference.py
@@ -2,12 +2,20 @@ import inspect
 from typing import Callable, Optional
 
 from nicegui import binding, ui
+from nicegui.elements.markdown import remove_indentation
 
 from ..style import create_anchor_name, subheading
 
 
 def generate_class_doc(class_obj: type, part_title: str) -> None:
     """Generate documentation for a class including all its methods and properties."""
+    doc = class_obj.__doc__ or class_obj.__init__.__doc__
+    if ':param' in doc:
+        subheading('Initializer', anchor_name=create_anchor_name(part_title.replace('Reference', 'Initializer')))
+        description = remove_indentation(doc.split('\n', 1)[-1])
+        lines = [line.replace(':param ', ':') for line in description.splitlines() if ':param' in line]
+        ui.restructured_text('\n'.join(lines)).classes('bold-links arrow-links rst-param-tables')
+
     mro = [base for base in class_obj.__mro__ if base.__module__.startswith('nicegui.')]
     ancestors = mro[1:]
     attributes = {}


### PR DESCRIPTION
This PR implements feature request #4107, adding a reference for `ui.menu_item` to the documentation.
To make it more useful, it also includes initializer parameters in every reference.