### PR TITLE
Add to `redis.from_url` connection parameters

### DIFF
--- a/nicegui/persistence/redis_persistent_dict.py
+++ b/nicegui/persistence/redis_persistent_dict.py
@@ -14,7 +14,13 @@ class RedisPersistentDict(PersistentDict):
     def __init__(self, *, url: str, id: str, key_prefix: str = 'nicegui:') -> None:  # pylint: disable=redefined-builtin
         if not optional_features.has('redis'):
             raise ImportError('Redis is not installed. Please run "pip install nicegui[redis]".')
-        self.redis_client = redis.from_url(url)
+        self.redis_client = redis.from_url(
+            url,
+            health_check_interval=10,
+            socket_connect_timeout=5,
+            retry_on_timeout=True,
+            socket_keepalive=True,
+        )
         self.pubsub = self.redis_client.pubsub()
         self.key = key_prefix + id
         super().__init__(data={}, on_change=self.publish)


### PR DESCRIPTION
This pull request includes an enhancement to the `RedisPersistentDict` class in the `nicegui/persistence/redis_persistent_dict.py` file to improve the reliability and performance of the Redis client connection.

Connection improvements to `RedisPersistentDict`:

* [`nicegui/persistence/redis_persistent_dict.py`](diffhunk://#diff-d52efa243ec1e0f3d58104376c85f0e294b7f2371679b32296c7fdd426195978L17-R23): Updated the initialization of the `redis_client` to include additional parameters such as `health_check_interval`, `socket_connect_timeout`, `retry_on_timeout`, and `socket_keepalive` to enhance connection stability and performance.