### PR TITLE
Add Leaflet WMS support

### DIFF
--- a/nicegui/elements/leaflet.js
+++ b/nicegui/elements/leaflet.js
@@ -127,11 +127,11 @@ export default {
   },
   methods: {
     add_layer(layer, id) {
-      if (layer.type == "tileLayer.wms") {
-        var l = L.tileLayer.wms(...layer.args);
-      } else {
-        var l = L[layer.type](...layer.args);
+      let obj = L;
+      for (const part of layer.type.split(".")) {
+        obj = obj[part];
       }
+      const l = obj(...layer.args);
       l.id = id;
       l.addTo(this.map);
     },

--- a/nicegui/elements/leaflet.js
+++ b/nicegui/elements/leaflet.js
@@ -127,7 +127,11 @@ export default {
   },
   methods: {
     add_layer(layer, id) {
-      const l = L[layer.type](...layer.args);
+      if (layer.type == "tileLayer.wms") {
+        var l = L.tileLayer.wms(...layer.args);
+      } else {
+        var l = L[layer.type](...layer.args);
+      }
       l.id = id;
       l.addTo(this.map);
     },

--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -16,6 +16,7 @@ class Leaflet(Element, component='leaflet.js', default_classes='nicegui-leaflet'
     from .leaflet_layers import GenericLayer as generic_layer
     from .leaflet_layers import Marker as marker
     from .leaflet_layers import TileLayer as tile_layer
+    from .leaflet_layers import WmsLayer as wms_layer
 
     center = binding.BindableProperty(lambda sender, value: cast(Leaflet, sender).set_center(value))
     zoom = binding.BindableProperty(lambda sender, value: cast(Leaflet, sender).set_zoom(value))

--- a/nicegui/elements/leaflet_layers.py
+++ b/nicegui/elements/leaflet_layers.py
@@ -32,6 +32,18 @@ class TileLayer(Layer):
 
 
 @dataclass(**KWONLY_SLOTS)
+class WmsLayer(Layer):
+    url_template: str
+    options: Dict = field(default_factory=dict)
+
+    def to_dict(self) -> Dict:
+        return {
+            'type': 'tileLayer.wms',
+            'args': [self.url_template, self.options],
+        }
+
+
+@dataclass(**KWONLY_SLOTS)
 class Marker(Layer):
     latlng: Tuple[float, float]
     options: Dict = field(default_factory=dict)

--- a/website/documentation/content/leaflet_documentation.py
+++ b/website/documentation/content/leaflet_documentation.py
@@ -21,10 +21,11 @@ def main_demo() -> None:
     You can find more map styles at <https://leaflet-extras.github.io/leaflet-providers/preview/>.
     Each call to `tile_layer` stacks upon the previous ones.
     So if you want to change the map style, you have to remove the default one first.
-    Both WMTS and WMS map services are supported.
+
+    *Updated in version 2.12.0: Both WMTS and WMS map services are supported.*
 ''')
 def map_style() -> None:
-    # WMTS (Web Map Tile Service)
+    ui.label('Web Map Tile Service')
     map1 = ui.leaflet(center=(51.505, -0.090), zoom=3)
     map1.clear_layers()
     map1.tile_layer(
@@ -36,7 +37,8 @@ def map_style() -> None:
                 'Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
         },
     )
-    # WMS (Web Map Service)
+
+    ui.label('Web Map Service')
     map2 = ui.leaflet(center=(51.505, -0.090), zoom=3)
     map2.clear_layers()
     map2.wms_layer(

--- a/website/documentation/content/leaflet_documentation.py
+++ b/website/documentation/content/leaflet_documentation.py
@@ -21,17 +21,28 @@ def main_demo() -> None:
     You can find more map styles at <https://leaflet-extras.github.io/leaflet-providers/preview/>.
     Each call to `tile_layer` stacks upon the previous ones.
     So if you want to change the map style, you have to remove the default one first.
+    Both WMTS and WMS map services are supported.
 ''')
 def map_style() -> None:
-    m = ui.leaflet(center=(51.505, -0.090), zoom=3)
-    m.clear_layers()
-    m.tile_layer(
+    # WMTS (Web Map Tile Service)
+    map1 = ui.leaflet(center=(51.505, -0.090), zoom=3)
+    map1.clear_layers()
+    map1.tile_layer(
         url_template=r'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
         options={
             'maxZoom': 17,
             'attribution':
                 'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="https://viewfinderpanoramas.org/">SRTM</a> | '
                 'Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
+        },
+    )
+    # WMS (Web Map Service)
+    map2 = ui.leaflet(center=(51.505, -0.090), zoom=3)
+    map2.clear_layers()
+    map2.wms_layer(
+        url_template='http://ows.mundialis.de/services/service?',
+        options={
+            'layers': 'TOPO-WMS,OSM-Overlay-WMS'
         },
     )
 


### PR DESCRIPTION
Currently only WMTS (Web Map Tile Service) Leaflet functionality is supported in NiceGUI (through `L.tileLayer`).

Leaflet.js also supports WMS (Web Map Service) though: https://leafletjs.com/examples/wms/wms.html

This PR implements Leaflet.js `L.tileLayer.wms` and adds an example to the documentation.