### PR TITLE
Server-Side Rendering by invoking NodeJS, Vue and Quasar for the HTML

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -124,7 +124,7 @@ class Client:
     def __exit__(self, *_) -> None:
         self.content.__exit__()
 
-    def build_response(self, request: Request, status_code: int = 200) -> Response:
+    async def build_response(self, request: Request, status_code: int = 200) -> Response:
         """Build a FastAPI response for the client."""
         self.outbox.updates.clear()
         prefix = request.headers.get('X-Forwarded-Prefix', request.scope.get('root_path', ''))

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -62,8 +62,8 @@ Client.auto_index_client = Client(page('/'), request=None).__enter__()  # pylint
 
 
 @app.get('/')
-def _get_index(request: Request) -> Response:
-    return Client.auto_index_client.build_response(request)
+async def _get_index(request: Request) -> Response:
+    return await Client.auto_index_client.build_response(request)
 
 
 @app.get(f'/_nicegui/{__version__}' + '/libraries/{key:path}')
@@ -147,7 +147,7 @@ async def _exception_handler_404(request: Request, exception: Exception) -> Resp
     log.warning(f'{request.url} not found')
     with Client(page(''), request=request) as client:
         error_content(404, exception)
-    return client.build_response(request, 404)
+    return await client.build_response(request, 404)
 
 
 @app.exception_handler(Exception)
@@ -155,7 +155,7 @@ async def _exception_handler_500(request: Request, exception: Exception) -> Resp
     log.exception(exception)
     with Client(page(''), request=request) as client:
         error_content(500, exception)
-    return client.build_response(request, 500)
+    return await client.build_response(request, 500)
 
 
 @sio.on('handshake')

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -138,7 +138,7 @@ class page:
             if isinstance(result, Response):  # NOTE if setup returns a response, we don't need to render the page
                 return result
             binding._refresh_step()  # pylint: disable=protected-access
-            return client.build_response(request)
+            return await client.build_response(request)
 
         parameters = [p for p in inspect.signature(func).parameters.values() if p.name != 'client']
         # NOTE adding request as a parameter so we can pass it to the client in the decorated function

--- a/nicegui/ssr.py
+++ b/nicegui/ssr.py
@@ -1,0 +1,283 @@
+import json
+from pathlib import Path
+import subprocess
+from nodejs_wheel import node, npm
+
+import uuid
+
+cwd = Path(__file__).parent
+
+print("cwd", cwd)
+
+package_json = cwd / 'package.json'
+
+quasar_path = cwd / 'node_modules' / 'quasar' / 'dist' / 'quasar.server.prod.js'
+
+
+def write_js_script(uuid: str, elements_string: str) -> None:
+    """Write the JavaScript script to a file."""
+    script = """
+// this runs in Node.js on the server.
+import { createSSRApp, withModifiers, withKeys, resolveComponent, h } from 'vue'
+// Vue's server-rendering API is exposed under `vue/server-renderer`.
+import { renderToString } from 'vue/server-renderer'
+// Quasar is a Vue.js framework for building responsive web applications.
+// @ts-ignore
+import { Quasar } from 'quasar'
+
+const True = true;
+const False = false;
+const None = undefined;
+
+const loaded_libraries = new Set();
+const loaded_components = new Set();
+
+function parseElements(raw_elements) {
+  return JSON.parse(
+    raw_elements
+      .replace(/&#36;/g, "$")
+      .replace(/&#96;/g, "`")
+      .replace(/&gt;/g, ">")
+      .replace(/&lt;/g, "<")
+      .replace(/&amp;/g, "&")
+  );
+}
+
+function replaceUndefinedAttributes(element) {
+  element.class ??= [];
+  element.style ??= {};
+  element.props ??= {};
+  element.text ??= null;
+  element.events ??= [];
+  element.update_method ??= null;
+  element.component ??= null;
+  element.libraries ??= [];
+  element.slots = {
+    default: { ids: element.children || [] },
+    ...(element.slots ?? {}),
+  };
+}
+
+function renderRecursively(elements, id) {
+  const element = elements[id];
+  if (element === undefined) {
+    return;
+  }
+
+  // @todo: Try avoid this with better handling of initial page load.
+  if (element.component) loaded_components.add(element.component.name);
+  element.libraries.forEach((library) => loaded_libraries.add(library.name));
+
+  const props = {
+    id: "c" + id,
+    ref: "r" + id,
+    key: id, // HACK: workaround for #600 and #898
+    class: element.class.join(" ") || undefined,
+    style: Object.entries(element.style).reduce((str, [p, val]) => `${str}${p}:${val};`, "") || undefined,
+    ...element.props,
+  };
+  Object.entries(props).forEach(([key, value]) => {
+    if (key.startsWith(":")) {
+      try {
+        try {
+          props[key.substring(1)] = new Function(`return (${value})`)();
+        } catch (e) {
+          props[key.substring(1)] = eval(value);
+        }
+        delete props[key];
+      } catch (e) {
+        console.error(`Error while converting ${key} attribute to function:`, e);
+      }
+    }
+  });
+  element.events.forEach((event) => {
+    let event_name = "on" + event.type[0].toLocaleUpperCase() + event.type.substring(1);
+    event.specials.forEach((s) => (event_name += s[0].toLocaleUpperCase() + s.substring(1)));
+
+    let handler;
+    if (event.js_handler) {
+      handler = eval(event.js_handler);
+    } else {
+      handler = (...args) => {
+        const emitter = () =>
+          window.socket?.emit("event", {
+            id: id,
+            client_id: window.clientId,
+            listener_id: event.listener_id,
+            args: stringifyEventArgs(args, event.args),
+          });
+        const delayed_emitter = () => {
+          if (window.did_handshake) emitter();
+          else setTimeout(emitter, 10);
+        };
+        throttle(delayed_emitter, event.throttle, event.leading_events, event.trailing_events, event.listener_id);
+        if (element.props["loopback"] === False && event.type == "update:modelValue") {
+          element.props["model-value"] = args;
+        }
+      };
+    }
+
+    handler = withModifiers(handler, event.modifiers);
+    handler = event.keys.length ? withKeys(handler, event.keys) : handler;
+    if (props[event_name]) {
+      props[event_name].push(handler);
+    } else {
+      props[event_name] = [handler];
+    }
+  });
+  const slots = {};
+  const element_slots = {
+    default: { ids: element.children || [] },
+    ...element.slots,
+  };
+  Object.entries(element_slots).forEach(([name, data]) => {
+    slots[name] = (props) => {
+      const rendered = [];
+      if (data.template) {
+        rendered.push(
+          h(
+            {
+              props: { props: { type: Object, default: {} } },
+              template: data.template,
+            },
+            {
+              props: props,
+            }
+          )
+        );
+      }
+      const children = data.ids.map((id) => renderRecursively(elements, id));
+      if (name === "default" && element.text !== null) {
+        children.unshift(element.text);
+      }
+      return [...rendered, ...children];
+    };
+  });
+  return h(resolveComponent(element.tag), props, slots);
+}
+
+const elements = parseElements(String.raw`ELEMENTS_GO_HERE`)
+
+Object.entries(elements).forEach(([_, element]) => replaceUndefinedAttributes(element));
+
+const app = createSSRApp({
+  data() {
+    return {
+      elements,
+    };
+  },
+  render() {
+    return renderRecursively(elements, 0);
+  },
+});
+
+app.use(Quasar, {});
+
+
+
+renderToString(app).then((html) => {
+  console.log(html)
+})
+"""
+    script = script.replace('ELEMENTS_GO_HERE', elements_string, 1)
+    with open(cwd / f'ssr_{uuid}.js', 'w') as file:
+        file.write(script)
+
+
+def delete_js_script(uuid: str) -> None:
+    """Delete the JavaScript script file."""
+    script_path = cwd / f'ssr_{uuid}.js'
+    if script_path.exists():
+        script_path.unlink()
+        print(f'Deleted {script_path}')
+    else:
+        print(f'{script_path} does not exist')
+
+
+def ensure_npm_init() -> None:
+    """Check if npm is initialized in the current directory."""
+    if package_json.exists():
+        print('npm already initialized')
+    else:
+        print('npm not initialized')
+        npm(['init', '-y'], cwd=cwd)
+
+
+def check_npm_install() -> None:
+    """Check if npm packages are installed in the current directory."""
+    ensure_npm_init()  # make a call to the lower-level check
+
+    def npm_install() -> None:
+        npm(['install', 'vue@3.4.38', 'quasar@2.16.9'], cwd=cwd)
+
+    with open(package_json, 'r') as file:
+        package_data = json.load(file)
+    for package in ['vue', 'quasar']:
+        if package in package_data.get('dependencies', {}):
+            print(f'{package} already installed')
+        else:
+            print("Did not install the required packages")
+            npm_install()
+            break
+
+    if not quasar_path.exists():
+        print('quasar.server.prod.js does not exist. This is strange but we will try again.')
+        npm_install()
+
+        if not quasar_path.exists():
+            print('quasar.server.prod.js still does not exist. This is a critical error.')
+            raise FileNotFoundError(f'{quasar_path} does not exist. Please check your installation.')
+
+
+def ensure_type_module() -> None:
+    """Check if the type module is set in package.json."""
+    check_npm_install()  # make a call to the lower-level check
+
+    with open(package_json, 'r') as file:
+        package_data = json.load(file)
+    if 'type' in package_data:
+        print('Type module already set')
+    else:
+        print('Setting type module')
+        package_data['type'] = 'module'
+        with open(package_json, 'w') as file:
+            json.dump(package_data, file, indent=4)
+
+
+def ensure_patch_quasar() -> None:
+    """Check if quasar is patched."""
+    ensure_type_module()  # make a call to the lower-level check
+
+    with open(quasar_path, 'r') as file:
+        quasar_data = file.read()
+    if '// modified by ssr.py' in quasar_data:
+        print('quasar.server.prod.js already patched')
+    else:
+        print('Patching quasar.server.prod.js')
+        quasar_data = quasar_data.replace(
+            'e.req.headers["user-agent"]||e.req.headers["User-Agent"]', 'e.req?.headers["user-agent"]||e.req?.headers["User-Agent"]')
+        quasar_data = quasar_data.replace('e,t={},o', 'e,t={},o={}')
+        quasar_data += '\n// modified by ssr.py'
+        with open(quasar_path, 'w') as file:
+            file.write(quasar_data)
+
+
+def get_ssr_output(elements_string: str) -> str:
+    """Get the SSR output."""
+    unique_id = str(uuid.uuid4())  # Generate a random UUID
+    write_js_script(unique_id, elements_string)
+    result = node([f'ssr_{unique_id}.js'], cwd=cwd, return_completed_process=True,
+                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.stderr:
+        print("Error:", result.stderr.decode('utf-8').strip())
+    print(result)
+    output = result.stdout.decode('utf-8').strip()
+    delete_js_script(unique_id)
+    return output
+
+
+ensure_patch_quasar()
+
+if __name__ == '__main__':
+    elements_input = input('Enter elements string: ')
+    print(get_ssr_output(elements_input))

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -316,7 +316,9 @@ window.onbeforeunload = function () {
 function createApp(elements, options) {
   Object.entries(elements).forEach(([_, element]) => replaceUndefinedAttributes(element));
   setInterval(() => ack(), 3000);
-  return (app = Vue.createApp({
+  if (options.isSSR) console.log("SSR mode active!");
+  const createVueApp = options.isSSR ? Vue.createSSRApp : Vue.createApp;
+  return (app = createVueApp({
     data() {
       return {
         elements,

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -36,7 +36,7 @@
     </script>
     {{ body_html | safe }}
 
-    <div id="app"></div>
+    <div id="app">{{ results_ssr | safe }}</div>
     <div id="popup" aria-hidden="true">
       <span>{{ translations.connection_lost }}</span>
       <span>{{ translations.trying_to_reconnect }}</span>
@@ -49,6 +49,7 @@
         extraHeaders: {{ socket_io_js_extra_headers | safe }},
         transports: {{ socket_io_js_transports | safe }},
         quasarConfig: {{ quasar_config | safe }},
+        isSSR: {% if results_ssr %}true{% else %}false{% endif %},
       });
 
       {{ js_imports | safe }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1760,6 +1760,40 @@ files = [
 ]
 
 [[package]]
+name = "nodejs-wheel"
+version = "22.14.0"
+description = "unoffical Node.js package"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "nodejs_wheel-22.14.0-py3-none-any.whl", hash = "sha256:27736c49046df3083c8fc31bdfe70f4a9652f89d231fb5b39f0f43735a7e8c8c"},
+    {file = "nodejs_wheel-22.14.0.tar.gz", hash = "sha256:1247d7a50d48e50d24c13bda3c1e26e63bfd8f1b5e08d41c1aaf1b30393e2c78"},
+]
+
+[package.dependencies]
+nodejs-wheel-binaries = "22.14.0"
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "22.14.0"
+description = "unoffical Node.js package"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "nodejs_wheel_binaries-22.14.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d8ab8690516a3e98458041286e3f0d6458de176d15c14f205c3ea2972131420d"},
+    {file = "nodejs_wheel_binaries-22.14.0-py2.py3-none-macosx_11_0_x86_64.whl", hash = "sha256:b2f200f23b3610bdbee01cf136279e005ffdf8ee74557aa46c0940a7867956f6"},
+    {file = "nodejs_wheel_binaries-22.14.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0877832abd7a9c75c8c5caafa37f986c9341ee025043c2771213d70c4c1defa"},
+    {file = "nodejs_wheel_binaries-22.14.0-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fded5a70a8a55c2135e67bd580d8b7f2e94fcbafcc679b6a2d5b92f88373d69"},
+    {file = "nodejs_wheel_binaries-22.14.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c1ade6f3ece458b40c02e89c91d5103792a9f18aaad5026da533eb0dcb87090e"},
+    {file = "nodejs_wheel_binaries-22.14.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:34fa5ed4cf3f65cbfbe9b45c407ffc2fc7d97a06cd8993e6162191ff81f29f48"},
+    {file = "nodejs_wheel_binaries-22.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:ca7023276327455988b81390fa6bbfa5191c1da7fc45bc57c7abc281ba9967e9"},
+    {file = "nodejs_wheel_binaries-22.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:fd59c8e9a202221e316febe1624a1ae3b42775b7fb27737bf12ec79565983eaf"},
+    {file = "nodejs_wheel_binaries-22.14.0.tar.gz", hash = "sha256:c1dc43713598c7310d53795c764beead861b8c5021fe4b1366cb912ce1a4c8bf"},
+]
+
+[[package]]
 name = "numpy"
 version = "1.24.4"
 description = "Fundamental package for array computing in Python"
@@ -1961,7 +1995,7 @@ files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
 ]
-markers = {main = "(extra == \"native\" and sys_platform == \"openbsd6\" or extra == \"matplotlib\" or extra == \"plotly\") and python_version >= \"3.8\""}
+markers = {main = "(extra == \"native\" and sys_platform == \"openbsd6\" or extra == \"plotly\" or extra == \"matplotlib\") and python_version >= \"3.8\""}
 
 [[package]]
 name = "pandas"
@@ -4385,4 +4419,4 @@ sass = ["libsass"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8"
-content-hash = "9d56e02408ddf68596416c26400f7b6c3e93d88701b0ad9637fd08dbbefa9bc8"
+content-hash = "cdf5766535d31c6bc08a481e94ac7b4905ea7b83fc775bdca83507bc0198e94f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ requests = ">=2.32.0" # https://github.com/zauberzeug/nicegui/security/dependabo
 urllib3 = ">=1.26.18,!=2.0.0,!=2.0.1,!=2.0.2,!=2.0.3,!=2.0.4,!=2.0.5,!=2.0.6,!=2.0.7,!=2.1.0,!=2.2.0,!=2.2.1" # https://github.com/zauberzeug/nicegui/security/dependabot/34
 certifi = ">=2024.07.04" # https://github.com/zauberzeug/nicegui/security/dependabot/35
 redis = { version = ">=4.0.0", optional = true }
+nodejs-wheel = "==22.*"
 
 [tool.poetry.extras]
 native = ["pywebview"]


### PR DESCRIPTION
https://github.com/zauberzeug/nicegui/discussions/4554

TL-DR: Server-side rendering makes the NiceGUI pages include valid HTML elements (instead of a string in JavaScript), enabling 
1. Browsers to show the elements much earlier in the page parsing process without waiting for the JavaScript to execute, 
2. Better SEO (search engine optimization) so that pages don't show up as ["Connection lost. Trying to reconnect..."](https://github.com/zauberzeug/nicegui/discussions/4506) for Google, Bing, Yandex, the alikes. 

---

Code is rather obvious: 

* `ssr.py` contains the logic of getting the HTML elements
* The chain of serving HTTP response (`client.py`, `index.html`, `nicegui.js` is reworked to call `Vue.createSSRApp` if elements are successfully yielded from SSR)
* For async, no choice but to change `client.build_response` to async. 

---


Remaining concerns: 

* Should separate this to a separate package, think: `pip install nicegui[ssr]` since not everyone wants +20MB just for the NodeJS instance
* Behaviour may not be acceptable for all pages, since +200ms processing time. Opt-in via `@ui.page` seems wiser. 
  * (in another PR) implement caching of the HTTP response? but the page will have outdated content and updates must be served via updating calls after `await ui.context.client.connected()`
* For SEO purposes, perhaps SSR is only done when the agent is known to be a web scraper? 
* Tried few hours at resolving hydration mismatch, no success!

<img width="211" alt="{D2226007-C4B3-4DA6-B298-85213AF5D1D0}" src="https://github.com/user-attachments/assets/433688e0-e3b2-4f02-aafe-0837d65278ef" />

