### PR TITLE
feat: add `timeout` method for `ui.notification`

### DIFF
--- a/nicegui/elements/notification.py
+++ b/nicegui/elements/notification.py
@@ -179,7 +179,10 @@ class Notification(Element, component='notification.js'):
 
     @property
     def timeout(self) -> float:
-        """Timeout of the notification in seconds."""
+        """Timeout of the notification in seconds.
+
+        *Added in version 2.13.0*
+        """
         return self._props['options']['timeout'] / 1000
 
     @timeout.setter

--- a/nicegui/elements/notification.py
+++ b/nicegui/elements/notification.py
@@ -199,6 +199,11 @@ class Notification(Element, component='notification.js'):
     def set_visibility(self, visible: bool) -> None:
         raise NotImplementedError('Use `dismiss()` to remove the notification. See #3670 for more information.')
 
+    def set_timeout(self,timeout: Optional[float]) -> None:
+        """Set the notification's timeout."""
+        self.props["options"]["timeout"] = (timeout or 0) *1000
+        self.update()
+
     def update(self) -> None:
         super().update()
         self.run_method('update_notification')

--- a/nicegui/elements/notification.py
+++ b/nicegui/elements/notification.py
@@ -178,7 +178,7 @@ class Notification(Element, component='notification.js'):
         self.update()
 
     @property
-    def timeout(self) -> Optional[float]:
+    def timeout(self) -> float:
         """Timeout of the notification in seconds."""
         return self._props['options']['timeout'] / 1000
 

--- a/nicegui/elements/notification.py
+++ b/nicegui/elements/notification.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import Any, Dict, Literal, Optional, Union
+from enum import Enum, auto
 
 from typing_extensions import Self
 
@@ -27,6 +28,8 @@ NotificationType = Optional[Literal[
     'ongoing',
 ]]
 
+class ChangeType(Enum):
+        NoneChange = auto()
 
 class Notification(Element, component='notification.js'):
 
@@ -178,6 +181,16 @@ class Notification(Element, component='notification.js'):
         self.update()
 
     @property
+    def timeout(self) -> Optional[float]:
+        """Timout of the notification."""
+        return self._props['options']['timeout']
+
+    @timeout.setter
+    def timeout(self,value: Optional[float]) -> None:
+        self._props["options"]["timeout"] = (value or 0) *1000
+        self.update()
+
+    @property
     def close_button(self) -> Union[bool, str]:
         """Whether the notification has a close button."""
         return self._props['options']['closeBtn']
@@ -198,11 +211,6 @@ class Notification(Element, component='notification.js'):
 
     def set_visibility(self, visible: bool) -> None:
         raise NotImplementedError('Use `dismiss()` to remove the notification. See #3670 for more information.')
-
-    def set_timeout(self,timeout: Optional[float]) -> None:
-        """Set the notification's timeout."""
-        self.props["options"]["timeout"] = (timeout or 0) *1000
-        self.update()
 
     def update(self) -> None:
         super().update()

--- a/nicegui/elements/notification.py
+++ b/nicegui/elements/notification.py
@@ -1,6 +1,5 @@
 import asyncio
 from typing import Any, Dict, Literal, Optional, Union
-from enum import Enum, auto
 
 from typing_extensions import Self
 
@@ -28,8 +27,6 @@ NotificationType = Optional[Literal[
     'ongoing',
 ]]
 
-class ChangeType(Enum):
-        NoneChange = auto()
 
 class Notification(Element, component='notification.js'):
 
@@ -182,12 +179,12 @@ class Notification(Element, component='notification.js'):
 
     @property
     def timeout(self) -> Optional[float]:
-        """Timout of the notification."""
-        return self._props['options']['timeout']
+        """Timeout of the notification in seconds."""
+        return self._props['options']['timeout'] / 1000
 
     @timeout.setter
-    def timeout(self,value: Optional[float]) -> None:
-        self._props["options"]["timeout"] = (value or 0) *1000
+    def timeout(self, value: Optional[float]) -> None:
+        self._props['options']['timeout'] = (value or 0) * 1000
         self.update()
 
     @property


### PR DESCRIPTION
This PR is based on #4437 , which explores a way to make notifications dismiss after a certain period of time.

This PR provides a method called `timeout` that allows people to directly override the value of timeout (instead of manually modifying the value of the props)

I did a simple test.It worked well.
```python
# notification.py (This PR did)
class Notification(Element, component='notification.js'):
    ...
    @property
    def timeout(self) -> Optional[float]:
        """The timout value of the notification."""
        return self._props['options']['timeout']

    @timeout.setter
    def timeout(self,value: Optional[float]) -> None:
        self._props["options"]["timeout"] = (value or 0) *1000
        self.update()

# test.py
import asyncio

from nicegui import ui

async def test_set_timeout():
    n = ui.notification("Test Notification",timeout=None)
    n.on_dismiss(lambda:print("Notification Dismiss."))
    await asyncio.sleep(3)
    n.message="Test Done"
    n.timeout = 3 # This is a new method

ui.button("Test").on_click(test_set_timeout)

ui.run()
```
That's all.

If you have any suggestions for changes to this PR, please let me know. Thanks a lot.