### PR TITLE
Add example for `Xterm.js` connected to Bash

### DIFF
--- a/examples/xterm/.gitignore
+++ b/examples/xterm/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/examples/xterm/README.md
+++ b/examples/xterm/README.md
@@ -1,0 +1,27 @@
+# Use Xterm.js as Third-party Dependency to run Bash
+
+This example demonstrates how to use the [Xterm.js](https://github.com/xtermjs/xterm.js) node module as dependency in a
+NiceGUI app. The app starts Bash in a pseudo-terminal (pty) and connects it to the Xterm.js element.
+
+In package.json, the `@xterm/xterm` module is listed as a dependency, while `terminal.js` and `terminal.py` define the
+new UI element which is then used in `main.py`.
+
+To run this example:
+
+1. First, install the third-party node modules (assuming you have NPM installed):
+
+   ```bash
+   npm install
+   ```
+
+   This will create a node_modules directory containing the `@xterm/xterm` module.
+   To install `npm`, you can use a node version manager like [nvm](https://github.com/nvm-sh/nvm).
+
+2. Now you can run the app as usual:
+
+   ```bash
+   python3 main.py
+   ```
+
+> [!WARNING] 
+> This example gives the clients full access to the server through Bash. Use with caution!

--- a/examples/xterm/main.py
+++ b/examples/xterm/main.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Example for integrating the `Terminal` component with `Bash` running in a pty.
+
+WARNING: This example gives the clients full access to the server through Bash. Use with caution!
+"""
+
+import asyncio
+import logging
+import os
+import pty
+import signal
+
+from terminal import Terminal
+
+from nicegui import app, context, ui
+from nicegui.logging import log
+
+# Firstly, we need to make the `xterm.css` file available to the application
+XTERM_CSS = app.add_static_file(local_file='node_modules/@xterm/xterm/css/xterm.css')
+
+
+# We create the terminals in a `ui.page`, so that each client gets its own terminal
+@ui.page("/")
+def _page():
+    # We need to add the `xterm.css` file to the head of the page
+    ui.add_head_html(f'<link href="{XTERM_CSS}" rel="stylesheet" type="text/css"/>')
+
+    # We now create the terminal (front-end) element for the client
+    client = context.client
+    ui.label(f'Terminal ({client.id})').style('font-weight: bold;')
+    terminal = Terminal()
+
+    async def run_bash():
+        # At this point, we need to create a new pseudo-terminal (pty) fork of the process
+        pty_pid, pty_fd = pty.fork()
+        if pty_pid == pty.CHILD:
+            # The child process of the fork gets replaced with 'bash'
+            os.execv('/bin/bash', ('bash',))
+        log.info('Terminal opened: %s', client.id)
+
+        def pty_to_terminal():
+            try:
+                data = os.read(pty_fd, 1024)
+            except OSError:
+                # There was an error reading the pty; probably bash was exited. Let's stop reading from it.
+                log.info('Stopping reading from pty: %s', client.id)
+                loop.remove_reader(pty_fd)
+            else:
+                terminal.write(data)
+
+        def terminal_to_pty(data: bytes):
+            try:
+                os.write(pty_fd, data)
+            except OSError:
+                # There was an error writing to the pty; probably bash was exited. Nothing to do.
+                pass
+
+        # Now we can connect the pty to the terminal
+        loop = asyncio.get_event_loop()
+        loop.add_reader(pty_fd, pty_to_terminal)
+        terminal.on_data(terminal_to_pty)
+
+        def kill_bash():
+            os.close(pty_fd)
+            os.kill(pty_pid, signal.SIGKILL)
+            log.info('Terminal closed: %s', client.id)
+
+        # Make sure to kill the bash process when the client disconnects
+        client.on_disconnect(kill_bash)
+        await client.disconnected()
+
+    client.safe_invoke(run_bash())
+
+
+if __name__ in {"__main__", "__mp_main__"}:
+    logging.basicConfig(level=logging.INFO)
+    ui.run()

--- a/examples/xterm/package.json
+++ b/examples/xterm/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@xterm/xterm": "^5.5.0"
+  }
+}

--- a/examples/xterm/terminal.js
+++ b/examples/xterm/terminal.js
@@ -1,0 +1,19 @@
+import "xterm";
+
+export default {
+  template: "<div></div>",
+  props: {
+    options: Array,
+  },
+  async mounted() {
+    this.terminal = new Terminal();
+    this.terminal.open(this.$el)
+    
+    this.terminal.onData((e) => this.$emit(`data`, e));
+  },
+  methods: {
+    write(data) {
+      return this.terminal.write(data);
+    },
+  },
+};

--- a/examples/xterm/terminal.py
+++ b/examples/xterm/terminal.py
@@ -1,0 +1,29 @@
+from typing import Callable, Dict, Optional, Union
+
+from nicegui import ui
+
+
+class Terminal(ui.element,
+               component='terminal.js',
+               dependencies=['node_modules/@xterm/xterm/lib/xterm.js']):
+
+    def __init__(self, options: Optional[Dict] = None) -> None:
+        """Terminal
+
+        An element that integrates `xterm` to emulate a terminal.
+        Note: This element provides only a front-end component without an underlying shell.
+        """
+        super().__init__()
+        self._props['options'] = options or {}
+
+    def on_data(self, callback: Callable[[bytes], None]) -> None:
+        """Add a callback to be invoked when data is received from the terminal."""
+        self.on('data', lambda event: callback(str(event.args).encode()))
+
+    def write(self, data: Union[bytes, str]) -> None:
+        """Write data to the terminal."""
+        if isinstance(data, bytes):
+            # Xterm.js accepts an `Uint8Array`, which we can get by converting `bytes` to a `list`
+            self.run_method('write', list(data))
+        else:
+            self.run_method('write', data)

--- a/website/examples.py
+++ b/website/examples.py
@@ -72,5 +72,7 @@ examples: List[Example] = [
     Example('OpenAI Assistant', "Using OpenAI's Assistant API with async/await"),
     Example('Redis Storage', 'Use Redis storage to share data across multiple instances behind a reverse proxy or load balancer'),
     Example('Google One-Tap Auth', 'Authenticate users via Google One-Tap'),
-    Example('Google OAuth2', 'Authenticate with Google OAuth2')
+    Example('Google OAuth2', 'Authenticate with Google OAuth2'),
+    Example(
+        'Xterm', 'Custom element based on [xterm.js](https://github.com/xtermjs/xterm.js), connected to Bash running in a pty'),
 ]


### PR DESCRIPTION
The discussion about integrating [Xterm.js](https://github.com/xtermjs/xterm.js) into `nicegui` (https://github.com/zauberzeug/nicegui/discussions/1846) seems to be stale...
However, I'd find it great to have `Xterm.js` in `nicegui`!

This PR just adds an example, but **I would be more than happy to close this PR and work on a proper integration** (including a "bell" event, a resizing event, addons like [@xterm/addon-web-links](https://github.com/xtermjs/xterm.js/tree/master/addons/addon-web-links), etc.).

## Use-cases for Xterm in nicegui:
* Provide a Terminal & Shell for native (electron-like) applications
* Provide a access to the Shell of a server through a web application, e.g. for a robot (this is the example in this PR, which has obvious security risks!)
* Display the output of a `subprocess` containing ANSI escape codes (this is what I'm mostly interested in)

## Example in this PR
The example integrates `Xterm.js` as a new element called `Terminal`, which provides a simple interface for reading and writing `bytes` from/to it.
This new element is then used in `main.py`, connecting in to `/bin/bash` running in a `pty.fork()` process.

The page looks as follows:
![image](https://github.com/user-attachments/assets/48c6a16d-1deb-4abf-824d-d02d3ee11dbe)
