### PR TITLE
Fix multi-cursor updates in `ui.codemirror`

### DIFF
--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -340,10 +340,10 @@ def _apply_change_set(doc, sections: List[int], inserted: List[List[str]]) -> st
     # based on https://github.com/codemirror/state/blob/main/src/change.ts
     assert sum(sections[::2]) == len(doc), 'Cannot apply change set to document due to length mismatch'
     pos = 0
-    new_doc = ''
+    parts = []
     joined_inserts = ('\n'.join(ins) for ins in inserted)
     for section in zip_longest(sections[::2], sections[1::2], joined_inserts, fillvalue=''):
         old_len, new_len, ins = cast(Tuple[int, int, str], section)
-        new_doc += doc[pos:pos + old_len] if new_len == -1 else ins
+        parts.append(doc[pos:pos + old_len] if new_len == -1 else ins)
         pos += old_len
-    return new_doc
+    return ''.join(parts)

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -1,6 +1,6 @@
-from itertools import zip_longest
+from itertools import accumulate, zip_longest
 from pathlib import Path
-from typing import List, Literal, Optional, Tuple, cast, get_args
+from typing import List, Literal, Optional, get_args
 
 from nicegui.elements.mixins.disableable_element import DisableableElement
 from nicegui.elements.mixins.value_element import ValueElement
@@ -338,12 +338,12 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
 
 def _apply_change_set(doc, sections: List[int], inserted: List[List[str]]) -> str:
     # based on https://github.com/codemirror/state/blob/main/src/change.ts
-    assert sum(sections[::2]) == len(doc), 'Cannot apply change set to document due to length mismatch'
-    pos = 0
-    parts = []
+    old_lengths = sections[::2]
+    new_lengths = sections[1::2]
+    end_positions = accumulate(old_lengths)
     joined_inserts = ('\n'.join(ins) for ins in inserted)
-    for section in zip_longest(sections[::2], sections[1::2], joined_inserts, fillvalue=''):
-        old_len, new_len, ins = cast(Tuple[int, int, str], section)
-        parts.append(doc[pos:pos + old_len] if new_len == -1 else ins)
-        pos += old_len
-    return ''.join(parts)
+    assert sum(old_lengths) == len(doc), 'Cannot apply change set to document due to length mismatch'
+    return ''.join(
+        doc[pos-old_len:pos] if new_len == -1 else ins  # type: ignore
+        for pos, old_len, new_len, ins in zip_longest(end_positions, old_lengths, new_lengths, joined_inserts, fillvalue='')
+    )

--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -340,10 +340,10 @@ def _apply_change_set(doc, sections: List[int], inserted: List[List[str]]) -> st
     # based on https://github.com/codemirror/state/blob/main/src/change.ts
     assert sum(sections[::2]) == len(doc), 'Cannot apply change set to document due to length mismatch'
     pos = 0
+    new_doc = ''
     joined_inserts = ('\n'.join(ins) for ins in inserted)
     for section in zip_longest(sections[::2], sections[1::2], joined_inserts, fillvalue=''):
         old_len, new_len, ins = cast(Tuple[int, int, str], section)
-        if new_len >= 0:
-            doc = doc[:pos] + ins + doc[pos + old_len:]
+        new_doc += doc[pos:pos + old_len] if new_len == -1 else ins
         pos += old_len
-    return doc
+    return new_doc

--- a/tests/test_codemirror.py
+++ b/tests/test_codemirror.py
@@ -42,3 +42,4 @@ def test_change_set():
     assert _apply_change_set('X', [1, -1, 0, 1], [[], ['Y']]) == 'XY'
     assert _apply_change_set('Hello', [5, -1, 0, 8], [[], [', world!']]) == 'Hello, world!'
     assert _apply_change_set('Hello, world!', [5, -1, 7, 0, 1, -1], []) == 'Hello!'
+    assert _apply_change_set('Hello, hello!', [2, -1, 3, 1, 4, -1, 3, 1, 1, -1], [[], ['y'], [], ['y']]) == 'Hey, hey!'


### PR DESCRIPTION
This PR fixes issue #4701 which has been introduced in PR #4676. When one change caused the content to shift, subsequent changes have been applied at the wrong position. This is fixed by creating a new string from scratch instead of manipulating the old string "in place". While at it, this PR replaces the many instantiations of large strings with a single `''.join()` operation to connect individual parts.