### PR TITLE
Filter keyboard events by type to ignore autocompletion

### DIFF
--- a/nicegui/elements/keyboard.js
+++ b/nicegui/elements/keyboard.js
@@ -2,10 +2,15 @@ export default {
   mounted() {
     for (const event of this.events) {
       document.addEventListener(event, (evt) => {
+        // https://github.com/zauberzeug/nicegui/issues/4290
+        if (!(evt instanceof KeyboardEvent)) return;
+
         // https://stackoverflow.com/a/36469636/3419103
         const focus = document.activeElement;
         if (focus && this.ignore.includes(focus.tagName.toLowerCase())) return;
+
         if (evt.repeat && !this.repeating) return;
+
         this.$emit("key", {
           action: event,
           altKey: evt.altKey,


### PR DESCRIPTION
This PR solves #4290 by ignoring keyboard events that are not of type `KeyboardEvent`.

It can be tested with the following snippet by picking an email from the dropdown list:
```py
ui.keyboard(ui.notify, ignore=[])
ui.input('email').props('autocomplete=email')
```
Without this PR, the autocompletion triggers a keyboard event, causing an exception due to missing attributes.
With this PR there is simply no keyboard event in this case.
