### PR TITLE
Prevent `ui.leaflet` from oscillating between two locations

### DIFF
--- a/nicegui/elements/leaflet.js
+++ b/nicegui/elements/leaflet.js
@@ -65,7 +65,6 @@ export default {
       "zoomanim",
     ]) {
       this.map.on(type, async (e) => {
-        await this.$nextTick(); // NOTE: allow zoom and center to both be updated
         this.$emit(`map-${type}`, {
           ...e,
           originalEvent: undefined,

--- a/nicegui/elements/leaflet.js
+++ b/nicegui/elements/leaflet.js
@@ -64,7 +64,7 @@ export default {
       "preclick",
       "zoomanim",
     ]) {
-      this.map.on(type, async (e) => {
+      this.map.on(type, (e) => {
         this.$emit(`map-${type}`, {
           ...e,
           originalEvent: undefined,

--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -61,6 +61,8 @@ class Leaflet(Element, component='leaflet.js', default_classes='nicegui-leaflet'
             options={'attribution': '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors'},
         )
 
+        self._send_update_on_value_change = True
+
     def __enter__(self) -> Self:
         Layer.current_leaflet = self
         return super().__enter__()
@@ -87,13 +89,15 @@ class Leaflet(Element, component='leaflet.js', default_classes='nicegui-leaflet'
         await self.client.connected(timeout=timeout)
         await event.wait()
 
-    async def _handle_moveend(self, e: GenericEventArguments) -> None:
-        await asyncio.sleep(0.02)  # NOTE: wait for zoom to be updated as well
+    def _handle_moveend(self, e: GenericEventArguments) -> None:
+        self._send_update_on_value_change = False
         self.center = e.args['center']
+        self._send_update_on_value_change = True
 
-    async def _handle_zoomend(self, e: GenericEventArguments) -> None:
-        await asyncio.sleep(0.02)  # NOTE: wait for center to be updated as well
+    def _handle_zoomend(self, e: GenericEventArguments) -> None:
+        self._send_update_on_value_change = False
         self.zoom = e.args['zoom']
+        self._send_update_on_value_change = True
 
     def run_method(self, name: str, *args: Any, timeout: float = 1) -> AwaitableResponse:
         if not self.is_initialized:
@@ -105,14 +109,16 @@ class Leaflet(Element, component='leaflet.js', default_classes='nicegui-leaflet'
         if self._props['center'] == center:
             return
         self._props['center'] = center
-        self.update()
+        if self._send_update_on_value_change:
+            self.update()
 
     def set_zoom(self, zoom: int) -> None:
         """Set the zoom level of the map."""
         if self._props['zoom'] == zoom:
             return
         self._props['zoom'] = zoom
-        self.update()
+        if self._send_update_on_value_change:
+            self.update()
 
     def remove_layer(self, layer: Layer) -> None:
         """Remove a layer from the map."""


### PR DESCRIPTION
This PR tries to solve #4061 by disabling update messages when new center and zoom values have been received from the client. This technique is also used for our `ValueElement`s.

A minor downside of this approach might be that maps on the auto-index page might not stay in sync between different browsers. But I think this is a reasonable tradeoff.