### PR TITLE
Add a new method Leaflet.set_view

### DIFF
--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -124,7 +124,7 @@ class Leaflet(Element, component='leaflet.js', default_classes='nicegui-leaflet'
         if self._send_update_on_value_change:
             self.run_map_method('setView', self.center, zoom)
 
-    def set_view(self, center: Tuple[float, float]=None, zoom:int=None) -> None:
+    def set_view(self, center: Optional[Tuple[float, float]]=None, zoom:Optional[int]=None) -> None:
         """Set the map to a new center location, zoom or both in a single operation."""
         if center is None and zoom is None:
             return

--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -124,6 +124,21 @@ class Leaflet(Element, component='leaflet.js', default_classes='nicegui-leaflet'
         if self._send_update_on_value_change:
             self.run_map_method('setView', self.center, zoom)
 
+    def set_view(self, center: Tuple[float, float]=None, zoom:int=None) -> None:
+        """Set the map to a new center location, zoom or both in a single operation."""
+        if center is None and zoom is None:
+            return
+        if center is not None and self._props['center'] != center:
+            self._props['center'] = center
+        else:
+            center = self.center
+        if zoom is not None and self._props['zoom'] != zoom:
+            self._props['zoom'] = zoom
+        else:
+            zoom = self.zoom
+        if self._send_update_on_value_change:
+            self.run_map_method('setView', center, zoom)
+
     def remove_layer(self, layer: Layer) -> None:
         """Remove a layer from the map."""
         self.layers.remove(layer)

--- a/tests/test_leaflet.py
+++ b/tests/test_leaflet.py
@@ -15,6 +15,13 @@ def test_leaflet(screen: Screen):
     ui.button('Berlin', on_click=lambda: m.set_center((52.520, 13.405)))
     ui.button('London', on_click=lambda: m.set_center((51.505, -0.090)))
 
+    ui.button('Zoom in (set_view)', on_click=lambda: m.set_view(zoom=m.zoom + 1))
+    ui.button('Zoom out (set_view)', on_click=lambda: m.set_view(zoom=m.zoom - 1))
+    ui.button('Berlin (set_view)', on_click=lambda: m.set_view((52.520, 13.405)))
+    ui.button('London (set_view)', on_click=lambda: m.set_view((51.505, -0.090)))
+    ui.button('Berlin Zoom In', on_click=lambda: m.set_view((52.520, 13.405), m.zoom + 1))
+    ui.button('London Zoom Out', on_click=lambda: m.set_view((51.505, -0.090), m.zoom - 1))
+
     screen.open('/')
     assert screen.find_all_by_class('leaflet-pane')
     assert screen.find_all_by_class('leaflet-control-container')
@@ -36,3 +43,27 @@ def test_leaflet(screen: Screen):
 
     screen.click('London')
     screen.should_contain('Center: 51.505, -0.090')
+
+    screen.click('Zoom in (set_view)')
+    screen.should_contain('Zoom: 14')
+    screen.should_contain('Center: 51.505, -0.090')
+
+    screen.click('Zoom out (set_view)')
+    screen.should_contain('Zoom: 13')
+    screen.should_contain('Center: 51.505, -0.090')
+
+    screen.click('Berlin (set_view)')
+    screen.should_contain('Center: 52.520, 13.405')
+    screen.should_contain('Zoom: 13')
+
+    screen.click('London (set_view)')
+    screen.should_contain('Center: 51.505, -0.090')
+    screen.should_contain('Zoom: 13')
+
+    screen.click('Berlin Zoom In')
+    screen.should_contain('Center: 52.520, 13.405')
+    screen.should_contain('Zoom: 14')
+
+    screen.click('London Zoom Out')
+    screen.should_contain('Center: 51.505, -0.090')
+    screen.should_contain('Zoom: 13')


### PR DESCRIPTION
Added the `set_view` method to set the center and zoom in one operation, because calling `set_zoom` and `set_center` one after the other was running only the latter command.

Resolves #4491 