### PR TITLE
Notify CodeMirror gracefully to avoid out-of-sync between CodeMirror and NiceGUI internal states

### DIFF
--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -337,7 +337,9 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
 
     def set_value(self, value: str) -> None:
         """Set the value of the editor."""
-        self.client.run_javascript(f'getElement({self.id}).setEditorValue("{value}")')
+        target_id = self.client._temporary_socket_id or self.client.id
+        self.client.outbox.enqueue_message(
+            'run_javascript', {'code': f'getElement({self.id}).setEditorValue("{value}")'}, target_id)
         super().set_value(value)
 
 # Below is a Python implementation of relevant parts of https://github.com/codemirror/state/blob/main/src/change.ts

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -335,6 +335,10 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
         new_value = changeset.apply(self.value)
         return new_value
 
+    def set_value(self, value: str) -> None:
+        """Set the value of the editor."""
+        self.client.run_javascript(f'getElement({self.id}).setEditorValue("{value}")')
+        super().set_value(value)
 
 # Below is a Python implementation of relevant parts of https://github.com/codemirror/state/blob/main/src/change.ts
 # to apply a ChangeSet to a text document.


### PR DESCRIPTION

fix #3337 

This is because, when you bind the value, eventually `set_value` in `ValueElement` is called, which does this:

https://github.com/zauberzeug/nicegui/blob/b9c9e8492750153d4b519b24da57b02751ff225f/nicegui/elements/mixins/value_element.py#L103-L108

That's quite a direct approach, and the CodeMirror can't accept that (or it needs to poll the value in the prop upon every update). 

Instead, CodeMirror offers another method for setting value, which is `setEditorValue`

<img width="392" alt="{F70AA4F6-3E5E-4381-8E83-9D5767FCA077}" src="https://github.com/user-attachments/assets/a4e1adb0-8f7d-47f3-9e00-58d83f0adf5c" />


We just need to call it, and CodeMirror will be "made aware" of a change in editor value, so the following ChangeSet can be applied properly. 