### PR TITLE
Fix leaked semaphore object warning

### DIFF
--- a/nicegui/native/__init__.py
+++ b/nicegui/native/__init__.py
@@ -1,4 +1,4 @@
-from .native import WindowProxy, method_queue, response_queue
+from .native import WindowProxy, method_queue, on_shutdown, on_startup, response_queue
 from .native_config import NativeConfig
 from .native_mode import activate, find_open_port
 
@@ -8,5 +8,7 @@ __all__ = [
     'activate',
     'find_open_port',
     'method_queue',
+    'on_shutdown',
+    'on_startup',
     'response_queue',
 ]

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -104,6 +104,7 @@ def activate(host: str, port: int, title: str, width: int, height: int, fullscre
         while not core.app.is_stopped:
             time.sleep(0.1)
         _thread.interrupt_main()
+        native.on_shutdown()
 
     if not optional_features.has('webview'):
         log.error('Native mode is not supported in this configuration.\n'
@@ -111,6 +112,7 @@ def activate(host: str, port: int, title: str, width: int, height: int, fullscre
         sys.exit(1)
 
     mp.freeze_support()
+    native.on_startup()
     args = host, port, title, width, height, fullscreen, frameless, native.method_queue, native.response_queue
     process = mp.Process(target=_open_window, args=args, daemon=True)
     process.start()


### PR DESCRIPTION
This pull request fixes #4131: a "leaked semaphore object" warning appears when aborting with CTRL-C in certain configurations. Semaphores are used internally in `multiprocessing.Queue` which never get cleaned up properly.

### Scenario 1: pressing CTRL-C in an FastAPI `app` stared via uvicron from the command line with auto-reloading

Because the `multiprocessing.Queue` objects in `native.py` have been created globally they where also instantiated when not in native mode.  This PR fixes this by only creating the objects when native mode is activated.

### Scenario 2: pressing CTRL-C when using `ui.run(native=True, reload=True)`

This is still unsolved. I'm not sure where to properly call the shutdown/cleanup function.