### PR TITLE
Keep single-use routes for a few seconds before pruning them

### DIFF
--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -23,6 +23,8 @@ from ..storage import Storage
 from .app_config import AppConfig
 from .range_response import get_range_response
 
+SINGLE_USE_ROUTE_TIMEOUT = 10.0
+
 
 class State(Enum):
     STOPPED = 0
@@ -205,7 +207,7 @@ class App(FastAPI):
         @self.get(path)
         def read_item() -> FileResponse:
             if single_use:
-                self._routes_to_remove[path] = time.time() + 10.0
+                self._routes_to_remove[path] = time.time() + SINGLE_USE_ROUTE_TIMEOUT
             return FileResponse(file, headers={'Cache-Control': f'public, max-age={max_cache_age}'})
 
         return urllib.parse.quote(path)
@@ -257,7 +259,7 @@ class App(FastAPI):
         @self.get(path)
         def read_item(request: Request, nicegui_chunk_size: int = 8192) -> Response:
             if single_use:
-                self._routes_to_remove[path] = time.time() + 10.0
+                self._routes_to_remove[path] = time.time() + SINGLE_USE_ROUTE_TIMEOUT
             return get_range_response(file, request, chunk_size=nicegui_chunk_size)
 
         return urllib.parse.quote(path)
@@ -295,4 +297,4 @@ class App(FastAPI):
             for path in routes:
                 self.remove_route(path)
                 del self._routes_to_remove[path]
-            await asyncio.sleep(10.0)
+            await asyncio.sleep(SINGLE_USE_ROUTE_TIMEOUT)

--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -7,7 +7,7 @@ import time
 import urllib
 from enum import Enum
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Iterator, List, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional, Union
 
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import FileResponse
@@ -41,7 +41,7 @@ class App(FastAPI):
         self.urls = ObservableSet()
         self._state: State = State.STOPPED
         self.config = AppConfig()
-        self._routes_to_remove: dict[str, float] = {}
+        self._routes_to_remove: Dict[str, float] = {}
 
         self._startup_handlers: List[Union[Callable[..., Any], Awaitable]] = []
         self._shutdown_handlers: List[Union[Callable[..., Any], Awaitable]] = []

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -129,6 +129,7 @@ async def _startup() -> None:
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(Client.prune_instances(), name='prune clients')
     background_tasks.create(Slot.prune_stacks(), name='prune slot stacks')
+    background_tasks.create(core.app.prune_single_use_routes(), name='prune single-use routes')
     background_tasks.create(core.app.storage.prune_tab_storage(), name='prune tab storage')
     air.connect()
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -5,6 +5,7 @@ import pytest
 from fastapi.responses import PlainTextResponse
 
 from nicegui import app, ui
+from nicegui.app import app as app_module
 from nicegui.testing import Screen, screen_plugin
 
 
@@ -31,6 +32,7 @@ def test_download_text_file(screen: Screen, test_route: str):  # pylint: disable
 def test_downloading_local_file_as_src(screen: Screen):
     IMAGE_FILE = Path(__file__).parent.parent / 'examples' / 'slideshow' / 'slides' / 'slide1.jpg'
     ui.button('download', on_click=lambda: ui.download(IMAGE_FILE))
+    app_module.SINGLE_USE_ROUTE_TIMEOUT = 0.1
 
     screen.open('/')
     route_count_before_download = len(app.routes)


### PR DESCRIPTION
As discussed in issue #4016, `ui.download` can fail on the auto-index page if multiple tabs try to download from a single-use route at the same time. The first download will remove the route and subsequent downloads will fail.

This PR addresses this problem by keeping used single-use routes in a dictionary with an expiration timestamp. A pruning loop will check this dictionary every 10 seconds and remove outdated routes.

Note that simply delaying the removal after creating a single-use route did not work. The path of a single-use route is basically a hash of the filepath and, thus, not unique to a single call to `ui.download`. Therefore a route could be used again and again, so we need to keep it as long as `ui.download` is still being called.
