### PR TITLE
docs(upload_documentation.py): update documentation on ui.upload to use new parameter name

### DIFF
--- a/website/documentation/content/upload_documentation.py
+++ b/website/documentation/content/upload_documentation.py
@@ -38,7 +38,7 @@ def show_file_content() -> None:
 
 @doc.demo('Uploading large files', '''
     Large file uploads may encounter issues due to the default file size parameter set within the underlying Starlette library.
-    To ensure smooth uploads of larger files, it is recommended to increase the `max_file_size` parameter in Starlette's `MultiPartParser` class from the default of `1024 * 1024` (1 MB) to a higher limit that aligns with the expected file sizes.
+    To ensure smooth uploads of larger files, it is recommended to increase the `spool_max_size` parameter in Starlette's `MultiPartParser` class from the default of `1024 * 1024` (1 MB) to a higher limit that aligns with the expected file sizes.
 
     This demo increases Starlette Multiparser's `max_file_size` to be kept in RAM to 5 MB.
     This change allows the system to handle larger files more efficiently by keeping them in RAM, thus avoiding the need to write data to temporary files on disk and preventing upload "stuttering".
@@ -48,7 +48,7 @@ def show_file_content() -> None:
 def uploading_large_files() -> None:
     from starlette.formparsers import MultiPartParser
 
-    MultiPartParser.max_file_size = 1024 * 1024 * 5  # 5 MB
+    MultiPartParser.spool_max_size = 1024 * 1024 * 5  # 5 MB
 
     ui.upload(on_upload=lambda e: ui.notify(f'Uploaded {e.name}')).classes('max-w-full')
 


### PR DESCRIPTION
Following the method described in the docs [here](https://nicegui.io/documentation/upload#uploading_large_files) no longer works. 

I did some digging and it's because of changes to starlette:
* `MultiPartParser`: Rename `max_file_size` to `spool_max_size` [#2780](https://github.com/encode/starlette/pull/2780).