### PR TITLE
Improve On Air reconnect behavior

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -14,8 +14,8 @@ import socketio.exceptions
 from . import background_tasks, core, helpers
 from .client import Client
 from .dataclasses import KWONLY_SLOTS
-from .elements.timer import Timer as timer
 from .logging import log
+from .timer import Timer as timer
 
 if TYPE_CHECKING:
     import httpx

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -178,6 +178,7 @@ class Air:
                 helpers.warn_once(self._host_unreachable_warning)
             else:
                 self.log.warning(f'Connection error: {message}')
+            await self.relay.disconnect()
 
         @self.relay.on('event')
         def _handle_event(data: Dict[str, Any]) -> None:


### PR DESCRIPTION
We noticed that an `socketio.AsyncClient` expects you to call `disconnect` if a connection error occurs. Otherwise `client.connected` might still be `True` and our re-connect timer early-exits.

Apart from that we noticed that air.py uses a `ui.timer` instead of `app.timer`. This is ok because it is instantiated on the auto-index page which lives forever, but it is a smell.