### PR TITLE
Add `reset`, `trigger`, and change handler for `ui.timer`

### DIFF
--- a/nicegui/timer.py
+++ b/nicegui/timer.py
@@ -1,16 +1,23 @@
 import asyncio
 import time
 from contextlib import nullcontext
-from typing import Any, Awaitable, Callable, ContextManager, Optional
+from typing import Any, Awaitable, Callable, ContextManager, Optional, cast, Self
 
 from . import background_tasks, core
 from .awaitable_response import AwaitableResponse
 from .binding import BindableProperty
 
 
+class AlreadyRanOnceError(Exception):
+    """Exception raised when the timer has already run once, so as to stop the outer while loop in _run_in_loop."""
+    pass
+
+
 class Timer:
-    active = BindableProperty()
-    interval = BindableProperty()
+    active = BindableProperty(
+        on_change=lambda sender, active: cast(Self, sender)._handle_active_change(active))  # pylint: disable=protected-access
+    interval = BindableProperty(
+        on_change=lambda sender, interval: cast(Self, sender)._handle_interval_change(interval))  # pylint: disable=protected-access
 
     def __init__(self,
                  interval: float,
@@ -18,6 +25,8 @@ class Timer:
                  active: bool = True,
                  once: bool = False,
                  immediate: bool = True,
+                 on_active_changed: Optional[Callable[[bool], None]] = None,
+                 on_interval_changed: Optional[Callable[[float], None]] = None,
                  ) -> None:
         """Timer
 
@@ -28,21 +37,41 @@ class Timer:
         :param interval: the interval in which the timer is called (can be changed during runtime)
         :param callback: function or coroutine to execute when interval elapses
         :param active: whether the callback should be executed or not (can be changed during runtime)
-        :param once: whether the callback is only executed once after a delay specified by `interval` (default: `False`)
+        :param once: whether the callback is only executed once after a delay specified by `interval` (default: `False`, can be changed during runtime)
         :param immediate: whether the callback should be executed immediately (default: `True`, ignored if `once` is `True`, *added in version 2.9.0*)
+        :param on_active_changed: callback which is invoked when the active state is changed (default: `None`)
+        :param on_interval_changed: callback which is invoked when the interval is changed (default: `None`)
         """
         super().__init__()
         self.interval = interval
         self.callback: Optional[Callable[..., Any]] = callback
         self.active = active
         self._is_canceled = False
-        self._immediate = immediate
+        self.once = once
+        self._immediate = immediate if not once else False
+        self._should_abort_sleep = asyncio.Event()
+        self._skip_callback_once_for_reset = False
+        self._on_active_changed: Optional[Callable[[bool], None]] = None
+        self._on_interval_changed: Optional[Callable[[float], None]] = None
 
-        coroutine = self._run_once if once else self._run_in_loop
+        if on_active_changed:
+            self.on_active_changed(on_active_changed)
+        if on_interval_changed:
+            self.on_interval_changed(on_interval_changed)
+
+        coroutine = self._run_in_loop
         if core.app.is_started:
             background_tasks.create(coroutine(), name=str(callback))
         else:
             core.app.on_startup(coroutine)
+
+    def _handle_active_change(self, active: bool) -> None:
+        if self._on_active_changed:
+            self._on_active_changed(active)
+
+    def _handle_interval_change(self, interval: float) -> None:
+        if self._on_interval_changed:
+            self._on_interval_changed(interval)
 
     def _get_context(self) -> ContextManager:
         return nullcontext()
@@ -60,21 +89,41 @@ class Timer:
         """Cancel the timer."""
         self._is_canceled = True
 
-    async def _run_once(self) -> None:
+    def trigger(self) -> None:
+        """Abort sleep to reset the remaining sleep time to the interval, triggering the callback immediately in doing so."""
+        assert not self._is_canceled, 'Cannot trigger a canceled timer'
+        self._should_abort_sleep.set()
+
+    def reset(self) -> None:
+        """Abort sleep to reset the remaining sleep time to the interval, but without triggering the callback."""
+        assert not self._is_canceled, 'Cannot reset a canceled timer'
+        self._skip_callback_once_for_reset = True
+        self.trigger()
+
+    def on_active_changed(self, callback: Callable[[bool], None]) -> Self:
+        """Set a callback which is invoked when the active state is changed."""
+        self._on_active_changed = callback
+        return self
+
+    def on_interval_changed(self, callback: Callable[[float], None]) -> Self:
+        """Set a callback which is invoked when the interval is changed."""
+        self._on_interval_changed = callback
+        return self
+
+    async def _sleep_with_abort(self, seconds: float) -> None:
+        """Sleep for a given number of seconds, but allow to abort the sleep."""
+        if seconds <= 0:
+            return
         try:
-            if not await self._can_start():
-                return
-            with self._get_context():
-                await asyncio.sleep(self.interval)
-                if self.active and not self._should_stop():
-                    await self._invoke_callback()
-        finally:
-            self._cleanup()
+            await asyncio.wait_for(self._should_abort_sleep.wait(), timeout=seconds)
+            self._should_abort_sleep.clear()
+        except asyncio.TimeoutError:
+            pass
 
     async def _run_in_loop(self) -> None:
         try:
             if not self._immediate:
-                await asyncio.sleep(self.interval)
+                await self._sleep_with_abort(self.interval)
             if not await self._can_start():
                 return
             with self._get_context():
@@ -84,23 +133,31 @@ class Timer:
                         if self.active:
                             await self._invoke_callback()
                         dt = time.time() - start
-                        await asyncio.sleep(self.interval - dt)
+                        await self._sleep_with_abort(self.interval - dt)
+                    except AlreadyRanOnceError:
+                        break
                     except asyncio.CancelledError:
                         break
                     except Exception as e:
                         core.app.handle_exception(e)
-                        await asyncio.sleep(self.interval)
+                        await self._sleep_with_abort(self.interval)
         finally:
             self._cleanup()
 
     async def _invoke_callback(self) -> None:
         try:
+            if self._skip_callback_once_for_reset:
+                self._skip_callback_once_for_reset = False
+                return
             assert self.callback is not None
             result = self.callback()
             if isinstance(result, Awaitable) and not isinstance(result, AwaitableResponse):
                 await result
         except Exception as e:
             core.app.handle_exception(e)
+        finally:
+            if self.once:
+                raise AlreadyRanOnceError('Timer has already run once and is set to once=True')
 
     async def _can_start(self) -> bool:
         return True


### PR DESCRIPTION
This PR fix #4670 by adding `reset()` and `trigger()` methods to `ui.timer`, enabling the user to skip the existing sleep when changing the interval, while choosing between not running (for `reset()`) or running (for `trigger()`) the callback while doing so. 

Notably, `_run_once` is removed, since it is possible to `reset()` a timer which is supposed to run once again and again, and the code needs a while loop logic, which I leverage the existing `_run_in_loop` to achieve. Rather, now we raise `AlreadyRanOnceError` if `once` is set, which also enables setting `once` dyanmically while the `ui.timer` is running. 

Some remaining issues: 
* Cannot do `timer.on_interval_changed(timer.trigger)` since then `timer.trigger` would receive too many arguments
* Let alone the one-line convenience method `timer = ui.timer(10, last_update.refresh, immediate=False, on_interval_changed=TRIGGER)`, since otherwise `timer = ui.timer(10, last_update.refresh, immediate=False, on_interval_changed=timer.trigger)` would not work since `timer` is not defined. 