### PR TITLE
Properly await coroutines registered with app.on_shutdown

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,12 @@ jobs:
           poetry run pip install -r tests/requirements.txt
           # try fix issue with importlib_resources
           poetry run pip install importlib-resources
-      # - name: test startup
-      #   run: poetry run ./test_startup.sh
+      - name: test startup
+        run: poetry run ./test_startup.sh
       - name: setup chromedriver
         uses: nanasess/setup-chromedriver@v2.3.0
       - name: pytest
-        run: poetry run pytest -k "test_user_simulation"
+        run: poetry run pytest
 
   slack:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: setup chromedriver
         uses: nanasess/setup-chromedriver@v2.3.0
       - name: pytest
-        run: poetry run pytest
+        run: poetry run pytest -s -v -W always
 
   slack:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,12 @@ jobs:
           poetry run pip install -r tests/requirements.txt
           # try fix issue with importlib_resources
           poetry run pip install importlib-resources
-      - name: test startup
-        run: poetry run ./test_startup.sh
+      # - name: test startup
+      #   run: poetry run ./test_startup.sh
       - name: setup chromedriver
         uses: nanasess/setup-chromedriver@v2.3.0
       - name: pytest
-        run: poetry run pytest
+        run: poetry run pytest -k "test_user_simulation"
 
   slack:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: setup chromedriver
         uses: nanasess/setup-chromedriver@v2.3.0
       - name: pytest
-        run: poetry run pytest -s -v -W always
+        run: poetry run pytest
 
   slack:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
       - name: set up Poetry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: set up Poetry

--- a/.github/workflows/update_version.py
+++ b/.github/workflows/update_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import sys
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 if __name__ == '__main__':
@@ -20,5 +20,5 @@ if __name__ == '__main__':
         if line.startswith('version: '):
             lines[i] = f'version: {version}'
         if line.startswith('date-released: '):
-            lines[i] = f'date-released: "{datetime.now(UTC).strftime(r"%Y-%m-%d")}"'
+            lines[i] = f'date-released: "{datetime.now(timezone.utc).strftime(r"%Y-%m-%d")}"'
     path.write_text('\n'.join(lines) + '\n', encoding='utf-8')

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import gzip
 import json
 import logging
@@ -11,6 +10,7 @@ from uuid import uuid4
 
 import socketio
 import socketio.exceptions
+import wait_for2
 
 from . import background_tasks, core, helpers
 from .client import Client
@@ -225,7 +225,7 @@ class Air:
         self.connecting = True
         try:
             if self.relay.connected:
-                await asyncio.wait_for(self.disconnect(), timeout=5)
+                await wait_for2.wait_for(self.disconnect(), timeout=5)
             self.log.debug('Connecting...')
             await self.relay.connect(
                 f'{RELAY_HOST}?device_token={self.token}',

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -270,10 +270,10 @@ class Air:
 def connect() -> None:
     """Connect to the NiceGUI On Air server if there is an air instance."""
     if core.air:
-        background_tasks.create(core.air.connect())
+        background_tasks.create(core.air.connect(), name='On Air connect')
 
 
 def disconnect() -> None:
     """Disconnect from the NiceGUI On Air server if there is an air instance."""
     if core.air:
-        background_tasks.create(core.air.disconnect())
+        background_tasks.create(core.air.disconnect(), name='On Air disconnect')

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -10,7 +10,6 @@ from uuid import uuid4
 
 import socketio
 import socketio.exceptions
-import wait_for2
 
 from . import background_tasks, core, helpers
 from .client import Client
@@ -225,7 +224,7 @@ class Air:
         self.connecting = True
         try:
             if self.relay.connected:
-                await wait_for2.wait_for(self.disconnect(), timeout=5)
+                await helpers.wait_for(self.disconnect(), timeout=5)
             self.log.debug('Connecting...')
             await self.relay.connect(
                 f'{RELAY_HOST}?device_token={self.token}',

--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -72,7 +72,7 @@ class App(FastAPI):
         for t in self._startup_handlers:
             Client.auto_index_client.safe_invoke(t)
         self.on_shutdown(self.storage.on_shutdown)
-        self.on_shutdown(background_tasks.on_shutdown)
+        self.on_shutdown(background_tasks.teardown)
         self._state = State.STARTED
 
     async def stop(self) -> None:

--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -71,6 +71,8 @@ class App(FastAPI):
         self._state = State.STARTING
         for t in self._startup_handlers:
             Client.auto_index_client.safe_invoke(t)
+        self.on_shutdown(self.storage.on_shutdown)
+        self.on_shutdown(background_tasks.on_shutdown)
         self._state = State.STARTED
 
     def stop(self) -> None:

--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -46,8 +46,6 @@ class App(FastAPI):
         self._disconnect_handlers: List[Union[Callable[..., Any], Awaitable]] = []
         self._exception_handlers: List[Callable[..., Any]] = [log.exception]
 
-        self.on_shutdown(self.storage.on_shutdown)
-
     @property
     def is_starting(self) -> bool:
         """Return whether NiceGUI is starting."""

--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -130,7 +130,7 @@ class App(FastAPI):
         for handler in self._exception_handlers:
             result = handler() if not inspect.signature(handler).parameters else handler(exception)
             if helpers.is_coroutine_function(handler):
-                background_tasks.create(result)
+                background_tasks.create(result, name=f'exception {handler.__name__}')
 
     def shutdown(self) -> None:
         """Shut down NiceGUI.

--- a/nicegui/app/range_response.py
+++ b/nicegui/app/range_response.py
@@ -1,6 +1,6 @@
 import hashlib
 import mimetypes
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Generator
 
@@ -13,7 +13,7 @@ mimetypes.init()
 def get_range_response(file: Path, request: Request, chunk_size: int) -> Response:
     """Get a Response for the given file, supporting range-requests, E-Tag and Last-Modified."""
     file_size = file.stat().st_size
-    last_modified_time = datetime.fromtimestamp(file.stat().st_mtime, UTC)
+    last_modified_time = datetime.fromtimestamp(file.stat().st_mtime, timezone.utc)
     start = 0
     end = file_size - 1
     status_code = 200

--- a/nicegui/app/range_response.py
+++ b/nicegui/app/range_response.py
@@ -1,6 +1,6 @@
 import hashlib
 import mimetypes
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Generator
 
@@ -13,7 +13,7 @@ mimetypes.init()
 def get_range_response(file: Path, request: Request, chunk_size: int) -> Response:
     """Get a Response for the given file, supporting range-requests, E-Tag and Last-Modified."""
     file_size = file.stat().st_size
-    last_modified_time = datetime.utcfromtimestamp(file.stat().st_mtime)
+    last_modified_time = datetime.fromtimestamp(file.stat().st_mtime, UTC)
     start = 0
     end = file_size - 1
     status_code = 200

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -84,8 +84,9 @@ async def _cancel_all(tasks: set[asyncio.Task]) -> None:
         try:
             await asyncio.wait(tasks, timeout=2.0)
         except asyncio.TimeoutError:
-            for task in [t for t in tasks if not t.done()]:
-                log.error(f'Task {task.get_name()} could not be aborted within timeout')
+            log.error('Could not cancel %s tasks within timeout: %s',
+                      len(tasks),
+                      ', '.join([t.get_name() for t in tasks if not t.done()]))
 
     running_tasks.clear()
     lazy_tasks_running.clear()

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -89,5 +89,7 @@ async def _cancel_all(tasks: set[asyncio.Task]) -> None:
                 if not task.done():
                     task_name = task.get_name() if hasattr(task, 'get_name') else 'unknown'
                     print(f'Task {task_name} could not be aborted within timeout')
+
+    await asyncio.sleep(0)  # ensure the loop can cancel the tasks before it stops
     running_tasks.clear()
     lazy_tasks_running.clear()

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -68,9 +68,9 @@ def _handle_task_result(task: asyncio.Task) -> None:
 
 async def on_shutdown() -> None:
     """Cancel all running tasks and coroutines on shutdown."""
-    for task in running_tasks:
+    for task in list(running_tasks):
         await _cancel_task(task)
-    for task in lazy_tasks_running.values():
+    for task in list(lazy_tasks_running.values()):
         await _cancel_task(task)
     for coroutine in lazy_coroutines_waiting.values():
         coroutine.close()

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 from typing import Any, Awaitable, Callable, Coroutine, Dict, Set
 
 from . import core, helpers
@@ -51,8 +52,13 @@ def create_lazy(coroutine: Awaitable, *, name: str) -> None:
 
 def await_on_shutdown(fn: Callable) -> Callable:
     """Tag a coroutine function so tasks created from it won't be cancelled during shutdown."""
-    functions_awaited_on_shutdown.add(fn)
-    return fn
+    @functools.wraps(fn)
+    async def wrapper(*args, **kwargs):
+        coro = fn(*args, **kwargs)
+        task = create(coro)
+        task._await_on_shutdown = True  # type: ignore[attr-defined]  # pylint: disable=protected-access
+        return task
+    return wrapper
 
 
 def _ensure_coroutine(awaitable: Awaitable[Any]) -> Coroutine[Any, Any, Any]:
@@ -79,7 +85,7 @@ async def teardown() -> None:
     while running_tasks or lazy_tasks_running:
         tasks = set(running_tasks) | set(lazy_tasks_running.values())
         for task in tasks:
-            if not task.done() and not task.cancelled() and not _should_await_on_shutdown(task):
+            if not task.done() and not task.cancelled() and not getattr(task, '_await_on_shutdown', False):
                 task.cancel()
         if tasks:
             await asyncio.sleep(0)  # NOTE: ensure the loop can cancel the tasks before it shuts down
@@ -93,11 +99,3 @@ async def teardown() -> None:
                 log.exception('Error while cancelling tasks')
     for coro in lazy_coroutines_waiting.values():
         coro.close()
-
-
-def _should_await_on_shutdown(task: asyncio.Task) -> bool:
-    try:
-        return any(fn.__code__ is task.get_coro().cr_frame.f_code  # type: ignore
-                   for fn in functions_awaited_on_shutdown)
-    except AttributeError:
-        return False

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -78,10 +78,16 @@ async def on_shutdown() -> None:
 
 
 async def _cancel_all(tasks: set[asyncio.Task]) -> None:
-    # Cancel all tasks
     for task in tasks:
         if not task.done():
             task.cancel()
-
+    if tasks:
+        try:
+            await asyncio.wait(tasks, timeout=2.0)
+        except asyncio.TimeoutError:
+            for task in tasks:
+                if not task.done():
+                    task_name = task.get_name() if hasattr(task, 'get_name') else 'unknown'
+                    print(f'Task {task_name} could not be aborted within timeout')
     running_tasks.clear()
     lazy_tasks_running.clear()

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -78,7 +78,7 @@ def _handle_task_result(task: asyncio.Task) -> None:
 async def teardown() -> None:
     """Cancel all running tasks and coroutines on shutdown. (For internal use only.)"""
     while running_tasks or lazy_tasks_running:
-        tasks = set(running_tasks) | set(lazy_tasks_running.values())
+        tasks = running_tasks | set(lazy_tasks_running.values())
         for task in tasks:
             if not task.done() and not task.cancelled() and not _should_await_on_shutdown(task):
                 task.cancel()

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -67,6 +67,7 @@ def _handle_task_result(task: asyncio.Task) -> None:
 
 
 async def on_shutdown() -> None:
+    """Cancel all running tasks and coroutines on shutdown."""
     current = asyncio.current_task()
     to_cancel = (
         set(running_tasks) |

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -76,13 +76,6 @@ def _handle_task_result(task: asyncio.Task) -> None:
         core.app.handle_exception(e)
 
 
-def _should_await_on_shutdown(task: asyncio.Task) -> bool:
-    try:
-        return any(fn.__code__ is task.get_coro().cr_frame.f_code for fn in functions_awaited_on_shutdown)
-    except AttributeError:
-        return False
-
-
 async def on_shutdown() -> None:
     """Cancel all running tasks and coroutines on shutdown."""
     while running_tasks or lazy_tasks_running:
@@ -102,3 +95,11 @@ async def on_shutdown() -> None:
                 log.exception('Error while cancelling tasks')
     for coro in lazy_coroutines_waiting.values():
         coro.close()
+
+
+def _should_await_on_shutdown(task: asyncio.Task) -> bool:
+    try:
+        return any(fn.__code__ is task.get_coro().cr_frame.f_code  # type: ignore
+                   for fn in functions_awaited_on_shutdown)
+    except AttributeError:
+        return False

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import weakref
 from typing import Any, Awaitable, Callable, Coroutine, Dict, Set
 
 from . import core, helpers
@@ -10,7 +11,7 @@ from .logging import log
 running_tasks: Set[asyncio.Task] = set()
 lazy_tasks_running: Dict[str, asyncio.Task] = {}
 lazy_coroutines_waiting: Dict[str, Coroutine[Any, Any, Any]] = {}
-functions_awaited_on_shutdown: Set[Callable] = set()
+functions_awaited_on_shutdown: weakref.WeakSet[Callable] = weakref.WeakSet()
 
 
 def create(coroutine: Awaitable, *, name: str = 'unnamed task') -> asyncio.Task:

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -85,7 +85,7 @@ async def on_shutdown() -> None:
         await asyncio.sleep(0)  # ensure the loop can cancel the tasks before it stops
         if tasks:
             try:
-                await wait_for2.wait_for(asyncio.gather(*tasks), return_exceptions=True, timeout=2.0)
+                await wait_for2.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=2.0)
             except asyncio.TimeoutError:
                 log.error('Could not cancel %s tasks within timeout: %s',
                           len(tasks),

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -11,7 +11,7 @@ lazy_tasks_running: Dict[str, asyncio.Task] = {}
 lazy_coroutines_waiting: Dict[str, Coroutine[Any, Any, Any]] = {}
 
 
-def create(coroutine: Awaitable, *, name: str = 'unnamed task') -> asyncio.Task:
+def create(awaitable: Awaitable, *, name: str = 'unnamed task') -> asyncio.Task:
     """Wraps a loop.create_task call and ensures there is an exception handler added to the task.
 
     If the task raises an exception, it is logged and handled by the global exception handlers.
@@ -19,8 +19,8 @@ def create(coroutine: Awaitable, *, name: str = 'unnamed task') -> asyncio.Task:
     See https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task.
     """
     assert core.loop is not None
-    coroutine = coroutine if asyncio.iscoroutine(coroutine) else asyncio.wait_for(coroutine, None)
-    task: asyncio.Task = core.loop.create_task(coroutine, name=name)
+    awaitable = awaitable if asyncio.iscoroutine(awaitable) else asyncio.wait_for(awaitable, None)
+    task: asyncio.Task = core.loop.create_task(awaitable, name=name)
     task.add_done_callback(_handle_task_result)
     running_tasks.add(task)
     task.add_done_callback(running_tasks.discard)

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -74,10 +74,10 @@ def _handle_task_result(task: asyncio.Task) -> None:
         core.app.handle_exception(e)
 
 
-async def on_shutdown() -> None:
-    """Cancel all running tasks and coroutines on shutdown."""
+async def teardown() -> None:
+    """Cancel all running tasks and coroutines on shutdown. (For internal use only.)"""
     while running_tasks or lazy_tasks_running:
-        tasks = (set(running_tasks) | set(lazy_tasks_running.values()))
+        tasks = set(running_tasks) | set(lazy_tasks_running.values())
         for task in tasks:
             if not task.done() and not task.cancelled() and not _should_await_on_shutdown(task):
                 task.cancel()
@@ -88,7 +88,7 @@ async def on_shutdown() -> None:
             except asyncio.TimeoutError:
                 log.error('Could not cancel %s tasks within timeout: %s',
                           len(tasks),
-                          ', '.join([t.get_name() for t in tasks if not t.done()]))
+                          ', '.join(t.get_name() for t in tasks if not t.done()))
             except Exception:
                 log.exception('Error while cancelling tasks')
     for coro in lazy_coroutines_waiting.values():

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -80,7 +80,7 @@ async def teardown() -> None:
     while running_tasks or lazy_tasks_running:
         tasks = running_tasks | set(lazy_tasks_running.values())
         for task in tasks:
-            if not task.done() and not task.cancelled() and not _should_await_on_shutdown(task):
+            if not task.done() and not task.cancelled() and not should_await_on_shutdown(task):
                 task.cancel()
         if tasks:
             await asyncio.sleep(0)  # NOTE: ensure the loop can cancel the tasks before it shuts down
@@ -96,7 +96,8 @@ async def teardown() -> None:
         coro.close()
 
 
-def _should_await_on_shutdown(task: asyncio.Task) -> bool:
+def should_await_on_shutdown(task: asyncio.Task) -> bool:
+    """Check if the task should be awaited on shutdown. (For internal use only.)"""
     try:
         return any(fn.__code__ is task.get_coro().cr_frame.f_code  # type: ignore
                    for fn in functions_awaited_on_shutdown)

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -54,3 +54,12 @@ def _handle_task_result(task: asyncio.Task) -> None:
         pass
     except Exception as e:
         core.app.handle_exception(e)
+
+
+def on_shutdown() -> None:
+    for task in running_tasks:
+        task.cancel()
+    for task in lazy_tasks_running.values():
+        task.cancel()
+    for coroutine in lazy_coroutines_waiting.values():
+        coroutine.close()

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -78,7 +78,7 @@ def _handle_task_result(task: asyncio.Task) -> None:
 
 def _should_await_on_shutdown(task: asyncio.Task) -> bool:
     try:
-        return any(fn.__code__ is task._coro.cr_frame.f_code for fn in functions_awaited_on_shutdown)  # pylint: disable=protected-access
+        return any(fn.__code__ is task.get_coro().cr_frame.f_code for fn in functions_awaited_on_shutdown)
     except AttributeError:
         return False
 

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Awaitable, Coroutine, Dict, Set
 
+import wait_for2
+
 from . import core
 from .logging import log
 
@@ -20,7 +22,7 @@ def create(awaitable: Awaitable, *, name: str = 'unnamed task') -> asyncio.Task:
     See https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task.
     """
     assert core.loop is not None
-    awaitable = awaitable if asyncio.iscoroutine(awaitable) else asyncio.wait_for(awaitable, None)
+    awaitable = awaitable if asyncio.iscoroutine(awaitable) else wait_for2.wait_for(awaitable, None)
     task: asyncio.Task = core.loop.create_task(awaitable, name=name)
     task.add_done_callback(_handle_task_result)
     running_tasks.add(task)

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -67,7 +67,10 @@ async def refresh_loop() -> None:
     """Refresh all bindings in an endless loop."""
     while True:
         _refresh_step()
-        await asyncio.sleep(core.app.config.binding_refresh_interval)
+        try:
+            await asyncio.sleep(core.app.config.binding_refresh_interval)
+        except asyncio.CancelledError:
+            break
 
 
 @contextmanager

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -280,7 +280,8 @@ class Client:
                 self._delete_tasks.pop(document_id)
                 if not self.shared:
                     self.delete()
-        self._delete_tasks[document_id] = background_tasks.create(delete_content())
+        self._delete_tasks[document_id] = \
+            background_tasks.create(delete_content(), name=f'delete content {document_id}')
 
     def _cancel_delete_task(self, document_id: str) -> None:
         if document_id in self._delete_tasks:
@@ -307,7 +308,7 @@ class Client:
                 async def func_with_client():
                     with self:
                         await func
-                background_tasks.create(func_with_client())
+                background_tasks.create(func_with_client(), name=f'client {self.id} {func.__name__}')
             else:
                 with self:
                     result = func(self) if len(inspect.signature(func).parameters) == 1 else func()
@@ -315,7 +316,7 @@ class Client:
                     async def result_with_client():
                         with self:
                             await result
-                    background_tasks.create(result_with_client())
+                    background_tasks.create(result_with_client(), name=f'client {self.id} {func.__name__}')
         except Exception as e:
             core.app.handle_exception(e)
 

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -303,12 +303,13 @@ class Client:
 
     def safe_invoke(self, func: Union[Callable[..., Any], Awaitable]) -> None:
         """Invoke the potentially async function in the client context and catch any exceptions."""
+        func_name = func.__name__ if hasattr(func, '__name__') else str(func)
         try:
             if isinstance(func, Awaitable):
                 async def func_with_client():
                     with self:
                         await func
-                background_tasks.create(func_with_client(), name=f'client {self.id} {func.__name__}')
+                background_tasks.create(func_with_client(), name=f'func with client {self.id} {func_name}')
             else:
                 with self:
                     result = func(self) if len(inspect.signature(func).parameters) == 1 else func()
@@ -316,7 +317,7 @@ class Client:
                     async def result_with_client():
                         with self:
                             await result
-                    background_tasks.create(result_with_client(), name=f'client {self.id} {func.__name__}')
+                    background_tasks.create(result_with_client(), name=f'result with client {self.id} {func_name}')
         except Exception as e:
             core.app.handle_exception(e)
 

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -313,7 +313,7 @@ class Client:
             else:
                 with self:
                     result = func(self) if len(inspect.signature(func).parameters) == 1 else func()
-                if helpers.is_coroutine_function(func):
+                if helpers.is_coroutine_function(func) and not isinstance(result, asyncio.Task):
                     async def result_with_client():
                         with self:
                             await result

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -379,4 +379,7 @@ class Client:
             except Exception:
                 # NOTE: make sure the loop doesn't crash
                 log.exception('Error while pruning clients')
-            await asyncio.sleep(10)
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                break

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -70,7 +70,7 @@ class ValidationElement(ValueElement):
                 self.error = await result
             if return_result:
                 raise NotImplementedError('The validate method cannot return results for async validation functions.')
-            background_tasks.create(await_error())
+            background_tasks.create(await_error(), name=f'validate {self.id}')
             return True
 
         if callable(self._validation):

--- a/nicegui/functions/refreshable.py
+++ b/nicegui/functions/refreshable.py
@@ -115,7 +115,7 @@ class refreshable(Generic[_P, _T]):
             if is_coroutine_function(self.func):
                 assert isinstance(result, Awaitable)
                 if core.loop and core.loop.is_running():
-                    background_tasks.create(result)
+                    background_tasks.create(result, name=f'refresh {self.func.__name__}')
                 else:
                     core.app.on_startup(result)
 

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -6,7 +6,7 @@ import socket
 import threading
 import time
 import webbrowser
-from collections.abc import Callable
+from collections.abc import Awaitable
 from pathlib import Path
 from typing import Any, Optional, Set, Tuple, Union
 
@@ -111,7 +111,7 @@ def event_type_to_camel_case(string: str) -> str:
     return '.'.join(kebab_to_camel_case(part) if part != '-' else part for part in string.split('.'))
 
 
-async def wait_for(fut: Callable, timeout: Optional[float] = None) -> None:
+async def wait_for(fut: Awaitable, timeout: Optional[float] = None) -> None:
     """Wait for a future to complete.
 
     This function is a wrapper around ``wait_for2.wait_for`` which is a drop-in replacement for ``asyncio.wait_for``.

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -6,8 +6,11 @@ import socket
 import threading
 import time
 import webbrowser
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Optional, Set, Tuple, Union
+
+import wait_for2
 
 from .logging import log
 
@@ -106,3 +109,12 @@ def kebab_to_camel_case(string: str) -> str:
 def event_type_to_camel_case(string: str) -> str:
     """Convert an event type string to camelCase."""
     return '.'.join(kebab_to_camel_case(part) if part != '-' else part for part in string.split('.'))
+
+
+async def wait_for(fut: Callable, timeout: Optional[float] = None) -> None:
+    """Wait for a future to complete.
+
+    This function is a wrapper around ``wait_for2.wait_for`` which is a drop-in replacement for ``asyncio.wait_for``.
+    It can be removed once we drop support for older versions than Python 3.13 which fixes ``asyncio.wait_for``.
+    """
+    return await wait_for2.wait_for(fut, timeout)

--- a/nicegui/javascript_request.py
+++ b/nicegui/javascript_request.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, ClassVar, Dict
 
-import wait_for2
+from . import helpers
 
 
 class JavaScriptRequest:
@@ -25,7 +25,7 @@ class JavaScriptRequest:
 
     def __await__(self) -> Any:
         try:
-            yield from wait_for2.wait_for(self._event.wait(), self.timeout).__await__()
+            yield from helpers.wait_for(self._event.wait(), self.timeout).__await__()
         except asyncio.TimeoutError as e:
             raise TimeoutError(f'JavaScript did not respond within {self.timeout:.1f} s') from e
         else:

--- a/nicegui/javascript_request.py
+++ b/nicegui/javascript_request.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import Any, ClassVar, Dict
 
+import wait_for2
+
 
 class JavaScriptRequest:
     _instances: ClassVar[Dict[str, JavaScriptRequest]] = {}
@@ -23,7 +25,7 @@ class JavaScriptRequest:
 
     def __await__(self) -> Any:
         try:
-            yield from asyncio.wait_for(self._event.wait(), self.timeout).__await__()
+            yield from wait_for2.wait_for(self._event.wait(), self.timeout).__await__()
         except asyncio.TimeoutError as e:
             raise TimeoutError(f'JavaScript did not respond within {self.timeout:.1f} s') from e
         else:

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import _thread
-import multiprocessing
 import multiprocessing as mp
 import queue
 import socket
@@ -93,8 +92,8 @@ def _start_window_method_executor(window: webview.Window,
             except Exception:
                 log.exception(f'error in window.{method_name}')
         # NOTE: we need to cleanup the multiprocessing queues, see https://github.com/zauberzeug/nicegui/issues/4131
-        if hasattr(multiprocessing.util, '_exit_function'):  # to make mypy happy
-            multiprocessing.util._exit_function()  # pylint: disable=protected-access
+        if hasattr(mp.util, '_exit_function'):  # to make mypy happy
+            mp.util._exit_function()  # pylint: disable=protected-access
 
     Thread(target=window_method_executor).start()
 

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import _thread
-import multiprocessing
 import multiprocessing as mp
 import queue
 import socket
@@ -92,8 +91,6 @@ def _start_window_method_executor(window: webview.Window,
                 time.sleep(0.016)  # NOTE: avoid issue https://github.com/zauberzeug/nicegui/issues/2482 on Windows
             except Exception:
                 log.exception(f'error in window.{method_name}')
-        # NOTE: we need to cleanup the multiprocessing queues, see https://github.com/zauberzeug/nicegui/issues/4131
-        multiprocessing.util._exit_function()  # pylint: disable=protected-access
 
     Thread(target=window_method_executor).start()
 

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -93,7 +93,8 @@ def _start_window_method_executor(window: webview.Window,
             except Exception:
                 log.exception(f'error in window.{method_name}')
         # NOTE: we need to cleanup the multiprocessing queues, see https://github.com/zauberzeug/nicegui/issues/4131
-        multiprocessing.util._exit_function()  # pylint: disable=protected-access
+        if hasattr(multiprocessing.util, '_exit_function'):  # to make mypy happy
+            multiprocessing.util._exit_function()  # pylint: disable=protected-access
 
     Thread(target=window_method_executor).start()
 

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -93,8 +93,7 @@ def _start_window_method_executor(window: webview.Window,
             except Exception:
                 log.exception(f'error in window.{method_name}')
         # NOTE: we need to cleanup the multiprocessing queues, see https://github.com/zauberzeug/nicegui/issues/4131
-        if hasattr(multiprocessing.util, '_exit_function'):  # to make mypy happy
-            multiprocessing.util._exit_function()  # pylint: disable=protected-access
+        multiprocessing.util._exit_function()  # pylint: disable=protected-access
 
     Thread(target=window_method_executor).start()
 

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import _thread
+import multiprocessing
 import multiprocessing as mp
 import queue
 import socket
@@ -92,8 +93,8 @@ def _start_window_method_executor(window: webview.Window,
             except Exception:
                 log.exception(f'error in window.{method_name}')
         # NOTE: we need to cleanup the multiprocessing queues, see https://github.com/zauberzeug/nicegui/issues/4131
-        if hasattr(mp.util, '_exit_function'):  # to make mypy happy
-            mp.util._exit_function()  # pylint: disable=protected-access
+        if hasattr(multiprocessing.util, '_exit_function'):  # to make mypy happy
+            multiprocessing.util._exit_function()  # pylint: disable=protected-access
 
     Thread(target=window_method_executor).start()
 

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import _thread
+import multiprocessing
 import multiprocessing as mp
 import queue
 import socket
@@ -91,6 +92,8 @@ def _start_window_method_executor(window: webview.Window,
                 time.sleep(0.016)  # NOTE: avoid issue https://github.com/zauberzeug/nicegui/issues/2482 on Windows
             except Exception:
                 log.exception(f'error in window.{method_name}')
+        # NOTE: we need to cleanup the multiprocessing queues, see https://github.com/zauberzeug/nicegui/issues/4131
+        multiprocessing.util._exit_function()  # pylint: disable=protected-access
 
     Thread(target=window_method_executor).start()
 

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -126,6 +126,7 @@ async def _startup() -> None:
         app.add_route('/favicon.ico', lambda _: FileResponse(Path(__file__).parent / 'static' / 'favicon.ico'))
     core.loop = asyncio.get_running_loop()
     app.start()
+    app.on_shutdown(app.storage.on_shutdown)
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(Client.prune_instances(), name='prune clients')
     background_tasks.create(Slot.prune_stacks(), name='prune slot stacks')

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -126,8 +126,6 @@ async def _startup() -> None:
         app.add_route('/favicon.ico', lambda _: FileResponse(Path(__file__).parent / 'static' / 'favicon.ico'))
     core.loop = asyncio.get_running_loop()
     app.start()
-    app.on_shutdown(app.storage.on_shutdown)
-    app.on_shutdown(background_tasks.on_shutdown)
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(Client.prune_instances(), name='prune clients')
     background_tasks.create(Slot.prune_stacks(), name='prune slot stacks')

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -142,7 +142,8 @@ async def _shutdown() -> None:
     await app.stop()
     run.tear_down()
     # NOTE: we need to cleanup the multiprocessing queues, see https://github.com/zauberzeug/nicegui/issues/4131
-    multiprocessing.util._exit_function()  # pylint: disable=protected-access
+    if hasattr(multiprocessing.util, '_exit_function'):  # to make mypy happy
+        multiprocessing.util._exit_function()  # pylint: disable=protected-access
 
 
 @app.exception_handler(404)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -127,6 +127,7 @@ async def _startup() -> None:
     core.loop = asyncio.get_running_loop()
     app.start()
     app.on_shutdown(app.storage.on_shutdown)
+    app.on_shutdown(background_tasks.on_shutdown)
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(Client.prune_instances(), name='prune clients')
     background_tasks.create(Slot.prune_stacks(), name='prune slot stacks')

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -138,7 +138,7 @@ async def _shutdown() -> None:
     if app.native.main_window:
         app.native.main_window.signal_server_shutdown()
     air.disconnect()
-    app.stop()
+    await app.stop()
     run.tear_down()
 
 

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -142,8 +142,7 @@ async def _shutdown() -> None:
     await app.stop()
     run.tear_down()
     # NOTE: we need to cleanup the multiprocessing queues, see https://github.com/zauberzeug/nicegui/issues/4131
-    if hasattr(multiprocessing.util, '_exit_function'):  # to make mypy happy
-        multiprocessing.util._exit_function()  # pylint: disable=protected-access
+    multiprocessing.util._exit_function()  # pylint: disable=protected-access
 
 
 @app.exception_handler(404)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -1,5 +1,6 @@
 import asyncio
 import mimetypes
+import multiprocessing
 import urllib.parse
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -140,6 +141,8 @@ async def _shutdown() -> None:
     air.disconnect()
     await app.stop()
     run.tear_down()
+    # NOTE: we need to cleanup the multiprocessing queues, see https://github.com/zauberzeug/nicegui/issues/4131
+    multiprocessing.util._exit_function()  # pylint: disable=protected-access
 
 
 @app.exception_handler(404)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -1,6 +1,5 @@
 import asyncio
 import mimetypes
-import multiprocessing
 import urllib.parse
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -141,8 +140,6 @@ async def _shutdown() -> None:
     air.disconnect()
     await app.stop()
     run.tear_down()
-    # NOTE: we need to cleanup the multiprocessing queues, see https://github.com/zauberzeug/nicegui/issues/4131
-    multiprocessing.util._exit_function()  # pylint: disable=protected-access
 
 
 @app.exception_handler(404)

--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -5,9 +5,7 @@ import time
 from collections import deque
 from typing import TYPE_CHECKING, Any, Deque, Dict, Optional, Tuple
 
-import wait_for2
-
-from . import background_tasks, core
+from . import background_tasks, core, helpers
 
 if TYPE_CHECKING:
     from .client import Client
@@ -74,7 +72,7 @@ class Outbox:
             try:
                 if not self._enqueue_event.is_set():
                     try:
-                        await wait_for2.wait_for(self._enqueue_event.wait(), timeout=1.0)
+                        await helpers.wait_for(self._enqueue_event.wait(), timeout=1.0)
                     except (TimeoutError, asyncio.TimeoutError):
                         continue
 

--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -5,6 +5,8 @@ import time
 from collections import deque
 from typing import TYPE_CHECKING, Any, Deque, Dict, Optional, Tuple
 
+import wait_for2
+
 from . import background_tasks, core
 
 if TYPE_CHECKING:
@@ -72,7 +74,7 @@ class Outbox:
             try:
                 if not self._enqueue_event.is_set():
                     try:
-                        await asyncio.wait_for(self._enqueue_event.wait(), timeout=1.0)
+                        await wait_for2.wait_for(self._enqueue_event.wait(), timeout=1.0)
                     except (TimeoutError, asyncio.TimeoutError):
                         continue
 

--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -101,7 +101,8 @@ class Outbox:
                         await coro
                     except Exception as e:
                         core.app.handle_exception(e)
-
+            except asyncio.CancelledError:
+                break
             except Exception as e:
                 core.app.handle_exception(e)
                 await asyncio.sleep(0.1)

--- a/nicegui/persistence/file_persistent_dict.py
+++ b/nicegui/persistence/file_persistent_dict.py
@@ -48,10 +48,10 @@ class FilePersistentDict(PersistentDict):
         async def backup() -> None:
             async with aiofiles.open(self.filepath, 'w', encoding=self.encoding) as f:
                 await f.write(json.dumps(self, indent=self.indent))
-        if core.loop:
+        if core.loop and core.loop.is_running():
             background_tasks.create_lazy(backup(), name=self.filepath.stem)
         else:
-            core.app.on_startup(backup())
+            self.filepath.write_text(json.dumps(self, indent=self.indent), encoding=self.encoding)
 
     def clear(self) -> None:
         super().clear()

--- a/nicegui/persistence/file_persistent_dict.py
+++ b/nicegui/persistence/file_persistent_dict.py
@@ -45,12 +45,13 @@ class FilePersistentDict(PersistentDict):
                 return
             self.filepath.parent.mkdir(exist_ok=True)
 
-        async def backup() -> None:
+        @background_tasks.await_on_shutdown
+        async def async_backup() -> None:
             async with aiofiles.open(self.filepath, 'w', encoding=self.encoding) as f:
                 await f.write(json.dumps(self, indent=self.indent))
 
         if core.loop and core.loop.is_running():
-            background_tasks.create_lazy(backup(), name=self.filepath.stem)
+            background_tasks.create_lazy(async_backup(), name=self.filepath.stem)
         else:
             self.filepath.write_text(json.dumps(self, indent=self.indent), encoding=self.encoding)
 

--- a/nicegui/persistence/file_persistent_dict.py
+++ b/nicegui/persistence/file_persistent_dict.py
@@ -48,6 +48,7 @@ class FilePersistentDict(PersistentDict):
         async def backup() -> None:
             async with aiofiles.open(self.filepath, 'w', encoding=self.encoding) as f:
                 await f.write(json.dumps(self, indent=self.indent))
+
         if core.loop and core.loop.is_running():
             background_tasks.create_lazy(backup(), name=self.filepath.stem)
         else:

--- a/nicegui/slot.py
+++ b/nicegui/slot.py
@@ -59,7 +59,10 @@ class Slot:
             except Exception:
                 # NOTE: make sure the loop doesn't crash
                 log.exception('Error while pruning slot stacks')
-            await asyncio.sleep(10)
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                break
 
 
 def get_task_id() -> int:

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -211,7 +211,7 @@ class Storage:
             self.path.rmdir()
 
     async def on_shutdown(self) -> None:
-        """Close all persistent storage."""
+        """Close all persistent storage. (For internal use only.)"""
         for user in self._users.values():
             await user.close()
         await self._general.close()

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -189,7 +189,10 @@ class Storage:
                     if isinstance(tab, PersistentDict):
                         await tab.close()
                     del self._tabs[tab_id]
-            await asyncio.sleep(PURGE_INTERVAL)
+            try:
+                await asyncio.sleep(PURGE_INTERVAL)
+            except asyncio.CancelledError:
+                break
 
     def clear(self) -> None:
         """Clears all storage."""

--- a/nicegui/testing/screen_plugin.py
+++ b/nicegui/testing/screen_plugin.py
@@ -75,11 +75,11 @@ def screen(nicegui_reset_globals,  # noqa: F811, pylint: disable=unused-argument
     prepare_simulation(request)
     screen_ = Screen(nicegui_driver, caplog)
     yield screen_
-    logs = screen_.caplog.get_records('call')
+    logs = [record for record in screen_.caplog.get_records('call') if record.levelname == 'ERROR']
     if screen_.is_open:
         screen_.shot(request.node.name)
     screen_.stop_server()
     if DOWNLOAD_DIR.exists():
         shutil.rmtree(DOWNLOAD_DIR)
     if logs:
-        pytest.fail('There were unexpected logs. See "Captured log call" below.', pytrace=False)
+        pytest.fail('There were unexpected ERROR logs.', pytrace=False)

--- a/nicegui/testing/user_download.py
+++ b/nicegui/testing/user_download.py
@@ -21,7 +21,8 @@ class UserDownload(Download):
         self.user = user
 
     def __call__(self, src: Union[str, Path, bytes], filename: Optional[str] = None, media_type: str = '') -> Any:
-        background_tasks.create(self._get(src), name=f'download {src}')
+        background_tasks.create(self._get(src),
+                                name=f'download {str(src[:10]) + "..." if isinstance(src, bytes) else src}')
 
     def file(self, path: Union[str, Path], filename: Optional[str] = None, media_type: str = '') -> None:
         self(path)

--- a/nicegui/testing/user_download.py
+++ b/nicegui/testing/user_download.py
@@ -21,7 +21,7 @@ class UserDownload(Download):
         self.user = user
 
     def __call__(self, src: Union[str, Path, bytes], filename: Optional[str] = None, media_type: str = '') -> Any:
-        background_tasks.create(self._get(src))
+        background_tasks.create(self._get(src), name=f'download {src}')
 
     def file(self, path: Union[str, Path], filename: Optional[str] = None, media_type: str = '') -> None:
         self(path)

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -72,7 +72,7 @@ class UserInteraction(Generic[T]):
             for element in self.elements:
                 if isinstance(element, ui.link):
                     href = element.props.get('href', '#')
-                    background_tasks.create(self.user.open(href))
+                    background_tasks.create(self.user.open(href), name=f'open {href}')
                     return self
 
                 if isinstance(element, ui.select):

--- a/nicegui/testing/user_navigate.py
+++ b/nicegui/testing/user_navigate.py
@@ -21,20 +21,23 @@ class UserNavigate(Navigate):
             # NOTE navigation to an element does not do anything in the user simulation (the whole content is always visible)
             return
         path = Client.page_routes[target] if callable(target) else target
-        background_tasks.create(self.user.open(path))
+        background_tasks.create(self.user.open(path), name=f'navigate to {path}')
 
     def back(self) -> None:
         current = self.user.back_history.pop()
         self.user.forward_history.append(current)
         target = self.user.back_history.pop()
-        background_tasks.create(self.user.open(target, clear_forward_history=False))
+        background_tasks.create(self.user.open(target, clear_forward_history=False), name=f'navigate back to {target}')
 
     def forward(self) -> None:
         if not self.user.forward_history:
             return
         target = self.user.forward_history[0]
         del self.user.forward_history[0]
-        background_tasks.create(self.user.open(target, clear_forward_history=False))
+        background_tasks.create(self.user.open(target, clear_forward_history=False),
+                                name=f'navigate forward to {target}')
 
     def reload(self) -> None:
-        background_tasks.create(self.user.open(self.user.back_history.pop(), clear_forward_history=False))
+        target = self.user.back_history.pop()
+        background_tasks.create(self.user.open(target, clear_forward_history=False),
+                                name=f'navigate reload to {target}')

--- a/poetry.lock
+++ b/poetry.lock
@@ -3952,6 +3952,17 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "s
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"GraalVM\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
 [[package]]
+name = "wait-for2"
+version = "0.3.2"
+description = "Asyncio wait_for that can handle simultaneous cancellation and future completion."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "wait_for2-0.3.2.tar.gz", hash = "sha256:93863026dc35f3471104ecf7de1f4a0b31f4c8b12a2241c0d6ee26dcc0c2092a"},
+]
+
+[[package]]
 name = "watchdog"
 version = "4.0.2"
 description = "Filesystem events monitoring"
@@ -4397,4 +4408,4 @@ sass = ["libsass"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8"
-content-hash = "4b89540e256cd3cb8b286c35f5453fbeafc757ea7a85bf342fd48c79f2f02bb6"
+content-hash = "c30b4e4324685f2f9bdbf9a42efe13f216a87f8aa113ad6922f11701a823c375"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ module = [
     "sass",
     "socketio.*",
     "vbuild",
+    "wait_for2",
     "webview.*", # can be removed with next pywebview release
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ requests = ">=2.32.0" # https://github.com/zauberzeug/nicegui/security/dependabo
 urllib3 = ">=1.26.18,!=2.0.0,!=2.0.1,!=2.0.2,!=2.0.3,!=2.0.4,!=2.0.5,!=2.0.6,!=2.0.7,!=2.1.0,!=2.2.0,!=2.2.1" # https://github.com/zauberzeug/nicegui/security/dependabot/34
 certifi = ">=2024.07.04" # https://github.com/zauberzeug/nicegui/security/dependabot/35
 redis = { version = ">=4.0.0", optional = true }
+wait_for2 = ">=0.3.2"
 
 [tool.poetry.extras]
 native = ["pywebview"]

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -1,0 +1,75 @@
+import asyncio
+
+from nicegui import background_tasks, ui
+from nicegui.testing import User
+
+# pylint: disable=missing-function-docstring
+
+
+async def test_awaiting_background_tasks_on_shutdown(user: User):
+
+    async def one():
+        nonlocal cancelled_one
+        try:
+            print('one start')
+            await asyncio.sleep(1)
+            print('one end')
+        except asyncio.CancelledError:
+            cancelled_one = True
+
+    @background_tasks.await_on_shutdown
+    async def two():
+        nonlocal cancelled_two
+        try:
+            print('two start')
+            await asyncio.sleep(1)
+            print('two end')
+        except asyncio.CancelledError:
+            cancelled_two = True
+
+    cancelled_one = False
+    cancelled_two = False
+
+    await user.open('/')
+    background_tasks.create(one(), name='one')
+    background_tasks.create(two(), name='two')
+    await asyncio.sleep(0.1)
+    # NOTE: teardown is called on shutdown; here we call it directly to test the teardown logic while test is still running
+    await background_tasks.teardown()
+    assert cancelled_one
+    assert not cancelled_two
+
+
+async def test_awaiting_click_handler_background_tasks_on_shutdown(user: User):
+
+    async def one():
+        nonlocal cancelled_one
+        try:
+            print('one start')
+            await asyncio.sleep(1)
+            print('one end')
+        except asyncio.CancelledError:
+            cancelled_one = True
+
+    @background_tasks.await_on_shutdown
+    async def two():
+        nonlocal cancelled_two
+        try:
+            print('two start')
+            await asyncio.sleep(1)
+            print('two end')
+        except asyncio.CancelledError:
+            cancelled_two = True
+
+    cancelled_one = False
+    cancelled_two = False
+    ui.button('One', on_click=lambda: background_tasks.create(one(), name='one'))
+    ui.button('Two', on_click=lambda: background_tasks.create(two(), name='two'))
+
+    await user.open('/')
+    user.find('One').click()
+    user.find('Two').click()
+    # NOTE: teardown is called on shutdown; here we call it directly to test the teardown logic while test is still running
+    await background_tasks.teardown()
+    assert cancelled_one
+    assert not cancelled_two

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -1,19 +1,21 @@
 import asyncio
 
+import pytest
+
 from nicegui import background_tasks, ui
 from nicegui.testing import User
 
 # pylint: disable=missing-function-docstring
 
 
-async def test_awaiting_background_tasks_on_shutdown(user: User):
+# NOTE: click handlers used to wrap background_task in a background_task (see https://github.com/zauberzeug/nicegui/pull/4641#issuecomment-2837448265)
+@pytest.mark.parametrize('with_click_handler', [False, True])
+async def test_awaiting_background_tasks_on_shutdown(user: User, with_click_handler: bool):
 
     async def one():
         nonlocal cancelled_one
         try:
-            print('one start')
             await asyncio.sleep(1)
-            print('one end')
         except asyncio.CancelledError:
             cancelled_one = True
 
@@ -21,43 +23,7 @@ async def test_awaiting_background_tasks_on_shutdown(user: User):
     async def two():
         nonlocal cancelled_two
         try:
-            print('two start')
             await asyncio.sleep(1)
-            print('two end')
-        except asyncio.CancelledError:
-            cancelled_two = True
-
-    cancelled_one = False
-    cancelled_two = False
-
-    await user.open('/')
-    background_tasks.create(one(), name='one')
-    background_tasks.create(two(), name='two')
-    await asyncio.sleep(0.1)
-    # NOTE: teardown is called on shutdown; here we call it directly to test the teardown logic while test is still running
-    await background_tasks.teardown()
-    assert cancelled_one
-    assert not cancelled_two
-
-
-async def test_awaiting_click_handler_background_tasks_on_shutdown(user: User):
-
-    async def one():
-        nonlocal cancelled_one
-        try:
-            print('one start')
-            await asyncio.sleep(1)
-            print('one end')
-        except asyncio.CancelledError:
-            cancelled_one = True
-
-    @background_tasks.await_on_shutdown
-    async def two():
-        nonlocal cancelled_two
-        try:
-            print('two start')
-            await asyncio.sleep(1)
-            print('two end')
         except asyncio.CancelledError:
             cancelled_two = True
 
@@ -67,9 +33,15 @@ async def test_awaiting_click_handler_background_tasks_on_shutdown(user: User):
     ui.button('Two', on_click=lambda: background_tasks.create(two(), name='two'))
 
     await user.open('/')
-    user.find('One').click()
-    user.find('Two').click()
-    await asyncio.sleep(0.1)
+    if with_click_handler:
+        user.find('One').click()
+        user.find('Two').click()
+    else:
+        background_tasks.create(one(), name='one')
+        background_tasks.create(two(), name='two')
+
+    await asyncio.sleep(0.1)  # NOTE: we need to wait for the tasks to be created
+
     # NOTE: teardown is called on shutdown; here we call it directly to test the teardown logic while test is still running
     await background_tasks.teardown()
     assert cancelled_one

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -69,6 +69,7 @@ async def test_awaiting_click_handler_background_tasks_on_shutdown(user: User):
     await user.open('/')
     user.find('One').click()
     user.find('Two').click()
+    await asyncio.sleep(0.1)
     # NOTE: teardown is called on shutdown; here we call it directly to test the teardown logic while test is still running
     await background_tasks.teardown()
     assert cancelled_one

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -11,24 +11,21 @@ from nicegui.testing import User
 # NOTE: click handlers, and system events used to wrap background_task in a background_task (see https://github.com/zauberzeug/nicegui/pull/4641#issuecomment-2837448265)
 @pytest.mark.parametrize('strategy', ['direct', 'click', 'system'])
 async def test_awaiting_background_tasks_on_shutdown(user: User, strategy: str):
+    cancelled = set()
 
     async def one():
-        nonlocal cancelled_one
         try:
             await asyncio.sleep(1)
         except asyncio.CancelledError:
-            cancelled_one = True
+            cancelled.add('one')
 
     @background_tasks.await_on_shutdown
     async def two():
-        nonlocal cancelled_two
         try:
             await asyncio.sleep(1)
         except asyncio.CancelledError:
-            cancelled_two = True
+            cancelled.add('two')
 
-    cancelled_one = False
-    cancelled_two = False
     ui.button('One', on_click=lambda: background_tasks.create(one(), name='one'))
     ui.button('Two', on_click=lambda: background_tasks.create(two(), name='two'))
 
@@ -49,5 +46,4 @@ async def test_awaiting_background_tasks_on_shutdown(user: User, strategy: str):
 
     # NOTE: teardown is called on shutdown; here we call it directly to test the teardown logic while test is still running
     await background_tasks.teardown()
-    assert cancelled_one
-    assert not cancelled_two
+    assert cancelled == {'one'}

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -446,7 +446,7 @@ def map_of_nicegui():
 
         - `create()`: create a background task
         - `create_lazy()`: prevent two tasks with the same name from running at the same time
-        - `@await_on_shutdown`: mark a coroutine function to be awaited during shutdown (by default all background tasks are cancelled)
+        - `await_on_shutdown`: mark a coroutine function to be awaited during shutdown (by default all background tasks are cancelled)
 
         #### `run`
 

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -446,6 +446,7 @@ def map_of_nicegui():
 
         - `create()`: create a background task
         - `create_lazy()`: prevent two tasks with the same name from running at the same time
+        - `@await_on_shutdown`: mark a coroutine function to be awaited during shutdown (by default all background tasks are cancelled)
 
         #### `run`
 

--- a/website/documentation/content/section_configuration_deployment.py
+++ b/website/documentation/content/section_configuration_deployment.py
@@ -82,8 +82,8 @@ def env_var_demo():
 
 
 doc.text('Background Tasks', '''
-    `background_tasks.create()` allows you to run an async function in the background and returns a task object.
-    By default these tasks will be automatically cancelled during shutdown.
+    `background_tasks.create()` allows you to run an async function in the background and return a task object.
+    By default the task will be automatically cancelled during shutdown.
     You can prevent this by using the `@background_tasks.await_on_shutdown` decorator.
     This is useful for tasks that need to be executed even after the app has been shut down.
 ''')
@@ -91,45 +91,44 @@ doc.text('Background Tasks', '''
 
 @doc.ui
 def background_tasks_demo():
-
     with ui.row().classes('w-full items-stretch'):
         with python_window(classes='max-w-lg w-full'):
             ui.markdown('''
-                    ```python
-                    from nicegui import app, background_tasks
+                ```python
+                from nicegui import app, background_tasks
 
-                    async def some_background_task():
-                        await asyncio.sleep(2)
-                        app.storage.client['msg'] = 'completed'
+                async def some_background_task():
+                    await asyncio.sleep(2)
+                    app.storage.client['msg'] = 'completed'
 
-                    @ui.page('/')
-                    def index():
-                        app.storage.client['msg'] = 'created'
-                        background_tasks.create(some_background_task())
-                        ui.label().bind_text_from(app.storage.user, 'msg')
+                @ui.page('/')
+                def index():
+                    app.storage.client['msg'] = 'created'
+                    background_tasks.create(some_background_task())
+                    ui.label().bind_text_from(app.storage.user, 'msg')
 
-                    ui.run()
-                    ```
-                ''')
+                ui.run()
+                ```
+            ''')
         with python_window(classes='max-w-lg w-full'):
             ui.markdown('''
-                    ```python
-                    from nicegui import app, background_tasks
+                ```python
+                from nicegui import app, background_tasks
 
-                    @background_tasks.await_on_shutdown
-                    async def some_background_task():
-                        await asyncio.sleep(2)
-                        print('task completed', flush=True)
+                @background_tasks.await_on_shutdown
+                async def some_background_task():
+                    await asyncio.sleep(2)
+                    print('task completed', flush=True)
 
-                    def shutdown():
-                        background_tasks.create(some_background_task())
-                        print('shutdown', flush=True)
-                        app.shutdown()
+                def shutdown():
+                    background_tasks.create(some_background_task())
+                    print('shutdown', flush=True)
+                    app.shutdown()
 
-                    app.on_startup(shutdown)
-                    ui.run()
-                    ```
-                ''')
+                app.on_startup(shutdown)
+                ui.run()
+                ```
+            ''')
 
 
 doc.text('Custom Vue Components', '''

--- a/website/documentation/content/section_configuration_deployment.py
+++ b/website/documentation/content/section_configuration_deployment.py
@@ -81,6 +81,57 @@ def env_var_demo():
     ui.label(f'Markdown content cache size is {markdown.prepare_content.cache_info().maxsize}')
 
 
+doc.text('Background Tasks', '''
+    `background_tasks.create()` allows you to run an async function in the background and returns a task object.
+    By default these tasks will be automatically cancelled during shutdown.
+    You can prevent this by using the `@background_tasks.await_on_shutdown` decorator.
+    This is useful for tasks that need to be executed even after the app has been shut down.
+''')
+
+
+@doc.ui
+def background_tasks_demo():
+
+    with ui.row().classes('w-full items-stretch'):
+        with python_window(classes='max-w-lg w-full'):
+            ui.markdown('''
+                    ```python
+                    from nicegui import app, background_tasks
+
+                    async def some_background_task():
+                        await asyncio.sleep(2)
+                        app.storage.client['msg'] = 'completed'
+
+                    @ui.page('/')
+                    def index():
+                        app.storage.client['msg'] = 'created'
+                        background_tasks.create(some_background_task())
+                        ui.label().bind_text_from(app.storage.user, 'msg')
+
+                    ui.run()
+                    ```
+                ''')
+        with python_window(classes='max-w-lg w-full'):
+            ui.markdown('''
+                    ```python
+                    from nicegui import app, background_tasks
+
+                    @background_tasks.await_on_shutdown
+                    async def some_background_task():
+                        await asyncio.sleep(2)
+                        print('task completed', flush=True)
+
+                    def shutdown():
+                        background_tasks.create(some_background_task())
+                        print('shutdown', flush=True)
+                        app.shutdown()
+
+                    app.on_startup(shutdown)
+                    ui.run()
+                    ```
+                ''')
+
+
 doc.text('Custom Vue Components', '''
     You can create custom components by subclassing `ui.element` and implementing a corresponding Vue component.
     The ["Custom Vue components" example](https://github.com/zauberzeug/nicegui/tree/main/examples/custom_vue_component)

--- a/website/documentation/content/section_configuration_deployment.py
+++ b/website/documentation/content/section_configuration_deployment.py
@@ -90,6 +90,7 @@ def env_var_demo():
 def background_tasks_demo():
     from nicegui import background_tasks
     import asyncio
+    import aiofiles
 
     results = {'answer': '?'}
 
@@ -100,7 +101,9 @@ def background_tasks_demo():
     @background_tasks.await_on_shutdown
     async def backup() -> None:
         await asyncio.sleep(1)
-        # pathlib.Path('backup.json').write_text(f'{results["answer"]}')
+        # async with aiofiles.open('backup.json', 'w') as f:
+        #     await f.write(f'{results["answer"]}')
+        # print('backup.json written', flush=True)
 
     ui.label().bind_text_from(results, 'answer', lambda x: f'answer: {x}')
     ui.button('Compute', on_click=lambda: background_tasks.create(compute()))


### PR DESCRIPTION
This PR started with the intent to fix #4592 which reported unawaited coroutines when running pytests. It turns out, the warning lead down a rabbit hole of problems. Here is a list of the major findings and fixes:

- the coroutines registered with `app.on_shutdown` have not been awaited properly
- `background_tasks` where not canceled on shutdown
- `outbox.loop` did not exit when receiving a cancel command
- handle cancellation in internal house-keeping loops (pruning, binding, ...)
- before Python 3.12 `asyncio.wait_for` misses cancel commands in certain conditions and must be fixed with [`wait-for2`](https://pypi.org/project/wait-for2/)
- ensure that all storage backups are written before exiting
- introduce `@background_tasks.await_on_shutdown` annotation to mark coroutines as "not to cancel on shutdown" (and thereby also fixes #4312)
- ~~clean up multiprocessing to not get "leaked semaphore" warnings (fix was described in https://github.com/zauberzeug/nicegui/issues/4131#issuecomment-2705100273)~~

Also this PR makes some minor improvements:

- disable pytest warning from upstream packages which we can do nothing about
- fix UTC warnings
- add names to background_tasks where ever possible
- only stop screen tests if console output contains "ERROR" (same as #4608 did for the user tests)
- first steps to add some `background_tasks` documentation
