### PR TITLE
Update issue and discussion templates with more information

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,10 +1,33 @@
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in NiceGUI! 🚀
+
+        Please answer the following questions to describe your idea or feature request. 🙏
   - type: textarea
     id: content
     attributes:
-      label: Idea
+      label: Description
       description: |
-        If possible, give a [minimal reproducible code example](https://en.wikipedia.org/wiki/Minimal_reproducible_example).
-        Put source code in [fenced code blocks with syntax highlighting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting).
+        What is your idea or feature request?
     validations:
       required: true
+  - type: textarea
+    id: content
+    attributes:
+      label: Contribution
+      description: |
+        How will the NiceGUI community benefit from it?
+    validations:
+      required: true
+  - type: textarea
+    id: example
+    attributes:
+      label: Example Code
+      description: |
+        How will the new feature be used?
+      placeholder: |
+        with ui.tic_tac_toe() as game:
+            game.make_move('X', (1, 1))
+      render: python

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -25,7 +25,7 @@ body:
           required: true
         - label: I searched the NiceGUI documentation, with the integrated search.
           required: true
-        - label: I already searched in Google "How to X in NiceGUI" and didn't find any information.
+        - label: I already searched online "How to X in NiceGUI" and didn't find any information.
           required: true
   - type: textarea
     id: example

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,11 +1,124 @@
 body:
-  - type: textarea
-    id: content
+  - type: markdown
     attributes:
-      label: Question
+      value: |
+        Thanks for your interest in NiceGUI! 🚀
+
+        Please follow these instructions, fill every question, and do every step. 🙏
+
+        We're asking this because answering questions and solving problems on GitHub consumes a lot of the time.
+
+        By asking questions in a structured way (following this) it will be much easier to help you.
+
+        And there's a high chance that you will find the solution along the way and you won't even have to submit it and wait for an answer. 😎
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: First Check
+      description: Please confirm and check all the following options.
+      options:
+        - label: I added a very descriptive title here.
+          required: true
+        - label: I have checked the [FAQs](/zauberzeug/nicegui/wiki/FAQs) for a similar question and didn't find it.
+          required: true
+        - label: I used the GitHub search to find a similar [question](https://github.com/zauberzeug/nicegui/discussions/categories/q-a) and didn't find it.
+          required: true
+        - label: I searched the NiceGUI documentation, with the integrated search.
+          required: true
+        - label: I already searched in Google "How to X in NiceGUI" and didn't find any information.
+          required: true
+  - type: textarea
+    id: example
+    attributes:
+      label: Example Code
       description: |
-        Search through [existing questions](https://github.com/zauberzeug/nicegui/discussions/categories/q-a) first.
-        If possible, give a [minimal reproducible code example](https://en.wikipedia.org/wiki/Minimal_reproducible_example).
-        Put source code in [fenced code blocks with syntax highlighting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting).
+        Please add a self-contained, [minimal, reproducible, example](https://stackoverflow.com/help/minimal-reproducible-example) with your use case.
+
+        If one can copy it, run it, and see it right away, there's a much higher chance we (or someone from the community) will be able to help you.
+
+      placeholder: |
+        from nicegui import ui
+
+        ui.label('Hello, world!')
+
+        ui.run()
+      render: python
     validations:
       required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        What is the problem, question, or error?
+
+        Write a short description telling us what you are doing, what you expect to happen, and what is currently happening.
+      placeholder: |
+        Start the app.
+        The browser opens and shows a label with text "Hello, world!".
+        But I expected it to show "Hello, Alice!".
+    validations:
+      required: true
+  - type: input
+    id: nicegui-version
+    attributes:
+      label: NiceGUI Version
+      description: |
+        What NiceGUI version are you using?
+
+        You can find the NiceGUI version with:
+
+        ```bash
+        python -c "import nicegui; print(nicegui.__version__)"
+        ```
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      description: |
+        What Python version are you using?
+
+        You can find the Python version with:
+
+        ```bash
+        python --version
+        ```
+    validations:
+      required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      description: What browser have you tested with?
+      multiple: true
+      options:
+        - Chrome
+        - Safari
+        - Edge
+        - Firefox
+        - Opera
+        - Samsung Internet
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What operating system are you on?
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Android
+        - iOS
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any additional context information or screenshots you think are useful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Report a Security Vulnerability
+    url: https://github.com/zauberzeug/nicegui?tab=security-ov-file#readme
+    about: Please review our security policy for more details.
   - name: Have an idea or a feature requests?
     url: https://github.com/zauberzeug/nicegui/discussions/categories/ideas-feature-requests
     about: Visit the "💡 Ideas / Feature Requests" forum to view, discuss, vote and propose ideas and feature suggestions.

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -21,7 +21,7 @@ body:
           required: true
         - label: This is not a Q&A. I am sure something is wrong with NiceGUI or its documentation.
           required: true
-        - label: I used the GitHub search to find a similar [issue](https://github.com/zauberzeug/nicegui/issues) and didn't find it.
+        - label: I used the GitHub search to find a similar [issue](https://github.com/zauberzeug/nicegui/issues) and came up empty.
           required: true
   - type: textarea
     id: example

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,19 +1,117 @@
 name: Report an issue
 description: Report a bug or some other unexpected behavior.
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in NiceGUI! 🚀
+
+        Please follow these instructions, fill every question, and do every step. 🙏
+
+        We're asking this because reading, reproducing and replying to issues consumes a lot of the time.
+
+        By reporting issues in a structured way (following this) it will be much easier to help.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: First Check
+      description: Please confirm and check all the following options.
+      options:
+        - label: I added a very descriptive title here.
+          required: true
+        - label: This is not a Q&A. I am sure something is wrong with NiceGUI or its documentation.
+          required: true
+        - label: I used the GitHub search to find a similar [issue](https://github.com/zauberzeug/nicegui/issues) and didn't find it.
+          required: true
   - type: textarea
-    id: content
+    id: example
+    attributes:
+      label: Example Code
+      description: |
+        If applicable, please add a self-contained, [minimal, reproducible, example](https://stackoverflow.com/help/minimal-reproducible-example) with your use case.
+
+        If one can copy it, run it, and see it right away, there's a much higher chance we (or someone from the community) will be able reproduce and fix the problem.
+      placeholder: |
+        from nicegui import ui
+
+        ui.label('Hello, world!')
+
+        ui.run()
+      render: python
+  - type: textarea
+    id: description
     attributes:
       label: Description
       description: |
-        Make sure it is really an issue (see [FAQs](/zauberzeug/nicegui/wiki/FAQs)).
-        A lot of people will read your message.
-        Make it worth their time.
+        What is the problem, question, or error?
 
-        1. What are you trying to do?
-          If possible, give a [minimal reproducible code example](https://en.wikipedia.org/wiki/Minimal_reproducible_example).
-          Put source code in [fenced code blocks with syntax highlighting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting).
-        2. What do you expect to happen?
-        3. What happens instead?
+        Write a short description telling us what you are doing, what you expect to happen, and what is currently happening.
+      placeholder: |
+        Start the app.
+        The browser opens and shows a label with text "Hello, world!".
+        But I expected it to show "Hello, Alice!".
     validations:
       required: true
+  - type: input
+    id: nicegui-version
+    attributes:
+      label: NiceGUI Version
+      description: |
+        What NiceGUI version are you using?
+
+        You can find the NiceGUI version with:
+
+        ```bash
+        python -c "import nicegui; print(nicegui.__version__)"
+        ```
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      description: |
+        What Python version are you using?
+
+        You can find the Python version with:
+
+        ```bash
+        python --version
+        ```
+    validations:
+      required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      description: What browser have you tested with?
+      multiple: true
+      options:
+        - Chrome
+        - Safari
+        - Edge
+        - Firefox
+        - Opera
+        - Samsung Internet
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What operating system are you on?
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Android
+        - iOS
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any additional context information or screenshots you think are useful.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+Security is very important for NiceGUI and its community. 🔒
+
+Learn more about it below. 👇
+
+## Versions
+
+The latest version of NiceGUI is supported.
+
+You are encouraged to write tests for your application and update your NiceGUI version frequently after ensuring that your tests are passing.
+This way you will benefit from the latest features, bug fixes, and **security fixes**.
+
+## Reporting a Vulnerability
+
+If you think you found a vulnerability, and even if you are not sure about it, please report it right away by sending an email to: nicegui@zauberzeug.com.
+Please try to be as explicit as possible, describing all the steps and example code to reproduce the security issue.
+
+We (the team at Zauberzeug) will review it thoroughly and get back to you.
+
+## Public Discussions
+
+Please restrain from publicly discussing a potential security vulnerability. 🙊
+
+It's better to discuss privately and try to find a solution first, to limit the potential impact as much as possible.
+
+---
+
+Thanks for your help!
+
+The NiceGUI community and the Zauberzeug team thank you for that. 🙇


### PR DESCRIPTION
In order to structure the submission of issue and Q&As a little more, I updated our templates and added more instructions and questions. (I got quite some inspiration from FastAPI.)

The templates can be previewed here:

- https://github.com/zauberzeug/nicegui/blob/templates/.github/ISSUE_TEMPLATE/issue.yml
- https://github.com/zauberzeug/nicegui/blob/templates/.github/DISCUSSION_TEMPLATE/q-a.yml
- https://github.com/zauberzeug/nicegui/blob/templates/.github/DISCUSSION_TEMPLATE/ideas.yml