### PR TITLE
Fix upload to zenodo by using our own built version

### DIFF
--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Upload to Zenodo
         id: release
-        uses: megasanjay/upload-to-zenodo@43390984723d64d501f361820f6e558dececdfcc
+        uses: codingpaula/upload-to-zenodo@fix-octet-stream
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           zenodo_token: ${{ secrets.ZENODO_TOKEN }}


### PR DESCRIPTION
Unfortunately, there hasn't been any progress on [this issue](https://github.com/megasanjay/upload-to-zenodo/issues/58), so this PR tests if the new version that was created by running `npm build` fixes our problem with the upload.

If this works, we will create another pull request on the original `upload-to-zenodo` repo.