### PR TITLE
Fix docs section_styling_appearance label bug

### DIFF
--- a/website/documentation/content/section_styling_appearance.py
+++ b/website/documentation/content/section_styling_appearance.py
@@ -75,9 +75,10 @@ def styling_demo():
                     with ui.row().classes('items-center gap-0 w-full'):
                         def handle_props(e: events.ValueChangeEventArguments):
                             element.props.clear()
-                            if select_element.options[select_element.value] not in ["ui.switch", "ui.checkbox"]:
+                            if isinstance(element, (ui.button, ui.input, ui.textarea)):
                                 element.props['label'] = 'element'
-                            element.props['color'] = 'primary'
+                            if isinstance(element, ui.button):
+                                element.props['color'] = 'primary'
                             try:
                                 element.props(e.value)
                             except ValueError:

--- a/website/documentation/content/section_styling_appearance.py
+++ b/website/documentation/content/section_styling_appearance.py
@@ -75,7 +75,8 @@ def styling_demo():
                     with ui.row().classes('items-center gap-0 w-full'):
                         def handle_props(e: events.ValueChangeEventArguments):
                             element.props.clear()
-                            element.props['label'] = 'Button'
+                            if select_element.options[select_element.value] not in ["ui.switch", "ui.checkbox"]:
+                                element.props['label'] = 'element'
                             element.props['color'] = 'primary'
                             try:
                                 element.props(e.value)


### PR DESCRIPTION
Originally reported to me by @hwtam privately. 

TL-DR: minor bugfix for https://nicegui.io/documentation/section_styling_appearance#try_styling_nicegui_elements_

Existing issue: 

1. Button string content becomes "Button" when it should be `ui.button('element')`, when anything is typed in the props input field. 

![image](https://github.com/user-attachments/assets/c5be0ecf-8ea5-4eb2-abd6-0037852dd518)

2. Mangled label for especially `ui.checkbox` and `ui.switch`

<img width="950" alt="{8D8C0ED1-66DF-4849-96DB-82FA460D8C87}" src="https://github.com/user-attachments/assets/cc61f5b9-ebd1-48c0-b308-6e3e0772fbbc" />

Proposed fix: 

* Change `element.props['label'] = 'Button'` to `element.props['label'] = 'element'`
* Never do `element.props['label'] = 'element'` if selected `ui.checkbox` or `ui.switch`
