### PR TITLE
Use custom reST element for documentation (fixes #4647)

### DIFF
--- a/website/documentation/__init__.py
+++ b/website/documentation/__init__.py
@@ -1,10 +1,12 @@
 from .content import overview, redirects, registry
+from .custom_restructured_text import CustomRestructuredText
 from .intro import create_intro
 from .rendering import render_page
 from .search import build_search_index
 from .windows import bash_window, browser_window, python_window
 
 __all__ = [
+    'CustomRestructuredText',
     'bash_window',
     'browser_window',
     'build_search_index',

--- a/website/documentation/custom_restructured_text.py
+++ b/website/documentation/custom_restructured_text.py
@@ -1,0 +1,12 @@
+from nicegui import ui
+from nicegui.elements.restructured_text import prepare_content
+
+
+class CustomRestructuredText(ui.restructured_text):
+    """Custom restructured text element that avoids field lists being interpreted as document-level fields (see #4647)."""
+
+    def _handle_content_change(self, content: str) -> None:
+        html = prepare_content('__PLACEHOLDER__\n\n' + content).replace('<p>__PLACEHOLDER__</p>\n', '')
+        if self._props.get('innerHTML') != html:
+            self._props['innerHTML'] = html
+            self.update()

--- a/website/documentation/reference.py
+++ b/website/documentation/reference.py
@@ -5,6 +5,7 @@ from nicegui import binding, ui
 from nicegui.elements.markdown import remove_indentation
 
 from ..style import create_anchor_name, subheading
+from .custom_restructured_text import CustomRestructuredText as custom_restructured_text
 
 
 def generate_class_doc(class_obj: type, part_title: str) -> None:
@@ -14,7 +15,7 @@ def generate_class_doc(class_obj: type, part_title: str) -> None:
         subheading('Initializer', anchor_name=create_anchor_name(part_title.replace('Reference', 'Initializer')))
         description = remove_indentation(doc.split('\n', 1)[-1])
         lines = [line.replace(':param ', ':') for line in description.splitlines() if ':param' in line]
-        ui.restructured_text('\n'.join(lines)).classes('bold-links arrow-links rst-param-tables')
+        custom_restructured_text('\n'.join(lines)).classes('bold-links arrow-links rst-param-tables')
 
     mro = [base for base in class_obj.__mro__ if base.__module__.startswith('nicegui.')]
     ancestors = mro[1:]
@@ -103,9 +104,9 @@ def _generate_method_signature_description(method: Callable) -> str:
     return description
 
 
-def _render_docstring(doc: str) -> ui.restructured_text:
+def _render_docstring(doc: str) -> custom_restructured_text:
     doc = _remove_indentation_from_docstring(doc)
-    return ui.restructured_text(doc).classes('bold-links arrow-links rst-param-tables')
+    return custom_restructured_text(doc).classes('bold-links arrow-links rst-param-tables')
 
 
 def _remove_indentation_from_docstring(text: str) -> str:

--- a/website/documentation/rendering.py
+++ b/website/documentation/rendering.py
@@ -3,6 +3,7 @@ from nicegui import ui
 from ..header import add_head_html, add_header
 from ..style import section_heading, subheading
 from .content import DocumentationPage
+from .custom_restructured_text import CustomRestructuredText as custom_restructured_text
 from .demo import demo
 from .reference import generate_class_doc
 
@@ -40,7 +41,7 @@ def render_page(documentation: DocumentationPage, *, with_menu: bool = True) -> 
                 subheading(part.title, link=part.link, major=part.reference is not None)
             if part.description:
                 if part.description_format == 'rst':
-                    element = ui.restructured_text(part.description.replace(':param ', ':'))
+                    element = custom_restructured_text(part.description.replace(':param ', ':'))
                 else:
                     element = ui.markdown(part.description)
                 element.classes('bold-links arrow-links')

--- a/website/search.py
+++ b/website/search.py
@@ -1,5 +1,7 @@
 from nicegui import __version__, background_tasks, events, ui
 
+from .documentation import CustomRestructuredText as custom_restructured_text
+
 
 class Search:
 
@@ -68,7 +70,7 @@ class Search:
                                         if result['item']['format'] == 'md':
                                             element = ui.markdown(intro)
                                         else:
-                                            element = ui.restructured_text(intro)
+                                            element = custom_restructured_text(intro)
                                         element.classes('text-grey line-clamp-1')
         background_tasks.create_lazy(handle_input(), name='handle_search_input')
 


### PR DESCRIPTION
This PR introduces a `custom_restructured_text` element to avoid field list items obtaining HTML classes if the field list is the first content in the document.