### PR TITLE
`run.set_cpu_bound_executor_type`: enable custom (android compatible) `cpu_bound`-exeuctors

### DIFF
--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -19,17 +19,8 @@ R = TypeVar('R')
 
 
 def set_cpu_bound_executor_type(executor_type: type):
-    """Set concurrent.futures.Executor compliant type for cpu_bound execution
-
-        Note: unfortunately this function will (very likely) be called before
-              all functions that are supposed to be called through the executor
-              are defined. As a result we can not instantiate the executor in
-              this function. If we would, the forked worker processes would not
-              be able to call these functions, because they are not defined yet
-              and thus don't exist in processes that are forked NOW....
-              Therefor this uncommon approach.
-    """
-    # makes no sense to call this function after ui.run which calls setup, right???
+    """Set concurrent.futures.Executor compliant type for cpu_bound execution"""
+    # makes no sense to call this function after ui.run which calls setup
     assert process_pool is None
     assert type(executor_type) is type
 


### PR DESCRIPTION
This PR proposes a new function in the run module -- called `set_cpu_bound_executor_type` -- which allows to exchange the type of the `(ProcessPool)Executor` used in `cpu_bound`.

As discussed in #4683 and #578 `run.cpu_bound` is not android compatible. The reason is that `concurrent.futures.ProcessPoolExecutor` is not android compatible (uses `multiprocessing.Queue` which uses named semaphores which are not available on android).
We gain (`cpu_bound`-) android compatibility as soon as we use an android compatible executor.

The proposed `set_cpu_bound_executor_type` function would outsource the mentioned issue to a custom executor which could be choosen and installed by the user.

With this PR, this works (on Linux, Windows (@evnchn right?) and Android):

```python
from nicegui import run
from aio_process_pool import Executor as AsyncExecutor

run.set_cpu_bound_executor_type(AsyncExecutor)
```

Note: `aio_process_pool` is an -- at least proof of concept -- implementation for an android compatible executor and is [available](https://github.com/jeff-dh/aio_process_pool).
