### PR TITLE
Run init of app.storage.general as early as possible

### DIFF
--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -46,7 +46,6 @@ class App(FastAPI):
         self._disconnect_handlers: List[Union[Callable[..., Any], Awaitable]] = []
         self._exception_handlers: List[Callable[..., Any]] = [log.exception]
 
-        self.on_startup(self.storage.general.initialize)
         self.on_shutdown(self.storage.on_shutdown)
 
     @property

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -44,9 +44,9 @@ class SocketIoApp(socketio.ASGIApp):
 
 core.app = app = App(default_response_class=NiceGUIJSONResponse, lifespan=_lifespan)
 try:
-    asyncio.get_running_loop().run_until_complete(core.app.storage.general.initialize())
-except RuntimeError:
     asyncio.run(core.app.storage.general.initialize())
+except RuntimeError:
+    background_tasks.create(core.app.storage.general.initialize(), name='initialize general storage')
 
 # NOTE we use custom json module which wraps orjson
 core.sio = sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*', json=json)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -43,6 +43,8 @@ class SocketIoApp(socketio.ASGIApp):
 
 
 core.app = app = App(default_response_class=NiceGUIJSONResponse, lifespan=_lifespan)
+asyncio.run(core.app.storage.general.initialize())
+
 # NOTE we use custom json module which wraps orjson
 core.sio = sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*', json=json)
 sio_app = SocketIoApp(socketio_server=sio, socketio_path='/socket.io')

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -43,7 +43,6 @@ class SocketIoApp(socketio.ASGIApp):
 
 
 core.app = app = App(default_response_class=NiceGUIJSONResponse, lifespan=_lifespan)
-
 # NOTE we use custom json module which wraps orjson
 core.sio = sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*', json=json)
 sio_app = SocketIoApp(socketio_server=sio, socketio_path='/socket.io')

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -43,11 +43,7 @@ class SocketIoApp(socketio.ASGIApp):
 
 
 core.app = app = App(default_response_class=NiceGUIJSONResponse, lifespan=_lifespan)
-try:
-    asyncio.run(core.app.storage.general.initialize())
-except RuntimeError:
-    core.loop = asyncio.get_running_loop()
-    background_tasks.create(core.app.storage.general.initialize(), name='initialize general storage')
+core.app.storage.general.initialize_sync()
 
 # NOTE we use custom json module which wraps orjson
 core.sio = sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*', json=json)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -46,6 +46,7 @@ core.app = app = App(default_response_class=NiceGUIJSONResponse, lifespan=_lifes
 try:
     asyncio.run(core.app.storage.general.initialize())
 except RuntimeError:
+    core.loop = asyncio.get_running_loop()
     background_tasks.create(core.app.storage.general.initialize(), name='initialize general storage')
 
 # NOTE we use custom json module which wraps orjson

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -43,8 +43,8 @@ class SocketIoApp(socketio.ASGIApp):
 
 
 core.app = app = App(default_response_class=NiceGUIJSONResponse, lifespan=_lifespan)
-# NOTE we use custom json module which wraps orjson
-core.sio = sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*', json=json)
+core.app.storage.general.initialize_sync()
+core.sio = sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*', json=json)  # custom orjson wrapper
 sio_app = SocketIoApp(socketio_server=sio, socketio_path='/socket.io')
 app.mount('/_nicegui_ws/', sio_app)
 

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -43,7 +43,6 @@ class SocketIoApp(socketio.ASGIApp):
 
 
 core.app = app = App(default_response_class=NiceGUIJSONResponse, lifespan=_lifespan)
-core.app.storage.general.initialize_sync()
 
 # NOTE we use custom json module which wraps orjson
 core.sio = sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*', json=json)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -43,7 +43,10 @@ class SocketIoApp(socketio.ASGIApp):
 
 
 core.app = app = App(default_response_class=NiceGUIJSONResponse, lifespan=_lifespan)
-asyncio.run(core.app.storage.general.initialize())
+try:
+    asyncio.get_running_loop().run_until_complete(core.app.storage.general.initialize())
+except RuntimeError:
+    asyncio.run(core.app.storage.general.initialize())
 
 # NOTE we use custom json module which wraps orjson
 core.sio = sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*', json=json)

--- a/nicegui/persistence/file_persistent_dict.py
+++ b/nicegui/persistence/file_persistent_dict.py
@@ -31,8 +31,7 @@ class FilePersistentDict(PersistentDict):
     def initialize_sync(self) -> None:
         try:
             if self.filepath.exists():
-                with open(self.filepath, encoding=self.encoding) as f:
-                    data = json.loads(f.read())
+                data = json.loads(self.filepath.read_text(encoding=self.encoding))
             else:
                 data = {}
             self.update(data)

--- a/nicegui/persistence/file_persistent_dict.py
+++ b/nicegui/persistence/file_persistent_dict.py
@@ -28,6 +28,17 @@ class FilePersistentDict(PersistentDict):
         except Exception:
             log.warning(f'Could not load storage file {self.filepath}')
 
+    def initialize_sync(self) -> None:
+        try:
+            if self.filepath.exists():
+                with open(self.filepath, encoding=self.encoding) as f:
+                    data = json.loads(f.read())
+            else:
+                data = {}
+            self.update(data)
+        except Exception:
+            log.warning(f'Could not load storage file {self.filepath}')
+
     def backup(self) -> None:
         """Back up the data to the given file path."""
         if not self.filepath.exists():

--- a/nicegui/persistence/persistent_dict.py
+++ b/nicegui/persistence/persistent_dict.py
@@ -9,5 +9,9 @@ class PersistentDict(observables.ObservableDict, abc.ABC):
     async def initialize(self) -> None:
         """Load initial data from the persistence layer."""
 
+    @abc.abstractmethod
+    def initialize_sync(self) -> None:
+        """Load initial data from the persistence layer in a synchronous context."""
+
     async def close(self) -> None:
         """Clean up the persistence layer."""

--- a/nicegui/persistence/redis_persistent_dict.py
+++ b/nicegui/persistence/redis_persistent_dict.py
@@ -3,6 +3,7 @@ from ..logging import log
 from .persistent_dict import PersistentDict
 
 try:
+    import redis as redis_sync
     import redis.asyncio as redis
     optional_features.register('redis')
 except ImportError:
@@ -15,6 +16,13 @@ class RedisPersistentDict(PersistentDict):
         if not optional_features.has('redis'):
             raise ImportError('Redis is not installed. Please run "pip install nicegui[redis]".')
         self.redis_client = redis.from_url(
+            url,
+            health_check_interval=10,
+            socket_connect_timeout=5,
+            retry_on_timeout=True,
+            socket_keepalive=True,
+        )
+        self.redis_client_sync = redis_sync.from_url(
             url,
             health_check_interval=10,
             socket_connect_timeout=5,
@@ -42,6 +50,14 @@ class RedisPersistentDict(PersistentDict):
                         self.update(new_data)
 
         background_tasks.create(listen(), name=f'redis-listen-{self.key}')
+
+    def initialize_sync(self) -> None:
+        """Load initial data from Redis and start listening for changes in a synchronous context."""
+        try:
+            data = self.redis_client_sync.get(self.key)
+            self.update(json.loads(data) if data else {})
+        except Exception:
+            log.warning(f'Could not load data from Redis with key {self.key}')
 
     def publish(self) -> None:
         """Publish the data to Redis and notify other instances."""

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -65,6 +65,7 @@ class Storage:
 
     def __init__(self) -> None:
         self._general = Storage._create_persistent_dict('general')
+        self.general.initialize_sync()
         self._users: Dict[str, PersistentDict] = {}
         self._tabs: Dict[str, ObservableDict] = {}
 

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -65,7 +65,7 @@ class Storage:
 
     def __init__(self) -> None:
         self._general = Storage._create_persistent_dict('general')
-        self.general.initialize_sync()
+        self._general.initialize_sync()
         self._users: Dict[str, PersistentDict] = {}
         self._tabs: Dict[str, ObservableDict] = {}
 

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -65,7 +65,6 @@ class Storage:
 
     def __init__(self) -> None:
         self._general = Storage._create_persistent_dict('general')
-        self._general.initialize_sync()
         self._users: Dict[str, PersistentDict] = {}
         self._tabs: Dict[str, ObservableDict] = {}
 


### PR DESCRIPTION
When introducing Redis storage in #4074, the initialization of persistent storage was made async to not block the main thread when loading data. For that to work the init must be done async -- which introduced #4352. This PR fixes the issue by moving the init of `app.storage.general` from app startup to import time and using `asyncio.run` to create a temporary event loop for the init.