### PR TITLE
"Software rugpull" for multi-worker support

### DIFF
--- a/examples/multiple_wokers/main.py
+++ b/examples/multiple_wokers/main.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import logging
+import os
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from nicegui import ui
+
+logging.basicConfig(level=logging.INFO)
+
+
+@asynccontextmanager
+async def lifespan(_):
+    worker_id = os.getpid()
+    logging.info(f'Worker {worker_id} started')
+    yield
+
+
+@ui.page('/')
+def show():
+    logging.info(f'Handling request in worker {os.getpid()}')
+    ui.label('Hello, FastAPI!')
+
+
+app = FastAPI(lifespan=lifespan)
+ui.run_with(app)
+
+if __name__ == '__main__':
+    print('Please start the app with a "uvicorn" command as shown in the start.sh script')

--- a/examples/multiple_wokers/start.sh
+++ b/examples/multiple_wokers/start.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")" # use path of this example as working directory; enables starting this script from anywhere
+uvicorn main:app --log-level warning --workers 4 --port 8000

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -348,6 +348,7 @@ function createApp(elements, options) {
             tab_id: TAB_ID,
             old_tab_id: OLD_TAB_ID,
             next_message_id: window.nextMessageId,
+            path: options.query.path,
           };
           window.socket.emit("handshake", args, (ok) => {
             if (!ok) {


### PR DESCRIPTION
> we create another client with the same id, and, we let it take over of the socket connection. 

---

https://github.com/zauberzeug/nicegui/discussions/1539#discussioncomment-12513394

Everything just works. 

I make a web request to port 8000 using my custom balancer, which remembers I made an HTTP request to which port (say: 8080), and actively refuses to let me talk to such port in the websocket (picking from 8081, 8082, 8083). 

_This is why it is beneficial to make your own balancer @rodja_ 😉

Then, on the page load for async pages, it loads up to the part before await ui.context.client.connected()

<img width="230" alt="{C03E4283-95E3-405E-B62B-6FE200076FF1}" src="https://github.com/user-attachments/assets/13a6ab44-1ced-4983-a046-2613047367f0" />


Afterwards, the "Software Rugpull" kicks in, and the page is swapped out with what the other process responds with. 

<img width="249" alt="{A196E690-F044-4D46-A2C2-B6F2C5235E8F}" src="https://github.com/user-attachments/assets/f6666c31-9d48-4138-8f03-fb153f56247d" />

For sync pages, the old content also briefly flashes before the new content from the client in the rugpull operation is written to the screen. 

<img width="269" alt="{E8DA6F65-5E4A-4B49-84A2-9F6AE1DC1B20}" src="https://github.com/user-attachments/assets/5155a52f-c42b-43ee-af06-7a8694a08555" />

Afterwards, the interactivity works properly following the new client. 

<img width="302" alt="{46ED10AA-AB8D-4379-B03D-84ECE79C04F2}" src="https://github.com/user-attachments/assets/21871d98-93f1-4f07-a988-94f29e94a471" />

---

But, let me also explain how it works. It's fun, really!


When, on handshake, it realizes it just got "cold-called" by a browser whose proclaimed `client_id` in the data doesn't exist, it: 
* Matches the request by immeidately spawning one such client with a matching `client_id`
* Digs through the page route to function dictionary in reverse and calling it
* Sets up the communication just like it would otherwise
* Return true so that the browser won't refresh

This is enabled by:
* making `await ui.context.client.connected()` do absolutely nothing if the client was spawned in response to a cold call
* Browser now also passes the `path` of the page, making it possible to do the reverse lookup in the page route to function dictionary

---

Honestly it is amazing that it works so well as it stands. I can already forsee some code cleanups. 

And also, the args and kwargs of the page are completely neglected as it stands. 