### PR TITLE
Make passing `Element` to `getElement` work

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -35,7 +35,7 @@ function replaceUndefinedAttributes(element) {
 }
 
 function getElement(id) {
-  const _id = id instanceof Element ? id.id : id;
+  const _id = id instanceof Element ? id.id.slice(1) : id;
   return mounted_app.$refs["r" + _id];
 }
 

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -35,7 +35,7 @@ function replaceUndefinedAttributes(element) {
 }
 
 function getElement(id) {
-  const _id = id instanceof HTMLElement ? id.id : id;
+  const _id = id instanceof Element ? id.id : id;
   return mounted_app.$refs["r" + _id];
 }
 


### PR DESCRIPTION
Fix #4674 and other issues. 

Most obviously: Passing HTMLElement now works (consider `getElement(c30)`)

More implicitly: Checking `id instanceof HTMLElement` is wrong logic, since the `id` property is introduced by `Element` (the base class which `HTMLElement` inherits from). 

Otherwise, code would not work, if we pass in, say, an `SVGElement`. 

Check here for more details about `Element.id`: https://developer.mozilla.org/en-US/docs/Web/API/Element/id