### PR TITLE
popup if socket.io message expected to be too long

### DIFF
--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -265,8 +265,8 @@ h6.q-timeline__title {
   outline: none;
 }
 
-/* connection popup */
-#popup {
+/* connection popup & too-long-message popup */
+.nicegui-error-popup {
   position: fixed;
   bottom: 0;
   left: 0;
@@ -282,13 +282,13 @@ h6.q-timeline__title {
   pointer-events: none;
   z-index: 10000;
 }
-.body--dark #popup {
+.body--dark .nicegui-error-popup {
   background-color: black;
 }
-.body--light #popup {
+.body--light .nicegui-error-popup {
   background-color: white;
 }
-#popup[aria-hidden="true"] {
+.nicegui-error-popup[aria-hidden="true"] {
   opacity: 0;
   visibility: hidden;
 }
@@ -297,10 +297,14 @@ h6.q-timeline__title {
   visibility: visible;
   transition-delay: 2000ms;
 }
-#popup > span:first-child {
+#popup_toolongmessage[aria-hidden="false"] {
+  opacity: 1;
+  visibility: visible;
+}
+.nicegui-error-popup > span:first-child {
   font-weight: bold;
 }
-#popup > span:first-child::before {
+.nicegui-error-popup > span:first-child::before {
   content: "⚠️";
   position: absolute;
   left: 1.5em;

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -178,13 +178,36 @@ function renderRecursively(elements, id) {
       handler = eval(event.js_handler);
     } else {
       handler = (...args) => {
-        const emitter = () =>
-          window.socket?.emit("event", {
+        const emitter = () => {
+          if (!window.socket) {
+            return;
+          }
+          const payload = {
             id: id,
             client_id: window.clientId,
             listener_id: event.listener_id,
             args: stringifyEventArgs(args, event.args),
-          });
+          };
+          const expected_socketio_payload = [
+            "event",
+            payload,
+          ]
+          console.log("Length of expected_socketio_payload: ", JSON.stringify(expected_socketio_payload).length + 2);
+
+          if (JSON.stringify(expected_socketio_payload).length + 2 > window.socket.io.engine.maxPayload) {
+            console.log("Payload size exceeds the maximum allowed limit.");
+            if (window.tooLongMessageTimer) {
+              clearTimeout(window.tooLongMessageTimer);
+            }
+            const popup = document.getElementById("popup_toolongmessage");
+            popup.ariaHidden = false;
+            window.tooLongMessageTimer = setTimeout(() => {
+              popup.ariaHidden = true;
+            }, 5000);
+            return;
+          }
+          window.socket.emit("event", payload);
+        };
         const delayed_emitter = () => {
           if (window.did_handshake) emitter();
           else setTimeout(emitter, 10);

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -40,9 +40,13 @@
     {{ body_html | safe }}
 
     <div id="app"></div>
-    <div id="popup" aria-hidden="true">
+    <div id="popup" class="nicegui-error-popup" aria-hidden="true">
       <span>{{ translations.connection_lost }}</span>
       <span>{{ translations.trying_to_reconnect }}</span>
+    </div>
+    <div id="popup_toolongmessage" class="nicegui-error-popup" aria-hidden="true">
+      <span>Message too long</span>
+      <span>The message is longer than what the server can handle.</span>
     </div>
     <script type="module">
       const app = createApp(parseElements(String.raw`{{ elements | safe }}`), {


### PR DESCRIPTION
fixes #3410 

TL-DR: Nobody in the chain of Python-EngineIO -> Python-SocketIO -> SocketIO.js is taking up the responsibility of limiting the message length in a verbose manner. NiceGUI is taking up the responsibility, then. 

Notable changes: 
* Refactor CSS to share styling between the existing disconnect popup and the new too-long-message popup
* Add popup into `index.html`
* JS estimate message length via trial-and-error, make popup show for 5 seconds after the last too-long-message

To-do and considerations: 
* Internationalization similar to #4324 
* Will there be performance penalty if we stringify once, and then Socket.IO swiftly stringifys again? 

Result: 
<img width="1280" alt="{12461EE6-429C-411B-BCFA-9C327F550267}" src="https://github.com/user-attachments/assets/35e353e2-1885-4bb7-bfc5-ec2cc6ce233f" />

