### PR TITLE
Add context manager to the user fixture

### DIFF
--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -54,7 +54,7 @@ class User:
 
         Example:
             with user:
-                table = one(ElementFilter(kind=ui.table))
+                tables = list(ElementFilter(kind=ui.table))
         """
         return self._client.__enter__()
 

--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -46,6 +46,21 @@ class User:
             raise ValueError('This user has not opened a page yet. Did you forgot to call .open()?')
         return self.client
 
+    def __enter__(self):
+        """Enter context manager for the underlying page.
+
+        Within a context manager block, create an ElementFilter to find elements
+        on the page.
+
+        Example:
+            with user:
+                table = one(ElementFilter(kind=ui.table))
+        """
+        return self._client.__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return self._client.__exit__(exc_type, exc_val, exc_tb)
+
     def __getattribute__(self, name: str) -> Any:
         if name not in {'notify', 'navigate', 'download'}:  # NOTE: avoid infinite recursion
             ui.navigate = self.navigate

--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -46,19 +46,10 @@ class User:
             raise ValueError('This user has not opened a page yet. Did you forgot to call .open()?')
         return self.client
 
-    def __enter__(self):
-        """Enter context manager for the underlying page.
-
-        Within a context manager block, create an ElementFilter to find elements
-        on the page.
-
-        Example:
-            with user:
-                tables = list(ElementFilter(kind=ui.table))
-        """
+    def __enter__(self) -> Client:
         return self._client.__enter__()
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         return self._client.__exit__(exc_type, exc_val, exc_tb)
 
     def __getattribute__(self, name: str) -> Any:

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -8,7 +8,7 @@ from fastapi import UploadFile
 from fastapi.datastructures import Headers
 from fastapi.responses import PlainTextResponse
 
-from nicegui import app, events, ui
+from nicegui import ElementFilter, app, events, ui
 from nicegui.testing import User
 
 # pylint: disable=missing-function-docstring
@@ -568,3 +568,14 @@ async def test_run_javascript(user: User):
     user.javascript_rules[re.compile(r'Math.sqrt\((\d+)\)')] = lambda match: int(match.group(1))**0.5
     await user.open('/')
     await user.should_see('42')
+
+
+async def test_context_manager(user: User) -> None:
+    @ui.page('/')
+    def index():
+        ui.button('click me', on_click=lambda: ui.label('clicked'))
+
+    await user.open('/')
+    with user:
+        elements = list(ElementFilter(kind=ui.button))
+    assert len(elements) == 1 and isinstance(elements[0], ui.button)

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -571,9 +571,7 @@ async def test_run_javascript(user: User):
 
 
 async def test_context_manager(user: User) -> None:
-    @ui.page('/')
-    def index():
-        ui.button('click me', on_click=lambda: ui.label('clicked'))
+    ui.button('click me')
 
     await user.open('/')
     with user:

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -120,8 +120,7 @@ doc.text('Using an ElementFilter', '''
 def using_an_elementfilter():
     with ui.row().classes('gap-4 items-stretch'):
         with python_window(classes='w-[400px]', title='UI code'):
-            ui.markdown(
-                '''
+            ui.markdown('''
                 ```python
                 ui.label('1').mark('number')
                 ui.label('2').mark('number')

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -78,15 +78,6 @@ doc.text('Querying', '''
 
 @doc.ui
 def querying():
-    ui.markdown('''
-        You can also use `ElementFilter` directly with `user`'s context manager
-        syntax. This can be useful in the following cases:
-
-        - Retrieving an element and interacting with it directly
-        - Retrieving elements in the order they appear on the page (for example,
-          if a test needs to verify the sequence of elements)
-    ''')
-
     with ui.row().classes('gap-4 items-stretch'):
         with python_window(classes='w-[400px]', title='some UI code'):
             ui.markdown('''
@@ -110,9 +101,53 @@ def querying():
                 await user.should_see('Hello')
                 await user.should_see(marker='greeting')
                 await user.should_see(kind=ui.icon)
-                
+                ```
+            ''')
+
+
+doc.text(
+    'Using ElementFilter directly',
+    '''
+    Since `user.find` uses a set to avoid duplicates, it does not preserve the order.
+    Consider how the order is not preserved after converting to a set and back in this code:
+    `list(set(["1", "2", "3"])) == ["3", "1", "2"]`.
+
+    Instead, it is possible to use [ElementFilter](/documentation/element_filter) directly
+    by entering the `user` context.
+''')
+
+
+@doc.ui
+def using_elementfilter_directly():
+    ui.markdown('''
+        By entering the `user` context and iterating over `ElementFilter`, you can preserve
+        the natural document order of matching elements.
+''')
+
+    with ui.row().classes('gap-4 items-stretch'):
+        with python_window(classes='w-[400px]', title='UI code'):
+            ui.markdown(
+                '''
+                ```python
+                ui.label("1").mark("text-123")
+                ui.label("2").mark("text-123")
+                ui.label("3").mark("text-123")
+                ```
+            ''')
+
+        with python_window(classes='w-[600px]', title='user assertions'):
+            ui.markdown(
+                '''
+                ```python
                 with user:
-                    icons = list(ElementFilter(kind=ui.icon))
+                    expected_text = ['1', '2', '3']
+                    assert [
+                        label.text == expected
+                        for label, expected in zip(
+                            ElementFilter(marker='text-123'),
+                            expected_text
+                        )
+                    ]
                 ```
             ''')
 

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -105,48 +105,39 @@ def querying():
             ''')
 
 
-doc.text(
-    'Using ElementFilter directly',
-    '''
-    It may be desirable to use ElementFilter for the following purposes:
+doc.text('Using an ElementFilter', '''
+    It may be desirable to use an [`ElementFilter`](/documentation/element_filter) to
 
-    - Preserve order of elements to check their order on the page
-    - More granular filtering options ([ElementFilter](/documentation/element_filter)),
-      such as `ElementFilter(...).within(...)`
+    - preserve the order of elements to check their order on the page, and
+    - more granular filtering options, such as `ElementFilter(...).within(...)`.
+
+    By entering the `user` context and iterating over `ElementFilter`,
+    you can preserve the natural document order of matching elements:
 ''')
 
 
 @doc.ui
-def using_elementfilter_directly():
-    ui.markdown('''
-        By entering the `user` context and iterating over `ElementFilter`, you can preserve
-        the natural document order of matching elements.
-''')
-
+def using_an_elementfilter():
     with ui.row().classes('gap-4 items-stretch'):
         with python_window(classes='w-[400px]', title='UI code'):
             ui.markdown(
                 '''
                 ```python
-                ui.label("1").mark("text-123")
-                ui.label("2").mark("text-123")
-                ui.label("3").mark("text-123")
+                ui.label('1').mark('number')
+                ui.label('2').mark('number')
+                ui.label('3').mark('number')
                 ```
             ''')
 
         with python_window(classes='w-[600px]', title='user assertions'):
-            ui.markdown(
-                '''
+            ui.markdown('''
                 ```python
                 with user:
-                    expected_text = ['1', '2', '3']
-                    assert [
-                        label.text == expected
-                        for label, expected in zip(
-                            ElementFilter(marker='text-123'),
-                            expected_text
-                        )
-                    ]
+                    elements = list(ElementFilter(marker='number'))
+                    assert len(elements) == 3
+                    assert elements[0].text == '1'
+                    assert elements[1].text == '2'
+                    assert elements[2].text == '3'
                 ```
             ''')
 

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -78,6 +78,15 @@ doc.text('Querying', '''
 
 @doc.ui
 def querying():
+    ui.markdown('''
+        You can also use `ElementFilter` directly with `user`'s context manager
+        syntax. This can be useful in the following cases:
+
+        - Retrieving an element and interacting with it directly
+        - Retrieving elements in the order they appear on the page (for example,
+          if a test needs to verify the sequence of elements)
+    ''')
+
     with ui.row().classes('gap-4 items-stretch'):
         with python_window(classes='w-[400px]', title='some UI code'):
             ui.markdown('''
@@ -101,6 +110,9 @@ def querying():
                 await user.should_see('Hello')
                 await user.should_see(marker='greeting')
                 await user.should_see(kind=ui.icon)
+                
+                with user:
+                    icons = list(ElementFilter(kind=ui.icon))
                 ```
             ''')
 

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -108,12 +108,11 @@ def querying():
 doc.text(
     'Using ElementFilter directly',
     '''
-    Since `user.find` uses a set to avoid duplicates, it does not preserve the order.
-    Consider how the order is not preserved after converting to a set and back in this code:
-    `list(set(["1", "2", "3"])) == ["3", "1", "2"]`.
+    It may be desirable to use ElementFilter for the following purposes:
 
-    Instead, it is possible to use [ElementFilter](/documentation/element_filter) directly
-    by entering the `user` context.
+    - Preserve order of elements to check their order on the page
+    - More granular filtering options ([ElementFilter](/documentation/element_filter)),
+      such as `ElementFilter(...).within(...)`
 ''')
 
 


### PR DESCRIPTION
This PR fix https://github.com/zauberzeug/nicegui/discussions/4667 by making user a context manager. By implementing `__enter__` and `__exit__` for user, we can with user: and then use the `ElementFilter` directly, overcoming how `user.find` returns a set, and enabling checking the order of filtered elements in testing.