### PR TITLE
Fix unexpected logs in pytest when using the user fixture

### DIFF
--- a/nicegui/testing/user_plugin.py
+++ b/nicegui/testing/user_plugin.py
@@ -49,9 +49,10 @@ async def user(nicegui_reset_globals,  # noqa: F811, pylint: disable=unused-argu
     ui.navigate = Navigate()
     ui.notify = notify
     ui.download = download
-    logs = caplog.get_records('call')
+
+    logs = [record for record in caplog.get_records('call') if record.levelname == 'ERROR']
     if logs:
-        pytest.fail('There were unexpected logs.', pytrace=False)
+        pytest.fail('There were unexpected ERROR logs.', pytrace=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
Attempt to resolve the catch all logs error when using the user fixture.

Relates to #4607 