### PR TITLE
Pass the NativeConfig object from MainProcess to native subprocess

### DIFF
--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -29,7 +29,7 @@ except ModuleNotFoundError:
 
 def _open_window(
     host: str, port: int, title: str, width: int, height: int, fullscreen: bool, frameless: bool,
-    method_queue: mp.Queue, response_queue: mp.Queue, native_config: NativeConfig
+    method_queue: mp.Queue, response_queue: mp.Queue, native_config: NativeConfig,
 ) -> None:
     while not helpers.is_port_open(host, port):
         time.sleep(0.1)

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -15,6 +15,7 @@ from .. import core, helpers, optional_features
 from ..logging import log
 from ..server import Server
 from . import native
+from .native_config import NativeConfig
 
 try:
     with warnings.catch_warnings():
@@ -28,10 +29,13 @@ except ModuleNotFoundError:
 
 def _open_window(
     host: str, port: int, title: str, width: int, height: int, fullscreen: bool, frameless: bool,
-    method_queue: mp.Queue, response_queue: mp.Queue,
+    method_queue: mp.Queue, response_queue: mp.Queue, native_config: NativeConfig
 ) -> None:
     while not helpers.is_port_open(host, port):
         time.sleep(0.1)
+
+    # Replace fresh, likely empty config with a config supplied to us via MainProcess
+    core.app.native = native_config
 
     window_kwargs = {
         'url': f'http://{host}:{port}',
@@ -111,7 +115,7 @@ def activate(host: str, port: int, title: str, width: int, height: int, fullscre
         sys.exit(1)
 
     mp.freeze_support()
-    args = host, port, title, width, height, fullscreen, frameless, native.method_queue, native.response_queue
+    args = host, port, title, width, height, fullscreen, frameless, native.method_queue, native.response_queue, core.app.native
     process = mp.Process(target=_open_window, args=args, daemon=True)
     process.start()
 


### PR DESCRIPTION
In order to fix [Issue 4319](https://github.com/zauberzeug/nicegui/issues/4319), I have added a few lines of code to explicitly pass the NativeConfig from the MainProcess through to the native_mode._open_window function.

While the original poster of the issue was discussing it in terms of problems with freezing Nicegui in an executable, the real problem (I believe) is simply that: since the execution for native code is done within a multiprocessing Process, the script is re-run, all dependencies are re-imported, so core.app.native is reset to be empty in the subprocess, and any code under a main guard is not run.

Minimal example:
```python
# This works fine
from nicegui import app, ui

ui.label("Test")

app.native.window_args['text_select'] = True
app.native.window_args['maximized'] = True

ui.run(title='Test', native=True, reload=False)
```

```python
# This will not apply native settings
from nicegui import app, ui

if __name__ == "__main__":
    ui.label("Test")

    app.native.window_args['text_select'] = True
    app.native.window_args['maximized'] = True

    ui.run(title='Test', native=True, reload=False)
```

My proposed patch simply passes the NativeConfig that exists in the main process to the subprocess when it initializes. This should reduce unexpected behavior from setting native settings from within a main guard