### PR TITLE
Improve the update mechanism for `ui.plotly`

### DIFF
--- a/nicegui/elements/plotly.py
+++ b/nicegui/elements/plotly.py
@@ -46,6 +46,7 @@ class Plotly(Element, component='plotly.vue', dependencies=['lib/plotly/plotly.m
     def update(self) -> None:
         self._props['options'] = self._get_figure_json()
         super().update()
+        self.run_method('update')
 
     def _get_figure_json(self) -> Dict:
         if isinstance(self.figure, go.Figure):

--- a/nicegui/elements/plotly.vue
+++ b/nicegui/elements/plotly.vue
@@ -8,9 +8,6 @@ export default {
     await import("plotly");
     this.update();
   },
-  updated() {
-    this.update();
-  },
   methods: {
     update() {
       // wait for plotly to be loaded


### PR DESCRIPTION
This PR tries to solve #4186 by calling the `update()` method in JavaScript explicitly rather than within the `updated` hook. It seems to resolve the problem described with the following code snippet:
```py
ui.label('1. Manually zoom the plot')
ui.button('2. Update the label', on_click=lambda: label.set_text(label.text + '.'))
ui.button('3. Update the plot', on_click=lambda: plot.update())
ui.label('4. --> The plot resets unexpectedly')

label = ui.label('...')
plot = ui.plotly({'layout': {'uirevision': 'constant'}})
```

Tests are passing and demos seem to work like before.