### PR TITLE
Fix potential matplotlib warning when using ui.line_plot.push

### DIFF
--- a/nicegui/elements/line_plot.py
+++ b/nicegui/elements/line_plot.py
@@ -42,19 +42,18 @@ class LinePlot(Pyplot):
         self._convert_to_html()
         return self
 
-    def push(self, x: List[float], Y: List[List[float]], x_limits: Union[None, Literal['auto'], Tuple[float, float]] = 'auto', y_limits: Union[None, Literal['auto'], Tuple[float, float]] = 'auto') -> None:
+    def push(self,
+             x: List[float],
+             Y: List[List[float]],
+             x_limits: Union[None, Literal['auto'], Tuple[float, float]] = 'auto',
+             y_limits: Union[None, Literal['auto'], Tuple[float, float]] = 'auto',
+             ) -> None:
         """Push new data to the plot.
 
         :param x: list of x values
         :param Y: list of lists of y values (one list per line)
-        :param x_limits: Update the x limits.
-            If None, then the limits are not updated.
-            If 'auto' and the x data points are all not the same value, then the limits will be auto updated.
-            If a tuple of values, then those values will be used for the limit. (default: 'auto')
-        :param y_limits: Update the x limits.
-            If None, then the limits are not updated.
-            If 'auto' and the y data points are all not the same value, then the limits will be auto updated.
-            If a tuple of values, then those values will be used for the limit. (default: 'auto')
+        :param x_limits: new x limits (tuple of floats, or "auto" to fit the data points, or ``None`` to leave unchanged)
+        :param y_limits: new y limits (tuple of floats, or "auto" to fit the data points, or ``None`` to leave unchanged)
         """
         self.push_counter += 1
 
@@ -69,23 +68,24 @@ class LinePlot(Pyplot):
             line.set_xdata(self.x)
             line.set_ydata(self.Y[i])
 
-        if x_limits is not None or y_limits is not None:
-            flat_y = [y_i for y in self.Y for y_i in y]
+        if isinstance(x_limits, tuple):
+            self.fig.gca().set_xlim(*x_limits)
+        elif x_limits == 'auto':
             min_x = min(self.x)
             max_x = max(self.x)
+            if min_x != max_x:
+                pad_x = 0.01 * (max_x - min_x)
+                self.fig.gca().set_xlim(min_x - pad_x, max_x + pad_x)
+
+        if isinstance(y_limits, tuple):
+            self.fig.gca().set_ylim(*y_limits)
+        elif y_limits == 'auto':
+            flat_y = [y_i for y in self.Y for y_i in y]
             min_y = min(flat_y)
             max_y = max(flat_y)
-            pad_x = 0.01 * (max_x - min_x)
-            pad_y = 0.01 * (max_y - min_y)
-            if x_limits == 'auto' and min_x != max_x:
-                self.fig.gca().set_xlim(min_x - pad_x, max_x + pad_x)
-            elif isinstance(x_limits, tuple):
-                self.fig.gca().set_xlim(*x_limits)
-
-            if y_limits == 'auto' and min_y != max_y:
+            if min_y != max_y:
+                pad_y = 0.01 * (max_y - min_y)
                 self.fig.gca().set_ylim(min_y - pad_y, max_y + pad_y)
-            elif isinstance(y_limits, tuple):
-                self.fig.gca().set_ylim(*y_limits)
 
         self._convert_to_html()
         self.update()

--- a/nicegui/elements/line_plot.py
+++ b/nicegui/elements/line_plot.py
@@ -42,11 +42,13 @@ class LinePlot(Pyplot):
         self._convert_to_html()
         return self
 
-    def push(self, x: List[float], Y: List[List[float]]) -> None:
+    def push(self, x: List[float], Y: List[List[float]], update_x_lims: bool = True, update_y_lims: bool = True) -> None:
         """Push new data to the plot.
 
         :param x: list of x values
         :param Y: list of lists of y values (one list per line)
+        :param update_x_lims: Update the x limits based on the current data points (default: True)
+        :param update_y_lims: Update the y limits based on the current data points (default: True)
         """
         self.push_counter += 1
 
@@ -61,15 +63,19 @@ class LinePlot(Pyplot):
             line.set_xdata(self.x)
             line.set_ydata(self.Y[i])
 
-        flat_y = [y_i for y in self.Y for y_i in y]
-        min_x = min(self.x)
-        max_x = max(self.x)
-        min_y = min(flat_y)
-        max_y = max(flat_y)
-        pad_x = 0.01 * (max_x - min_x)
-        pad_y = 0.01 * (max_y - min_y)
-        self.fig.gca().set_xlim(min_x - pad_x, max_x + pad_x)
-        self.fig.gca().set_ylim(min_y - pad_y, max_y + pad_y)
+        if update_x_lims or update_y_lims:
+            flat_y = [y_i for y in self.Y for y_i in y]
+            min_x = min(self.x)
+            max_x = max(self.x)
+            min_y = min(flat_y)
+            max_y = max(flat_y)
+            pad_x = 0.01 * (max_x - min_x)
+            pad_y = 0.01 * (max_y - min_y)
+            if update_x_lims and min_x != max_x:
+                self.fig.gca().set_xlim(min_x - pad_x, max_x + pad_x)
+            if update_y_lims and min_y != max_y:
+                self.fig.gca().set_ylim(min_y - pad_y, max_y + pad_y)
+
         self._convert_to_html()
         self.update()
 

--- a/nicegui/elements/line_plot.py
+++ b/nicegui/elements/line_plot.py
@@ -45,6 +45,7 @@ class LinePlot(Pyplot):
     def push(self,
              x: List[float],
              Y: List[List[float]],
+             *,
              x_limits: Union[None, Literal['auto'], Tuple[float, float]] = 'auto',
              y_limits: Union[None, Literal['auto'], Tuple[float, float]] = 'auto',
              ) -> None:

--- a/nicegui/elements/line_plot.py
+++ b/nicegui/elements/line_plot.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, List, Literal, Tuple, Union
 
 from .pyplot import Pyplot
 
@@ -42,13 +42,19 @@ class LinePlot(Pyplot):
         self._convert_to_html()
         return self
 
-    def push(self, x: List[float], Y: List[List[float]], update_x_lims: bool = True, update_y_lims: bool = True) -> None:
+    def push(self, x: List[float], Y: List[List[float]], x_limits: Union[None, Literal['auto'], Tuple[float, float]] = 'auto', y_limits: Union[None, Literal['auto'], Tuple[float, float]] = 'auto') -> None:
         """Push new data to the plot.
 
         :param x: list of x values
         :param Y: list of lists of y values (one list per line)
-        :param update_x_lims: Update the x limits based on the current data points (default: True)
-        :param update_y_lims: Update the y limits based on the current data points (default: True)
+        :param x_limits: Update the x limits.
+            If None, then the limits are not updated.
+            If 'auto' and the x data points are all not the same value, then the limits will be auto updated.
+            If a tuple of values, then those values will be used for the limit. (default: 'auto')
+        :param y_limits: Update the x limits.
+            If None, then the limits are not updated.
+            If 'auto' and the y data points are all not the same value, then the limits will be auto updated.
+            If a tuple of values, then those values will be used for the limit. (default: 'auto')
         """
         self.push_counter += 1
 
@@ -63,7 +69,7 @@ class LinePlot(Pyplot):
             line.set_xdata(self.x)
             line.set_ydata(self.Y[i])
 
-        if update_x_lims or update_y_lims:
+        if x_limits is not None or y_limits is not None:
             flat_y = [y_i for y in self.Y for y_i in y]
             min_x = min(self.x)
             max_x = max(self.x)
@@ -71,10 +77,15 @@ class LinePlot(Pyplot):
             max_y = max(flat_y)
             pad_x = 0.01 * (max_x - min_x)
             pad_y = 0.01 * (max_y - min_y)
-            if update_x_lims and min_x != max_x:
+            if x_limits == 'auto' and min_x != max_x:
                 self.fig.gca().set_xlim(min_x - pad_x, max_x + pad_x)
-            if update_y_lims and min_y != max_y:
+            elif isinstance(x_limits, tuple):
+                self.fig.gca().set_xlim(*x_limits)
+
+            if y_limits == 'auto' and min_y != max_y:
                 self.fig.gca().set_ylim(min_y - pad_y, max_y + pad_y)
+            elif isinstance(y_limits, tuple):
+                self.fig.gca().set_ylim(*y_limits)
 
         self._convert_to_html()
         self.update()

--- a/website/documentation/content/line_plot_documentation.py
+++ b/website/documentation/content/line_plot_documentation.py
@@ -31,10 +31,12 @@ def main_demo() -> None:
             ui.timer(10.0, turn_off, once=True)
     line_checkbox.on('update:model-value', handle_change, args=[None])
 
-@doc.demo("Setting Custom Limits",
+
+@doc.demo('Setting Custom Limits',
           """
         By default, the x and y limits are calculated and changed based on new data points.
-        You can disable this behovior by passing `update_x_lims = True` and/or `update_y_lims = True` to `push`.
+        You can disable this behovior by passing `x_limits = None` and/or `y_limits = None` to `push`.
+        You can also have the push method set custom limits by passing a tuple of `(min, max)` to `x_limits`/`y_limits`.
 """)
 def lims_demo() -> None:
     import math
@@ -45,13 +47,15 @@ def lims_demo() -> None:
         .with_legend(['sin'], loc='upper center', ncol=1)
 
     with line_plot:
-        plt.ylim([0,1])
+        plt.ylim([0, 1])
 
     def update_line_plot() -> None:
         now = datetime.now()
         x = now.timestamp()
         y1 = math.sin(x)
-        line_plot.push([now], [[y1]], update_y_lims=False)
+        line_plot.push([now], [[y1]], y_limits=None)
+        ## or to set the limits here
+        line_plot.push([now], [[y1]], y_limits=(-1,1))
 
     line_updates = ui.timer(0.1, update_line_plot, active=False)
     line_checkbox = ui.checkbox('active').bind_value(line_updates, 'active')
@@ -65,5 +69,6 @@ def lims_demo() -> None:
         if line_checkbox.value:
             ui.timer(10.0, turn_off, once=True)
     line_checkbox.on('update:model-value', handle_change, args=[None])
+
 
 doc.reference(ui.line_plot)

--- a/website/documentation/content/line_plot_documentation.py
+++ b/website/documentation/content/line_plot_documentation.py
@@ -16,46 +16,7 @@ def main_demo() -> None:
         x = now.timestamp()
         y1 = math.sin(x)
         y2 = math.cos(x)
-        line_plot.push([now], [[y1], [y2]])
-
-    line_updates = ui.timer(0.1, update_line_plot, active=False)
-    line_checkbox = ui.checkbox('active').bind_value(line_updates, 'active')
-
-    # END OF DEMO
-    def handle_change(e: events.GenericEventArguments) -> None:
-        def turn_off() -> None:
-            line_checkbox.set_value(False)
-            ui.notify('Turning off that line plot to save resources on our live demo server. 😎')
-        line_checkbox.value = e.args
-        if line_checkbox.value:
-            ui.timer(10.0, turn_off, once=True)
-    line_checkbox.on('update:model-value', handle_change, args=[None])
-
-
-@doc.demo('Setting Custom Limits',
-          """
-        By default, the x and y limits are calculated and changed based on new data points.
-        You can disable this behovior by passing `x_limits = None` and/or `y_limits = None` to `push`.
-        You can also have the push method set custom limits by passing a tuple of `(min, max)` to `x_limits`/`y_limits`.
-""")
-def lims_demo() -> None:
-    import math
-    from datetime import datetime
-    import matplotlib.pyplot as plt
-
-    line_plot = ui.line_plot(n=1, limit=20, figsize=(3, 2), update_every=5) \
-        .with_legend(['sin'], loc='upper center', ncol=1)
-
-    with line_plot:
-        plt.ylim([0, 1])
-
-    def update_line_plot() -> None:
-        now = datetime.now()
-        x = now.timestamp()
-        y1 = math.sin(x)
-        line_plot.push([now], [[y1]], y_limits=None)
-        ## or to set the limits here
-        line_plot.push([now], [[y1]], y_limits=(-1,1))
+        line_plot.push([now], [[y1], [y2]], y_limits=(-1.5, 1.5))
 
     line_updates = ui.timer(0.1, update_line_plot, active=False)
     line_checkbox = ui.checkbox('active').bind_value(line_updates, 'active')

--- a/website/documentation/content/line_plot_documentation.py
+++ b/website/documentation/content/line_plot_documentation.py
@@ -31,5 +31,39 @@ def main_demo() -> None:
             ui.timer(10.0, turn_off, once=True)
     line_checkbox.on('update:model-value', handle_change, args=[None])
 
+@doc.demo("Setting Custom Limits",
+          """
+        By default, the x and y limits are calculated and changed based on new data points.
+        You can disable this behovior by passing `update_x_lims = True` and/or `update_y_lims = True` to `push`.
+""")
+def lims_demo() -> None:
+    import math
+    from datetime import datetime
+    import matplotlib.pyplot as plt
+
+    line_plot = ui.line_plot(n=1, limit=20, figsize=(3, 2), update_every=5) \
+        .with_legend(['sin'], loc='upper center', ncol=1)
+
+    with line_plot:
+        plt.ylim([0,1])
+
+    def update_line_plot() -> None:
+        now = datetime.now()
+        x = now.timestamp()
+        y1 = math.sin(x)
+        line_plot.push([now], [[y1]], update_y_lims=False)
+
+    line_updates = ui.timer(0.1, update_line_plot, active=False)
+    line_checkbox = ui.checkbox('active').bind_value(line_updates, 'active')
+
+    # END OF DEMO
+    def handle_change(e: events.GenericEventArguments) -> None:
+        def turn_off() -> None:
+            line_checkbox.set_value(False)
+            ui.notify('Turning off that line plot to save resources on our live demo server. 😎')
+        line_checkbox.value = e.args
+        if line_checkbox.value:
+            ui.timer(10.0, turn_off, once=True)
+    line_checkbox.on('update:model-value', handle_change, args=[None])
 
 doc.reference(ui.line_plot)


### PR DESCRIPTION
## Description

When trying to use `ui.line_plot.push` with x or y values that are all equal, you get the following matplotlib warning:
```
lib/python3.12/site-packages/nicegui/elements/line_plot.py:72: UserWarning: Attempting to set identical low and high ylims makes transformation singular; automatically expanding.
  self.fig.gca().set_ylim(min_y - pad_y, max_y + pad_y)
```

This PR changes 2 things:

1. It will not update the x and/or y limits if their respective data points are all the same value.
2. Add `update_y_lims` and `update_x_lims` parameters to `push` that will disable the limits updating for that push. This will also allow for custom limits to be set (and not reset every call to push).

## Example

This example will have a warning on the current version of nicegui.

```python
from nicegui import ui

lp = ui.line_plot(n=1)

i = 0
def update_lp():
    global i
    lp.push([i], [[0]])
    # lp.push([i], [[0]], update_y_lims=False)

    i += 1
ui.timer(1, update_lp)
ui.run()
```
