### PR TITLE
 Introduce QSlideItem element

### DIFF
--- a/nicegui/elements/slide_item.py
+++ b/nicegui/elements/slide_item.py
@@ -5,6 +5,7 @@ from typing import Literal, Optional
 from typing_extensions import Self
 
 from ..events import ClickEventArguments, GenericEventArguments, Handler, handle_event
+from ..slot import Slot
 from .mixins.disableable_element import DisableableElement
 
 SlideSides = Literal['left', 'right', 'top', 'bottom']
@@ -33,7 +34,7 @@ class SlideItem(DisableableElement):
               side: SlideSides, *,
               on_slide: Optional[Handler[GenericEventArguments]] = None,
               color: Optional[str] = 'primary',
-              ) -> Self:
+              ) -> Slot:
         """Slide
 
         This method adds a slide action to a specified side of the `SlideItem`

--- a/nicegui/elements/slide_item.py
+++ b/nicegui/elements/slide_item.py
@@ -20,18 +20,18 @@ class SlideItem(DisableableElement):
 
         This element is based on Quasar's `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
 
-        If the text parameter is provided, an item will be created with the given text.
+        If the ``text`` parameter is provided, a nested ``ui.item`` element will be created with the given text.
         If you want to customize how the text is displayed, you can place custom elements inside the slide item.
 
-        To fill slots for individual slide actions, use the ``action`` method with a side argument
-        ("left", "right", "top", or "bottom") or the ``left``, ``right``, ``top``, or ``bottom`` methods.
+        To fill slots for individual slide actions, use the ``left``, ``right``, ``top``, or ``bottom`` methods or
+        the ``action`` method with a side argument ("left", "right", "top", or "bottom").
 
         Once a slide action has occurred, the slide item can be reset back to its initial state using the ``reset`` method.
 
         *Added in version 2.12.0*
 
         :param text: text to be displayed (default: "")
-        :param on_change: callback which is invoked when any slide action is activated
+        :param on_slide: callback which is invoked when any slide action is activated
         """
         super().__init__(tag='q-slide-item')
 

--- a/nicegui/elements/slide_item.py
+++ b/nicegui/elements/slide_item.py
@@ -1,0 +1,152 @@
+from typing import Literal, Optional
+
+from typing_extensions import Self
+
+from ..events import ClickEventArguments, GenericEventArguments, Handler, handle_event
+from .mixins.disableable_element import DisableableElement
+
+SlideSides = Literal['left', 'right', 'top', 'bottom']
+
+
+class SlideSide(DisableableElement):
+    def __init__(self,
+                 side: SlideSides, *,
+                 on_slide: Optional[Handler[GenericEventArguments]] = None,
+                 color: Optional[str] = 'primary',
+                 ) -> None:
+        """Side
+
+        This element is based on Quasar's on the side slots of `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
+
+        The Side element can only be used as a child of the `SlideItem` element.
+
+        :param side: side of the Slide Item where the slide should be added (`left`, `right`, `top`, `bottom`)
+        :param on_slide: callback which is invoked when the slide action is activated
+        :param color: the color of the slide background (either a Quasar, Tailwind, or CSS color or `None`, default: 'primary')
+        """
+        super().__init__()
+
+        self.side = side
+
+        self._slide_item_parent = self.parent_slot.parent
+        if not isinstance(self._slide_item_parent, SlideItem):
+            raise ValueError('Incorrect parent element used')
+
+        self._slide_item_parent.add_slot(side)
+        self._slide_item_parent._props[f'{side}-color'] = color
+
+        self.default_slot = self._slide_item_parent.slots[side]
+
+        if side not in self._slide_item_parent._active_slides:
+            self._slide_item_parent._active_slides.append(side)
+
+        if on_slide:
+            self.on_slide(on_slide)
+
+    def on_slide(self, callback: Handler[GenericEventArguments]) -> Self:
+        """Add a callback to be invoked when the Slide Side is activated."""
+        self._slide_item_parent.on(self.side, lambda _: handle_event(
+            callback, GenericEventArguments(sender=self, client=self.client, args=self.side)))
+        return self
+
+
+class SlideItem(DisableableElement):
+    def __init__(self,
+                 on_change: Optional[Handler[ClickEventArguments]] = None):
+        """Slide Item
+
+        This element is based on Quasar's `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
+
+        The Slide Item element is related to the `Item` element and supports `ItemSection` for text, icons, etc.
+        To add slide actions use in conjunction with `LeftSlide`, `RightSlide`, `TopSlide`, and `BottomSlide`
+
+        :param on_change: callback which is invoked when any slide action is activated
+        """
+        super().__init__(tag='q-slide-item')
+
+        self._active_slides = []
+
+        if on_change:
+            self.on_change(on_change)
+
+    def on_change(self, callback: Handler[ClickEventArguments]) -> Self:
+        """Add a callback to be invoked when the Slide Item is clicked."""
+        self.on('action', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)))
+        return self
+
+    def reset(self) -> None:
+        """Reset the Slide Item to initial state"""
+        self.run_method('reset')
+
+    @property
+    def active_slides(self) -> list:
+        """Returns a list of active Slide Sides"""
+        return self._active_slides
+
+
+class LeftSlide(SlideSide):
+    def __init__(self,
+                 on_slide: Optional[Handler[GenericEventArguments]] = None,
+                 color: Optional[str] = 'primary',
+                 ) -> None:
+        """Left Slide
+
+        This element is based on Quasar's on the `Left` slot of `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
+
+        The Left Slide element can only be used as a child of the `SlideItem` element.
+
+        :param on_slide: callback which is invoked when the left slide action is activated
+        :param color: the color of the slide background (either a Quasar, Tailwind, or CSS color or `None`, default: 'primary')
+        """
+        super().__init__('left', color=color, on_slide=on_slide)
+
+
+class RightSlide(SlideSide):
+    def __init__(self,
+                 on_slide: Optional[Handler[GenericEventArguments]] = None,
+                 color: Optional[str] = 'primary',
+                 ) -> None:
+        """Right Slide
+
+        This element is based on Quasar's on the `Right` slot of `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
+
+        The Right Slide element can only be used as a child of the `SlideItem` element.
+
+        :param on_slide: callback which is invoked when the right slide action is activated
+        :param color: the color of the slide background (either a Quasar, Tailwind, or CSS color or `None`, default: 'primary')
+        """
+        super().__init__('right', color=color, on_slide=on_slide)
+
+
+class TopSlide(SlideSide):
+    def __init__(self,
+                 on_slide: Optional[Handler[GenericEventArguments]] = None,
+                 color: Optional[str] = 'primary',
+                 ) -> None:
+        """Top Slide
+
+        This element is based on Quasar's on the `Top` slot of `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
+
+        The Top Slide element can only be used as a child of the `SlideItem` element.
+
+        :param on_slide: callback which is invoked when the top slide action is activated
+        :param color: the color of the slide background (either a Quasar, Tailwind, or CSS color or `None`, default: 'primary')
+        """
+        super().__init__('top', color=color, on_slide=on_slide)
+
+
+class BottomSlide(SlideSide):
+    def __init__(self,
+                 on_slide: Optional[Handler[GenericEventArguments]] = None,
+                 color: Optional[str] = 'primary',
+                 ) -> None:
+        """Bottom Slide
+
+        This element is based on Quasar's on the `Bottom` slot of `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
+
+        The Bottom Slide element can only be used as a child of the `SlideItem` element.
+
+        :param on_slide: callback which is invoked when the bottom slide action is activated
+        :param color: the color of the slide background (either a Quasar, Tailwind, or CSS color or `None`, default: 'primary')
+        """
+        super().__init__('bottom', color=color, on_slide=on_slide)

--- a/nicegui/elements/slide_item.py
+++ b/nicegui/elements/slide_item.py
@@ -10,59 +10,6 @@ from .mixins.disableable_element import DisableableElement
 SlideSides = Literal['left', 'right', 'top', 'bottom']
 
 
-class SlideSide(DisableableElement):
-    def __init__(self,
-                 side: SlideSides, *,
-                 on_slide: Optional[Handler[GenericEventArguments]] = None,
-                 color: Optional[str] = 'primary',
-                 ) -> None:
-        """Side
-
-        This element is based on Quasar's on the side slots of `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
-
-        The Side element can only be used as a child of the `SlideItem` element.
-
-        :param side: side of the Slide Item where the slide should be added (`left`, `right`, `top`, `bottom`)
-        :param on_slide: callback which is invoked when the slide action is activated
-        :param color: the color of the slide background (either a Quasar, Tailwind, or CSS color or `None`, default: 'primary')
-        """
-        super().__init__()
-
-        self.side = side
-
-        self._slide_item_parent = self._get_slide_parent()
-
-        self._slide_item_parent.add_slot(side)
-        self._slide_item_parent._props[f'{side}-color'] = color
-
-        self.default_slot = self._slide_item_parent.slots[side]
-
-        if side not in self._slide_item_parent._active_slides:
-            self._slide_item_parent._active_slides.append(side)
-
-        if on_slide:
-            self.on_slide(on_slide)
-
-    def _get_slide_parent(self) -> SlideItem:
-        """Get parent slot and confirms it is of `SlideItem` type"""
-
-        if self.parent_slot is None:
-            raise ValueError('Parent slot can not be established')
-
-        slide_item_parent = self.parent_slot.parent
-
-        if not isinstance(slide_item_parent, SlideItem):
-            raise ValueError('Incorrect parent used, `SlideSide` must inherit from `SlideItem`')
-
-        return slide_item_parent
-
-    def on_slide(self, callback: Handler[GenericEventArguments]) -> Self:
-        """Add a callback to be invoked when the Slide Side is activated."""
-        self._slide_item_parent.on(self.side, lambda _: handle_event(
-            callback, GenericEventArguments(sender=self, client=self.client, args=self.side)))
-        return self
-
-
 class SlideItem(DisableableElement):
     def __init__(self,
                  on_change: Optional[Handler[ClickEventArguments]] = None):
@@ -70,11 +17,11 @@ class SlideItem(DisableableElement):
 
         This element is based on Quasar's `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
 
-        The Slide Item element is related to the `Item` element and supports `ItemSection` for text, icons, etc.
-        To add slide actions use in conjunction with `LeftSlide`, `RightSlide`, `TopSlide`, and `BottomSlide`
+        To add slide actions to a specific side (`left`, `right`, `top`, `bottom`) use the `slide` method.
 
         :param on_change: callback which is invoked when any slide action is activated
         """
+
         super().__init__(tag='q-slide-item')
 
         self._active_slides: list[str] = []
@@ -82,9 +29,39 @@ class SlideItem(DisableableElement):
         if on_change:
             self.on_change(on_change)
 
+    def slide(self,
+              side: SlideSides, *,
+              on_slide: Optional[Handler[GenericEventArguments]] = None,
+              color: Optional[str] = 'primary',
+              ) -> Self:
+        """Slide
+
+        This method adds a slide action to a specified side of the `SlideItem`
+
+        :param side: side of the Slide Item where the slide should be added (`left`, `right`, `top`, `bottom`)
+        :param on_slide: callback which is invoked when the slide action is activated
+        :param color: the color of the slide background (either a Quasar, Tailwind, or CSS color or `None`, default: 'primary')
+        """
+
+        if color:
+            self._props[f'{side}-color'] = color
+
+        if on_slide:
+            self.on_slide(side, on_slide)
+
+        if side not in self._active_slides:
+            self._active_slides.append(side)
+
+        return self.add_slot(side)
+
     def on_change(self, callback: Handler[ClickEventArguments]) -> Self:
-        """Add a callback to be invoked when the Slide Item is clicked."""
+        """Add a callback to be invoked when the Slide Item is changed."""
         self.on('action', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)))
+        return self
+
+    def on_slide(self, side: SlideSides, callback: Handler[GenericEventArguments]) -> Self:
+        """Add a callback to be invoked when a Slide Side is activated."""
+        self.on(side, lambda _: handle_event(callback, GenericEventArguments(sender=self, client=self.client, args=side)))
         return self
 
     def reset(self) -> None:
@@ -95,71 +72,3 @@ class SlideItem(DisableableElement):
     def active_slides(self) -> list:
         """Returns a list of active Slide Sides"""
         return self._active_slides
-
-
-class LeftSlide(SlideSide):
-    def __init__(self,
-                 on_slide: Optional[Handler[GenericEventArguments]] = None,
-                 color: Optional[str] = 'primary',
-                 ) -> None:
-        """Left Slide
-
-        This element is based on Quasar's on the `Left` slot of `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
-
-        The Left Slide element can only be used as a child of the `SlideItem` element.
-
-        :param on_slide: callback which is invoked when the left slide action is activated
-        :param color: the color of the slide background (either a Quasar, Tailwind, or CSS color or `None`, default: 'primary')
-        """
-        super().__init__('left', color=color, on_slide=on_slide)
-
-
-class RightSlide(SlideSide):
-    def __init__(self,
-                 on_slide: Optional[Handler[GenericEventArguments]] = None,
-                 color: Optional[str] = 'primary',
-                 ) -> None:
-        """Right Slide
-
-        This element is based on Quasar's on the `Right` slot of `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
-
-        The Right Slide element can only be used as a child of the `SlideItem` element.
-
-        :param on_slide: callback which is invoked when the right slide action is activated
-        :param color: the color of the slide background (either a Quasar, Tailwind, or CSS color or `None`, default: 'primary')
-        """
-        super().__init__('right', color=color, on_slide=on_slide)
-
-
-class TopSlide(SlideSide):
-    def __init__(self,
-                 on_slide: Optional[Handler[GenericEventArguments]] = None,
-                 color: Optional[str] = 'primary',
-                 ) -> None:
-        """Top Slide
-
-        This element is based on Quasar's on the `Top` slot of `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
-
-        The Top Slide element can only be used as a child of the `SlideItem` element.
-
-        :param on_slide: callback which is invoked when the top slide action is activated
-        :param color: the color of the slide background (either a Quasar, Tailwind, or CSS color or `None`, default: 'primary')
-        """
-        super().__init__('top', color=color, on_slide=on_slide)
-
-
-class BottomSlide(SlideSide):
-    def __init__(self,
-                 on_slide: Optional[Handler[GenericEventArguments]] = None,
-                 color: Optional[str] = 'primary',
-                 ) -> None:
-        """Bottom Slide
-
-        This element is based on Quasar's on the `Bottom` slot of `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
-
-        The Bottom Slide element can only be used as a child of the `SlideItem` element.
-
-        :param on_slide: callback which is invoked when the bottom slide action is activated
-        :param color: the color of the slide background (either a Quasar, Tailwind, or CSS color or `None`, default: 'primary')
-        """
-        super().__init__('bottom', color=color, on_slide=on_slide)

--- a/nicegui/elements/slide_item.py
+++ b/nicegui/elements/slide_item.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import List, Literal, Optional
 
 from typing_extensions import Self
 
@@ -12,8 +12,8 @@ SlideSides = Literal['left', 'right', 'top', 'bottom']
 
 
 class SlideItem(DisableableElement):
-    def __init__(self,
-                 on_change: Optional[Handler[ClickEventArguments]] = None):
+
+    def __init__(self, on_change: Optional[Handler[ClickEventArguments]] = None) -> None:
         """Slide Item
 
         This element is based on Quasar's `QSlideItem <https://quasar.dev/vue-components/slide-item/>`_ component.
@@ -22,10 +22,9 @@ class SlideItem(DisableableElement):
 
         :param on_change: callback which is invoked when any slide action is activated
         """
-
         super().__init__(tag='q-slide-item')
 
-        self._active_slides: list[str] = []
+        self._active_slides: List[str] = []
 
         if on_change:
             self.on_change(on_change)
@@ -43,7 +42,6 @@ class SlideItem(DisableableElement):
         :param on_slide: callback which is invoked when the slide action is activated
         :param color: the color of the slide background (either a Quasar, Tailwind, or CSS color or `None`, default: 'primary')
         """
-
         if color:
             self._props[f'{side}-color'] = color
 
@@ -70,6 +68,6 @@ class SlideItem(DisableableElement):
         self.run_method('reset')
 
     @property
-    def active_slides(self) -> list:
+    def active_slides(self) -> List[str]:
         """Returns a list of active Slide Sides"""
         return self._active_slides

--- a/nicegui/elements/slide_item.py
+++ b/nicegui/elements/slide_item.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Literal, Optional
 
 from typing_extensions import Self
@@ -28,9 +30,7 @@ class SlideSide(DisableableElement):
 
         self.side = side
 
-        self._slide_item_parent = self.parent_slot.parent
-        if not isinstance(self._slide_item_parent, SlideItem):
-            raise ValueError('Incorrect parent element used')
+        self._slide_item_parent = self._get_slide_parent()
 
         self._slide_item_parent.add_slot(side)
         self._slide_item_parent._props[f'{side}-color'] = color
@@ -42,6 +42,19 @@ class SlideSide(DisableableElement):
 
         if on_slide:
             self.on_slide(on_slide)
+
+    def _get_slide_parent(self) -> SlideItem:
+        """Get parent slot and confirms it is of `SlideItem` type"""
+
+        if self.parent_slot is None:
+            raise ValueError('Parent slot can not be established')
+
+        slide_item_parent = self.parent_slot.parent
+
+        if not isinstance(slide_item_parent, SlideItem):
+            raise ValueError('Incorrect parent used, `SlideSide` must inherit from `SlideItem`')
+
+        return slide_item_parent
 
     def on_slide(self, callback: Handler[GenericEventArguments]) -> Self:
         """Add a callback to be invoked when the Slide Side is activated."""
@@ -64,7 +77,7 @@ class SlideItem(DisableableElement):
         """
         super().__init__(tag='q-slide-item')
 
-        self._active_slides = []
+        self._active_slides: list[str] = []
 
         if on_change:
             self.on_change(on_change)

--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -27,6 +27,7 @@ from .slot import Slot
 if TYPE_CHECKING:
     from .client import Client
     from .element import Element
+    from .elements.slide_item import SlideSide
     from .observables import ObservableCollection
 
 
@@ -54,6 +55,11 @@ class GenericEventArguments(UiEventArguments):
 @dataclass(**KWONLY_SLOTS)
 class ClickEventArguments(UiEventArguments):
     pass
+
+
+@dataclass(**KWONLY_SLOTS)
+class SlideEventArguments(UiEventArguments):
+    side: SlideSide
 
 
 @dataclass(**KWONLY_SLOTS)

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -8,6 +8,7 @@ __all__ = [
     'audio',
     'avatar',
     'badge',
+    'bottom_slide',
     'button',
     'button_group',
     'card',
@@ -58,6 +59,7 @@ __all__ = [
     'label',
     'leaflet',
     'left_drawer',
+    'left_slide',
     'line_plot',
     'linear_progress',
     'link',
@@ -87,6 +89,7 @@ __all__ = [
     'refreshable_method',
     'restructured_text',
     'right_drawer',
+    'right_slide',
     'row',
     'run',
     'run_javascript',
@@ -97,6 +100,8 @@ __all__ = [
     'select',
     'separator',
     'skeleton',
+    'slide_item',
+    'slide_side',
     'slider',
     'space',
     'spinner',
@@ -119,6 +124,7 @@ __all__ = [
     'timer',
     'toggle',
     'tooltip',
+    'top_slide',
     'tree',
     'update',
     'upload',
@@ -200,6 +206,12 @@ from .elements.scroll_area import ScrollArea as scroll_area
 from .elements.select import Select as select
 from .elements.separator import Separator as separator
 from .elements.skeleton import Skeleton as skeleton
+from .elements.slide_item import BottomSlide as bottom_slide
+from .elements.slide_item import LeftSlide as left_slide
+from .elements.slide_item import RightSlide as right_slide
+from .elements.slide_item import SlideItem as slide_item
+from .elements.slide_item import SlideSide as slide_side
+from .elements.slide_item import TopSlide as top_slide
 from .elements.slider import Slider as slider
 from .elements.space import Space as space
 from .elements.spinner import Spinner as spinner

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -8,7 +8,6 @@ __all__ = [
     'audio',
     'avatar',
     'badge',
-    'bottom_slide',
     'button',
     'button_group',
     'card',
@@ -59,7 +58,6 @@ __all__ = [
     'label',
     'leaflet',
     'left_drawer',
-    'left_slide',
     'line_plot',
     'linear_progress',
     'link',
@@ -89,7 +87,6 @@ __all__ = [
     'refreshable_method',
     'restructured_text',
     'right_drawer',
-    'right_slide',
     'row',
     'run',
     'run_javascript',
@@ -101,7 +98,6 @@ __all__ = [
     'separator',
     'skeleton',
     'slide_item',
-    'slide_side',
     'slider',
     'space',
     'spinner',
@@ -124,7 +120,6 @@ __all__ = [
     'timer',
     'toggle',
     'tooltip',
-    'top_slide',
     'tree',
     'update',
     'upload',
@@ -206,12 +201,7 @@ from .elements.scroll_area import ScrollArea as scroll_area
 from .elements.select import Select as select
 from .elements.separator import Separator as separator
 from .elements.skeleton import Skeleton as skeleton
-from .elements.slide_item import BottomSlide as bottom_slide
-from .elements.slide_item import LeftSlide as left_slide
-from .elements.slide_item import RightSlide as right_slide
 from .elements.slide_item import SlideItem as slide_item
-from .elements.slide_item import SlideSide as slide_side
-from .elements.slide_item import TopSlide as top_slide
 from .elements.slider import Slider as slider
 from .elements.space import Space as space
 from .elements.spinner import Spinner as spinner

--- a/tests/test_slide_item.py
+++ b/tests/test_slide_item.py
@@ -1,0 +1,65 @@
+from selenium.webdriver.common.action_chains import ActionChains
+
+from nicegui import ui
+from nicegui.testing import Screen
+
+
+def test_slide_item(screen: Screen):
+    with ui.slide_item(on_change=lambda: label.set_text('Event: change')) as s:
+        ui.label('slide item')
+        ui.left_slide()
+    label = ui.label('None')
+
+    screen.open('/')
+    slide_item = screen.find_element(s)
+    screen.should_contain('slide item')
+    screen.should_contain('None')
+
+    ActionChains(screen.selenium) \
+        .move_to_element_with_offset(slide_item, -20, 0) \
+        .click_and_hold() \
+        .pause(1) \
+        .move_by_offset(60, 0) \
+        .pause(1) \
+        .release() \
+        .perform()
+    screen.wait(1)
+    screen.should_contain('Event: change')
+
+
+def test_slide_side(screen: Screen):
+    with ui.slide_item() as s:
+        ui.label('slide item')
+        ui.left_slide(on_slide=lambda: label.set_text('Event: left slide'))
+        ui.right_slide(on_slide=lambda: label.set_text('Event: right slide'))
+
+    label = ui.label('None')
+
+    screen.open('/')
+    slide_item = screen.find_element(s)
+    screen.should_contain('None')
+
+    ActionChains(screen.selenium) \
+        .move_to_element_with_offset(slide_item, -20, 0) \
+        .click_and_hold() \
+        .pause(1) \
+        .move_by_offset(60, 0) \
+        .pause(1) \
+        .release() \
+        .perform()
+    screen.wait(1)
+    screen.should_contain('Event: left slide')
+
+    s.reset()
+    screen.wait(1)
+
+    ActionChains(screen.selenium) \
+        .move_to_element_with_offset(slide_item, 20, 0) \
+        .click_and_hold() \
+        .pause(1) \
+        .move_by_offset(-60, 0) \
+        .pause(1) \
+        .release() \
+        .perform()
+    screen.wait(1)
+    screen.should_contain('Event: right slide')

--- a/tests/test_slide_item.py
+++ b/tests/test_slide_item.py
@@ -5,61 +5,56 @@ from nicegui.testing import Screen
 
 
 def test_slide_item(screen: Screen):
-    with ui.slide_item(on_change=lambda: label.set_text('Event: change')) as s:
+    with ui.slide_item(on_change=lambda: label.set_text('Event: change')) as slide_item:
         ui.label('slide item')
-        s.slide(side='left')
+        slide_item.slide(side='left')
     label = ui.label('None')
 
     screen.open('/')
-    slide_item = screen.find_element(s)
     screen.should_contain('slide item')
     screen.should_contain('None')
 
     ActionChains(screen.selenium) \
-        .move_to_element_with_offset(slide_item, -20, 0) \
+        .move_to_element_with_offset(screen.find_element(slide_item), -20, 0) \
         .click_and_hold() \
         .pause(1) \
         .move_by_offset(60, 0) \
         .pause(1) \
         .release() \
         .perform()
-    screen.wait(1)
     screen.should_contain('Event: change')
 
 
 def test_slide_side(screen: Screen):
-    with ui.slide_item() as s:
+    with ui.slide_item() as slide_item:
         ui.label('slide item')
-        s.slide(side='left', on_slide=lambda: label.set_text('Event: left slide'))
-        s.slide(side='right', on_slide=lambda: label.set_text('Event: right slide'))
+        slide_item.slide(side='left', on_slide=lambda: label.set_text('Event: left slide'))
+        slide_item.slide(side='right', on_slide=lambda: label.set_text('Event: right slide'))
 
     label = ui.label('None')
 
     screen.open('/')
-    slide_item = screen.find_element(s)
     screen.should_contain('None')
 
     ActionChains(screen.selenium) \
-        .move_to_element_with_offset(slide_item, -20, 0) \
+        .move_to_element_with_offset(screen.find_element(slide_item), -20, 0) \
         .click_and_hold() \
         .pause(1) \
         .move_by_offset(60, 0) \
         .pause(1) \
         .release() \
         .perform()
-    screen.wait(1)
     screen.should_contain('Event: left slide')
 
-    s.reset()
+    slide_item.reset()
     screen.wait(1)
 
     ActionChains(screen.selenium) \
-        .move_to_element_with_offset(slide_item, 20, 0) \
+        .move_to_element_with_offset(screen.find_element(slide_item), 20, 0) \
         .click_and_hold() \
         .pause(1) \
         .move_by_offset(-60, 0) \
         .pause(1) \
         .release() \
         .perform()
-    screen.wait(1)
     screen.should_contain('Event: right slide')

--- a/tests/test_slide_item.py
+++ b/tests/test_slide_item.py
@@ -7,7 +7,7 @@ from nicegui.testing import Screen
 def test_slide_item(screen: Screen):
     with ui.slide_item(on_change=lambda: label.set_text('Event: change')) as s:
         ui.label('slide item')
-        ui.left_slide()
+        s.slide(side='left')
     label = ui.label('None')
 
     screen.open('/')
@@ -30,8 +30,8 @@ def test_slide_item(screen: Screen):
 def test_slide_side(screen: Screen):
     with ui.slide_item() as s:
         ui.label('slide item')
-        ui.left_slide(on_slide=lambda: label.set_text('Event: left slide'))
-        ui.right_slide(on_slide=lambda: label.set_text('Event: right slide'))
+        s.slide(side='left', on_slide=lambda: label.set_text('Event: left slide'))
+        s.slide(side='right', on_slide=lambda: label.set_text('Event: right slide'))
 
     label = ui.label('None')
 

--- a/tests/test_slide_item.py
+++ b/tests/test_slide_item.py
@@ -5,10 +5,9 @@ from nicegui.testing import Screen
 
 
 def test_slide_item(screen: Screen):
-    with ui.slide_item(on_change=lambda: label.set_text('Event: change')) as slide_item:
-        ui.label('slide item')
-        slide_item.slide(side='left')
     label = ui.label('None')
+    with ui.slide_item('slide item', on_slide=lambda e: label.set_text(f'Event: {e.side}')) as slide_item:
+        slide_item.left()
 
     screen.open('/')
     screen.should_contain('slide item')
@@ -17,21 +16,19 @@ def test_slide_item(screen: Screen):
     ActionChains(screen.selenium) \
         .move_to_element_with_offset(screen.find_element(slide_item), -20, 0) \
         .click_and_hold() \
-        .pause(1) \
+        .pause(0.5) \
         .move_by_offset(60, 0) \
-        .pause(1) \
+        .pause(0.5) \
         .release() \
         .perform()
-    screen.should_contain('Event: change')
+    screen.should_contain('Event: left')
 
 
 def test_slide_side(screen: Screen):
-    with ui.slide_item() as slide_item:
-        ui.label('slide item')
-        slide_item.slide(side='left', on_slide=lambda: label.set_text('Event: left slide'))
-        slide_item.slide(side='right', on_slide=lambda: label.set_text('Event: right slide'))
-
     label = ui.label('None')
+    with ui.slide_item('slide item') as slide_item:
+        slide_item.left(on_slide=lambda e: label.set_text(f'Event: {e.side}'))
+        slide_item.right(on_slide=lambda e: label.set_text(f'Event: {e.side}'))
 
     screen.open('/')
     screen.should_contain('None')
@@ -39,22 +36,22 @@ def test_slide_side(screen: Screen):
     ActionChains(screen.selenium) \
         .move_to_element_with_offset(screen.find_element(slide_item), -20, 0) \
         .click_and_hold() \
-        .pause(1) \
+        .pause(0.5) \
         .move_by_offset(60, 0) \
-        .pause(1) \
+        .pause(0.5) \
         .release() \
         .perform()
-    screen.should_contain('Event: left slide')
+    screen.should_contain('Event: left')
 
     slide_item.reset()
-    screen.wait(1)
+    screen.should_contain('slide item')
 
     ActionChains(screen.selenium) \
         .move_to_element_with_offset(screen.find_element(slide_item), 20, 0) \
         .click_and_hold() \
-        .pause(1) \
+        .pause(0.5) \
         .move_by_offset(-60, 0) \
-        .pause(1) \
+        .pause(0.5) \
         .release() \
         .perform()
-    screen.should_contain('Event: right slide')
+    screen.should_contain('Event: right')

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -466,6 +466,7 @@ q-layout
     Label [text=Hidden, visible=False]
 '''.strip()
 
+
 async def test_typing_to_disabled_element(user: User) -> None:
     initial_value = 'Hello first'
     given_new_input = 'Hello second'

--- a/website/documentation/content/section_page_layout.py
+++ b/website/documentation/content/section_page_layout.py
@@ -12,6 +12,7 @@ from . import (
     grid_documentation,
     list_documentation,
     menu_documentation,
+    slide_item_documentation,
     notification_documentation,
     notify_documentation,
     pagination_documentation,
@@ -56,6 +57,7 @@ doc.intro(column_documentation)
 doc.intro(row_documentation)
 doc.intro(grid_documentation)
 doc.intro(list_documentation)
+doc.intro(slide_item_documentation)
 doc.intro(fullscreen_documentation)
 
 

--- a/website/documentation/content/slide_item_documentation.py
+++ b/website/documentation/content/slide_item_documentation.py
@@ -1,0 +1,58 @@
+from nicegui import ui
+
+from . import doc
+
+
+@doc.demo(ui.slide_item)
+def main_demo() -> None:
+    with ui.list().props('dense separator'):
+        with ui.slide_item():
+            with ui.item_section().classes('h-20'):
+                ui.item_label('Slide me Left or Right')
+            with ui.left_slide(color='green'):
+                ui.item_label('Left')
+            with ui.right_slide(color='red'):
+                ui.item_label('Right')
+        with ui.slide_item():
+            with ui.item_section().classes('h-20'):
+                ui.item_label('Slide me Up or Down')
+            with ui.top_slide(color='blue'):
+                ui.item_label('Top')
+            with ui.bottom_slide(color='purple'):
+                ui.item_label('Bottom')
+
+
+@doc.demo('Change and Slide Callbacks', '''
+    A callback function can be triggered when the slide changes and when a specific side is selected.
+''')
+def slide_callbacks():
+    with ui.list().props('dense separator'):
+        with ui.slide_item(on_change=lambda: ui.notify('Slide changed')):
+            with ui.item_section().classes('h-20'):
+                ui.item_label('Slide me Left or Right')
+            with ui.left_slide(on_slide=lambda s: ui.notify(f'Slide {s.args} triggered')):
+                ui.icon('arrow_back')
+            with ui.right_slide(on_slide=lambda s: ui.notify(f'Slide {s.args} triggered')):
+                ui.icon('arrow_forward')
+
+
+@doc.demo('Resetting the Slide Item', '''
+    Once a Slide action has occured the Slide Item can be reset back to initial state.
+''')
+def slide_reset():
+    with ui.list().props('dense separator'):
+        with ui.slide_item() as slide_item:
+            with ui.item_section().classes('h-20'):
+                ui.item_label('Slide me Up or Down')
+            with ui.top_slide(color='blue'):
+                ui.item_label('Top')
+            with ui.bottom_slide(color='purple'):
+                ui.item_label('Bottom')
+
+    ui.button('Reset Slide Item', on_click=lambda: slide_item.reset())
+
+
+doc.reference(ui.left_slide, title='Reference for ui.left_slide')
+doc.reference(ui.right_slide, title='Reference for ui.left_slide')
+doc.reference(ui.top_slide, title='Reference for ui.top_slide')
+doc.reference(ui.bottom_slide, title='Reference for ui.bottom_slide')

--- a/website/documentation/content/slide_item_documentation.py
+++ b/website/documentation/content/slide_item_documentation.py
@@ -6,20 +6,18 @@ from . import doc
 @doc.demo(ui.slide_item)
 def main_demo() -> None:
     with ui.list().props('dense separator'):
-        with ui.slide_item():
-            with ui.item_section().classes('h-20'):
-                ui.item_label('Slide me Left or Right')
-            with ui.left_slide(color='green'):
-                ui.item_label('Left')
-            with ui.right_slide(color='red'):
-                ui.item_label('Right')
-        with ui.slide_item():
-            with ui.item_section().classes('h-20'):
-                ui.item_label('Slide me Up or Down')
-            with ui.top_slide(color='blue'):
-                ui.item_label('Top')
-            with ui.bottom_slide(color='purple'):
-                ui.item_label('Bottom')
+        with ui.slide_item().classes('h-20') as slide_item_one:
+            ui.item('Slide me Left or Right')
+            with slide_item_one(side='left', color='green'):
+                ui.label('Left')
+            with slide_item_one(side='right', color='red'):
+                ui.label('Right')
+        with ui.slide_item().classes('h-20') as slide_item_two:
+            ui.item('Slide me Up or Down')
+            with slide_item_two.slide(side='top', color='blue'):
+                ui.label('Top')
+            with slide_item_two.slide(side='bottom', color='purple'):
+                ui.label('Bottom')
 
 
 @doc.demo('Change and Slide Callbacks', '''
@@ -27,12 +25,11 @@ def main_demo() -> None:
 ''')
 def slide_callbacks():
     with ui.list().props('dense separator'):
-        with ui.slide_item(on_change=lambda: ui.notify('Slide changed')):
-            with ui.item_section().classes('h-20'):
-                ui.item_label('Slide me Left or Right')
-            with ui.left_slide(on_slide=lambda s: ui.notify(f'Slide {s.args} triggered')):
+        with ui.slide_item(on_change=lambda: ui.notify('Slide changed')).classes('h-20') as slide_item:
+            ui.item('Slide me Left or Right')
+            with slide_item.slide(side='left', on_slide=lambda s: ui.notify(f'Slide {s.args} triggered')):
                 ui.icon('arrow_back')
-            with ui.right_slide(on_slide=lambda s: ui.notify(f'Slide {s.args} triggered')):
+            with slide_item.slide(side='right', on_slide=lambda s: ui.notify(f'Slide {s.args} triggered')):
                 ui.icon('arrow_forward')
 
 
@@ -41,18 +38,11 @@ def slide_callbacks():
 ''')
 def slide_reset():
     with ui.list().props('dense separator'):
-        with ui.slide_item() as slide_item:
-            with ui.item_section().classes('h-20'):
-                ui.item_label('Slide me Up or Down')
-            with ui.top_slide(color='blue'):
-                ui.item_label('Top')
-            with ui.bottom_slide(color='purple'):
-                ui.item_label('Bottom')
+        with ui.slide_item().classes('h-20') as slide_item:
+            ui.item('Slide me Up or Down')
+            with slide_item.slide(side='top', color='blue'):
+                ui.label('Top')
+            with slide_item.slide(side='bottom', color='purple'):
+                ui.label('Bottom')
 
     ui.button('Reset Slide Item', on_click=lambda: slide_item.reset())
-
-
-doc.reference(ui.left_slide, title='Reference for ui.left_slide')
-doc.reference(ui.right_slide, title='Reference for ui.left_slide')
-doc.reference(ui.top_slide, title='Reference for ui.top_slide')
-doc.reference(ui.bottom_slide, title='Reference for ui.bottom_slide')

--- a/website/documentation/content/slide_item_documentation.py
+++ b/website/documentation/content/slide_item_documentation.py
@@ -5,44 +5,59 @@ from . import doc
 
 @doc.demo(ui.slide_item)
 def main_demo() -> None:
-    with ui.list().props('separator'):
-        with ui.slide_item() as slide_item_one:
-            ui.item('Slide me Left or Right')
-            with slide_item_one.slide('left', color='green'):
-                ui.label('Left')
-            with slide_item_one.slide('right', color='red'):
-                ui.label('Right')
-        with ui.slide_item() as slide_item_two:
-            ui.item('Slide me Up or Down')
-            with slide_item_two.slide('top', color='blue'):
-                ui.label('Top')
-            with slide_item_two.slide('bottom', color='purple'):
-                ui.label('Bottom')
+    with ui.list().props('bordered separator'):
+        with ui.slide_item('Slide me left or right') as slide_item_1:
+            slide_item_1.left('Left', color='green')
+            slide_item_1.right('Right', color='red')
+        with ui.slide_item('Slide me up or down') as slide_item_2:
+            slide_item_2.top('Top', color='blue')
+            slide_item_2.bottom('Bottom', color='purple')
 
 
-@doc.demo('Change and Slide Callbacks', '''
-    A callback function can be triggered when the slide changes and when a specific side is selected.
+@doc.demo('More Complex Layout', '''
+    You can fill the slide item and its action slots with custom UI elements.
+''')
+def complex_demo():
+    with ui.list().props('bordered'):
+        with ui.slide_item() as slide_item:
+            with ui.item():
+                with ui.item_section().props('avatar'):
+                    ui.icon('person')
+                with ui.item_section():
+                    ui.item_label('Alice A. Anderson')
+                    ui.item_label('CEO').props('caption')
+            with slide_item.left(on_slide=lambda: ui.notify('Calling...')):
+                with ui.item(on_click=slide_item.reset):
+                    with ui.item_section().props('avatar'):
+                        ui.icon('phone')
+                    ui.item_section('Call')
+            with slide_item.right(on_slide=lambda: ui.notify('Texting...')):
+                with ui.item(on_click=slide_item.reset):
+                    ui.item_section('Text')
+                    with ui.item_section().props('avatar'):
+                        ui.icon('message')
+
+
+@doc.demo('Slide handlers', '''
+    An event handler can be triggered when a specific side is selected.
 ''')
 def slide_callbacks():
-    with ui.list().props('separator'):
-        with ui.slide_item(on_change=lambda: ui.notify('Slide changed')) as slide_item:
-            ui.item('Slide me Left or Right')
-            with slide_item.slide('left', on_slide=lambda s: ui.notify(f'Slide {s.args} triggered')):
-                ui.icon('arrow_back')
-            with slide_item.slide('right', on_slide=lambda s: ui.notify(f'Slide {s.args} triggered')):
-                ui.icon('arrow_forward')
+    with ui.list().props('bordered'):
+        with ui.slide_item('Slide me', on_slide=lambda e: ui.notify(f'Slide: {e.side}')) as slide_item:
+            slide_item.left('A', on_slide=lambda e: ui.notify(f'A ({e.side})'))
+            slide_item.right('B', on_slide=lambda e: ui.notify(f'B ({e.side})'))
 
 
 @doc.demo('Resetting the Slide Item', '''
-    Once a slide action has occurred, the slide item can be reset back to initial state.
+    Once a slide action has occurred, the slide item can be reset back to initial state using the ``reset`` method.
 ''')
 def slide_reset():
-    with ui.list().props('separator'):
+    with ui.list().props('bordered'):
         with ui.slide_item() as slide_item:
-            ui.item('Slide me Up or Down')
-            with slide_item.slide('top', color='blue'):
-                ui.label('Top')
-            with slide_item.slide('bottom', color='purple'):
-                ui.label('Bottom')
+            ui.item('Slide me')
+            with slide_item.left(color='blue'):
+                ui.item('Left')
+            with slide_item.right(color='purple'):
+                ui.item('Right')
 
-    ui.button('Reset Slide Item', on_click=slide_item.reset)
+    ui.button('Reset', on_click=slide_item.reset)

--- a/website/documentation/content/slide_item_documentation.py
+++ b/website/documentation/content/slide_item_documentation.py
@@ -14,7 +14,7 @@ def main_demo() -> None:
             slide_item_2.bottom('Bottom', color='purple')
 
 
-@doc.demo('More Complex Layout', '''
+@doc.demo('More complex layout', '''
     You can fill the slide item and its action slots with custom UI elements.
 ''')
 def complex_demo():
@@ -48,8 +48,8 @@ def slide_callbacks():
             slide_item.right('B', on_slide=lambda e: ui.notify(f'B ({e.side})'))
 
 
-@doc.demo('Resetting the Slide Item', '''
-    Once a slide action has occurred, the slide item can be reset back to initial state using the ``reset`` method.
+@doc.demo('Resetting the slide item', '''
+    After a slide action has occurred, the slide item can be reset back to its initial state using the ``reset`` method.
 ''')
 def slide_reset():
     with ui.list().props('bordered'):

--- a/website/documentation/content/slide_item_documentation.py
+++ b/website/documentation/content/slide_item_documentation.py
@@ -5,18 +5,18 @@ from . import doc
 
 @doc.demo(ui.slide_item)
 def main_demo() -> None:
-    with ui.list().props('dense separator'):
-        with ui.slide_item().classes('h-20') as slide_item_one:
+    with ui.list().props('separator'):
+        with ui.slide_item() as slide_item_one:
             ui.item('Slide me Left or Right')
-            with slide_item_one(side='left', color='green'):
+            with slide_item_one.slide('left', color='green'):
                 ui.label('Left')
-            with slide_item_one(side='right', color='red'):
+            with slide_item_one.slide('right', color='red'):
                 ui.label('Right')
-        with ui.slide_item().classes('h-20') as slide_item_two:
+        with ui.slide_item() as slide_item_two:
             ui.item('Slide me Up or Down')
-            with slide_item_two.slide(side='top', color='blue'):
+            with slide_item_two.slide('top', color='blue'):
                 ui.label('Top')
-            with slide_item_two.slide(side='bottom', color='purple'):
+            with slide_item_two.slide('bottom', color='purple'):
                 ui.label('Bottom')
 
 
@@ -24,25 +24,25 @@ def main_demo() -> None:
     A callback function can be triggered when the slide changes and when a specific side is selected.
 ''')
 def slide_callbacks():
-    with ui.list().props('dense separator'):
-        with ui.slide_item(on_change=lambda: ui.notify('Slide changed')).classes('h-20') as slide_item:
+    with ui.list().props('separator'):
+        with ui.slide_item(on_change=lambda: ui.notify('Slide changed')) as slide_item:
             ui.item('Slide me Left or Right')
-            with slide_item.slide(side='left', on_slide=lambda s: ui.notify(f'Slide {s.args} triggered')):
+            with slide_item.slide('left', on_slide=lambda s: ui.notify(f'Slide {s.args} triggered')):
                 ui.icon('arrow_back')
-            with slide_item.slide(side='right', on_slide=lambda s: ui.notify(f'Slide {s.args} triggered')):
+            with slide_item.slide('right', on_slide=lambda s: ui.notify(f'Slide {s.args} triggered')):
                 ui.icon('arrow_forward')
 
 
 @doc.demo('Resetting the Slide Item', '''
-    Once a Slide action has occured the Slide Item can be reset back to initial state.
+    Once a slide action has occurred, the slide item can be reset back to initial state.
 ''')
 def slide_reset():
-    with ui.list().props('dense separator'):
-        with ui.slide_item().classes('h-20') as slide_item:
+    with ui.list().props('separator'):
+        with ui.slide_item() as slide_item:
             ui.item('Slide me Up or Down')
-            with slide_item.slide(side='top', color='blue'):
+            with slide_item.slide('top', color='blue'):
                 ui.label('Top')
-            with slide_item.slide(side='bottom', color='purple'):
+            with slide_item.slide('bottom', color='purple'):
                 ui.label('Bottom')
 
-    ui.button('Reset Slide Item', on_click=lambda: slide_item.reset())
+    ui.button('Reset Slide Item', on_click=slide_item.reset)


### PR DESCRIPTION
This PR introduces a Slide Item element based on Quasar's QSlideItem https://quasar.dev/vue-components/slide-item

@falkoschindler and @rodja I would be keen to hear your feedback on how I handled the `LeftSlide`, `RightSlide`, etc relationship with `SlideItem`, I feel there may be a better way to add the association of their slot to the parent element.

I'm also interested to hear your feedback on whether an `on_change` callback is really needed if each slot already has an `on_slide` callback.

I was undecided whether creating `LeftSlide`, `RightSlide`, etc classes were truly necessary, a user could just use `SlideSide` with the `side` parameter, but noted the style of `Drawer`, `LeftDrawer`, `RightDrawer` so aligned to this.

---

Feature request: #4282