### PR TITLE
Support on_begin_upload for ui.upload

### DIFF
--- a/nicegui/elements/upload.py
+++ b/nicegui/elements/upload.py
@@ -27,14 +27,24 @@ class Upload(DisableableElement, component='upload.js'):
 
         Based on Quasar's `QUploader <https://quasar.dev/vue-components/uploader>`_ component.
 
+        Upload event handlers are called in the following order:
+
+        1. ``on_begin_upload``: The client begins uploading one or more files to the server.
+        2. ``on_upload``: The upload of an individual file is complete.
+        3. ``on_multi_upload``: The upload of all selected files is complete.
+
+        The following event handler is already called during the file selection process:
+
+        - ``on_rejected``: One or more files have been rejected.
+
         :param multiple: allow uploading multiple files at once (default: `False`)
         :param max_file_size: maximum file size in bytes (default: `0`)
         :param max_total_size: maximum total size of all files in bytes (default: `0`)
         :param max_files: maximum number of files (default: `0`)
-        :param on_begin_upload: callback to execute when upload begins
+        :param on_begin_upload: callback to execute when upload begins  (*added in version 2.14.0*)
         :param on_upload: callback to execute for each uploaded file
         :param on_multi_upload: callback to execute after multiple files have been uploaded
-        :param on_rejected: callback to execute for each rejected file
+        :param on_rejected: callback to execute when one or more files have been rejected during file selection
         :param label: label for the uploader (default: `''`)
         :param auto_upload: automatically upload files when they are selected (default: `False`)
         """
@@ -112,7 +122,7 @@ class Upload(DisableableElement, component='upload.js'):
         return self
 
     def on_rejected(self, callback: Handler[UiEventArguments]) -> Self:
-        """Add a callback to be invoked when a file is rejected."""
+        """Add a callback to be invoked when one or more files have been rejected during file selection."""
         self.on('rejected', lambda: handle_event(callback, UiEventArguments(sender=self, client=self.client)), args=[])
         return self
 


### PR DESCRIPTION
Fulfills https://github.com/zauberzeug/nicegui/discussions/4541

TL-DR: run `on_begin_upload` handler as soon as the server receive an upload, without waiting for the rest of the data to flow in. 

Ref https://github.com/zauberzeug/nicegui/discussions/4541#discussioncomment-12651783 on existing solution using `ui.upload().on('uploading', ...`: My solution should be slightly more accurate, in case network congestion means that WebSocket goes through but the upload requests gets stuck for some reason. 

---

Testing script: 

```py
from nicegui import ui

@ui.page("/")
def main_page():
    my_upload = ui.upload(on_begin_upload=lambda e: print(f"Upload started: {e}"), 
                          on_upload=lambda e: print(f"Upload: {e}"), 
                          on_multi_upload=lambda e: print(f"Multi upload: {e}"), 
                          on_rejected=lambda e: print(f"Rejected: {e}"))

    my_upload.on_begin_upload(lambda e: ui.notify(f"Upload started: {e}"))
    my_upload.on_upload(lambda e: ui.notify(f"Upload: {e}"))
    my_upload.on_multi_upload(lambda e: ui.notify(f"Multi upload: {e}"))
    my_upload.on_rejected(lambda e: ui.notify(f"Rejected: {e}"))

ui.run()
```

Throttle the speed in DevTools and you'll see it work. 

<img width="1079" alt="{93479A85-6820-4623-B27F-538CA66839B8}" src="https://github.com/user-attachments/assets/d4bfc6e4-7831-498d-94a7-cf4a035fa92e" />
