### PR TITLE
Introduce `_waiting_for_connection` event for more efficient page function

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -56,6 +56,7 @@ class Client:
 
         self.elements: Dict[int, Element] = {}
         self.next_element_id: int = 0
+        self._waiting_for_connection: asyncio.Event = asyncio.Event()
         self.is_waiting_for_connection: bool = False
         self.is_waiting_for_disconnect: bool = False
         self.environ: Optional[Dict[str, Any]] = None
@@ -177,6 +178,7 @@ class Client:
     async def connected(self, timeout: float = 3.0, check_interval: float = 0.1) -> None:
         """Block execution until the client is connected."""
         self.is_waiting_for_connection = True
+        self._waiting_for_connection.set()
         deadline = time.time() + timeout
         while not self.has_socket_connection:
             if time.time() > deadline:

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import time
 from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
@@ -124,11 +123,13 @@ class page:
                     with client:
                         return await result
                 task = background_tasks.create(wait_for_result())
-                deadline = time.time() + self.response_timeout
-                while task and not client.is_waiting_for_connection and not task.done():
-                    if time.time() > deadline:
-                        raise TimeoutError(f'Response not ready after {self.response_timeout} seconds')
-                    await asyncio.sleep(0.1)
+                try:
+                    await asyncio.wait([
+                        task,
+                        asyncio.create_task(client._waiting_for_connection.wait()),  # pylint: disable=protected-access
+                    ], timeout=self.response_timeout, return_when=asyncio.FIRST_COMPLETED)
+                except asyncio.TimeoutError as e:
+                    raise TimeoutError(f'Response not ready after {self.response_timeout} seconds') from e
                 if task.done():
                     result = task.result()
                 else:


### PR DESCRIPTION
@evnchn After thinking about PRs #4461 and #4462, I came up with another idea how we can wait for async page functions more efficiently. By introducing a new "waiting for connection" event, we can simultaneously wait for both:
1. our task waiting for the page function to return
2. the new event which occurs when the page function calls `await client.connected()`.

Furthermore, we can specify a timeout very easily.

@evnchn What do you think? Does that solve our problem?
