### PR TITLE
improve update of notifications

### DIFF
--- a/nicegui/elements/notification.js
+++ b/nicegui/elements/notification.js
@@ -4,10 +4,10 @@ export default {
   mounted() {
     this.notification = Quasar.Notify.create(this.convertedOptions);
   },
-  updated() {
-    this.notification(this.convertedOptions);
-  },
   methods: {
+    update_notification() {
+      this.notification(this.convertedOptions);
+    },
     dismiss() {
       this.notification();
     },

--- a/nicegui/elements/notification.py
+++ b/nicegui/elements/notification.py
@@ -77,7 +77,6 @@ class Notification(Element, component='notification.js'):
                 'closeBtn': close_button,
                 'timeout': (timeout or 0) * 1000,
                 'group': False,
-                'attrs': {'data-id': f'nicegui-dialog-{self.id}'},
             }
             if type is not None:
                 self._props['options']['type'] = type
@@ -199,3 +198,7 @@ class Notification(Element, component='notification.js'):
 
     def set_visibility(self, visible: bool) -> None:
         raise NotImplementedError('Use `dismiss()` to remove the notification. See #3670 for more information.')
+
+    def update(self) -> None:
+        super().update()
+        self.run_method('update_notification')

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -37,3 +37,22 @@ def test_dismiss(screen: Screen):
     screen.wait(1.5)
     screen.should_not_contain('Hi!')
     assert len(b.client.layout.default_slot.children) == 1
+
+
+def test_no_reset_by_other_notifications(screen: Screen):
+    # see #4373
+    ui.button('Button A', on_click=lambda: ui.notification('Notification A', timeout=1.0))
+    ui.button('Button B', on_click=lambda: ui.notification('Notification B', timeout=1.0))
+    ui.button('Button C', on_click=lambda: ui.notification('Notification C', timeout=1.0))
+    ui.button('Button D', on_click=lambda: ui.notification('Notification D', timeout=1.0))
+
+    screen.open('/')
+    screen.click('Button A')
+    screen.wait(1)
+    screen.click('Button B')
+    screen.wait(1)
+    screen.click('Button C')
+    screen.wait(1)
+    screen.click('Button D')
+    screen.should_contain('Notification D')
+    screen.should_not_contain('Notification A')


### PR DESCRIPTION
As noticed in #4373, notifications received an update when another notification was created. This update called `this.notification()`, causing progress bars to reset. This PR solves this problem by explicitly calling an `update_notification()` method on UI updates, but preventing the accidental updates caused by other notifications.

Can be tested with a simple `ui.notification`:
```py
ui.button('Notify', on_click=lambda: ui.notification('Hi!'))
```
Clicking the button again and again will prevent any notification from disappearing after the default timeout of 5 seconds.

(By the way: I removed an obsolete "data-id" attribute. This hasn't been in use since #2983.)