### PR TITLE
Bulk vue updates on update

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -382,16 +382,14 @@ function createApp(elements, options) {
 
           await Promise.all(loadPromises);
 
-          Vue.nextTick(() => {
-            for (const [id, element] of Object.entries(msg)) {
-              if (element === null) {
-                delete this.elements[id];
-                continue;
-              }
-              this.elements[id] = element;
-              replaceUndefinedAttributes(this.elements, id);
+          for (const [id, element] of Object.entries(msg)) {
+            if (element === null) {
+              delete this.elements[id];
+              continue;
             }
-          });
+            this.elements[id] = element;
+            replaceUndefinedAttributes(this.elements, id);
+          }
         },
         run_javascript: (msg) => runJavascript(msg.code, msg.request_id),
         open: (msg) => {


### PR DESCRIPTION
I noticed that adding or changing a large number of elements, especially inside an SVG tag, takes very long.

This changes the update handler to first load all dependencies in parallel and then update the elements.