### PR TITLE
Feat: Override dependencies at lib/

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import os
 import re
 from copy import copy
 from pathlib import Path
@@ -93,8 +94,16 @@ class Element(Visibility):
         base = Path(inspect.getfile(cls)).parent
 
         def glob_absolute_paths(file: Union[str, Path]) -> List[Path]:
+            LIB_OVERRIDE_DIRECTORY = Path(os.getenv('NICEGUI_LIB_OVERRIDE_DIRECTORY', ''))
             path = Path(file)
             if not path.is_absolute():
+                if LIB_OVERRIDE_DIRECTORY and str(path).startswith('lib'):
+                    path_override = LIB_OVERRIDE_DIRECTORY / path
+                    if path_override.exists():
+                        path = path_override
+                        print(f'Using override path: {path}')
+                    else:
+                        print(f'Override path does not exist: {path_override}')
                 path = base / path
             return sorted(path.parent.glob(path.name), key=lambda p: p.stem)
 

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -94,16 +94,13 @@ class Element(Visibility):
         base = Path(inspect.getfile(cls)).parent
 
         def glob_absolute_paths(file: Union[str, Path]) -> List[Path]:
-            LIB_OVERRIDE_DIRECTORY = Path(os.getenv('NICEGUI_LIB_OVERRIDE_DIRECTORY', ''))
             path = Path(file)
             if not path.is_absolute():
-                if LIB_OVERRIDE_DIRECTORY and str(path).startswith('lib'):
-                    path_override = LIB_OVERRIDE_DIRECTORY / path
-                    if path_override.exists():
-                        path = path_override
-                        print(f'Using override path: {path}')
-                    else:
-                        print(f'Override path does not exist: {path_override}')
+                lib_path = os.getenv('NICEGUI_LIB_OVERRIDE_DIRECTORY')
+                if lib_path and path.parts[0] == 'lib':
+                    path = Path(lib_path) / path
+                    assert path.exists(), f'Override path does not exist: {path}'
+                    print(f'Using override path: {path}')
                 path = base / path
             return sorted(path.parent.glob(path.name), key=lambda p: p.stem)
 

--- a/website/documentation/content/section_configuration_deployment.py
+++ b/website/documentation/content/section_configuration_deployment.py
@@ -112,6 +112,7 @@ doc.text('', '''
     - `RST_CONTENT_CACHE_SIZE` (default: 1000): The maximum number of ReStructuredText content snippets that are cached in memory.
     - `NICEGUI_REDIS_URL` (default: None, means local file storage): The URL of the Redis server to use for shared persistent storage.
     - `NICEGUI_REDIS_KEY_PREFIX` (default: "nicegui:"): The prefix for Redis keys.
+    - `NICEGUI_LIB_OVERRIDE_DIRECTORY` (default: None): The path to a directory containing libraries to override the default ones.
 ''')
 def env_var_demo():
     from nicegui.elements import markdown


### PR DESCRIPTION
This PR allows the user to set `NICEGUI_LIB_OVERRIDE_DIRECTORY` in env to a directory, for which it contains what _would have been_ in NiceGUI's `lib/` folder. 

This way, the user can override NiceGUI's dependencies with newer ones, skipping forward in the release cycle. 

Combined with a beta feedback system, we can collect information on whether a new version of JS dependency will work with NiceGUI or not, potentially easin upcoming releases, and empowering us to move faster 🚀

Demo code:

```py
from nicegui import ui
import os
from pathlib import Path
os.environ['NICEGUI_LIB_OVERRIDE_DIRECTORY'] = str(Path(__file__).parent / 'lib_override')

grid = ui.aggrid({
    'defaultColDef': {'flex': 1},
    'columnDefs': [
        {'headerName': 'Name', 'field': 'name'},
        {'headerName': 'Age', 'field': 'age'},
    ],
    'rowData': [
        {'name': 'Alice', 'age': 18},
        {'name': 'Bob', 'age': 21},
        {'name': 'Carol', 'age': 42},
    ],
    'rowSelection': 'multiple',
}).classes('max-h-40')

ui.run(reload=True)
```

Ensure in same folder as your test script, `lib_override/lib/aggrid/ag-grid-community.min.js` is accessible. 

Without override:

<img width="630" alt="{A4504147-9A07-487E-8D34-3A899EDBEBE7}" src="https://github.com/user-attachments/assets/caf58af5-0c43-454d-82dd-d4bc550b9618" />


With override: 

<img width="629" alt="{BD7CE54B-AA7E-4C59-8181-D49892436680}" src="https://github.com/user-attachments/assets/8e8bf33e-3195-4a47-a9aa-ba4dd88bc6c9" />


Notice the new styling. 

Remaining tasks: 

- [ ] Should we add this?
- [ ] Where should we place the option? Is environment variables a good idea? 
- [ ] Why it doesn't work when I try and shove the option into core.app.config? 
- [ ] Why the environment variable is ignored when I do `reload=False`?
- [ ] Documentation?
- [ ] Underlying framework to receive beta feedback?