### PR TITLE
Interactive image layer

### DIFF
--- a/nicegui/elements/interactive_image.py
+++ b/nicegui/elements/interactive_image.py
@@ -101,3 +101,12 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
             return
         self._props['t'] = time.time()
         self.update()
+
+    def add_layer(self) -> InteractiveImage:
+        """Add a new layer with its own content.
+
+        *Added in version 2.17.0*
+        """
+        with self:
+            return InteractiveImage(source=self._props['src'], size=self._props['size']) \
+                .classes('nicegui-interactive-image-layer')

--- a/nicegui/elements/interactive_image.py
+++ b/nicegui/elements/interactive_image.py
@@ -102,11 +102,11 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
         self._props['t'] = time.time()
         self.update()
 
-    def add_layer(self) -> InteractiveImage:
+    def add_layer(self, *, content: str = '') -> InteractiveImage:
         """Add a new layer with its own content.
 
         *Added in version 2.17.0*
         """
         with self:
-            return InteractiveImage(source=self._props['src'], size=self._props['size']) \
+            return InteractiveImage(self._props['src'], content=content, size=self._props['size']) \
                 .classes('nicegui-interactive-image-layer')

--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -263,8 +263,14 @@ h6.q-timeline__title {
 .nicegui-scene-view[data-initializing] {
   visibility: hidden;
 }
-
-/* CodeMirror */
+.nicegui-interactive-image-layer {
+  position: absolute !important;
+  inset: 0;
+  pointer-events: none;
+}
+.nicegui-interactive-image-layer img {
+  display: none;
+}
 .nicegui-codemirror .cm-editor.cm-focused {
   outline: none;
 }

--- a/tests/test_interactive_image.py
+++ b/tests/test_interactive_image.py
@@ -95,3 +95,14 @@ def test_loaded_event(screen: Screen):
     screen.click('Change Source')
     screen.should_contain('loaded')
     assert (screen.find_by_tag('img').get_attribute('src') or '').endswith(URL_PATH2)
+
+
+def test_add_layer(screen: Screen):
+    ii = ui.interactive_image(URL_PATH1, content='<rect x="0" y="0" width="100" height="100" fill="red" />')
+    ii.add_layer(content='<circle cx="100" cy="100" r="15" />')
+
+    screen.open('/')
+    screen.find_by_tag('svg')
+    with screen.implicitly_wait(0.5):
+        assert len(screen.find_all_by_tag('rect')) == 1
+        assert len(screen.find_all_by_tag('circle')) == 1

--- a/website/documentation/content/interactive_image_documentation.py
+++ b/website/documentation/content/interactive_image_documentation.py
@@ -16,6 +16,31 @@ def main_demo() -> None:
     ii = ui.interactive_image(src, on_mouse=mouse_handler, events=['mousedown', 'mouseup'], cross=True)
 
 
+@doc.demo('Adding layers', '''
+    In some cases you might want to add different groups of SVG elements to an image.
+    Maybe there is one element that needs frequent updates, while the other elements are rarely changed.
+    Putting all elements in the same SVG can lead to performance issues,
+    because the whole SVG needs to be sent to the client whenever one of the elements changes.
+
+    The solution is to add multiple layers to the image.
+    Each layer is a separate SVG element, which means that each layer can be updated independently.
+
+    The following demo shows this concept in action, even though both layers are changed at the same time.
+
+    *Added in version 2.17.0*
+''')
+def adding_layers():
+    from nicegui import events
+
+    def mouse_handler(e: events.MouseEventArguments):
+        image.content += f'<circle cx="{e.image_x}" cy="{e.image_y}" r="30" fill="none" stroke="red" stroke-width="4" />'
+        highlight.content = f'<circle cx="{e.image_x}" cy="{e.image_y}" r="28" fill="yellow" opacity="0.5" />'
+
+    src = 'https://picsum.photos/id/674/640/360'
+    image = ui.interactive_image(src, on_mouse=mouse_handler, cross=True)
+    highlight = image.add_layer()
+
+
 @doc.demo('Nesting elements', '''
     You can nest elements inside an interactive image.
     Use Tailwind classes like "absolute top-0 left-0" to position the label absolutely with respect to the image.


### PR DESCRIPTION
This PR allows adding layers to `ui.interactive_image`.

In some cases you might want to add different groups of SVG elements to an image. Maybe there is one element that needs frequent updates, while the other elements are rarely changed. Putting all elements in the same SVG can lead to performance issues, because the whole SVG needs to be sent to the client whenever one of the elements changes.

The solution is to add multiple layers to the image. Each layer is a separate SVG element, which means that each layer can be updated independently.

```py
def mouse_handler(e: events.MouseEventArguments):
    image.content += f'<circle cx="{e.image_x}" cy="{e.image_y}" r="30" fill="none" stroke="red" stroke-width="4" />'
    highlight.content = f'<circle cx="{e.image_x}" cy="{e.image_y}" r="28" fill="yellow" opacity="0.5" />'

image = ui.interactive_image('https://picsum.photos/id/674/640/360', on_mouse=mouse_handler, cross=True)
highlight = image.add_layer()
```

<img width="303" alt="Screenshot 2025-05-07 at 15 56 36" src="https://github.com/user-attachments/assets/bf8a3acf-c79f-4701-8774-bdb7728eabbf" />
