### PR TITLE
dynamically mirror 'Other HTML elements' demo

### DIFF
--- a/website/documentation/content/html_documentation.py
+++ b/website/documentation/content/html_documentation.py
@@ -15,7 +15,7 @@ def demo_inline() -> None:
     ui.html('This is <u>emphasized</u>.', tag='em')
 
 
-@doc.demo('Other HTML Elements', '''
+HTML_ELEMENTS_DEMO = doc.demo('Other HTML Elements', '''
     There is also an `html` module that allows you to insert other HTML elements like `<span>`, `<div>`, `<p>`, etc.
     It is equivalent to using the `ui.element` method with the `tag` argument.
 
@@ -24,6 +24,8 @@ def demo_inline() -> None:
 
     *Added in version 2.5.0*
 ''')
+
+@HTML_ELEMENTS_DEMO
 def other_html_elements():
     from nicegui import html, ui
 

--- a/website/documentation/content/html_documentation.py
+++ b/website/documentation/content/html_documentation.py
@@ -15,7 +15,7 @@ def demo_inline() -> None:
     ui.html('This is <u>emphasized</u>.', tag='em')
 
 
-HTML_ELEMENTS_DEMO = doc.demo('Other HTML Elements', '''
+@doc.demo(other_html_elements_title := 'Other HTML Elements', other_html_elements_description := '''
     There is also an `html` module that allows you to insert other HTML elements like `<span>`, `<div>`, `<p>`, etc.
     It is equivalent to using the `ui.element` method with the `tag` argument.
 
@@ -24,8 +24,6 @@ HTML_ELEMENTS_DEMO = doc.demo('Other HTML Elements', '''
 
     *Added in version 2.5.0*
 ''')
-
-@HTML_ELEMENTS_DEMO
 def other_html_elements():
     from nicegui import html, ui
 

--- a/website/documentation/content/section_text_elements.py
+++ b/website/documentation/content/section_text_elements.py
@@ -20,26 +20,4 @@ doc.intro(markdown_documentation)
 doc.intro(restructured_text_documentation)
 doc.intro(mermaid_documentation)
 doc.intro(html_documentation)
-
-
-@doc.demo('Other HTML Elements', '''
-    There is an `html` module that allows you to insert other HTML elements like `<span>`, `<div>`, `<p>`, etc.
-    It is equivalent to using the `ui.element` method with the `tag` argument.
-
-    Like with any other element, you can add classes, style, props, tooltips and events.
-    One convenience is that the keyword arguments are automatically added to the element's `props` dictionary.
-
-    *Added in version 2.5.0*
-''')
-def other_html_elements():
-    from nicegui import html, ui
-
-    with html.section().style('font-size: 120%'):
-        html.strong('This is bold.') \
-            .classes('cursor-pointer') \
-            .on('click', lambda: ui.notify('Bold!'))
-        html.hr()
-        html.em('This is italic.').tooltip('Nice!')
-        with ui.row():
-            html.img().props('src=https://placehold.co/60')
-            html.img(src='https://placehold.co/60')
+HTML_ELEMENTS_DEMO(other_html_elements)

--- a/website/documentation/content/section_text_elements.py
+++ b/website/documentation/content/section_text_elements.py
@@ -9,6 +9,7 @@ from . import (
     mermaid_documentation,
     restructured_text_documentation,
 )
+from .html_documentation import other_html_elements_description, other_html_elements_title, other_html_elements
 
 doc.title('*Text* Elements')
 
@@ -20,4 +21,4 @@ doc.intro(markdown_documentation)
 doc.intro(restructured_text_documentation)
 doc.intro(mermaid_documentation)
 doc.intro(html_documentation)
-HTML_ELEMENTS_DEMO(other_html_elements)
+doc.demo(other_html_elements_title, other_html_elements_description)(other_html_elements)


### PR DESCRIPTION
In PR https://github.com/zauberzeug/nicegui/pull/4027 it was decided to copy&paste the other HTML section because we want the users to find it both under "text elements" as well as when looking into the ui.html element. Duplicating the section isn't a very nice solution though. Maybe this PR is a better idea for keeping the information in both places?