### PR TITLE
Flush data when performing backup for persistent dict

### DIFF
--- a/nicegui/persistence/file_persistent_dict.py
+++ b/nicegui/persistence/file_persistent_dict.py
@@ -36,8 +36,12 @@ class FilePersistentDict(PersistentDict):
             self.filepath.parent.mkdir(exist_ok=True)
 
         async def backup() -> None:
-            async with aiofiles.open(self.filepath, 'w', encoding=self.encoding) as f:
-                await f.write(json.dumps(self, indent=self.indent))
+            try:
+                async with aiofiles.open(self.filepath, 'w', encoding=self.encoding) as f:
+                    await f.write(json.dumps(self, indent=self.indent))
+                    await f.flush()
+            except Exception:
+                log.exception('Error during file persistence backup')
         if core.loop:
             background_tasks.create_lazy(backup(), name=self.filepath.stem)
         else:


### PR DESCRIPTION
This PR tries to fix #4312 by flushing the data after writing to a persistent file for backup.