### PR TITLE
Fix tests folder structure in project_structure_documentation.py

### DIFF
--- a/website/documentation/content/project_structure_documentation.py
+++ b/website/documentation/content/project_structure_documentation.py
@@ -160,6 +160,7 @@ def modular_project():
                 │   ├── __init__.py
                 │   └── startup.py
                 └── tests
+                    ├── __init__.py
                     ├── conftest.py
                     └── test_app.py
                 ```


### PR DESCRIPTION
Otherwise you get an error:
```bash
ImportError while loading conftest '/Users/jay/fubar/tests/conftest.py'.
tests/conftest.py:3: in <module>
    from app.startup import startup
E   ModuleNotFoundError: No module named 'app'
```
