### PR TITLE
feat: support delegated event handling

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -320,26 +320,6 @@ class Element(Visibility):
             Tooltip(text)
         return self
 
-    @overload
-    def on(self,
-           type: str,  # pylint: disable=redefined-builtin
-           *,
-           js_handler: Optional[str] = None,
-           ) -> Self:
-        ...
-
-    @overload
-    def on(self,
-           type: str,  # pylint: disable=redefined-builtin
-           handler: Optional[events.Handler[events.GenericEventArguments]] = None,
-           args: Union[None, Sequence[str], Sequence[Optional[Sequence[str]]]] = None,
-           *,
-           throttle: float = 0.0,
-           leading_events: bool = True,
-           trailing_events: bool = True,
-           ) -> Self:
-        ...
-
     def on(self,
            type: str,  # pylint: disable=redefined-builtin
            handler: Optional[events.Handler[events.GenericEventArguments]] = None,
@@ -360,9 +340,6 @@ class Element(Visibility):
         :param trailing_events: whether to trigger the event handler after the last event occurrence (default: `True`)
         :param js_handler: JavaScript code that is executed upon occurrence of the event, e.g. `(evt) => alert(evt)` (default: `None`)
         """
-        if handler and js_handler:
-            raise ValueError('Either handler or js_handler can be specified, but not both')
-
         if handler or js_handler:
             listener = EventListener(
                 element_id=self.id,

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -83,6 +83,15 @@ function emitEvent(event_name, ...args) {
   getElement(0).$emit(event_name, ...args);
 }
 
+function emitEventTo(id, event, ...args) {
+  window.socket?.emit("event", {
+    id: id,
+    client_id: window.clientId,
+    listener_id: event.listener_id,
+    args: stringifyEventArgs(args, event.args),
+  });
+}
+
 function stringifyEventArgs(args, event_args) {
   const result = [];
   args.forEach((arg, i) => {
@@ -182,13 +191,7 @@ function renderRecursively(elements, id) {
       handler = eval(event.js_handler);
     } else {
       handler = (...args) => {
-        const emitter = () =>
-          window.socket?.emit("event", {
-            id: id,
-            client_id: window.clientId,
-            listener_id: event.listener_id,
-            args: stringifyEventArgs(args, event.args),
-          });
+        const emitter = () => emitEventTo(id, event, ...args);
         const delayed_emitter = () => {
           if (window.did_handshake) emitter();
           else setTimeout(emitter, 10);

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -177,13 +177,14 @@ function renderRecursively(elements, id) {
     let event_name = "on" + event.type[0].toLocaleUpperCase() + event.type.substring(1);
     event.specials.forEach((s) => (event_name += s[0].toLocaleUpperCase() + s.substring(1)));
 
-    let emitEventToSelf = function(...args) {
-      const emitter = () => window.socket?.emit("event", {
-        id: id,
-        client_id: window.clientId,
-        listener_id: event.listener_id,
-        args: stringifyEventArgs(args, event.args),
-      });
+    let emitEventToSelf = (...args) => {
+      const emitter = () =>
+        window.socket?.emit("event", {
+          id: id,
+          client_id: window.clientId,
+          listener_id: event.listener_id,
+          args: stringifyEventArgs(args, event.args),
+        });
       const delayed_emitter = () => {
         if (window.did_handshake) emitter();
         else setTimeout(emitter, 10);

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -191,3 +191,22 @@ def test_js_handler(screen: Screen) -> None:
     screen.open('/')
     screen.click('Button')
     screen.should_contain('Click!')
+
+
+def test_delegated_event(screen: Screen) -> None:
+    data = [f'Item {i}' for i in range(5)]
+    snippet = ''.join(f'<li data-index={i}>{item}</li>' for i, item in enumerate(data))
+    root = ui.html(snippet, tag='ul')
+
+    clicked = []
+    def on_click(e):
+        clicked.append(int(e.args['index']))
+
+    root.on('click', on_click, js_handler=f'(e) => emitEventTo({root.id}, event, e.target.dataset)')
+
+    # test
+    screen.open('/')
+    for i, _ in enumerate(data):
+        screen.selenium.find_element(By.CSS_SELECTOR, f'li:nth-child({i+1})').click()
+
+    assert clicked == list(range(len(data)))

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -202,7 +202,7 @@ def test_delegated_event(screen: Screen) -> None:
     def on_click(e):
         clicked.append(int(e.args['index']))
 
-    root.on('click', on_click, js_handler=f'(e) => emitEventTo({root.id}, event, e.target.dataset)')
+    root.on('click', on_click, js_handler="(e) => emitEventToSelf(e.target.dataset)")
 
     # test
     screen.open('/')


### PR DESCRIPTION
1. Allow setting `handler` and `js_handler` at the same time, the `js_handler` can be used to override the default behavior at js side and has the ability to emit event to call the `handler` at server side, specifically, it can change how event args are constructed.
2. Provide utility function `emitEventToSelf` at js side, only available in `js_handler` context

Please check the unit test case for usage:

https://github.com/zauberzeug/nicegui/pull/4618/files#diff-17a9b99a7b95f217c0c8d0f8d0c9d852368eb8e2e14883d26b443483e1b7597fR196-R212

---

Feature request: #4611