### PR TITLE
EChart resizeObserver skipping initial rendering

### DIFF
--- a/nicegui/elements/echart.js
+++ b/nicegui/elements/echart.js
@@ -54,13 +54,10 @@ export default {
       this.chart.on(event, (e) => this.$emit(`chart:${event}`, e));
     }
 
-    // Prevent interruption of chart animations due to resize operations.
-    // It is recommended to register the callbacks for such an event before setOption.
-    const createResizeObserver = () => {
-      new ResizeObserver(this.chart.resize).observe(this.$el);
-      this.chart.off("finished", createResizeObserver);
-    };
-    this.chart.on("finished", createResizeObserver);
+    this.initialResizeTriggered = false;
+    const initialHeight = this.$el.offsetHeight;
+    const initialWidth = this.$el.offsetWidth;
+    const resizeObserver = new ResizeObserver(this.resizeChart).observe(this.$el);
 
     this.update_chart();
   },
@@ -71,6 +68,16 @@ export default {
     this.chart.dispose();
   },
   methods: {
+    resizeChart() {
+      if (!this.initialResizeTriggered) {
+        this.initialResizeTriggered = true;
+        if (this.$el.offsetWidth === initialWidth && this.$el.offsetHeight === initialHeight) {
+          return;
+        }
+      } else {
+        this.chart.resize();
+      }
+    },
     update_chart() {
       if (!this.chart) {
         setTimeout(this.update_chart, 10);


### PR DESCRIPTION
Should fix #4535 overcoming the before discussed resizing approaches causing issues, illustrated [here](https://[depley.github.io/nicegui-custom-echarts/](https://depley.github.io/nicegui-custom-echarts/)) 

Suggested solution is based on [ecomfe/vue-echarts .. autoresize.ts](https://github.com/ecomfe/vue-echarts/blob/b7852ab6430084c54a8e1c0a05648748da94bc64/src/composables/autoresize.ts#L7).
Basically a direct attached resizeObserver but skipping an initial resize if the initial size of the container element hasn't changed.

The in [#4535 comment](https://github.com/zauberzeug/nicegui/issues/4535#issuecomment-2781492261) discussed MREs can be reproduced in nicegui via

```py
from nicegui import ui

# scatter series chart
# expected behaviour: should not render twice initially, render once after resizing
echart_many_data = ui.echart({
    'xAxis': {'type': 'value'},
    'yAxis': {'type': 'value'},
    'series': [{
        'type': 'scatter',
        'data': [[x, x] for x in range(20_000)]
    }],
})

# line series chart
# expected behaviour: animation drawing a line and points on initial rendering 
# (broken animation behaviour was that the line is already there)  
echart_animation = ui.echart({
    'xAxis': {
        'type': 'category',
        'data': ["Mon", "Tue", "Wed", "Thu", "Fri"],
    },
    'yAxis': {'type': 'value'},
    'series': [{
        'type': 'line',
        'data': [150, 230, 224, 147, 260],
    }],
})

ui.run()
```

