### PR TITLE
fix `ui.codemirror` on JS UTF-16-based indexing (memoize JS length per char + bisect) 

### DIFF
--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -284,7 +284,7 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
         """
         super().__init__(value=value, on_value_change=self._update_cumulative)
         self._cumulative_corresponds_to_string = value
-        self._cumulative_js_length = []
+        self._cumulative_js_length: List[int] = []
         self._update_cumulative(forced=True)
         if on_change is not None:
             super().on_value_change(on_change)

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -351,7 +351,11 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
         doc = self.value
 
         def find_python_index(js_index: int) -> int:
-            return bisect.bisect_right(self._cumulative_js_length, js_index)
+            if js_index == 0:
+                return 0
+            lo = max(0, len(self._cumulative_js_length) - (get_total_js_length(self._cumulative_js_length) - js_index))
+            hi = min(js_index, len(self._cumulative_js_length))
+            return bisect.bisect_right(self._cumulative_js_length, js_index, lo, hi)
         assert sum(sections[::2]) == get_total_js_length(
             self._cumulative_js_length), 'Cannot apply change set to document due to length mismatch'
         pos = 0

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -389,10 +389,10 @@ def get_total_js_length(cumulative_js_length: List[int]) -> int:
 def find_python_index(js_index: int, cumulative_js_length: List[int]) -> int:
     if js_index == 0:
         return 0
-    lo = max(0, len(cumulative_js_length) - (get_total_js_length(cumulative_js_length) - js_index))
-    hi = min(js_index, len(cumulative_js_length))
+    lo1 = len(cumulative_js_length) - (get_total_js_length(cumulative_js_length) - js_index)
+    hi1 = js_index
     lo2 = (js_index + 1) // 2
-    hi2 = min(js_index, len(cumulative_js_length) - (get_total_js_length(cumulative_js_length) - js_index + 1) // 2)
-    lo = max(lo, lo2)
-    hi = min(hi, hi2)
+    hi2 = len(cumulative_js_length) - (get_total_js_length(cumulative_js_length) - js_index + 1) // 2
+    lo = max(lo1, lo2, 0)
+    hi = min(hi1, hi2, len(cumulative_js_length))
     return bisect.bisect_right(cumulative_js_length, js_index, lo, hi)

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -1,5 +1,6 @@
+from itertools import zip_longest
 from pathlib import Path
-from typing import Callable, List, Literal, Optional, get_args
+from typing import List, Literal, Optional, Tuple, cast, get_args
 
 from nicegui.elements.mixins.disableable_element import DisableableElement
 from nicegui.elements.mixins.value_element import ValueElement
@@ -332,80 +333,17 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
 
     def _event_args_to_value(self, e: GenericEventArguments) -> str:
         """The event contains a change set which is applied to the current value."""
-        changeset = _ChangeSet(sections=e.args['sections'], inserted=e.args['inserted'])
-        new_value = changeset.apply(self.value)
-        return new_value
+        return _apply_change_set(self.value, e.args['sections'], e.args['inserted'])
 
 
-# Below is a Python implementation of relevant parts of https://github.com/codemirror/state/blob/main/src/change.ts
-# to apply a ChangeSet to a text document.
-
-
-class _ChangeSet:
-    """A change set represents a group of modifications to a document."""
-
-    def __init__(self, sections: List[int], inserted: List[List[str]]) -> None:
-        # From https://github.com/codemirror/state/blob/main/src/change.ts#L21:
-        # Sections are encoded as pairs of integers. The first is the
-        # length in the current document, and the second is -1 for
-        # unaffected sections, and the length of the replacement content
-        # otherwise. So an insertion would be (0, n>0), a deletion (n>0,
-        # 0), and a replacement two positive numbers.
-        self.sections: List[int] = sections
-        self.inserted: List[str] = ['\n'.join(ins) for ins in inserted]
-
-    def length(self) -> int:
-        """Calculate the length of the document before the change."""
-        return sum(self.sections[::2])
-
-    def apply(self, doc: str) -> str:
-        """Apply the changes to a document, returning the modified document."""
-        if self.length() != len(doc):
-            raise ValueError('Cannot apply change set to a document with the wrong length')
-        return _iter_changes(self, doc, _replacement_func, individual=False)
-
-    def __str__(self) -> str:
-        return f'ChangeSet(sections={self.sections}, inserted={self.inserted})'
-
-
-def _iter_changes(
-    changeset: _ChangeSet, doc: str, func: Callable[[str, int, int, int, int, str], str], individual: bool
-) -> str:
-    inserted = changeset.inserted
-    posA, posB, i = 0, 0, 0
-
-    while i < len(changeset.sections):
-        len_ = changeset.sections[i]
-        i += 1
-        ins = changeset.sections[i]
-        i += 1
-
-        if ins < 0:
-            posA += len_
-            posB += len_
-        else:
-            endA, endB = posA, posB
-            text = ''
-            while True:
-                endA += len_
-                endB += ins
-                if ins and inserted:
-                    text = text + inserted[(i - 2) // 2]
-                if individual or i == len(changeset.sections) or changeset.sections[i + 1] < 0:
-                    break
-                len_ = changeset.sections[i]
-                i += 1
-                ins = changeset.sections[i]
-                i += 1
-            doc = func(doc, posA, endA, posB, endB, text)
-            posA, posB = endA, endB
-
+def _apply_change_set(doc, sections: List[int], inserted: List[List[str]]) -> str:
+    # based on https://github.com/codemirror/state/blob/main/src/change.ts
+    assert sum(sections[::2]) == len(doc), 'Cannot apply change set to document due to length mismatch'
+    pos = 0
+    joined_inserts = ('\n'.join(ins) for ins in inserted)
+    for section in zip_longest(sections[::2], sections[1::2], joined_inserts, fillvalue=''):
+        old_len, new_len, ins = cast(Tuple[int, int, str], section)
+        if new_len >= 0:
+            doc = doc[:pos] + ins + doc[pos + old_len:]
+        pos += old_len
     return doc
-
-
-def _replace_range(doc: str, from_: int, to: int, new: str) -> str:
-    return doc[:from_] + new + doc[to:]
-
-
-def _replacement_func(doc: str, from_a: int, to_a: int, from_b: int, _to_b: int, text: str) -> str:
-    return _replace_range(doc, from_b, from_b + (to_a - from_a), text)

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -376,8 +376,7 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
 
 
 def get_cumulative_js_length(doc: str) -> List[int]:
-    cumulative_js_length = list(accumulate(len(c.encode('utf-16be'))//2 for c in doc))
-    return cumulative_js_length
+    return list(accumulate(len(c.encode('utf-16be'))//2 for c in doc))
 
 
 def get_total_js_length(cumulative_js_length: List[int]) -> int:

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -364,13 +364,12 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
                 doc = doc[:first_part_index] + ins + doc[second_part_index:]
 
                 ins_cumulative_js_length = get_cumulative_js_length(ins)
-                ins_total_length = get_total_length_from_cumulative(ins_cumulative_js_length)
                 first_part_cumulative_js_length = self._cumulative_js_length[:first_part_index]
-                first_part_total_length = get_total_length_from_cumulative(first_part_cumulative_js_length)
 
                 self._cumulative_js_length = first_part_cumulative_js_length + \
-                    [x + first_part_total_length for x in ins_cumulative_js_length] + \
-                    [x + ins_total_length for x in self._cumulative_js_length[second_part_index:]]
+                    [x + get_total_length_from_cumulative(first_part_cumulative_js_length) for x in ins_cumulative_js_length] + \
+                    [x + get_total_length_from_cumulative(ins_cumulative_js_length)
+                     for x in self._cumulative_js_length[second_part_index:]]
             pos += old_len
             self._cumulative_corresponds_to_string = doc
         return doc

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -1,4 +1,4 @@
-from itertools import zip_longest
+from itertools import accumulate, zip_longest
 from pathlib import Path
 from typing import List, Literal, Optional, Tuple, cast, get_args
 
@@ -376,8 +376,7 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
 
 
 def get_cumulative_js_length(doc: str) -> List[int]:
-    js_length_per_character = [len(c.encode('utf-16be'))//2 for c in doc]
-    cumulative_js_length = [sum(js_length_per_character[:i+1]) for i in range(len(js_length_per_character))]
+    cumulative_js_length = list(accumulate(len(c.encode('utf-16be'))//2 for c in doc))
     return cumulative_js_length
 
 

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -345,10 +345,14 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
         return b''.join(b'\0\1' if ord(c) > 0xFFFF else b'\1' for c in doc)
 
     def _update_codepoints(self) -> None:
-        """Update ``self.emojies`` for the current value.
+        """Update `self._codepoints` and `self._codepoints_represents`.
 
-        The emojies are a concatenation of '0' for code points <=0xFFFF and '01' for code points >0xFFFF.
-        This is used to convert JavaScript string indices to Python by summing ``emojies`` up to the JavaScript index.
+        `self._codepoints` are a concatenation of '1' for code points <=0xFFFF and '01' for code points >0xFFFF.
+        This captures how many Unicode code points are encoded by each UTF-16 code unit.
+        This is used to convert JavaScript string indices to Python by summing `self._codepoints` up to the JavaScript index.
+
+        `self._codepoints_represents` is the string which matches `self._codepoints`.
+        This is used to check if the value has changed and to avoid unnecessary updates.
         """
         if self.value == self._codepoints_represents:
             return

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -284,6 +284,7 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
         """
         super().__init__(value=value, on_value_change=self._update_cumulative)
         self._cumulative_corresponds_to_string = value
+        self._cumulative_js_length = []
         self._update_cumulative(forced=True)
         if on_change is not None:
             super().on_value_change(on_change)
@@ -375,8 +376,10 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
 
 
 def get_cumulative_js_length(doc: str) -> List[int]:
+    """Returns a list, where for each index i, the value is the length of the string from 0 to i in UTF-16 (imagine js_len(doc[:i])"""
     return list(accumulate(len(c.encode('utf-16be'))//2 for c in doc))
 
 
 def get_total_js_length(cumulative_js_length: List[int]) -> int:
+    """Returns the length of the string in UTF-16 (imagine js_len(doc))"""
     return cumulative_js_length[-1] if cumulative_js_length else 0

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -1,3 +1,4 @@
+import bisect
 from itertools import accumulate, zip_longest
 from pathlib import Path
 from typing import List, Literal, Optional, Tuple, cast, get_args
@@ -5,8 +6,6 @@ from typing import List, Literal, Optional, Tuple, cast, get_args
 from nicegui.elements.mixins.disableable_element import DisableableElement
 from nicegui.elements.mixins.value_element import ValueElement
 from nicegui.events import GenericEventArguments, Handler, ValueChangeEventArguments
-
-import bisect
 
 SUPPORTED_LANGUAGES = Literal[
     'Angular Template',

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -351,16 +351,7 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
         doc = self.value
 
         def _find_python_index(js_index: int) -> int:
-            if js_index == 0:
-                return 0
-            lo1 = max(0, len(self._cumulative_js_length) - (get_total_js_length(self._cumulative_js_length) - js_index))
-            hi1 = min(js_index, len(self._cumulative_js_length))
-            lo2 = (js_index + 1) // 2
-            hi2 = min(js_index, len(self._cumulative_js_length) -
-                      (get_total_js_length(self._cumulative_js_length) - js_index + 1) // 2)
-            lo = max(lo1, lo2)
-            hi = min(hi1, hi2)
-            return bisect.bisect_right(self._cumulative_js_length, js_index, lo, hi)
+            return find_python_index(js_index, self._cumulative_js_length)
         assert sum(sections[::2]) == get_total_js_length(
             self._cumulative_js_length), 'Cannot apply change set to document due to length mismatch'
         pos = 0
@@ -393,3 +384,15 @@ def get_cumulative_js_length(doc: str) -> List[int]:
 def get_total_js_length(cumulative_js_length: List[int]) -> int:
     """Returns the length of the string in UTF-16 (imagine js_len(doc))"""
     return cumulative_js_length[-1] if cumulative_js_length else 0
+
+
+def find_python_index(js_index: int, cumulative_js_length: List[int]) -> int:
+    if js_index == 0:
+        return 0
+    lo = max(0, len(cumulative_js_length) - (get_total_js_length(cumulative_js_length) - js_index))
+    hi = min(js_index, len(cumulative_js_length))
+    lo2 = (js_index + 1) // 2
+    hi2 = min(js_index, len(cumulative_js_length) - (get_total_js_length(cumulative_js_length) - js_index + 1) // 2)
+    lo = max(lo, lo2)
+    hi = min(hi, hi2)
+    return bisect.bisect_right(cumulative_js_length, js_index, lo, hi)

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -367,13 +367,14 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
                 second_index = find_python_index(pos + old_len)
                 doc = doc[:first_index] + ins + doc[second_index:]
 
-                ins_cumulative_js_length = get_cumulative_js_length(ins)
-                first_part_cumulative_js_length = self._cumulative_js_length[:first_index]
+                just_before_original_end_part = self._cumulative_js_length[second_index - 1] if second_index > 0 else 0
+                original_end_part = self._cumulative_js_length[second_index:]
 
-                self._cumulative_js_length = first_part_cumulative_js_length + \
-                    [x + get_total_js_length(first_part_cumulative_js_length) for x in ins_cumulative_js_length] + \
-                    [x + get_total_js_length(ins_cumulative_js_length)
-                     for x in self._cumulative_js_length[second_index:]]
+                self._cumulative_js_length = self._cumulative_js_length[:first_index]
+                self._cumulative_js_length += [x + get_total_js_length(self._cumulative_js_length)
+                                               for x in get_cumulative_js_length(ins)]
+                self._cumulative_js_length += [(x - just_before_original_end_part) +
+                                               get_total_js_length(self._cumulative_js_length) for x in original_end_part]
             pos += old_len
             self._cumulative_corresponds_to_string = doc
         return doc

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -387,6 +387,10 @@ def get_total_js_length(cumulative_js_length: List[int]) -> int:
 
 
 def find_python_index(js_index: int, cumulative_js_length: List[int]) -> int:
+    """Given a js_index, returns the position in cumulative_js_length (1-based)
+
+    Note that 1-based indexing enables doc[:find_python_index(pos)] to replace doc[:pos]
+    """
     if js_index == 0:
         return 0
     lo1 = len(cumulative_js_length) - (get_total_js_length(cumulative_js_length) - js_index)

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -369,7 +369,9 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
         parts_codepoint: List[bytes] = []
         for pos, old_len, new_len, ins in zip(end_positions, old_lengths, new_lengths, joined_inserts):
             if new_len == -1:
-                parts.append(doc[self._codepoints[:pos-old_len].count(1):self._codepoints[:pos].count(1)])
+                first_slice_point = self._codepoints[:pos - old_len].count(1)
+                second_slice_point = first_slice_point + self._codepoints[pos - old_len: pos].count(1)
+                parts.append(doc[first_slice_point: second_slice_point])
                 parts_codepoint.append(self._codepoints[pos - old_len: pos])
             else:
                 parts.append(ins)

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -348,7 +348,7 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
 
     def _apply_change_set(self, sections: List[int], inserted: List[List[str]]) -> str:
         # based on https://github.com/codemirror/state/blob/main/src/change.ts
-        doc = self.value
+        doc = self.value or ''
 
         def _find_python_index(js_index: int) -> int:
             return find_python_index(js_index, self._cumulative_js_length)
@@ -378,7 +378,7 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
 
 def get_cumulative_js_length(doc: str) -> List[int]:
     """Returns a list, where for each index i, the value is the length of the string from 0 to i in UTF-16 (imagine js_len(doc[:i])"""
-    return list(accumulate(len(c.encode('utf-16be'))//2 for c in doc))
+    return list(accumulate(len(c.encode('utf-16be'))//2 for c in doc)) if doc else []
 
 
 def get_total_js_length(cumulative_js_length: List[int]) -> int:
@@ -391,7 +391,7 @@ def find_python_index(js_index: int, cumulative_js_length: List[int]) -> int:
 
     Note that 1-based indexing enables doc[:find_python_index(pos)] to replace doc[:pos]
     """
-    if js_index == 0:
+    if js_index == 0 or not cumulative_js_length:
         return 0
     lo1 = len(cumulative_js_length) - (get_total_js_length(cumulative_js_length) - js_index)
     hi1 = js_index

--- a/tests/test_codemirror.py
+++ b/tests/test_codemirror.py
@@ -1,11 +1,11 @@
-from itertools import product
 from typing import Dict, List
 
 import pytest
 
 from nicegui import ui
-from nicegui.elements.codemirror import find_python_index, get_cumulative_js_length
 from nicegui.testing import Screen
+
+# pylint: disable=protected-access
 
 
 def test_codemirror(screen: Screen):
@@ -46,6 +46,9 @@ def test_supported_values(screen: Screen):
     ('Hello', [5, -1, 0, 8], [[], [', world!']], 'Hello, world!'),
     ('Hello, world!', [5, -1, 7, 0, 1, -1], [], 'Hello!'),
     ('Hello, hello!', [2, -1, 3, 1, 4, -1, 3, 1, 1, -1], [[], ['y'], [], ['y']], 'Hey, hey!'),
+    ('Hello, world!', [5, -1, 1, 3, 7, -1], [[], [' 🙂']], 'Hello 🙂 world!'),
+    ('Hey! 🙂', [7, -1, 0, 4], [[], [' Ho!']], 'Hey! 🙂 Ho!'),
+    ('Ha 🙂\nha 🙂', [3, -1, 2, 0, 4, -1, 2, 0], [[], [''], [], ['']], 'Ha \nha '),
 ])
 def test_change_set(screen: Screen, doc: str, sections: List[int], inserted: List[List[str]], expected: str):
     editor = ui.codemirror(doc)
@@ -54,9 +57,9 @@ def test_change_set(screen: Screen, doc: str, sections: List[int], inserted: Lis
     assert editor._apply_change_set(sections, inserted) == expected
 
 
-def test_find_python_index():
-    n = 10
-    for combination in product([chr(20), chr(70000)], repeat=n):
-        cumulative_js_length = get_cumulative_js_length(combination)
-        for elem in cumulative_js_length:
-            assert cumulative_js_length[find_python_index(elem, cumulative_js_length)-1] == elem, f'Failed for {elem}'
+def test_emojies():
+    assert ui.codemirror._encode_emojies('') == b''
+    assert ui.codemirror._encode_emojies('Hello') == bytes([0, 0, 0, 0, 0])
+    assert ui.codemirror._encode_emojies('🙂') == bytes([0, 1])
+    assert ui.codemirror._encode_emojies('Hello 🙂') == bytes([0, 0, 0, 0, 0, 0, 0, 1])
+    assert ui.codemirror._encode_emojies('😎😎😎') == bytes([0, 1, 0, 1, 0, 1])

--- a/tests/test_codemirror.py
+++ b/tests/test_codemirror.py
@@ -74,4 +74,4 @@ def test_find_python_index():
     for combination in product([chr(20), chr(70000)], repeat=n):
         cumulative_js_length = get_cumulative_js_length(combination)
         for elem in cumulative_js_length:
-            assert cumulative_js_length[find_python_index(elem, cumulative_js_length)-1] == elem, f"Failed for {elem}"
+            assert cumulative_js_length[find_python_index(elem, cumulative_js_length)-1] == elem, f'Failed for {elem}'

--- a/tests/test_codemirror.py
+++ b/tests/test_codemirror.py
@@ -1,6 +1,7 @@
 from typing import Dict, List
 
 from nicegui import ui
+from nicegui.elements.codemirror import _apply_change_set
 from nicegui.testing import Screen
 
 
@@ -31,3 +32,13 @@ def test_supported_values(screen: Screen):
     screen.wait_for('Done')
     assert values['languages'] == values['supported_languages']
     assert values['themes'] == values['supported_themes']
+
+
+def test_change_set():
+    assert _apply_change_set('', [0, 1], [['A']]) == 'A'
+    assert _apply_change_set('', [0, 2], [['AB']]) == 'AB'
+    assert _apply_change_set('X', [1, 2], [['AB']]) == 'AB'
+    assert _apply_change_set('X', [1, -1], []) == 'X'
+    assert _apply_change_set('X', [1, -1, 0, 1], [[], ['Y']]) == 'XY'
+    assert _apply_change_set('Hello', [5, -1, 0, 8], [[], [', world!']]) == 'Hello, world!'
+    assert _apply_change_set('Hello, world!', [5, -1, 7, 0, 1, -1], []) == 'Hello!'

--- a/tests/test_codemirror.py
+++ b/tests/test_codemirror.py
@@ -57,9 +57,9 @@ def test_change_set(screen: Screen, doc: str, sections: List[int], inserted: Lis
     assert editor._apply_change_set(sections, inserted) == expected
 
 
-def test_emojies():
-    assert ui.codemirror._encode_emojies('') == b''
-    assert ui.codemirror._encode_emojies('Hello') == bytes([0, 0, 0, 0, 0])
-    assert ui.codemirror._encode_emojies('🙂') == bytes([0, 1])
-    assert ui.codemirror._encode_emojies('Hello 🙂') == bytes([0, 0, 0, 0, 0, 0, 0, 1])
-    assert ui.codemirror._encode_emojies('😎😎😎') == bytes([0, 1, 0, 1, 0, 1])
+def test_encode_codepoints():
+    assert ui.codemirror._encode_codepoints('') == b''
+    assert ui.codemirror._encode_codepoints('Hello') == bytes([1, 1, 1, 1, 1])
+    assert ui.codemirror._encode_codepoints('🙂') == bytes([0, 1])
+    assert ui.codemirror._encode_codepoints('Hello 🙂') == bytes([1, 1, 1, 1, 1, 1, 0, 1])
+    assert ui.codemirror._encode_codepoints('😎😎😎') == bytes([0, 1, 0, 1, 0, 1])

--- a/tests/test_codemirror.py
+++ b/tests/test_codemirror.py
@@ -45,6 +45,7 @@ def test_supported_values(screen: Screen):
     ('X', [1, -1, 0, 1], [[], ['Y']], 'XY'),
     ('Hello', [5, -1, 0, 8], [[], [', world!']], 'Hello, world!'),
     ('Hello, world!', [5, -1, 7, 0, 1, -1], [], 'Hello!'),
+    ('Hello, hello!', [2, -1, 3, 1, 4, -1, 3, 1, 1, -1], [[], ['y'], [], ['y']], 'Hey, hey!'),
 ])
 def test_change_set(screen: Screen, doc: str, sections: List[int], inserted: List[List[str]], expected: str):
     editor = ui.codemirror(doc)

--- a/tests/test_codemirror.py
+++ b/tests/test_codemirror.py
@@ -1,7 +1,8 @@
+from itertools import product
 from typing import Dict, List
 
 from nicegui import ui
-from nicegui.elements.codemirror import _apply_change_set
+from nicegui.elements.codemirror import find_python_index, get_cumulative_js_length
 from nicegui.testing import Screen
 
 
@@ -35,10 +36,42 @@ def test_supported_values(screen: Screen):
 
 
 def test_change_set():
-    assert _apply_change_set('', [0, 1], [['A']]) == 'A'
-    assert _apply_change_set('', [0, 2], [['AB']]) == 'AB'
-    assert _apply_change_set('X', [1, 2], [['AB']]) == 'AB'
-    assert _apply_change_set('X', [1, -1], []) == 'X'
-    assert _apply_change_set('X', [1, -1, 0, 1], [[], ['Y']]) == 'XY'
-    assert _apply_change_set('Hello', [5, -1, 0, 8], [[], [', world!']]) == 'Hello, world!'
-    assert _apply_change_set('Hello, world!', [5, -1, 7, 0, 1, -1], []) == 'Hello!'
+    @ui.page('/')
+    def page():
+        editor = ui.codemirror()
+
+        editor.value = ''
+        editor._apply_change_set([0, 1], [['A']])
+        assert editor.value == 'A'
+
+        editor.value = ''
+        editor._apply_change_set([0, 2], [['AB']])
+        assert editor.value == 'AB'
+
+        editor.value = 'X'
+        editor._apply_change_set([1, 2], [['AB']])
+        assert editor.value == 'AB'
+
+        editor.value = 'X'
+        editor._apply_change_set([1, -1], [])
+        assert editor.value == 'X'
+
+        editor.value = 'X'
+        editor._apply_change_set([1, -1, 0, 1], [[], ['Y']])
+        assert editor.value == 'XY'
+
+        editor.value = 'Hello'
+        editor._apply_change_set([5, -1, 0, 8], [[], [', world!']])
+        assert editor.value == 'Hello, world!'
+
+        editor.value = 'Hello, world!'
+        editor._apply_change_set([5, -1, 7, 0, 1, -1], [])
+        assert editor.value == 'Hello!'
+
+
+def test_find_python_index():
+    n = 10
+    for combination in product([chr(20), chr(70000)], repeat=n):
+        cumulative_js_length = get_cumulative_js_length(combination)
+        for elem in cumulative_js_length:
+            assert cumulative_js_length[find_python_index(elem, cumulative_js_length)-1] == elem, f"Failed for {elem}"


### PR DESCRIPTION
This PR is in response to #4676 being merged, implementing the approach at https://github.com/zauberzeug/nicegui/pull/4578#issuecomment-2816803235 to fix #4575 

Recap of the technique: 

> Maintain a list `self._cumulative_js_length`, same length as the Python string, which stores the number of UTF-16 code points per character in the Python string. 
> 
> Do a binary search to find the starting index to slice the Python string into. Do another binary search to find the ending index to slice the Python string into as well.
> 
> Don't forget to recompute `self._cumulative_js_length` on change of `self.value` if it has been mutated by others (obvious by the fact that the new value is different to `self._cumulative_corresponds_to_string`

Changes in the code:
* `import bisect` (duh)
* Do not attach the `on_change` via `super().__init__(value=value, on_value_change=on_change)`. We want our internal handler `self._update_cumulative` to always go first. Attach the `on_change` via `super().on_value_change(on_change)`
* Move `_apply_change_set` inside the class (since it is no longer in a vacuum but relies on several instance variables)
* Helper function `get_cumulative_js_length` is introduced, returning `[1, 2, 4, 5, 6]` if passed "aa🔄bb"
* Inner function `find_python_index_given_js_index`: consider "aa🔄bb", say we want to find where to slice, if JS-side calls for `doc[:4]` in its minds. `bisect.bisect_right([1,2,4,5,6],4)` yields 3, meaning we should in-return do `doc[:3]` to mirror JS-side intention. 
* Helper function `get_total_length_from_cumulative` is introduced. Would return `0` if input `[]`, `5` if input `[1, 2, 3, 4, 5]`

---

Remaining tasks:

- [x] avoid counting 1s twice?
- [x] update docstrings
- [x] ~~use separate event for emitting change sets, avoiding the need for selectively blocking `_update_codepoints`~~ it was easier to stick with the "update:model-value" event but to use `_send_update_on_value_change` for an early exit
- [x] check variable naming
