### PR TITLE
Add `socket_id` to `UIEventArguments`; use new `client.target` where possible

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -169,7 +169,7 @@ class Air:
                 arg0 = json.loads(args[0])
                 arg0['socket_id'] = client_id  # HACK: translate socket_id of ui.scene's init event
                 args[0] = json.dumps(arg0)
-            client.handle_event(data['msg'])
+            client.handle_event(data['sid'], data['msg'])
 
         @self.relay.on('javascript_response')
         def _handle_javascript_response(data: Dict[str, Any]) -> None:

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -377,10 +377,10 @@ class Element(Visibility):
             self.update()
         return self
 
-    def _handle_event(self, msg: Dict) -> None:
+    def _handle_event(self, sid: str, msg: Dict) -> None:
         listener = self._event_listeners[msg['listener_id']]
         storage.request_contextvar.set(listener.request)
-        args = events.GenericEventArguments(sender=self, client=self.client, args=msg['args'])
+        args = events.GenericEventArguments(sender=self, client=self.client, socket_id=sid, args=msg['args'])
         events.handle_event(listener.handler, args)
 
     def update(self) -> None:

--- a/nicegui/elements/button.py
+++ b/nicegui/elements/button.py
@@ -39,7 +39,7 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
 
     def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
         """Add a callback to be invoked when the button is clicked."""
-        self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
+        self.on('click', lambda e: handle_event(callback, ClickEventArguments.from_generic_event(e)), [])
         return self
 
     def _text_to_model_text(self, text: str) -> None:

--- a/nicegui/elements/button_dropdown.py
+++ b/nicegui/elements/button_dropdown.py
@@ -48,7 +48,7 @@ class DropdownButton(IconElement, TextElement, DisableableElement, BackgroundCol
             self._props['split'] = True
 
         if on_click:
-            self.on('click', lambda _: handle_event(on_click, ClickEventArguments(sender=self, client=self.client)), [])
+            self.on('click', lambda e: handle_event(on_click, ClickEventArguments.from_generic_event(e)), [])
 
     def _text_to_model_text(self, text: str) -> None:
         self._props['label'] = text

--- a/nicegui/elements/chip.py
+++ b/nicegui/elements/chip.py
@@ -56,5 +56,5 @@ class Chip(IconElement, ValueElement, TextElement, BackgroundColorElement, TextC
         """Add a callback to be invoked when the chip is clicked."""
         self._props['clickable'] = True
         self.update()
-        self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
+        self.on('click', lambda e: handle_event(callback, ClickEventArguments.from_generic_event(e)), [])
         return self

--- a/nicegui/elements/color_picker.py
+++ b/nicegui/elements/color_picker.py
@@ -26,7 +26,7 @@ class ColorPicker(Menu):
         with self:
             def handle_change(e: GenericEventArguments):
                 for handler in self._pick_handlers:
-                    handle_event(handler, ColorPickEventArguments(sender=self, client=self.client, color=e.args))
+                    handle_event(handler, ColorPickEventArguments.from_generic_event(e, color=e.args))
             self.q_color = Element('q-color').on('change', handle_change)
 
     def set_color(self, color: str) -> None:

--- a/nicegui/elements/echart.py
+++ b/nicegui/elements/echart.py
@@ -50,9 +50,8 @@ class EChart(Element,
     def on_point_click(self, callback: Handler[EChartPointClickEventArguments]) -> Self:
         """Add a callback to be invoked when a point is clicked."""
         def handle_point_click(e: GenericEventArguments) -> None:
-            handle_event(callback, EChartPointClickEventArguments(
-                sender=self,
-                client=self.client,
+            handle_event(callback, EChartPointClickEventArguments.from_generic_event(
+                e,
                 component_type=e.args['componentType'],
                 series_type=e.args['seriesType'],
                 series_index=e.args['seriesIndex'],

--- a/nicegui/elements/interactive_image.py
+++ b/nicegui/elements/interactive_image.py
@@ -72,9 +72,8 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
         """Add a callback to be invoked when a mouse event occurs."""
         def handle_mouse(e: GenericEventArguments) -> None:
             args = cast(dict, e.args)
-            arguments = MouseEventArguments(
-                sender=self,
-                client=self.client,
+            arguments = MouseEventArguments.from_generic_event(
+                e,
                 type=args.get('mouse_event_type', ''),
                 image_x=args.get('image_x', 0.0),
                 image_y=args.get('image_y', 0.0),

--- a/nicegui/elements/item.py
+++ b/nicegui/elements/item.py
@@ -33,7 +33,7 @@ class Item(DisableableElement):
     def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
         """Add a callback to be invoked when the List Item is clicked."""
         self._props['clickable'] = True  # idempotent
-        self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)))
+        self.on('click', lambda e: handle_event(callback, ClickEventArguments.from_generic_event(e)))
         return self
 
 

--- a/nicegui/elements/joystick.py
+++ b/nicegui/elements/joystick.py
@@ -35,27 +35,32 @@ class Joystick(Element,
         self._move_handlers = [on_move] if on_move else []
         self._end_handlers = [on_end] if on_end else []
 
-        def handle_start() -> None:
+        def handle_start(e: GenericEventArguments) -> None:
             self.active = True
-            args = JoystickEventArguments(sender=self, client=self.client, action='start')
+            args = JoystickEventArguments.from_generic_event(
+                e,
+                action='start',
+            )
             for handler in self._start_handlers:
                 handle_event(handler, args)
 
         def handle_move(e: GenericEventArguments) -> None:
             if self.active:
-                args = JoystickEventArguments(sender=self,
-                                              client=self.client,
-                                              action='move',
-                                              x=float(e.args['data']['vector']['x']),
-                                              y=float(e.args['data']['vector']['y']))
+                args = JoystickEventArguments.from_generic_event(
+                    e,
+                    action='move',
+                    x=float(e.args['data']['vector']['x']),
+                    y=float(e.args['data']['vector']['y']),
+                )
                 for handler in self._move_handlers:
                     handle_event(handler, args)
 
-        def handle_end() -> None:
+        def handle_end(e: GenericEventArguments) -> None:
             self.active = False
-            args = JoystickEventArguments(sender=self,
-                                          client=self.client,
-                                          action='end')
+            args = JoystickEventArguments.from_generic_event(
+                e,
+                action='end',
+            )
             for handler in self._end_handlers:
                 handle_event(handler, args)
 

--- a/nicegui/elements/keyboard.py
+++ b/nicegui/elements/keyboard.py
@@ -88,13 +88,7 @@ class Keyboard(Element, component='keyboard.js'):
             code=e.args['code'],
             location=e.args['location'],
         )
-        arguments = KeyEventArguments(
-            sender=self,
-            client=self.client,
-            action=action,
-            modifiers=modifiers,
-            key=key,
-        )
+        arguments = KeyEventArguments.from_generic_event(e, action=action, modifiers=modifiers, key=key)
         for handler in self._key_handlers:
             handle_event(handler, arguments)
 

--- a/nicegui/elements/notification.py
+++ b/nicegui/elements/notification.py
@@ -190,7 +190,7 @@ class Notification(Element, component='notification.js'):
 
     def on_dismiss(self, callback: Handler[UiEventArguments]) -> Self:
         """Add a callback to be invoked when the notification is dismissed."""
-        self.on('dismiss', lambda _: handle_event(callback, UiEventArguments(sender=self, client=self.client)), [])
+        self.on('dismiss', lambda e: handle_event(callback, UiEventArguments.from_generic_event(e)), [])
         return self
 
     def dismiss(self) -> None:

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -183,9 +183,8 @@ class Scene(Element,
         await event.wait()
 
     def _handle_click(self, e: GenericEventArguments) -> None:
-        arguments = SceneClickEventArguments(
-            sender=self,
-            client=self.client,
+        arguments = SceneClickEventArguments.from_generic_event(
+            e,
             click_type=e.args['click_type'],
             button=e.args['button'],
             alt=e.args['alt_key'],
@@ -204,9 +203,8 @@ class Scene(Element,
             handle_event(handler, arguments)
 
     def _handle_drag(self, e: GenericEventArguments) -> None:
-        arguments = SceneDragEventArguments(
-            sender=self,
-            client=self.client,
+        arguments = SceneDragEventArguments.from_generic_event(
+            e,
             type=e.args['type'],
             object_id=e.args['object_id'],
             object_name=e.args['object_name'],

--- a/nicegui/elements/scene_view.py
+++ b/nicegui/elements/scene_view.py
@@ -73,9 +73,8 @@ class SceneView(Element,
         await event.wait()
 
     def _handle_click(self, e: GenericEventArguments) -> None:
-        arguments = SceneClickEventArguments(
-            sender=self,
-            client=self.client,
+        arguments = SceneClickEventArguments.from_generic_event(
+            e,
             click_type=e.args['click_type'],
             button=e.args['button'],
             alt=e.args['alt_key'],

--- a/nicegui/elements/scroll_area.py
+++ b/nicegui/elements/scroll_area.py
@@ -36,9 +36,8 @@ class ScrollArea(Element, default_classes='nicegui-scroll-area'):
         return self
 
     def _handle_scroll(self, handler: Optional[Handler[ScrollEventArguments]], e: GenericEventArguments) -> None:
-        handle_event(handler, ScrollEventArguments(
-            sender=self,
-            client=self.client,
+        handle_event(handler, ScrollEventArguments.from_generic_event(
+            e,
             vertical_position=e.args['verticalPosition'],
             vertical_percentage=e.args['verticalPercentage'],
             vertical_size=e.args['verticalSize'],

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -84,7 +84,7 @@ class Table(FilterElement, component='table.js'):
             else:
                 self.selected = [row for row in self.selected if row[row_key] not in e.args['keys']]
             self.update()
-            arguments = TableSelectionEventArguments(sender=self, client=self.client, selection=self.selected)
+            arguments = TableSelectionEventArguments.from_generic_event(e, selection=self.selected)
             for handler in self._selection_handlers:
                 handle_event(handler, arguments)
         self.on('selection', handle_selection, ['added', 'rows', 'keys'])
@@ -92,7 +92,7 @@ class Table(FilterElement, component='table.js'):
         def handle_pagination_change(e: GenericEventArguments) -> None:
             self.pagination = e.args
             self.update()
-            arguments = ValueChangeEventArguments(sender=self, client=self.client, value=self.pagination)
+            arguments = ValueChangeEventArguments.from_generic_event(e, value=self.pagination)
             for handler in self._pagination_change_handlers:
                 handle_event(handler, arguments)
         self.on('update:pagination', handle_pagination_change)

--- a/nicegui/elements/tree.py
+++ b/nicegui/elements/tree.py
@@ -64,19 +64,19 @@ class Tree(FilterElement):
         def handle_selected(e: GenericEventArguments) -> None:
             update_prop('selected', e.args)
             for handler in self._select_handlers:
-                handle_event(handler, ValueChangeEventArguments(sender=self, client=self.client, value=e.args))
+                handle_event(handler, ValueChangeEventArguments.from_generic_event(e, value=e.args))
         self.on('update:selected', handle_selected)
 
         def handle_expanded(e: GenericEventArguments) -> None:
             update_prop('expanded', e.args)
             for handler in self._expand_handlers:
-                handle_event(handler, ValueChangeEventArguments(sender=self, client=self.client, value=e.args))
+                handle_event(handler, ValueChangeEventArguments.from_generic_event(e, value=e.args))
         self.on('update:expanded', handle_expanded)
 
         def handle_ticked(e: GenericEventArguments) -> None:
             update_prop('ticked', e.args)
             for handler in self._tick_handlers:
-                handle_event(handler, ValueChangeEventArguments(sender=self, client=self.client, value=e.args))
+                handle_event(handler, ValueChangeEventArguments.from_generic_event(e, value=e.args))
         self.on('update:ticked', handle_ticked)
 
     def on_select(self, callback: Handler[ValueChangeEventArguments]) -> Self:

--- a/nicegui/elements/upload.py
+++ b/nicegui/elements/upload.py
@@ -77,6 +77,7 @@ class Upload(DisableableElement, component='upload.js'):
                 handle_event(upload_handler, UploadEventArguments(
                     sender=self,
                     client=self.client,
+                    socket_id='',  # TODO: can we do better here?
                     content=upload.file,
                     name=upload.filename or '',
                     type=upload.content_type or '',
@@ -84,6 +85,7 @@ class Upload(DisableableElement, component='upload.js'):
         multi_upload_args = MultiUploadEventArguments(
             sender=self,
             client=self.client,
+            socket_id='',  # TODO: can we do better here?
             contents=[upload.file for upload in uploads],
             names=[upload.filename or '' for upload in uploads],
             types=[upload.content_type or '' for upload in uploads],
@@ -103,7 +105,7 @@ class Upload(DisableableElement, component='upload.js'):
 
     def on_rejected(self, callback: Handler[UiEventArguments]) -> Self:
         """Add a callback to be invoked when a file is rejected."""
-        self.on('rejected', lambda: handle_event(callback, UiEventArguments(sender=self, client=self.client)), args=[])
+        self.on('rejected', lambda e: handle_event(callback, UiEventArguments.from_generic_event(e)), args=[])
         return self
 
     def reset(self) -> None:

--- a/nicegui/functions/notify.py
+++ b/nicegui/functions/notify.py
@@ -50,4 +50,4 @@ def notify(message: Any, *,
     options['message'] = str(message)
     options.update(kwargs)
     client = context.client
-    client.outbox.enqueue_message('notify', options, client.id)
+    client.outbox.enqueue_message('notify', options, client.target)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -188,11 +188,11 @@ def _on_disconnect(sid: str) -> None:
 
 
 @sio.on('event')
-def _on_event(_: str, msg: Dict) -> None:
+def _on_event(sid: str, msg: Dict) -> None:
     client = Client.instances.get(msg['client_id'])
     if not client or not client.has_socket_connection:
         return
-    client.handle_event(msg)
+    client.handle_event(sid, msg)
 
 
 @sio.on('javascript_response')

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -47,8 +47,12 @@ class UserInteraction(Generic[T]):
                 for listener in element._event_listeners.values():  # pylint: disable=protected-access
                     if listener.type != event:
                         continue
-                    event_arguments = events.GenericEventArguments(sender=element, client=self.user.client, args={})
-                    events.handle_event(listener.handler, event_arguments)
+                    events.handle_event(listener.handler, events.GenericEventArguments(
+                        sender=element,
+                        client=self.user.client,
+                        socket_id='',  # TODO: can we do better here?
+                        args={},
+                    ))
         return self
 
     def type(self, text: str) -> Self:
@@ -86,8 +90,12 @@ class UserInteraction(Generic[T]):
                     args = None
                     if isinstance(element, (ui.checkbox, ui.switch)):
                         args = not element.value
-                    event_arguments = events.GenericEventArguments(sender=element, client=self.user.client, args=args)
-                    events.handle_event(listener.handler, event_arguments)
+                    events.handle_event(listener.handler, events.GenericEventArguments(
+                        sender=element,
+                        client=self.user.client,
+                        socket_id='',  # TODO: can we do better here?
+                        args=args,
+                    ))
         return self
 
     def clear(self) -> Self:


### PR DESCRIPTION
This PR addresses issue #4016 and feature request #4218:

- [x] UI events should provide a socket ID to be used with the `client.individual_target` context.
- [x] `ui.navigate`, `ui.download()` and `ui.notify()` should adhere to the `client.individual_target` context.
- [ ] `ui.download()` on the auto-index page (without using `client.individual_target`) should raise an exception.

Unfortunately, the current implementation has one main drawback:

- [ ] The new socket ID argument affects all existing event argument classes. Therefore this change might break existing use code.

The PR is still a draft because we're thinking about alternative solutions, like automatically calling event handlers in the context of the current socket. This would automatically trigger notifications, downloads and navigations on the socket that caused the event. But it could also affect `run_method()` and `run_javascript()` calls, which might not be desired.