### PR TITLE
User testing, save response and print method

### DIFF
--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -35,6 +35,7 @@ class User:
         self.navigate = UserNavigate(self)
         self.notify = UserNotify()
         self.download = UserDownload(self)
+        self.response = None
 
     @property
     def _client(self) -> Client:
@@ -65,6 +66,7 @@ class User:
         self.back_history.append(path)
         if clear_forward_history:
             self.forward_history.clear()
+        self.response = response
         return self.client
 
     @overload
@@ -185,6 +187,9 @@ class User:
                 raise AssertionError('expected to find at least one ' +
                                      self._build_error_message(target, kind, marker, content))
         return UserInteraction(self, elements, target)
+
+    def print(self, message):
+        raise ValueError(message, Warning)
 
     @property
     def current_layout(self) -> Element:

--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -189,7 +189,7 @@ class User:
         return UserInteraction(self, elements, target)
 
     def print(self, message):
-        raise ValueError(message, Warning)
+        raise ValueError(message)
 
     def routes(self):
         return Client.page_routes.values()

--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -191,6 +191,9 @@ class User:
     def print(self, message):
         raise ValueError(message, Warning)
 
+    def routes(self):
+        raise Client.page_routes.values()
+
     @property
     def current_layout(self) -> Element:
         """Return the root layout element of the current page."""

--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -192,7 +192,7 @@ class User:
         raise ValueError(message, Warning)
 
     def routes(self):
-        raise Client.page_routes.values()
+        return Client.page_routes.values()
 
     @property
     def current_layout(self) -> Element:


### PR DESCRIPTION
As per title now the response is saved so it is possible to get more information like the URL where the user is or check the response code.

Also the `print` function probably isn't the best but let's to print something in the pytest output as it isn't very easy to do that.

I was trying to get the actual URL after the various redirects but `response.history` with:
```py
async def test_navigate_to(user: User) -> None:
    @ui.page('/')
    def index() -> None:
        ui.navigate.to('/login')

    @ui.page('/login')
    def login() -> None:
        ui.input('Username')

    await user.open('/')
    user.print(user.response.history)
    # await user.should_see('Username')
    user.find('Username').type('admin')
```

Return an empty list, I think because the redirect happens next the open so at that time there wasn't the reidrect but I am not finding a way to get the actual url where it is the user.