### PR TITLE
Fix native select and change event capture for `json_editor` element.

### DIFF
--- a/nicegui/elements/json_editor.js
+++ b/nicegui/elements/json_editor.js
@@ -4,10 +4,10 @@ export default {
   template: "<div></div>",
   mounted() {
     this.properties.onChange = (updatedContent, previousContent, { contentErrors, patchResult }) => {
-      this.$emit("change", { content: updatedContent, errors: contentErrors });
+      this.$emit("content_change", { content: updatedContent, errors: contentErrors });
     };
     this.properties.onSelect = (selection) => {
-      this.$emit("select", { selection: selection });
+      this.$emit("content_select", { selection: selection });
     };
 
     this.checkValidation();

--- a/nicegui/elements/json_editor.py
+++ b/nicegui/elements/json_editor.py
@@ -48,14 +48,14 @@ class JsonEditor(Element, component='json_editor.js', dependencies=['lib/vanilla
         """Add a callback to be invoked when the content changes."""
         def handle_on_change(e: GenericEventArguments) -> None:
             handle_event(callback, JsonEditorChangeEventArguments(sender=self, client=self.client, **e.args))
-        self.on('change', handle_on_change, ['content', 'errors'])
+        self.on('content_change', handle_on_change, ['content', 'errors'])
         return self
 
     def on_select(self, callback: Handler[JsonEditorSelectEventArguments]) -> Self:
         """Add a callback to be invoked when some of the content has been selected."""
         def handle_on_select(e: GenericEventArguments) -> None:
             handle_event(callback, JsonEditorSelectEventArguments(sender=self, client=self.client, **e.args))
-        self.on('select', handle_on_select, ['selection'])
+        self.on('content_select', handle_on_select, ['selection'])
         return self
 
     @property


### PR DESCRIPTION
The `svelte-jsoneditor` library seems to have some native events which utilize the `select` and `change` naming. This causes exceptions once these reach the `NiceGUI` event handlers without expected arguments. This PR changes these names to remove the conflict. Per issue https://github.com/zauberzeug/nicegui/issues/4397.