### PR TITLE
Register middlewares as late as possible

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -7,7 +7,6 @@ from typing import Any, Dict
 
 import socketio
 from fastapi import HTTPException, Request
-from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, Response
 
 from . import air, background_tasks, binding, core, favicon, helpers, json, run, welcome
@@ -17,7 +16,6 @@ from .dependencies import js_components, libraries, resources
 from .error import error_content
 from .json import NiceGUIJSONResponse
 from .logging import log
-from .middlewares import RedirectWithPrefixMiddleware
 from .page import page
 from .slot import Slot
 from .staticfiles import CacheControlledStaticFiles
@@ -54,8 +52,6 @@ app.mount('/_nicegui_ws/', sio_app)
 mimetypes.add_type('text/javascript', '.js')
 mimetypes.add_type('text/css', '.css')
 
-app.add_middleware(GZipMiddleware)
-app.add_middleware(RedirectWithPrefixMiddleware)
 static_files = CacheControlledStaticFiles(
     directory=(Path(__file__).parent / 'static').resolve(),
     follow_symlink=True,

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Tuple, TypedDict, Union
 
+from fastapi.middleware.gzip import GZipMiddleware
 from starlette.routing import Route
 from uvicorn.main import STARTUP_FAILURE
 from uvicorn.supervisors import ChangeReload, Multiprocess
@@ -16,6 +17,7 @@ from .air import Air
 from .client import Client
 from .language import Language
 from .logging import log
+from .middlewares import RedirectWithPrefixMiddleware
 from .server import CustomServerConfig, Server
 
 APP_IMPORT_STRING = 'nicegui:app'
@@ -122,6 +124,8 @@ def run(*,
         show_welcome_message=show_welcome_message,
     )
     core.app.config.endpoint_documentation = endpoint_documentation
+    core.app.add_middleware(GZipMiddleware)
+    core.app.add_middleware(RedirectWithPrefixMiddleware)
 
     for route in core.app.routes:
         if not isinstance(route, Route):


### PR DESCRIPTION
This PR moves the middleware registration from import time to the actual call of `ui.run`.  Thereby the middlewares are also run before middlewares which are added by user code. See the the authentication example for an actual use-case where this is convinient:

https://github.com/zauberzeug/nicegui/blob/09f4c34049b37907174bfe3109aae4b834f80863/examples/authentication/main.py#L28C2-L33C40

Without this change, the `RedirectResponse` does not work properly behind a reverse proxy with subpath or NiceGUI On Air, because the rewriting of the path prefix which is done by our `RedirectWithPrefixMiddleware` is not applied.

ToDos:

- [ ] test with simple NiceGUI App which has no `if __name__ in ('__mp_main__', '__main__')` guard
- [ ] implement and test `ui.run_with`