### PR TITLE
Fix "leaked semaphore object" warnings

### DIFF
--- a/nicegui/native/__init__.py
+++ b/nicegui/native/__init__.py
@@ -1,4 +1,4 @@
-from .native import WindowProxy, method_queue, response_queue
+from .native import WindowProxy
 from .native_config import NativeConfig
 from .native_mode import activate, find_open_port
 
@@ -7,6 +7,4 @@ __all__ = [
     'WindowProxy',
     'activate',
     'find_open_port',
-    'method_queue',
-    'response_queue',
 ]

--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -12,14 +12,14 @@ response_queue: Optional[Queue] = None
 
 
 def create_queues() -> None:
-    """Create the message queues."""
+    """Create the message queues. (For internal use only.)"""
     global method_queue, response_queue  # pylint: disable=global-statement # noqa: PLW0603
     method_queue = Queue()
     response_queue = Queue()
 
 
 def remove_queues() -> None:
-    """Remove the message queues by closing them and waiting for threads to finish."""
+    """Remove the message queues by closing them and waiting for threads to finish. (For internal use only.)"""
     global method_queue, response_queue  # pylint: disable=global-statement # noqa: PLW0603
     if method_queue is not None:
         method_queue.close()

--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -2,13 +2,34 @@
 import inspect
 import warnings
 from multiprocessing import Queue
-from typing import Any, Callable, Tuple
+from typing import Any, Callable, Optional, Tuple
 
 from .. import run
 from ..logging import log
 
-method_queue: Queue = Queue()
-response_queue: Queue = Queue()
+method_queue: Optional[Queue] = None
+response_queue: Optional[Queue] = None
+
+
+def create_queues() -> None:
+    """Create the message queues."""
+    global method_queue, response_queue  # pylint: disable=global-statement # noqa: PLW0603
+    method_queue = Queue()
+    response_queue = Queue()
+
+
+def remove_queues() -> None:
+    """Remove the message queues by closing them and waiting for threads to finish."""
+    global method_queue, response_queue  # pylint: disable=global-statement # noqa: PLW0603
+    if method_queue is not None:
+        method_queue.close()
+        method_queue.join_thread()
+        method_queue = None
+    if response_queue is not None:
+        response_queue.close()
+        response_queue.join_thread()
+        response_queue = None
+
 
 try:
     with warnings.catch_warnings():
@@ -120,11 +141,14 @@ try:
             raise NotImplementedError(f'exposing "{function}" is not supported')
 
         def _send(self, *args: Any, **kwargs: Any) -> None:
+            assert method_queue is not None
             name = inspect.currentframe().f_back.f_code.co_name  # type: ignore
             method_queue.put((name, args, kwargs))
 
         async def _request(self, *args: Any, **kwargs: Any) -> Any:
             def wrapper(*args: Any, **kwargs: Any) -> Any:
+                assert method_queue is not None
+                assert response_queue is not None
                 try:
                     method_queue.put((name, args, kwargs))
                     return response_queue.get()  # wait for the method to be called and writing its result to the queue

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -104,6 +104,7 @@ def activate(host: str, port: int, title: str, width: int, height: int, fullscre
         while not core.app.is_stopped:
             time.sleep(0.1)
         _thread.interrupt_main()
+        native.remove_queues()
 
     if not optional_features.has('webview'):
         log.error('Native mode is not supported in this configuration.\n'
@@ -111,6 +112,7 @@ def activate(host: str, port: int, title: str, width: int, height: int, fullscre
         sys.exit(1)
 
     mp.freeze_support()
+    native.create_queues()
     args = host, port, title, width, height, fullscreen, frameless, native.method_queue, native.response_queue
     process = mp.Process(target=_open_window, args=args, daemon=True)
     process.start()

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -126,6 +126,7 @@ async def _startup() -> None:
         app.add_route('/favicon.ico', lambda _: FileResponse(Path(__file__).parent / 'static' / 'favicon.ico'))
     core.loop = asyncio.get_running_loop()
     app.start()
+    run.setup()
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(Client.prune_instances(), name='prune clients')
     background_tasks.create(Slot.prune_stacks(), name='prune slot stacks')

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -125,8 +125,8 @@ async def _startup() -> None:
     else:
         app.add_route('/favicon.ico', lambda _: FileResponse(Path(__file__).parent / 'static' / 'favicon.ico'))
     core.loop = asyncio.get_running_loop()
-    app.start()
     run.setup()
+    app.start()
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(Client.prune_instances(), name='prune clients')
     background_tasks.create(Slot.prune_stacks(), name='prune slot stacks')

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -16,8 +16,8 @@ P = ParamSpec('P')
 R = TypeVar('R')
 
 
-def setup():
-    """Setup the process pool. (For internal use only)"""
+def setup() -> None:
+    """Setup the process pool. (For internal use only.)"""
     global process_pool  # pylint: disable=global-statement # noqa: PLW0603
     process_pool = ProcessPoolExecutor()
 

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -84,6 +84,7 @@ def tear_down() -> None:
     """Kill all processes and threads."""
     if helpers.is_pytest():
         return
+    assert process_pool is not None
     for p in process_pool._processes.values():  # pylint: disable=protected-access
         p.kill()
     kwargs = {'cancel_futures': True} if sys.version_info >= (3, 9) else {}

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -3,17 +3,23 @@ import sys
 import traceback
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from functools import partial
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 from typing_extensions import ParamSpec
 
 from . import core, helpers
 
-process_pool = ProcessPoolExecutor()
+process_pool: Optional[ProcessPoolExecutor] = None
 thread_pool = ThreadPoolExecutor()
 
 P = ParamSpec('P')
 R = TypeVar('R')
+
+
+def setup():
+    """Setup the process pool. (For internal use only)"""
+    global process_pool  # pylint: disable=global-statement # noqa: PLW0603
+    process_pool = ProcessPoolExecutor()
 
 
 class SubprocessException(Exception):

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -211,8 +211,8 @@ def run(*,
         **kwargs,
     )
     config.storage_secret = storage_secret
-    config.method_queue = native_module.method_queue if native else None
-    config.response_queue = native_module.response_queue if native else None
+    config.method_queue = native_module.native.method_queue if native else None
+    config.response_queue = native_module.native.response_queue if native else None
     Server.create_singleton(config)
 
     if (reload or config.workers > 1) and not isinstance(config.app, str):


### PR DESCRIPTION
This PR builds on #4132 which was reverted due to problems when opening file dialogs and similar. In this PR we do the following:

- re-apply all changes from #4132 (eg. only setup and tear down `Queue` objects when in native mode)
- fix the native file dialog opening problem by [correctly passing the `Queue` objects via server config](https://github.com/zauberzeug/nicegui/blob/72246eaee169c4d48371daf809d6df48195f1e4b/nicegui/ui_run.py#L214-L215)
- ensure `ProcessPool` from `ui.run` is only created on the main process which makes the tear down (otherwise the `ProcessPool` creates leaked semaphore object warnings in the pywebview subprocess).