### PR TITLE
Image and Video Overlays in Leaflet API

### DIFF
--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -17,6 +17,8 @@ class Leaflet(Element, component='leaflet.js', default_classes='nicegui-leaflet'
     from .leaflet_layers import Marker as marker
     from .leaflet_layers import TileLayer as tile_layer
     from .leaflet_layers import WmsLayer as wms_layer
+    from .leaflet_layers import ImageOverlay as image_overlay
+    from .leaflet_layers import VideoOverlay as video_overlay
 
     center = binding.BindableProperty(lambda sender, value: cast(Leaflet, sender).set_center(value))
     zoom = binding.BindableProperty(lambda sender, value: cast(Leaflet, sender).set_zoom(value))

--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -14,11 +14,11 @@ from .leaflet_layer import Layer
 class Leaflet(Element, component='leaflet.js', default_classes='nicegui-leaflet'):
     # pylint: disable=import-outside-toplevel
     from .leaflet_layers import GenericLayer as generic_layer
+    from .leaflet_layers import ImageOverlay as image_overlay
     from .leaflet_layers import Marker as marker
     from .leaflet_layers import TileLayer as tile_layer
-    from .leaflet_layers import WmsLayer as wms_layer
-    from .leaflet_layers import ImageOverlay as image_overlay
     from .leaflet_layers import VideoOverlay as video_overlay
+    from .leaflet_layers import WmsLayer as wms_layer
 
     center = binding.BindableProperty(lambda sender, value: cast(Leaflet, sender).set_center(value))
     zoom = binding.BindableProperty(lambda sender, value: cast(Leaflet, sender).set_zoom(value))

--- a/nicegui/elements/leaflet_layers.py
+++ b/nicegui/elements/leaflet_layers.py
@@ -44,6 +44,32 @@ class WmsLayer(Layer):
 
 
 @dataclass(**KWONLY_SLOTS)
+class ImageOverlay(Layer):
+    url: str
+    bounds: List[List[float]]
+    options: Dict = field(default_factory=dict)
+
+    def to_dict(self) -> Dict:
+        return {
+            'type': 'imageOverlay',
+            'args': [self.url, self.bounds, self.options],
+        }
+
+
+@dataclass(**KWONLY_SLOTS)
+class VideoOverlay(Layer):
+    url: str | List[str]
+    bounds: List[List[float]]
+    options: Dict = field(default_factory=dict)
+
+    def to_dict(self) -> Dict:
+        return {
+            'type': 'videoOverlay',
+            'args': [self.url, self.bounds, self.options],
+        }
+
+
+@dataclass(**KWONLY_SLOTS)
 class Marker(Layer):
     latlng: Tuple[float, float]
     options: Dict = field(default_factory=dict)

--- a/nicegui/elements/leaflet_layers.py
+++ b/nicegui/elements/leaflet_layers.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 from typing_extensions import Self
 
@@ -58,7 +58,7 @@ class ImageOverlay(Layer):
 
 @dataclass(**KWONLY_SLOTS)
 class VideoOverlay(Layer):
-    url: str | List[str]
+    url: Union[str, List[str]]
     bounds: List[List[float]]
     options: Dict = field(default_factory=dict)
 

--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -220,7 +220,7 @@
   height: 16rem;
 }
 .nicegui-leaflet video.leaflet-image-layer {
-  max-width: none;
+  max-width: none; /* HACK: make the video show up */
 }
 .nicegui-log {
   padding: 0.5rem;

--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -219,6 +219,9 @@
   width: 100%;
   height: 16rem;
 }
+.nicegui-leaflet video.leaflet-image-layer {
+  max-width: none;
+}
 .nicegui-log {
   padding: 0.5rem;
   scroll-padding-bottom: 0.5rem;

--- a/website/documentation/content/leaflet_documentation.py
+++ b/website/documentation/content/leaflet_documentation.py
@@ -77,48 +77,29 @@ def move_markers() -> None:
     ui.button('Move marker', on_click=lambda: marker.move(51.51, -0.09))
 
 
-@doc.demo('Overlaying Image', '''
+@doc.demo('Image Overlays', '''
     Leaflet supports [image overlays](https://leafletjs.com/reference.html#imageoverlay).
     You can add an image overlay with the `image_overlay` method.
-
-    Example is from [Leaflet Image Overlay](https://leafletjs.com/examples/overlays/#:~:text=use%20these%20overlays.-,ImageOverlay,-L.ImageOverlay%20is).
 ''')
 def overlay_image():
-    m = ui.leaflet(center=(40.73997376331186, -74.22363281250001), zoom=11).classes('h-96')
+    m = ui.leaflet(center=(40.74, -74.18), zoom=11)
     m.image_overlay(
         url='https://maps.lib.utexas.edu/maps/historical/newark_nj_1922.jpg',
-        bounds=[[40.799311, -74.118464], [40.68202047785919, -74.33]],
-        options={
-            'opacity': 0.8,
-            'errorOverlayUrl': 'https://cdn-icons-png.flaticon.com/512/110/110686.png',
-            'alt': 'Image of Newark, N.J. in 1922. Source: The University of Texas at Austin, UT Libraries Map Collection.',
-            'interactive': True,
-        },
+        bounds=[[40.712216, -74.22655], [40.773941, -74.12544]],
+        options={'opacity': 0.8},
     )
 
 
-@doc.demo('Overlaying Video', '''
+@doc.demo('Video Overlays', '''
     Leaflet supports [video overlays](https://leafletjs.com/reference.html#videooverlay).
     You can add a video overlay with the `video_overlay` method.
-
-    Example is from [Leaflet Video Overlay](https://leafletjs.com/examples/overlays/#:~:text=example%20stand%2Dalone.-,VideoOverlay,-Video%20used%20to).
 ''')
 def overlay_video():
-    m = ui.leaflet(center=(22.998851594142923, -114.87304687500001), zoom=4).classes('h-96')
+    m = ui.leaflet(center=(23.0, -115.0), zoom=3)
     m.video_overlay(
-        url=[
-            'https://labs.mapbox.com/bites/00188/patricia_nasa.webm',
-            'https://labs.mapbox.com/bites/00188/patricia_nasa.mp4',
-        ],
+        url='https://www.mapbox.com/bites/00188/patricia_nasa.webm',
         bounds=[[32, -130], [13, -100]],
-        options={
-            'opacity': 0.8,
-            'errorOverlayUrl': 'https://cdn-icons-png.flaticon.com/512/110/110686.png',
-            'interactive': True,
-            'autoplay': True,
-            'muted': True,
-            'playsInline': True,
-        },
+        options={'opacity': 0.8, 'autoplay': True, 'playsInline': True},
     )
 
 

--- a/website/documentation/content/leaflet_documentation.py
+++ b/website/documentation/content/leaflet_documentation.py
@@ -77,6 +77,51 @@ def move_markers() -> None:
     ui.button('Move marker', on_click=lambda: marker.move(51.51, -0.09))
 
 
+@doc.demo('Overlaying Image', '''
+    Leaflet supports [image overlays](https://leafletjs.com/reference.html#imageoverlay).
+    You can add an image overlay with the `image_overlay` method.
+          
+    Example is from [Leaflet Image Overlay](https://leafletjs.com/examples/overlays/#:~:text=use%20these%20overlays.-,ImageOverlay,-L.ImageOverlay%20is).
+''')
+def overlay_image():
+    m = ui.leaflet(center=(40.73997376331186, -74.22363281250001), zoom=11).classes('h-96')
+    m.image_overlay(
+        url='https://maps.lib.utexas.edu/maps/historical/newark_nj_1922.jpg',
+        bounds=[[40.799311, -74.118464], [40.68202047785919, -74.33]],
+        options={
+            'opacity': 0.8,
+            'errorOverlayUrl': 'https://cdn-icons-png.flaticon.com/512/110/110686.png',
+            'alt': 'Image of Newark, N.J. in 1922. Source: The University of Texas at Austin, UT Libraries Map Collection.',
+            'interactive': True,
+        },
+    )
+
+
+@doc.demo('Overlaying Video', '''
+    Leaflet supports [video overlays](https://leafletjs.com/reference.html#videooverlay).
+    You can add a video overlay with the `video_overlay` method.
+          
+    Example is from [Leaflet Video Overlay](https://leafletjs.com/examples/overlays/#:~:text=example%20stand%2Dalone.-,VideoOverlay,-Video%20used%20to).
+''')
+def overlay_video():
+    m = ui.leaflet(center=(22.998851594142923, -114.87304687500001), zoom=4).classes('h-96')
+    m.video_overlay(
+        url=[
+            'https://labs.mapbox.com/bites/00188/patricia_nasa.webm',
+            'https://labs.mapbox.com/bites/00188/patricia_nasa.mp4',
+        ],
+        bounds=[[32, -130], [13, -100]],
+        options={
+            'opacity': 0.8,
+            'errorOverlayUrl': 'https://cdn-icons-png.flaticon.com/512/110/110686.png',
+            'interactive': True,
+            'autoplay': True,
+            'muted': True,
+            'playsInline': True,
+        },
+    )
+
+
 @doc.demo('Vector Layers', '''
     Leaflet supports a set of [vector layers](https://leafletjs.com/reference.html#:~:text=VideoOverlay-,Vector%20Layers,-Path) like circle, polygon etc.
     These can be added with the `generic_layer` method.

--- a/website/documentation/content/leaflet_documentation.py
+++ b/website/documentation/content/leaflet_documentation.py
@@ -80,7 +80,7 @@ def move_markers() -> None:
 @doc.demo('Overlaying Image', '''
     Leaflet supports [image overlays](https://leafletjs.com/reference.html#imageoverlay).
     You can add an image overlay with the `image_overlay` method.
-          
+
     Example is from [Leaflet Image Overlay](https://leafletjs.com/examples/overlays/#:~:text=use%20these%20overlays.-,ImageOverlay,-L.ImageOverlay%20is).
 ''')
 def overlay_image():
@@ -100,7 +100,7 @@ def overlay_image():
 @doc.demo('Overlaying Video', '''
     Leaflet supports [video overlays](https://leafletjs.com/reference.html#videooverlay).
     You can add a video overlay with the `video_overlay` method.
-          
+
     Example is from [Leaflet Video Overlay](https://leafletjs.com/examples/overlays/#:~:text=example%20stand%2Dalone.-,VideoOverlay,-Video%20used%20to).
 ''')
 def overlay_video():


### PR DESCRIPTION
Fix #4686 and enables native usage of Image and Video Overlays in Leaflet API, without resorting to `m.generic_layer`

Change in `leaflet.py` and `leaflet_layers.py` should be easy to understand. Heck, they are written by GitHub copilot in full, after I type a single character. 

Notable details:
- Documentation aims to recreate the Leaflet demos 1:1
- Required a CSS tweak to make the video show up
- SVGOverlay not working, despite my best efforts (dumped 2 hours into it), so was not included. 