### PR TITLE
Removing list args when emitting events

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -80,7 +80,7 @@ function getComputedProp(target, prop_name) {
 }
 
 function emitEvent(event_name, ...args) {
-  getElement(0).$emit(event_name, ...args);
+  getElement(0).$emit(event_name, args);
 }
 
 function stringifyEventArgs(args, event_args) {


### PR DESCRIPTION
Apparently, the args are not passed when we use ... in front of args. Removing the dots solves the issue.