### PR TITLE
Block datatypes which causes Vue to grind to halt in `ui.table` `rows`

### DIFF
--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -62,6 +62,17 @@ class Table(FilterElement, component='table.js'):
             first_row = rows[0] if rows else {}
             columns = [{'name': key, 'label': str(key).upper(), 'field': key, 'sortable': True} for key in first_row]
 
+        for row in rows:
+            for key, value in row.items():
+                if isinstance(value, list):
+                    row[key] = ''.join(map(str, value))
+                elif isinstance(value, dict):
+                    row[key] = ''
+                elif isinstance(value, set):
+                    row[key] = ''.join(map(str, value))
+                elif isinstance(value, tuple):
+                    row[key] = ''.join(map(str, value))
+
         self._column_defaults = column_defaults
         self._use_columns_from_df = False
         self._props['columns'] = self._normalize_columns(columns)


### PR DESCRIPTION
This PR fix #2744 with a rather heavy-handed approach of converting all data types which could possibly cause Vue to grind to a halt to be string, and disables dicts altogether. 

<img width="1213" alt="{982BB1D4-AA24-4854-842D-E2BC015F882F}" src="https://github.com/user-attachments/assets/c3446cd8-27b8-43b2-b260-3b8249275ba0" />

This brings the behaviour in line to Vue

```html
<html>
  <head>
    <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons" rel="stylesheet" type="text/css" />
    <link href="https://cdn.jsdelivr.net/npm/quasar@2.15.1/dist/quasar.prod.css" rel="stylesheet" type="text/css" />
  </head>
  <body>
    <div id="q-app">
      <q-table :columns="[{'name': 'A','label': 'A','field': 'A'}]" :rows="[{'A': 'string'}, {'A': 123}, {'A': true}, {'A': new Date('2025-05-03')}, {'A': [1, 2, 3]}, {'A': { key: 'value' }}, {'A': null}, {'A': function() { return true; }}, {'A': Symbol('a')}]" row-key="id" />
    </div>
    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js"></script>
    <script src="https://cdn.jsdelivr.net/npm/quasar@2.15.1/dist/quasar.umd.prod.js"></script>
    <script>
      const app = Vue.createApp({ setup() { return {}; } });
      app.use(Quasar);
      app.mount("#q-app");
    </script>
  </body>
</html>
```