### PR TITLE
await asyncio.sleep(0) gives a chance the task to start

### DIFF
--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -125,6 +125,7 @@ class page:
                         return await result
                 task = background_tasks.create(wait_for_result())
                 deadline = time.time() + self.response_timeout
+                await asyncio.sleep(0)  # NOTE give the task a chance to start
                 while task and not client.is_waiting_for_connection and not task.done():
                     if time.time() > deadline:
                         raise TimeoutError(f'Response not ready after {self.response_timeout} seconds')


### PR DESCRIPTION
https://github.com/zauberzeug/nicegui/pull/4450#issuecomment-2717173679

Otherwise, async pages with (1) no awaits in them at all or (2) all awaits after `await ui.context.client.connected()` incur 100ms latency. 

Test page: 

```py
@ui.page("/example2")
async def page_example2():
    pass
```

With the change: 

<img width="668" alt="{A43F5BF4-B79B-4062-9D94-3F0D7623C225}" src="https://github.com/user-attachments/assets/eff571ce-0944-486a-a522-2ed3200f61b3" />


Without the change: 

<img width="667" alt="{4F85CB08-29BC-4EF8-9203-AD0CD8851255}" src="https://github.com/user-attachments/assets/f0e53c4c-3c22-43af-a179-4ff47aff61e6" />
