### PR TITLE
Project BASE - Faster HTTP Reconnect

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -136,7 +136,7 @@ class Client:
             'client_id': self.id,
             'next_message_id': self.outbox.next_message_id,
         }
-        vue_html, vue_styles, vue_scripts, imports, js_imports, js_imports_urls = \
+        vue_html, vue_styles, vue_scripts, imports, js_imports, js_imports_urls, js_imports_raw = \
             generate_resources(prefix, self.elements.values())
         context = {
             'version': __version__,
@@ -166,6 +166,7 @@ class Client:
             'socket_io_js_transports': core.app.config.socket_io_js_transports,
         }
         if send_json:
+            context['js_import_raw'] = js_imports_raw
             return JSONResponse(
                 content=context,
                 status_code=status_code,

--- a/nicegui/dependencies.py
+++ b/nicegui/dependencies.py
@@ -141,6 +141,7 @@ def generate_resources(prefix: str, elements: Iterable[Element]) -> Tuple[List[s
     imports: Dict[str, str] = {}
     js_imports: List[str] = []
     js_imports_urls: List[str] = []
+    js_imports_raw: Dict[str, Dict[str, str]] = {}
 
     # build the importmap structure for exposed libraries
     for key, library in libraries.items():
@@ -172,6 +173,10 @@ def generate_resources(prefix: str, elements: Iterable[Element]) -> Tuple[List[s
                 url = f'{prefix}/_nicegui/{__version__}/components/{js_component.key}'
                 js_imports.append(f'import {{ default as {js_component.name} }} from "{url}";')
                 js_imports.append(f'app.component("{js_component.tag}", {js_component.name});')
+                js_imports_raw[js_component.name] = {
+                    'tag': js_component.tag,
+                    'url': url,
+                }
                 js_imports_urls.append(url)
                 done_components.add(js_component.key)
-    return vue_html, vue_styles, vue_scripts, imports, js_imports, js_imports_urls
+    return vue_html, vue_styles, vue_scripts, imports, js_imports, js_imports_urls, js_imports_raw

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -112,6 +112,7 @@ class page:
         @wraps(func)
         async def decorated(*dec_args, **dec_kwargs) -> Response:
             request = dec_kwargs['request']
+            special_header_set_in_request = 'X-NiceGUI-Client-ID' in request.headers
             # NOTE cleaning up the keyword args so the signature is consistent with "func" again
             dec_kwargs = {k: v for k, v in dec_kwargs.items() if k in parameters_of_decorated_func}
             with Client(self, request=request) as client:
@@ -141,6 +142,8 @@ class page:
             if isinstance(result, Response):  # NOTE if setup returns a response, we don't need to render the page
                 return result
             binding._refresh_step()  # pylint: disable=protected-access
+            if special_header_set_in_request:
+                return client.build_response(request, send_json=True)
             return client.build_response(request)
 
         parameters = [p for p in inspect.signature(func).parameters.values() if p.name != 'client']

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -447,3 +447,36 @@ for (let sheet of document.styleSheets) {
     }
   }
 }
+
+function softReload(url) {
+  // Make the GET request
+  window.socket.disconnect();
+  fetch(url, {
+    method: 'GET',
+    headers: new Headers({
+      'X-NiceGUI-Client-ID': 'your-client-id' // Replace with your actual client ID
+    })
+  })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Network response was not ok')
+      }
+      return response.json()
+    })
+    .then(data => {
+      console.log(data)
+      // Handle the response data
+      createApp(parseElements(data.elements), {
+        version: data.version,
+        prefix: data.prefix,
+        query: data.socket_io_js_query_params,
+        extraHeaders: data.socket_io_js_extra_headers,
+        transports: data.socket_io_js_transports,
+        quasarConfig: JSON.parse(data.quasar_config),
+      })
+      app.mount("#app")
+    })
+    .catch(error => {
+      console.error('There was a problem with the fetch operation:', error)
+    })
+}

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -473,8 +473,19 @@ function softReload(url) {
         extraHeaders: data.socket_io_js_extra_headers,
         transports: data.socket_io_js_transports,
         quasarConfig: JSON.parse(data.quasar_config),
-      })
-      app.mount("#app")
+      });
+      const importPromises = Object.entries(data.js_import_raw).map(([name, value]) => {
+        console.log(`Importing element ${name}`);
+        return import(value.url).then((module) => {
+          console.log(`Imported element ${name} from ${value.url}`, module);
+          app.component(value.tag, module.default);
+        });
+      });
+
+      Promise.all(importPromises).then(() => {
+        eval(data.vue_scripts); // required for plotly and some libraries
+        app.mount("#app");
+      });
     })
     .catch(error => {
       console.error('There was a problem with the fetch operation:', error)


### PR DESCRIPTION
This PR introduces a HTTP-based special mechanism for loading in the page which is must faster than the browser. 

#### Brief explainer

The server, upon the setting of a special private header `'X-NiceGUI-Client-ID'`, instead of serving HTML, _proceeds instead_ to serve it in JSON machine-readable format. 

Which, the special JavaScript function `softReload` will:

- Disconnect the old Socket.IO
- Fetch with special header and parse JSON
- Re-run `createApp(...)`
- Dynamically import any JS modules and add them to add component
- Re-execute `vue_script` for the Plotly and similar elements which rely on it
- Mount the app to `#app`

Essentially, it does what a page load will do, but without a page load. 

---

#### Name meaning of BASE

BASE stands for "Because Asked Server Explicitly", which is an (admittedly not very good) acryonym reflecting on the nature that the client asks the server explicitly for reconnection advice via HTTP, including the crucial Client ID. 

This contrasts with project ACID #4552 before it, which the client can say it had any arbitrary Client ID via Socket.IO, and the server must bend around it by then suddenly spawning in the Client, bypassing HTTP layer entirely. 

---

#### Advantages

Advantages shared common between ACID and BASE: 

- Fast page switching (implemented via softReload) 
- Zero Flash Of Unstyled Content as a baseline guarantee. 
- Fast reconnection in case client destroyed, because disconnected over the timeout duration / server reboot (to be implemented)

Advantages exclusive to BASE: 

- Maintains the one-to-one relationship between HTTP request and NiceGUI Client instances
- Ensures Middlewares stay effective
- Avoids fallacies such as HTTP GET parameters being lost
- Practically zero-impact on userspace code, since server-side all new logic is basically not involved if `'X-NiceGUI-Client-ID'` is not set in header
- May make creating custom NiceGUI frontends (like an ESP32 touchscreen UI) slightly easier, though not by much. 

---

#### Remaining tasks

- [ ] Assess benefit VS impact
- [ ] Finish off the fast reconnection in client destroyed / server reboot situation
- [ ] `softReload` doesn't set browser URL bar
- [ ] Extensive testing (non-negotiable)
- [ ] Extensive documentation 
- [ ] Drop unused fields from the JSONResponse if they are not needed by the reload process
- [ ] Can we make the typical page load in code and the `softReload` code to be unified? This can further ensure exact same behaviour.  

---

#### Testing code

<details>
<summary> My testing code </summary>


```py
import plotly.graph_objects as go
from nicegui import ui
from random import random


def menu():
    with ui.row():
        ui.label('Menu').classes('text-2xl text-gray-700')
        ui.button('Page 1', on_click=lambda: ui.navigate.to('/page1'))
        ui.button('Page 2', on_click=lambda: ui.navigate.to('/page2'))
        ui.button('Page 3', on_click=lambda: ui.navigate.to('/page3'))
        ui.button('Page 4', on_click=lambda: ui.navigate.to('/page4'))
        ui.button('Page 5', on_click=lambda: ui.navigate.to('/page5'))
    with ui.row():
        ui.button('Soft Page 1', on_click=lambda: ui.run_javascript('softReload("/page1")'))
        ui.button('Soft Page 2', on_click=lambda: ui.run_javascript('softReload("/page2")'))
        ui.button('Soft Page 3', on_click=lambda: ui.run_javascript('softReload("/page3")'))
        ui.button('Soft Page 4', on_click=lambda: ui.run_javascript('softReload("/page4")'))
        ui.button('Soft Page 5', on_click=lambda: ui.run_javascript('softReload("/page5")'))


@ui.page('/page1')
def page1():
    menu()
    ui.label('Page 1').classes('text-2xl text-red-500')


@ui.page('/page2')
def page2():
    menu()
    ui.label('Page 2').classes('text-2xl text-blue-500')


@ui.page('/page3')
def page3():
    menu()
    with ui.card():
        ui.mermaid('''
            graph TD
            A --> B
            A --> C
            A --> D
        ''')

# page4 with plotly


@ui.page('/page4')
def page4():
    menu()
    fig = go.Figure()
    fig.update_layout(margin=dict(l=0, r=0, t=0, b=0))
    plot = ui.plotly(fig).classes('w-full h-40')

    def add_trace():
        fig.add_trace(go.Scatter(x=[1, 2, 3], y=[random(), random(), random()]))
        plot.update()

    ui.button('Add trace', on_click=add_trace)

# page5 with dark mode


@ui.page('/page5')
def page5():
    menu()
    dark = ui.dark_mode()
    ui.switch('Dark mode').bind_value(dark)


menu()

ui.run()
```


</details>

Results: 

- Switching through all 5 pages work seamlessly, despite starting on whichever page. 
- Since Mermaid loaded in while starting from page 1, loading ES modules works. 
- Since Plotly loaded in while starting from page 1, loading `vue_scripts` works. 