### PR TITLE
Wait for leaflet to load before loading additional resources.

### DIFF
--- a/nicegui/elements/leaflet.js
+++ b/nicegui/elements/leaflet.js
@@ -17,8 +17,8 @@ export default {
     await Promise.all([
       loadResource(window.path_prefix + `${this.resource_path}/leaflet/leaflet.css`),
       loadResource(window.path_prefix + `${this.resource_path}/leaflet/leaflet.js`),
-      ...this.additional_resources.map((resource) => loadResource(resource)),
     ]);
+    await Promise.all(this.additional_resources.map((resource) => loadResource(resource)));
     if (this.draw_control) {
       await Promise.all([
         loadResource(window.path_prefix + `${this.resource_path}/leaflet-draw/leaflet.draw.css`),


### PR DESCRIPTION
In reference to [4395](https://github.com/zauberzeug/nicegui/issues/4395), this fix lets leaflet load before loading additional resources.