### PR TITLE
run.py: little refactoring to gain basic android compatibility

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -125,6 +125,7 @@ async def _startup() -> None:
     else:
         app.add_route('/favicon.ico', lambda _: FileResponse(Path(__file__).parent / 'static' / 'favicon.ico'))
     core.loop = asyncio.get_running_loop()
+    run.setup()
     app.start()
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(Client.prune_instances(), name='prune clients')

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -125,7 +125,6 @@ async def _startup() -> None:
     else:
         app.add_route('/favicon.ico', lambda _: FileResponse(Path(__file__).parent / 'static' / 'favicon.ico'))
     core.loop = asyncio.get_running_loop()
-    run.setup()
     app.start()
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(Client.prune_instances(), name='prune clients')

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -113,7 +113,6 @@ async def _startup() -> None:
                            'remove the guard or replace it with\n'
                            '   if __name__ in {"__main__", "__mp_main__"}:\n'
                            'to allow for multiprocessing.')
-    await welcome.collect_urls()
     # NOTE ping interval and timeout need to be lower than the reconnect timeout, but can't be too low
     sio.eio.ping_interval = max(app.config.reconnect_timeout * 0.8, 4)
     sio.eio.ping_timeout = max(app.config.reconnect_timeout * 0.4, 2)
@@ -126,6 +125,7 @@ async def _startup() -> None:
         app.add_route('/favicon.ico', lambda _: FileResponse(Path(__file__).parent / 'static' / 'favicon.ico'))
     core.loop = asyncio.get_running_loop()
     run.setup()
+    await welcome.collect_urls()
     app.start()
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(Client.prune_instances(), name='prune clients')

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -113,6 +113,7 @@ async def _startup() -> None:
                            'remove the guard or replace it with\n'
                            '   if __name__ in {"__main__", "__mp_main__"}:\n'
                            'to allow for multiprocessing.')
+    await welcome.collect_urls()
     # NOTE ping interval and timeout need to be lower than the reconnect timeout, but can't be too low
     sio.eio.ping_interval = max(app.config.reconnect_timeout * 0.8, 4)
     sio.eio.ping_timeout = max(app.config.reconnect_timeout * 0.4, 2)
@@ -125,7 +126,6 @@ async def _startup() -> None:
         app.add_route('/favicon.ico', lambda _: FileResponse(Path(__file__).parent / 'static' / 'favicon.ico'))
     core.loop = asyncio.get_running_loop()
     run.setup()
-    await welcome.collect_urls()
     app.start()
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
     background_tasks.create(Client.prune_instances(), name='prune clients')

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -27,6 +27,7 @@ def setup() -> None:
     except NotImplementedError:
         logging.warning('Failed to initialize ProcessPoolExecutor')
 
+
 class SubprocessException(Exception):
     """A picklable exception to represent exceptions raised in subprocesses."""
 

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -102,11 +102,9 @@ def tear_down() -> None:
         return
 
     kwargs = {'cancel_futures': True} if sys.version_info >= (3, 9) else {}
-
     if process_pool is not None:
         for p in process_pool._processes.values():  # pylint: disable=protected-access
             p.kill()
         process_pool.shutdown(wait=True, **kwargs)
-
     if thread_pool is not None:
         thread_pool.shutdown(wait=False, **kwargs)

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -21,8 +21,7 @@ def setup() -> None:
     """Setup the process pool. (For internal use only.)"""
     global process_pool  # pylint: disable=global-statement # noqa: PLW0603
     try:
-        if process_pool is None:
-            process_pool = ProcessPoolExecutor()
+        process_pool = ProcessPoolExecutor()
     except NotImplementedError:
         logging.warning('Failed to initialize ProcessPoolExecutor')
 

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import sys
 import traceback
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
@@ -24,12 +25,12 @@ def setup() -> None:
         if process_pool is None:
             process_pool = ProcessPoolExecutor()
     except NotImplementedError:
-        pass
+        logging.warning('Failed to initialize ProcessPoolExecutor')
     try:
         if thread_pool is None:
             thread_pool = ThreadPoolExecutor()
     except NotImplementedError:
-        pass
+        logging.warning('Failed to initialize ThreadPoolExecutor')
 
 class SubprocessException(Exception):
     """A picklable exception to represent exceptions raised in subprocesses."""

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -66,16 +66,16 @@ async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs)
     It is encouraged to create static methods (or free functions) which get all the data as simple parameters (eg. no class/ui logic)
     and return the result (instead of writing it in class properties or global variables).
     """
-    global process_pool
-    if not process_pool:
+    global process_pool # pylint: disable=global-statement # noqa: PLW0603
+    if process_pool is None:
         process_pool = ProcessPoolExecutor()
     return await _run(process_pool, safe_callback, callback, *args, **kwargs)
 
 
 async def io_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
     """Run an I/O-bound function in a separate thread."""
-    global thread_pool
-    if not thread_pool:
+    global thread_pool # pylint: disable=global-statement # noqa: PLW0603
+    if thread_pool is None:
         thread_pool = ThreadPoolExecutor()
     return await _run(thread_pool, callback, *args, **kwargs)
 
@@ -84,12 +84,13 @@ def tear_down() -> None:
     """Kill all processes and threads."""
     if helpers.is_pytest():
         return
-    assert process_pool is not None
-    for p in process_pool._processes.values():  # pylint: disable=protected-access
-        p.kill()
+
     kwargs = {'cancel_futures': True} if sys.version_info >= (3, 9) else {}
 
-    if process_pool:
+    if not process_pool is None:
+        for p in process_pool._processes.values():  # pylint: disable=protected-access
+            p.kill()
         process_pool.shutdown(wait=True, **kwargs)
-    if thread_pool:
+
+    if not thread_pool is None:
         thread_pool.shutdown(wait=False, **kwargs)

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -81,11 +81,17 @@ async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs)
     It is encouraged to create static methods (or free functions) which get all the data as simple parameters (eg. no class/ui logic)
     and return the result (instead of writing it in class properties or global variables).
     """
+    if process_pool is None:
+        raise RuntimeError('Process pool not set up. Call run.setup() first.')
+
     return await _run(process_pool, safe_callback, callback, *args, **kwargs)
 
 
 async def io_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
     """Run an I/O-bound function in a separate thread."""
+    if thread_pool is None:
+        raise RuntimeError('Thread pool not set up. Call run.setup() first.')
+
     return await _run(thread_pool, callback, *args, **kwargs)
 
 

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -18,9 +18,8 @@ R = TypeVar('R')
 
 
 def setup() -> None:
-    """Setup the process pool and the thread pool. (For internal use only.)"""
+    """Setup the process pool. (For internal use only.)"""
     global process_pool  # pylint: disable=global-statement # noqa: PLW0603
-    global thread_pool  # pylint: disable=global-statement # noqa: PLW0603
     try:
         if process_pool is None:
             process_pool = ProcessPoolExecutor()

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -77,7 +77,7 @@ async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs)
     and return the result (instead of writing it in class properties or global variables).
     """
     if process_pool is None:
-        raise RuntimeError('Process pool not set up. Call run.setup() first.')
+        raise RuntimeError('Process pool not set up.')
 
     return await _run(process_pool, safe_callback, callback, *args, **kwargs)
 


### PR DESCRIPTION
This PR refactors the initialization of the ThreadPoolExecutor and the ProcessPoolExecutor in `run.py` a little. As a result they get initialized on the first call to `io_bound` respectively `cpu_bound` on demand.

This is necessary to achieve basic android compatibility (#578) since named semaphores are not available on android which the named Executors use and therefor throw an exception on initialization.

With this change nicegui runs on android under the following conditions:
- calling `run.io_bound` and `run.cpu_bound` will throw exceptions (named semaphores not available)
- host must not equal '0.0.0.0' for now (because otherwise `welcome.py` makes an `io_bound` call)

`run.io_bound` and `run.cpu_bound` support might follow in a separate PR.

 With this PR the basic example app at https://github.com/jeff-dh/niceApp works on android (at least in my environment)