### PR TITLE
Show On Air connection errors with message from server

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -156,7 +156,7 @@ class Air:
 
         @self.relay.on('connect_error')
         async def _handle_connect_error(data) -> None:
-            self.log.debug(f'Connection error: {data}')
+            self.log.warning(f'Connection error: {data["message"]}')
 
         @self.relay.on('event')
         def _handle_event(data: Dict[str, Any]) -> None:

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -156,7 +156,7 @@ class Air:
 
         @self.relay.on('connect_error')
         async def _handle_connect_error(data) -> None:
-            self.log.warning(f'Connection error: {data["message"]}')
+            self.log.warning(f'Connection error: {data.get("message", "Unknown error")}')
 
         @self.relay.on('event')
         def _handle_event(data: Dict[str, Any]) -> None:


### PR DESCRIPTION
This PR displays the connection error message from the server to help users understand why the connection can not be established.