### PR TITLE
Tolerant gethtmlelement

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -40,7 +40,12 @@ function getElement(id) {
 }
 
 function getHtmlElement(id) {
-  return document.getElementById(`c${id}`);
+  id_as_a_string = id.toString();
+  if (!id_as_a_string.startsWith("c")) {
+    id_as_a_string = "c" + id_as_a_string;
+  }
+  console.log("getHtmlElement", id_as_a_string);
+  return document.getElementById(id_as_a_string);
 }
 
 function runMethod(target, method_name, args) {

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -40,7 +40,7 @@ function getElement(id) {
 }
 
 function getHtmlElement(id) {
-  id_as_a_string = id.toString();
+  let id_as_a_string = id.toString();
   if (!id_as_a_string.startsWith("c")) {
     id_as_a_string = "c" + id_as_a_string;
   }

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -44,7 +44,6 @@ function getHtmlElement(id) {
   if (!id_as_a_string.startsWith("c")) {
     id_as_a_string = "c" + id_as_a_string;
   }
-  console.log("getHtmlElement", id_as_a_string);
   return document.getElementById(id_as_a_string);
 }
 


### PR DESCRIPTION
This PR fix #4633 side effect: Users may be inclined to pass `element.html_id` to getHtmlElement, which doesn't work. 

Implementation details: 

* We do NOT do the type-checking or try-except solution as mentioned here https://github.com/zauberzeug/nicegui/pull/4633#issuecomment-2834621081
* This is because, an explicit type-checking solution goes against duck typing, and breaks existing user code if they are crazy enough to pass a BigInt (think: `getHtmlElement(3n)`), or some other object which `toString` to a string of integer fine, but is not in our whitelist (think: `JSBI`, custom objects)
* try-except can be potentially dangerous, since it makes the `getHtmlElement` susceptible to hijack. 
  * If an attacker injects an element with id `cc5`, it could be selected on `getHtmlElement("c5")`*
  * If an attacker injects an element with id `5`, it could be selected `getHtmlElement(5)`*
* Rather, we maintain **maximum compatbility** by keeping the spirit of `toString`, and changing the appending "c" to do it only if it doesn't already have "c" in front. 

*provided the element with id "c5" doesn't exist for any reason