### PR TITLE
Ensure valid host when opening native window

### DIFF
--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -176,7 +176,8 @@ def run(*,
         host = host or '127.0.0.1'
         port = port or native_module.find_open_port()
         width, height = window_size or (800, 600)
-        native_module.activate(host, port, title, width, height, fullscreen, frameless)
+        native_host = '127.0.0.1' if host == '0.0.0.0' else host
+        native_module.activate(native_host, port, title, width, height, fullscreen, frameless)
     else:
         port = port or 8080
         host = host or '0.0.0.0'


### PR DESCRIPTION
This PR fixes #4438, which describes that using `ui.run(host='0.0.0.0', native=True)` is currently broken. The problem is that `0.0.0.0` is an placeholder to tell the operating system to bind to all interfaces. But `0.0.0.0` is not a valid IP to be accessed. So we need to make sure to not pass it to the native browser window.