### PR TITLE
let add_css, add_scss and add_sass set shared=True

### DIFF
--- a/nicegui/functions/style.py
+++ b/nicegui/functions/style.py
@@ -13,7 +13,7 @@ from .. import helpers
 from .html import add_head_html
 
 
-def add_css(content: Union[str, Path]) -> None:
+def add_css(content: Union[str, Path], shared: bool = False) -> None:
     """Add CSS style definitions to the page.
 
     This function can be used to add CSS style definitions to the head of the HTML page.
@@ -24,10 +24,10 @@ def add_css(content: Union[str, Path]) -> None:
     """
     if helpers.is_file(content):
         content = Path(content).read_text(encoding='utf-8')
-    add_head_html(f'<style>{content}</style>')
+    add_head_html(f'<style>{content}</style>', shared=shared)
 
 
-def add_scss(content: Union[str, Path], *, indented: bool = False) -> None:
+def add_scss(content: Union[str, Path], *, indented: bool = False, shared: bool = False) -> None:
     """Add SCSS style definitions to the page.
 
     This function can be used to add SCSS style definitions to the head of the HTML page.
@@ -42,10 +42,10 @@ def add_scss(content: Union[str, Path], *, indented: bool = False) -> None:
 
     if helpers.is_file(content):
         content = Path(content).read_text(encoding='utf-8')
-    add_css(sass.compile(string=str(content).strip(), indented=indented))
+    add_css(sass.compile(string=str(content).strip(), indented=indented), shared=shared)
 
 
-def add_sass(content: Union[str, Path]) -> None:
+def add_sass(content: Union[str, Path], shared: bool = False) -> None:
     """Add SASS style definitions to the page.
 
     This function can be used to add SASS style definitions to the head of the HTML page.
@@ -54,4 +54,4 @@ def add_sass(content: Union[str, Path]) -> None:
 
     :param content: SASS content (string or file path)
     """
-    add_scss(content, indented=True)
+    add_scss(content, indented=True, shared=shared)

--- a/nicegui/functions/style.py
+++ b/nicegui/functions/style.py
@@ -13,7 +13,7 @@ from .. import helpers
 from .html import add_head_html
 
 
-def add_css(content: Union[str, Path], shared: bool = False) -> None:
+def add_css(content: Union[str, Path], *, shared: bool = False) -> None:
     """Add CSS style definitions to the page.
 
     This function can be used to add CSS style definitions to the head of the HTML page.
@@ -21,6 +21,7 @@ def add_css(content: Union[str, Path], shared: bool = False) -> None:
     *Added in version 2.0.0*
 
     :param content: CSS content (string or file path)
+    :param shared: whether to add the code to all pages (default: ``False``, *added in version 2.14.0*)
     """
     if helpers.is_file(content):
         content = Path(content).read_text(encoding='utf-8')
@@ -36,6 +37,7 @@ def add_scss(content: Union[str, Path], *, indented: bool = False, shared: bool 
 
     :param content: SCSS content (string or file path)
     :param indented: whether the content is indented (SASS) or not (SCSS) (default: `False`)
+    :param shared: whether to add the code to all pages (default: ``False``, *added in version 2.14.0*)
     """
     if not optional_features.has('sass'):
         raise ImportError('Please run "pip install libsass" to use SASS or SCSS.')
@@ -45,7 +47,7 @@ def add_scss(content: Union[str, Path], *, indented: bool = False, shared: bool 
     add_css(sass.compile(string=str(content).strip(), indented=indented), shared=shared)
 
 
-def add_sass(content: Union[str, Path], shared: bool = False) -> None:
+def add_sass(content: Union[str, Path], *, shared: bool = False) -> None:
     """Add SASS style definitions to the page.
 
     This function can be used to add SASS style definitions to the head of the HTML page.
@@ -53,5 +55,6 @@ def add_sass(content: Union[str, Path], shared: bool = False) -> None:
     *Added in version 2.0.0*
 
     :param content: SASS content (string or file path)
+    :param shared: whether to add the code to all pages (default: ``False``, *added in version 2.14.0*)
     """
     add_scss(content, indented=True, shared=shared)


### PR DESCRIPTION
TL-DR: As said in the title. 

---

I am not sure why it wasn't added in the first place. 

`shared=True` was added in this commit: https://github.com/zauberzeug/nicegui/commit/a09e713ece9099bc2d7164894d2d17d646b1d618, which was in [v1.4.6](https://github.com/zauberzeug/nicegui/releases/tag/v1.4.6)

`ui.add_css` was added in this commit: https://github.com/zauberzeug/nicegui/commit/3e5f92b23c5c7dfa9ab7306c52c84236e5fc0a34 ([v1.4.20](https://github.com/zauberzeug/nicegui/releases/tag/v1.4.20)), with `ui.add_style` (the precursor) in https://github.com/zauberzeug/nicegui/commit/a0c49a9112cfd04bc8d83d61ea5fc224ab52c95f ([v1.4.19](https://github.com/zauberzeug/nicegui/releases/tag/v1.4.19))

So the function which used `add_head_html` was added after the addition of `shared=True`? Why not expose all parameters of `add_head_html` since day1, if `ui.add_css` was just a wrapper around it which opens a `<style>` tag for you? 🤔 Or am I missing something here...