### PR TITLE
Only delete page content if the number of connections is zero

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -139,12 +139,12 @@ class Air:
             return True
 
         @self.relay.on('client_disconnect')
-        def _handle_client_disconnect(data: Dict[str, Any]) -> None:
+        async def _handle_client_disconnect(data: Dict[str, Any]) -> None:
             self.log.debug('client disconnected.')
             client_id = data['client_id']
             if client_id not in Client.instances:
                 return
-            Client.instances[client_id].handle_disconnect()
+            await Client.instances[client_id].handle_disconnect()
 
         @self.relay.on('connect')
         async def _handle_connect() -> None:

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -135,7 +135,7 @@ class Air:
                 core.app.storage.copy_tab(data['old_tab_id'], data['tab_id'])
             client.tab_id = data['tab_id']
             client.on_air = True
-            client.handle_handshake(data.get('next_message_id'))
+            client.handle_handshake(data['sid'], data.get('next_message_id'))
             return True
 
         @self.relay.on('client_disconnect')
@@ -144,7 +144,7 @@ class Air:
             client_id = data['client_id']
             if client_id not in Client.instances:
                 return
-            Client.instances[client_id].handle_disconnect()
+            Client.instances[client_id].handle_disconnect(data['sid'])
 
         @self.relay.on('connect')
         async def _handle_connect() -> None:

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -139,12 +139,12 @@ class Air:
             return True
 
         @self.relay.on('client_disconnect')
-        async def _handle_client_disconnect(data: Dict[str, Any]) -> None:
+        def _handle_client_disconnect(data: Dict[str, Any]) -> None:
             self.log.debug('client disconnected.')
             client_id = data['client_id']
             if client_id not in Client.instances:
                 return
-            await Client.instances[client_id].handle_disconnect()
+            Client.instances[client_id].handle_disconnect()
 
         @self.relay.on('connect')
         async def _handle_connect() -> None:

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -135,7 +135,7 @@ class Air:
                 core.app.storage.copy_tab(data['old_tab_id'], data['tab_id'])
             client.tab_id = data['tab_id']
             client.on_air = True
-            client.handle_handshake(data['sid'], data.get('next_message_id'))
+            client.handle_handshake(data['sid'], data['document_id'], data.get('next_message_id'))
             return True
 
         @self.relay.on('client_disconnect')

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -251,16 +251,16 @@ class Client:
 
     def handle_disconnect(self) -> None:
         """Wait for the browser to reconnect; invoke disconnect handlers if it doesn't."""
-        async def delete_content() -> None:
-            await asyncio.sleep(self.page.resolve_reconnect_timeout())
-            if self._num_connections == 0:
-                self.delete()
         self._num_connections -= 1
         for t in self.disconnect_handlers:
             self.safe_invoke(t)
         for t in core.app._disconnect_handlers:  # pylint: disable=protected-access
             self.safe_invoke(t)
         if not self.shared:
+            async def delete_content() -> None:
+                await asyncio.sleep(self.page.resolve_reconnect_timeout())
+                if self._num_connections == 0:
+                    self.delete()
             self._delete_task = background_tasks.create(delete_content())
 
     def handle_event(self, msg: Dict) -> None:

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -268,7 +268,7 @@ class Client:
                 self._num_connections.pop(socket_id)
                 if not self.shared:
                     self.delete()
-        self._delete_task = background_tasks.create(delete_content())
+        self._delete_tasks[socket_id] = background_tasks.create(delete_content())
 
     def _cancel_delete_task(self, socket_id: str) -> None:
         if socket_id in self._delete_tasks:

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -269,6 +269,7 @@ class Client:
                 for t in core.app._disconnect_handlers:  # pylint: disable=protected-access
                     self.safe_invoke(t)
                 self._num_connections.pop(document_id)
+                self._delete_tasks.pop(document_id)
                 if not self.shared:
                     self.delete()
         self._delete_tasks[document_id] = background_tasks.create(delete_content())

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -178,13 +178,13 @@ async def _on_handshake(sid: str, data: Dict[str, Any]) -> bool:
 
 
 @sio.on('disconnect')
-def _on_disconnect(sid: str) -> None:
+async def _on_disconnect(sid: str) -> None:
     query_bytes: bytearray = sio.get_environ(sid)['asgi.scope']['query_string']
     query = urllib.parse.parse_qs(query_bytes.decode())
     client_id = query['client_id'][0]
     client = Client.instances.get(client_id)
     if client:
-        client.handle_disconnect()
+        await client.handle_disconnect()
 
 
 @sio.on('event')

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -171,7 +171,7 @@ async def _on_handshake(sid: str, data: Dict[str, Any]) -> bool:
     else:
         client.environ = sio.get_environ(sid)
         await sio.enter_room(sid, client.id)
-    client.handle_handshake(sid, data.get('next_message_id'))
+    client.handle_handshake(sid, data['document_id'], data.get('next_message_id'))
     assert client.tab_id is not None
     await core.app.storage._create_tab_storage(client.tab_id)  # pylint: disable=protected-access
     return True

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -171,7 +171,7 @@ async def _on_handshake(sid: str, data: Dict[str, Any]) -> bool:
     else:
         client.environ = sio.get_environ(sid)
         await sio.enter_room(sid, client.id)
-    client.handle_handshake(data.get('next_message_id'))
+    client.handle_handshake(sid, data.get('next_message_id'))
     assert client.tab_id is not None
     await core.app.storage._create_tab_storage(client.tab_id)  # pylint: disable=protected-access
     return True
@@ -184,7 +184,7 @@ def _on_disconnect(sid: str) -> None:
     client_id = query['client_id'][0]
     client = Client.instances.get(client_id)
     if client:
-        client.handle_disconnect()
+        client.handle_disconnect(sid)
 
 
 @sio.on('event')

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -178,13 +178,13 @@ async def _on_handshake(sid: str, data: Dict[str, Any]) -> bool:
 
 
 @sio.on('disconnect')
-async def _on_disconnect(sid: str) -> None:
+def _on_disconnect(sid: str) -> None:
     query_bytes: bytearray = sio.get_environ(sid)['asgi.scope']['query_string']
     query = urllib.parse.parse_qs(query_bytes.decode())
     client_id = query['client_id'][0]
     client = Client.instances.get(client_id)
     if client:
-        await client.handle_disconnect()
+        client.handle_disconnect()
 
 
 @sio.on('event')

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -331,6 +331,7 @@ function createApp(elements, options) {
     },
     mounted() {
       mounted_app = this;
+      window.documentId = createRandomUUID();
       window.clientId = options.query.client_id;
       const url = window.location.protocol === "https:" ? "wss://" : "ws://" + window.location.host;
       window.path_prefix = options.prefix;
@@ -347,6 +348,7 @@ function createApp(elements, options) {
         connect: () => {
           const args = {
             client_id: window.clientId,
+            document_id: window.documentId,
             tab_id: TAB_ID,
             old_tab_id: OLD_TAB_ID,
             next_message_id: window.nextMessageId,

--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -61,7 +61,11 @@ class User:
         client_id = match.group(1)
         self.client = Client.instances[client_id]
         self.sio.on('connect')
-        await _on_handshake(f'test-{uuid4()}', {'client_id': self.client.id, 'tab_id': str(uuid4())})
+        await _on_handshake(f'test-{uuid4()}', {
+            'client_id': self.client.id,
+            'tab_id': str(uuid4()),
+            'document_id': str(uuid4()),
+        })
         self.back_history.append(path)
         if clear_forward_history:
             self.forward_history.clear()


### PR DESCRIPTION
This PR tries to solve #4253 with a new `_num_connections` counter. On handshake the counter is increased, on disconnect it is decreased. On disconnect, after awaiting the reconnect timeout, the page content is only deleted if the number of connections is zero.

Possible scenarios:

- normal reconnect:
    ```
    handshake (num=1) ... disconnect (num=0) ... handshake (num=1) ... after delay: don't delete
    ```
- strange reconnect with handshake before disconnect:
    ```
    handshake (num=1) ... handshake (num=2) ... disconnect (num=1) ... after delay: don't delete
    ```
- normal disconnect:
    ```
    handshake (num=1) ... disconnect (num=0) ... after delay: delete
    ```

While working on the handshake and disconnect implementation, I noticed an inconsistency with `app.on_connect` and `app.on_disconnect`: While connect handlers are called on reconnect, disconnect handlers are not. In this PR I changed it so that both handlers are called during reconnection. We should clarify if this is the desired behavior.
