### PR TITLE
Project ACID (Automatic Client-ID) aka "software rugpull"

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -138,6 +138,7 @@ class Client:
             **core.app.config.socket_io_js_query_params,
             'client_id': self.id,
             'next_message_id': self.outbox.next_message_id,
+            'path': request.url.path,
         }
         vue_html, vue_styles, vue_scripts, imports, js_imports = generate_resources(prefix, self.elements.values())
         return templates.TemplateResponse(

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -70,6 +70,7 @@ class Client:
         self._deleted = False
         self._socket_to_document_id: Dict[str, str] = {}
         self.tab_id: Optional[str] = None
+        self._socket_id: Optional[str] = None
 
         self.page = page
         self.outbox = Outbox(self)
@@ -250,6 +251,7 @@ class Client:
         self._socket_to_document_id[socket_id] = document_id
         self._cancel_delete_task(document_id)
         self._num_connections[document_id] += 1
+        self._socket_id = socket_id
         if next_message_id is not None:
             self.outbox.try_rewind(next_message_id)
         storage.request_contextvar.set(self.request)

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -48,9 +48,12 @@ class Client:
     shared_body_html = ''
     """HTML to be inserted in the <body> of every page template."""
 
-    def __init__(self, page: page, *, request: Optional[Request]) -> None:
+    def __init__(self, page: page, *, request: Optional[Request], force_id: str = None) -> None:
         self.request: Optional[Request] = request
-        self.id = str(uuid.uuid4())
+        if force_id is not None:
+            self.id = force_id
+        else:
+            self.id = str(uuid.uuid4())
         self.created = time.time()
         self.instances[self.id] = self
 

--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -4,6 +4,9 @@ from ..client import Client
 from ..context import context
 from ..element import Element
 from .javascript import run_javascript
+from .. import background_tasks
+from .. import core
+from .. import ui
 
 
 class Navigate:
@@ -40,6 +43,16 @@ class Navigate:
         It is equivalent to clicking the reload button in the browser.
         """
         run_javascript('history.go(0)')
+
+    def soft_reload(self) -> None:
+        """ui.navigate.soft_reload
+
+        Reload the current page contents without triggering a reload in the browser. 
+        It is done by terminating the socket.io connection, purging the client, and reconnecting.
+        """
+        # basically await core.sio.disconnect(ui.context.client._socket_id)
+        background_tasks.create(core.sio.disconnect(ui.context.client._socket_id))
+        ui.context.client.delete()
 
     def to(self, target: Union[Callable[..., Any], str, Element], new_tab: bool = False) -> None:
         """ui.navigate.to (formerly ui.open)

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, Dict, ClassVar
 
 from fastapi import Request, Response
 
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
 
 
 class page:
+
+    instances: ClassVar[Dict[str, page]] = {}
+    """Maps paths to pages."""
 
     def __init__(self,
                  path: str, *,
@@ -69,6 +72,8 @@ class page:
         self.kwargs = kwargs
         self.api_router = api_router or core.app.router
         self.reconnect_timeout = reconnect_timeout
+
+        self.instances[path] = self
 
         create_favicon_route(self.path, favicon)
 

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -348,6 +348,7 @@ function createApp(elements, options) {
             tab_id: TAB_ID,
             old_tab_id: OLD_TAB_ID,
             next_message_id: window.nextMessageId,
+            path: options.query.path,
           };
           window.socket.emit("handshake", args, (ok) => {
             if (!ok) {

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -351,6 +351,10 @@ function createApp(elements, options) {
             path: options.query.path,
           };
           window.socket.emit("handshake", args, (ok) => {
+            if (ok == "ACID") {
+              window.nextMessageId = 0; // because there are no messages in a newly created ACID (automatic client-id) client!
+              console.log("resetting nextMessageId to 0");
+            }
             if (!ok) {
               console.log("reloading because handshake failed for clientId " + window.clientId);
               window.location.reload();
@@ -373,6 +377,8 @@ function createApp(elements, options) {
         },
         disconnect: () => {
           document.getElementById("popup").ariaHidden = false;
+          console.log("immediately attempt a reconnect (ACID)");
+          window.socket.connect();
         },
         update: async (msg) => {
           const loadPromises = Object.entries(msg)


### PR DESCRIPTION
This is a reimagination of the "software rugpull" PR https://github.com/zauberzeug/nicegui/pull/4487

TL-DR: Software rugpull is back, renamed to ACID (Automatic Client-ID). It enables zero-browser-reload (no F5) in server reboot, client disconnect for longer duration than reconnect_timeout, and content reload. Name is awesome, Code is clean, PR is clear. 

### Introduction to ACID (Automatic Client-ID) aka "software rugpull", for the uninitiated

The ACID approach (previously called "software rugpull") shakes up the foundation of NiceGUI that is **"for a browser client, there must immediately be a matching client instance in the server, or the client must start over** and challenges an almost unstated rule that, in tricky circumstances **reloading is the best way to solve all issues**

It is achieved by automatically generated a client instance in the server with a matching `client_id` as the one reported by the browser (which, either, was deleted due to timeout, never existed since the server had a reboot, or intentionally deleted for `ui.navigate.soft_reload`), then deceiving the handshake code below into always returning True (hence the "software rugpull" nature, ref: https://youtu.be/q5M0TwnkWUM?t=3735)

### What happened to the old PR

I'll be honest, that PR was one of the worse I have done. 
* Not having a good name
* Implementation is a bit buggy and rough
* Was done to solve a need which few had (multi-worker without sticky session)

### What led to this new PR

Despite the above, the idea proposed in the old PR was sound, and this PR takes what was in that old PR, makes it better, and enables the 3 following functions: 
* **Zero-browser-reload** on client reconnection due to server reboot
* **Zero-browser-reload** on client reconnecting after being disconnected for a duration longer than `reconnect_timeout`
* **Zero-browser-reload** function `ui.navigate.soft_reload`, which reloads the content of the page without the equivalent of pressing F5 on the browser. 

And, to maximize the chance that this PR goes through, I have included: 
* An awesome name, **ACID**, for this PR and the operation covered within
* Stage the changes in separate commits for easier to read
* Honestly the best PR description I have written so far

### Testing code

I know you can't wait 😉

```py
import asyncio
from nicegui import ui, core
import uuid
import time

def show_client_id():
    client_id = ui.context.client.id
    ui.label(f'Client ID: {client_id}')

def show_page_was_loaded_at_unix_timestamp():
    page_was_loaded_at_unix_timestamp = int(time.time())
    ui.label(f'Page was loaded at unix timestamp: {page_was_loaded_at_unix_timestamp}')

ui.label('Hey! Here is the auto-index page')
show_client_id()
ui.label('The client ID should not change in the auto-index page.')
ui.link('Go to async page', '/async_page')
ui.link('Go to sync page', '/sync_page')

@ui.page('/sync_page', title='Sync page')
def sync_page():
    print('sync_page')
    ui.label('This is a sync page')
    show_client_id()
    show_page_was_loaded_at_unix_timestamp()
    ui.label('The client ID should change on each page load.')
    ui.link('Go back to auto-index page', '/')
    ui.button('Soft reload (built-in code)', on_click=ui.navigate.soft_reload)

@ui.page('/async_page', title='Async page')
async def async_page(arg1: str = 'default', arg2: int = 0):
    print('async_page')
    ui.label('This is an async page')
    ui.label(f'arg1: {arg1}')
    ui.label(f'arg2: {arg2}')
    show_client_id()
    show_page_was_loaded_at_unix_timestamp()
    ui.label('The client ID should change on each page load.')
    random_uuid = str(uuid.uuid4())
    counter_label = ui.label("0")
    def increment_label():
        current_value = int(counter_label.text)
        counter_label.set_text(str(current_value + 1))
    ui.button('Increment label', on_click=increment_label)
    print("Emitted UUID:", random_uuid)
    ui.label(f'Here is a random UUID: {random_uuid}')
    ui.link('Go back to auto-index page', '/')
    await ui.context.client.connected()
    await asyncio.sleep(0.5)
    ui.label('=== The client is connected ===')
    show_client_id()
    ui.label('The client ID should remain consistent to the above.')
    ui.label(f'Here is the all-caps UUID: {random_uuid.upper()}')
    result_js = await ui.run_javascript('30 + 9')
    ui.label(f'Here is the result of a javascript expression: {result_js}. Are you a fan of Hatsune Miku?')
    async def try_and_close_the_websocket():
        print('Trying to close the websocket for id:', ui.context.client.id)
        print("Client's socket_id:", ui.context.client._socket_id)
        await core.sio.disconnect(ui.context.client._socket_id)
        # purge the client
        ui.context.client.delete()

    ui.button('Soft reload (userspace code)', on_click=try_and_close_the_websocket)
    ui.button('Soft reload (built-in code)', on_click=ui.navigate.soft_reload)

ui.run(reconnect_timeout=15, port=4552) # shorter timeout for testing purposes
```

Notable points:
* No page reload on server restart nor extended duration (>15s) without internet (block it in DevTools)
* "Soft reload" simply flashes the page for a bit while the new content comes, no page reload involved

### Rough explanation of the commits

**General modification to enable ACID maneuver**

#### expose path of page on handshake + expose path of page to client for its handshake

This allows the browser client, when making a handshake to reconnect, to inform the server which page it was originally visiting (say `/async_page`). Subsequently in the ACID maneuver, the corresponding page function will then be found (`for func, path in Client.page_routes.items():`) and swiftly executed so as to create the ACID client to match the handshake request. 

#### allow force-set ID for client

Since a client is matched via the `client_id`, and I personally don't want to implement logic to change the `client_id` in the browser side, I made it so that the server would accept _whatever_ `client_id` was passed in to the server. This meant that simply doing `self.id = str(uuid.uuid4())` would not be enough. Rather, `self.id = force_id` is called if `force_id` was passed in

#### page keep track of instances for ACID to find the right one

Makes sense shortly, since we need to re-find the page instance for `with Client(proper_page, request=None, force_id=data['client_id']) as fake_client:`

**The important bit**

#### The crux of ACID (Automatic Client-ID) aka "software rugpull"

_TL-DR:_ 

I stand by my old comment in https://github.com/zauberzeug/nicegui/pull/4487#issuecomment-2727915895
> At this point the behaviour of `_on_handshake` **diverges greatly** from the traditional behaviour. For, upon the reception of a non-existent client_id in the handshake, the handler **proceeds instead** to create a matching client with the correct id and invokes the page function, establishing communication properly to a browser that is none-the-wiser. 

Major difference being, in this new PR:
* Do not instantiate a new `page` class with the same path. Use the correct `page` instance as provided by "page keep track of instances for ACID to find the right one"
* Since the client is connected via WebSocket, there is no need to override `Client.connected`, and we can await the page function as usual. Since it is a mirror of `nicegui/page.py`, I have sneaked in changes from #4551, which should be fine. If not we rollback
* No longer re-implement the logic for handling `tab_id` and `environ` and `sio.enter_room`. Instead, we fully embrace into the "rugpull" nature by simply let `client = Client.instances.get(data['client_id'])` to find our made-up client and handle the logic there. 
* Assert the result is not a FastAPI Response, since it is WebSocket, how to serve a HTTP response...

**Enable `ui.navigate.soft_reload`**

#### client keep track of the socket id (for ui.navigate.soft_reload())

It is used for shutting down the Socket.IO connection. Without it, I don't see how it can be possible...

#### browser to aggressively reconnect for ACID

If I am not mistaken, as of writing, NiceGUI never offered any public or private methods to disconnect the Socket.IO connection gracefully (or in a way that the `disconnect` handler will be called), since the `socket_id` (not any UUID generated by NiceGUI, mind you, but ID generated by Python.SocketIO, which looks like `xq8S7tkOWr3iIu-KAAAD`) was never kept track of. 
Therefore, my argument is, I can simply define the behaviour of disconnect to be an immediate reconnect, without fear it break existing code. 

NOTE: When the browser reconnects, it starts over by setting `window.nextMessageId = 0`. This is because, though there may be 1000 messages from the old client, we still want to listen to every single message broadcasted by the new client. 

#### ui.navigate.soft_reload() code

It is simply the `try_and_close_the_websocket` in the testing code, baked into the NiceGUI library. 

The procedure for soft_reload:
* Find the Socket.IO and shut it down
* Delete the client
* When the browser reconnects, the client no longer exist, so the ACID maneuver gets triggered, re-running the page function and serving new content to the browser

### Remaining concerns

* Need more exhaustive testing over compatibility. I need sleep (it's 5AM now and I haven't slept) so no I didn't do that...
* Will this open us up to potential DDOS attack? (well if a malicious actor want to exhaust CPU by running the page function many time, they would originally need to fetch the index.html, now they don't. Not much of a big difference if you ask me, but anywayd)
* args and kwargs passed into the page function (from FastAPI, think: URL params) are dropped on ACID maneuver. Should we let browser report to us what were they? Should the server store what were they? (I am thinking the first solution, but I am not sure because there may be some serialization issues when convert between JS-acceptable and Python-acceptable format. Though I don't want to let that one deficiency hold back this PR.)























