### PR TITLE
Typo bugfix in elements/editor.js

### DIFF
--- a/nicegui/elements/editor.js
+++ b/nicegui/elements/editor.js
@@ -8,7 +8,7 @@ export default {
       <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
         <slot :name="slot" v-bind="slotProps || {}" />
       </template>
-    </q-input>
+    </q-editor>
   `,
   props: {
     value: String,


### PR DESCRIPTION
The q-editor html tag in the template was never closed, instead a q-input tag was closed.

Just by coincident stumbled over this, no negative impact experienced using the qeditor so far, nevertheless it should be fixed obviously.