### PR TITLE
Profile imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv
 .nicegui/
 *.sqlite*
 .DS_Store
+*.lprof

--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -7,8 +7,9 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterator, List, Optional, Union
 
-from fastapi import FastAPI, HTTPException, Request, Response
-from fastapi.responses import FileResponse
+from fastapi import FastAPI, HTTPException
+from starlette.requests import Request
+from starlette.responses import FileResponse, Response
 
 from .. import background_tasks, helpers
 from ..client import Client

--- a/nicegui/app/range_response.py
+++ b/nicegui/app/range_response.py
@@ -4,8 +4,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Generator
 
-from fastapi import Request
-from fastapi.responses import Response, StreamingResponse
+from starlette.requests import Request
+from starlette.responses import Response, StreamingResponse
 
 mimetypes.init()
 

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -9,9 +9,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, ClassVar, Dict, Iterable, Iterator, List, Optional, Union
 
-from fastapi import Request
-from fastapi.responses import Response
-from fastapi.templating import Jinja2Templates
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.templating import Jinja2Templates
 from typing_extensions import Self
 
 from . import background_tasks, binding, core, helpers, json, storage

--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -3,8 +3,8 @@ from functools import lru_cache
 from typing import List
 
 import markdown2
-from fastapi.responses import PlainTextResponse
 from pygments.formatters import HtmlFormatter  # pylint: disable=no-name-in-module
+from starlette.responses import PlainTextResponse
 
 from .. import core
 from ..version import __version__

--- a/nicegui/elements/upload.py
+++ b/nicegui/elements/upload.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional, cast
 
-from fastapi import Request
 from starlette.datastructures import UploadFile
+from starlette.requests import Request
 from typing_extensions import Self
 
 from ..events import Handler, MultiUploadEventArguments, UiEventArguments, UploadEventArguments, handle_event

--- a/nicegui/event_listener.py
+++ b/nicegui/event_listener.py
@@ -2,7 +2,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional, Sequence
 
-from fastapi import Request
+from starlette.requests import Request
 
 from .dataclasses import KWONLY_SLOTS
 

--- a/nicegui/favicon.py
+++ b/nicegui/favicon.py
@@ -6,7 +6,7 @@ import urllib.parse
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
-from fastapi.responses import FileResponse, Response, StreamingResponse
+from starlette.responses import FileResponse, Response, StreamingResponse
 
 from . import core
 from .helpers import is_file

--- a/nicegui/json/builtin_wrapper.py
+++ b/nicegui/json/builtin_wrapper.py
@@ -3,7 +3,7 @@ import json
 from datetime import date, datetime
 from typing import Any, Optional, Tuple
 
-from fastapi import Response
+from starlette.responses import Response
 
 HAS_NUMPY = importlib.util.find_spec('numpy') is not None
 

--- a/nicegui/json/orjson_wrapper.py
+++ b/nicegui/json/orjson_wrapper.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, Tuple
 
 # pylint: disable=no-member
 import orjson
-from fastapi import Response
+from starlette.responses import Response
 
 HAS_NUMPY = importlib.util.find_spec('numpy') is not None
 

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -6,8 +6,9 @@ from pathlib import Path
 from typing import Any, Dict
 
 import socketio
-from fastapi import HTTPException, Request
-from fastapi.responses import FileResponse, Response
+from fastapi import HTTPException
+from starlette.requests import Request
+from starlette.responses import FileResponse, Response
 
 from . import air, background_tasks, binding, core, favicon, helpers, json, run, welcome
 from .app import App

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -7,7 +7,8 @@ from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
-from fastapi import Request, Response
+from starlette.requests import Request
+from starlette.responses import Response
 
 from . import background_tasks, binding, core, helpers
 from .client import Client

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -127,124 +127,147 @@ __all__ = [
     'video',
 ]
 
-from .context import context
-from .element import Element as element
-from .elements.aggrid import AgGrid as aggrid
-from .elements.audio import Audio as audio
-from .elements.avatar import Avatar as avatar
-from .elements.badge import Badge as badge
-from .elements.button import Button as button
-from .elements.button_dropdown import DropdownButton as dropdown_button
-from .elements.button_group import ButtonGroup as button_group
-from .elements.card import Card as card
-from .elements.card import CardActions as card_actions
-from .elements.card import CardSection as card_section
-from .elements.carousel import Carousel as carousel
-from .elements.carousel import CarouselSlide as carousel_slide
-from .elements.chat_message import ChatMessage as chat_message
-from .elements.checkbox import Checkbox as checkbox
-from .elements.chip import Chip as chip
-from .elements.code import Code as code
-from .elements.codemirror import CodeMirror as codemirror
-from .elements.color_input import ColorInput as color_input
-from .elements.color_picker import ColorPicker as color_picker
-from .elements.colors import Colors as colors
-from .elements.column import Column as column
-from .elements.context_menu import ContextMenu as context_menu
-from .elements.dark_mode import DarkMode as dark_mode
-from .elements.date import Date as date
-from .elements.dialog import Dialog as dialog
-from .elements.echart import EChart as echart
-from .elements.editor import Editor as editor
-from .elements.expansion import Expansion as expansion
-from .elements.fullscreen import Fullscreen as fullscreen
-from .elements.grid import Grid as grid
-from .elements.highchart import highchart
-from .elements.html import Html as html
-from .elements.icon import Icon as icon
-from .elements.image import Image as image
-from .elements.input import Input as input  # pylint: disable=redefined-builtin
-from .elements.interactive_image import InteractiveImage as interactive_image
-from .elements.item import Item as item
-from .elements.item import ItemLabel as item_label
-from .elements.item import ItemSection as item_section
-from .elements.joystick import Joystick as joystick
-from .elements.json_editor import JsonEditor as json_editor
-from .elements.keyboard import Keyboard as keyboard
-from .elements.knob import Knob as knob
-from .elements.label import Label as label
-from .elements.leaflet import Leaflet as leaflet
-from .elements.line_plot import LinePlot as line_plot
-from .elements.link import Link as link
-from .elements.link import LinkTarget as link_target
-from .elements.list import List as list  # pylint: disable=redefined-builtin
-from .elements.log import Log as log
-from .elements.markdown import Markdown as markdown
-from .elements.menu import Menu as menu
-from .elements.menu import MenuItem as menu_item
-from .elements.mermaid import Mermaid as mermaid
-from .elements.notification import Notification as notification
-from .elements.number import Number as number
-from .elements.pagination import Pagination as pagination
-from .elements.plotly import Plotly as plotly
-from .elements.progress import CircularProgress as circular_progress
-from .elements.progress import LinearProgress as linear_progress
-from .elements.pyplot import Matplotlib as matplotlib
-from .elements.pyplot import Pyplot as pyplot
-from .elements.query import Query as query
-from .elements.radio import Radio as radio
-from .elements.range import Range as range  # pylint: disable=redefined-builtin
-from .elements.rating import Rating as rating
-from .elements.restructured_text import ReStructuredText as restructured_text
-from .elements.row import Row as row
-from .elements.scene import Scene as scene
-from .elements.scene_view import SceneView as scene_view
-from .elements.scroll_area import ScrollArea as scroll_area
-from .elements.select import Select as select
-from .elements.separator import Separator as separator
-from .elements.skeleton import Skeleton as skeleton
-from .elements.slide_item import SlideItem as slide_item
-from .elements.slider import Slider as slider
-from .elements.space import Space as space
-from .elements.spinner import Spinner as spinner
-from .elements.splitter import Splitter as splitter
-from .elements.stepper import Step as step
-from .elements.stepper import Stepper as stepper
-from .elements.stepper import StepperNavigation as stepper_navigation
-from .elements.switch import Switch as switch
-from .elements.table import Table as table
-from .elements.tabs import Tab as tab
-from .elements.tabs import TabPanel as tab_panel
-from .elements.tabs import TabPanels as tab_panels
-from .elements.tabs import Tabs as tabs
-from .elements.teleport import Teleport as teleport
-from .elements.textarea import Textarea as textarea
-from .elements.time import Time as time
-from .elements.timeline import Timeline as timeline
-from .elements.timeline import TimelineEntry as timeline_entry
-from .elements.timer import Timer as timer
-from .elements.toggle import Toggle as toggle
-from .elements.tooltip import Tooltip as tooltip
-from .elements.tree import Tree as tree
-from .elements.upload import Upload as upload
-from .elements.video import Video as video
-from .functions import clipboard
-from .functions.download import download
-from .functions.html import add_body_html, add_head_html
-from .functions.javascript import run_javascript
-from .functions.navigate import navigate
-from .functions.notify import notify
-from .functions.on import on
-from .functions.page_title import page_title
-from .functions.refreshable import refreshable, refreshable_method, state
-from .functions.style import add_css, add_sass, add_scss
-from .functions.update import update
-from .page import page
-from .page_layout import Drawer as drawer
-from .page_layout import Footer as footer
-from .page_layout import Header as header
-from .page_layout import LeftDrawer as left_drawer
-from .page_layout import PageSticky as page_sticky
-from .page_layout import RightDrawer as right_drawer
-from .ui_run import run
-from .ui_run_with import run_with
+
+@profile
+def import_ui():
+    global context, element, aggrid, audio, avatar, badge, button, dropdown_button, button_group
+    global card, card_actions, card_section, carousel, carousel_slide, chat_message, checkbox
+    global chip, code, codemirror, color_input, color_picker, colors, column, context_menu
+    global dark_mode, date, dialog, echart, editor, expansion, fullscreen, grid, highchart
+    global html, icon, image, input, interactive_image, item, item_label, item_section
+    global joystick, json_editor, keyboard, knob, label, leaflet, line_plot, link, link_target
+    global list, log, markdown, menu, menu_item, mermaid, notification, number, pagination
+    global plotly, circular_progress, linear_progress, matplotlib, pyplot, query, radio
+    global range, rating, restructured_text, row, scene, scene_view, scroll_area, select
+    global separator, skeleton, slide_item, slider, space, spinner, splitter, step, stepper
+    global stepper_navigation, switch, table, tab, tab_panel, tab_panels, tabs, teleport
+    global textarea, time, timeline, timeline_entry, timer, toggle, tooltip, tree, upload
+    global video, clipboard, download, add_body_html, add_head_html, run_javascript, navigate
+    global notify, on, page_title, refreshable, refreshable_method, state, add_css, add_sass
+    global add_scss, update, page, drawer, footer, header, left_drawer, page_sticky
+    global right_drawer, run, run_with
+
+    from .context import context
+    from .element import Element as element
+    from .elements.aggrid import AgGrid as aggrid
+    from .elements.audio import Audio as audio
+    from .elements.avatar import Avatar as avatar
+    from .elements.badge import Badge as badge
+    from .elements.button import Button as button
+    from .elements.button_dropdown import DropdownButton as dropdown_button
+    from .elements.button_group import ButtonGroup as button_group
+    from .elements.card import Card as card
+    from .elements.card import CardActions as card_actions
+    from .elements.card import CardSection as card_section
+    from .elements.carousel import Carousel as carousel
+    from .elements.carousel import CarouselSlide as carousel_slide
+    from .elements.chat_message import ChatMessage as chat_message
+    from .elements.checkbox import Checkbox as checkbox
+    from .elements.chip import Chip as chip
+    from .elements.code import Code as code
+    from .elements.codemirror import CodeMirror as codemirror
+    from .elements.color_input import ColorInput as color_input
+    from .elements.color_picker import ColorPicker as color_picker
+    from .elements.colors import Colors as colors
+    from .elements.column import Column as column
+    from .elements.context_menu import ContextMenu as context_menu
+    from .elements.dark_mode import DarkMode as dark_mode
+    from .elements.date import Date as date
+    from .elements.dialog import Dialog as dialog
+    from .elements.echart import EChart as echart
+    from .elements.editor import Editor as editor
+    from .elements.expansion import Expansion as expansion
+    from .elements.fullscreen import Fullscreen as fullscreen
+    from .elements.grid import Grid as grid
+    from .elements.highchart import highchart
+    from .elements.html import Html as html
+    from .elements.icon import Icon as icon
+    from .elements.image import Image as image
+    from .elements.input import Input as input  # pylint: disable=redefined-builtin
+    from .elements.interactive_image import InteractiveImage as interactive_image
+    from .elements.item import Item as item
+    from .elements.item import ItemLabel as item_label
+    from .elements.item import ItemSection as item_section
+    from .elements.joystick import Joystick as joystick
+    from .elements.json_editor import JsonEditor as json_editor
+    from .elements.keyboard import Keyboard as keyboard
+    from .elements.knob import Knob as knob
+    from .elements.label import Label as label
+    from .elements.leaflet import Leaflet as leaflet
+    from .elements.line_plot import LinePlot as line_plot
+    from .elements.link import Link as link
+    from .elements.link import LinkTarget as link_target
+    from .elements.list import List as list  # pylint: disable=redefined-builtin
+    from .elements.log import Log as log
+    from .elements.markdown import Markdown as markdown
+    from .elements.menu import Menu as menu
+    from .elements.menu import MenuItem as menu_item
+    from .elements.mermaid import Mermaid as mermaid
+    from .elements.notification import Notification as notification
+    from .elements.number import Number as number
+    from .elements.pagination import Pagination as pagination
+    from .elements.plotly import Plotly as plotly
+    from .elements.progress import CircularProgress as circular_progress
+    from .elements.progress import LinearProgress as linear_progress
+    from .elements.pyplot import Matplotlib as matplotlib
+    from .elements.pyplot import Pyplot as pyplot
+    from .elements.query import Query as query
+    from .elements.radio import Radio as radio
+    from .elements.range import Range as range  # pylint: disable=redefined-builtin
+    from .elements.rating import Rating as rating
+    from .elements.restructured_text import ReStructuredText as restructured_text
+    from .elements.row import Row as row
+    from .elements.scene import Scene as scene
+    from .elements.scene_view import SceneView as scene_view
+    from .elements.scroll_area import ScrollArea as scroll_area
+    from .elements.select import Select as select
+    from .elements.separator import Separator as separator
+    from .elements.skeleton import Skeleton as skeleton
+    from .elements.slide_item import SlideItem as slide_item
+    from .elements.slider import Slider as slider
+    from .elements.space import Space as space
+    from .elements.spinner import Spinner as spinner
+    from .elements.splitter import Splitter as splitter
+    from .elements.stepper import Step as step
+    from .elements.stepper import Stepper as stepper
+    from .elements.stepper import StepperNavigation as stepper_navigation
+    from .elements.switch import Switch as switch
+    from .elements.table import Table as table
+    from .elements.tabs import Tab as tab
+    from .elements.tabs import TabPanel as tab_panel
+    from .elements.tabs import TabPanels as tab_panels
+    from .elements.tabs import Tabs as tabs
+    from .elements.teleport import Teleport as teleport
+    from .elements.textarea import Textarea as textarea
+    from .elements.time import Time as time
+    from .elements.timeline import Timeline as timeline
+    from .elements.timeline import TimelineEntry as timeline_entry
+    from .elements.timer import Timer as timer
+    from .elements.toggle import Toggle as toggle
+    from .elements.tooltip import Tooltip as tooltip
+    from .elements.tree import Tree as tree
+    from .elements.upload import Upload as upload
+    from .elements.video import Video as video
+    from .functions import clipboard
+    from .functions.download import download
+    from .functions.html import add_body_html, add_head_html
+    from .functions.javascript import run_javascript
+    from .functions.navigate import navigate
+    from .functions.notify import notify
+    from .functions.on import on
+    from .functions.page_title import page_title
+    from .functions.refreshable import refreshable, refreshable_method, state
+    from .functions.style import add_css, add_sass, add_scss
+    from .functions.update import update
+    from .page import page
+    from .page_layout import Drawer as drawer
+    from .page_layout import Footer as footer
+    from .page_layout import Header as header
+    from .page_layout import LeftDrawer as left_drawer
+    from .page_layout import PageSticky as page_sticky
+    from .page_layout import RightDrawer as right_drawer
+    from .ui_run import run
+    from .ui_run_with import run_with
+
+
+import_ui()

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Tuple, TypedDict, Union
 
-from fastapi.middleware.gzip import GZipMiddleware
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.routing import Route
 from uvicorn.main import STARTUP_FAILURE
 from uvicorn.supervisors import ChangeReload, Multiprocess

--- a/nicegui/ui_run_with.py
+++ b/nicegui/ui_run_with.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
-from fastapi import FastAPI
-from fastapi.middleware.gzip import GZipMiddleware
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+from starlette.middleware.gzip import GZipMiddleware
 
 from . import core, storage
 from .air import Air

--- a/profile_imports.py
+++ b/profile_imports.py
@@ -1,0 +1,15 @@
+# NOTE: run this file like this:
+#
+# kernprof -l -v profile_imports.py
+
+import sys
+
+from line_profiler import LineProfiler
+
+profile = LineProfiler()
+sys.modules['__main__'].__dict__['profile'] = profile
+
+if True:
+    from nicegui import ui
+
+profile.print_stats()

--- a/profile_imports.py
+++ b/profile_imports.py
@@ -2,9 +2,12 @@
 #
 # kernprof -l -v profile_imports.py
 
+import os
 import sys
 
 from line_profiler import LineProfiler
+
+os.environ['MATPLOTLIB'] = 'false'
 
 profile = LineProfiler()
 sys.modules['__main__'].__dict__['profile'] = profile


### PR DESCRIPTION
Inspired by discussion #4353, this draft pull request serves as a playground to profile the import of NiceGUI's `ui` module (and maybe others).

Two insights so far:

1. Often we can avoid importing FastAPI by importing things like `Request` or `Response` from Starlette instead. At the moment, however, this only shifts the required import time to app.py where we want to subclass the FastAPI app.
2. When importing `ui` on my machine, 70% of the time is spent importing Matplotlib. And we already have an environment variable to disable it. So it should be straight forward to save some time by setting this variable when creating a subprocess.