### PR TITLE
Use `element._update_method` for `ui.codemirror`

### DIFF
--- a/nicegui/elements/codemirror.js
+++ b/nicegui/elements/codemirror.js
@@ -87,12 +87,15 @@ export default {
         effects: this.themeConfig.reconfigure([new_theme]),
       });
     },
-    setEditorValue() {
+    setEditorValueFromProps() {
+      this.setEditorValue(this.value);
+    },
+    setEditorValue(value) {
       if (!this.editor) return;
-      if (this.editor.state.doc.toString() === this.value) return;
+      if (this.editor.state.doc.toString() === value) return;
 
       this.emitting = false;
-      this.editor.dispatch({ changes: { from: 0, to: this.editor.state.doc.length, insert: this.value } });
+      this.editor.dispatch({ changes: { from: 0, to: this.editor.state.doc.length, insert: value } });
       this.emitting = true;
     },
     setDisabled(disabled) {

--- a/nicegui/elements/codemirror.js
+++ b/nicegui/elements/codemirror.js
@@ -13,9 +13,6 @@ export default {
     highlightWhitespace: Boolean,
   },
   watch: {
-    value(newValue) {
-      this.setEditorValue(newValue);
-    },
     language(newLanguage) {
       this.setLanguage(newLanguage);
     },
@@ -90,12 +87,12 @@ export default {
         effects: this.themeConfig.reconfigure([new_theme]),
       });
     },
-    setEditorValue(value) {
+    setEditorValue() {
       if (!this.editor) return;
-      if (this.editor.state.doc.toString() === value) return;
+      if (this.editor.state.doc.toString() === this.value) return;
 
       this.emitting = false;
-      this.editor.dispatch({ changes: { from: 0, to: this.editor.state.doc.length, insert: value } });
+      this.editor.dispatch({ changes: { from: 0, to: this.editor.state.doc.length, insert: this.value } });
       this.emitting = true;
     },
     setDisabled(disabled) {

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -288,6 +288,7 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
         self._props['indent'] = indent
         self._props['lineWrapping'] = line_wrapping
         self._props['highlightWhitespace'] = highlight_whitespace
+        self._update_method = 'setEditorValue'
 
     @property
     def theme(self) -> str:

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -288,7 +288,7 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
         self._props['indent'] = indent
         self._props['lineWrapping'] = line_wrapping
         self._props['highlightWhitespace'] = highlight_whitespace
-        self._update_method = 'setEditorValue'
+        self._update_method = 'setEditorValueFromProps'
 
     @property
     def theme(self) -> str:


### PR DESCRIPTION
This PR is an alternative to #4586 to fix #3337. Watching the `value` in Vue didn't work, which is why the frontend didn't update when changing the editor value programmatically. This PR leverages the new `_update_method` to tell the client to always call `setEditorValue()` after receiving an update.