### PR TITLE
Avoid KeyErrors caused by late `ui.run_javascript` responses

### DIFF
--- a/nicegui/javascript_request.py
+++ b/nicegui/javascript_request.py
@@ -19,6 +19,8 @@ class JavaScriptRequest:
     @classmethod
     def resolve(cls, request_id: str, result: Any) -> None:
         """Store the result of a JavaScript request and unblock the awaiter."""
+        if request_id not in cls._instances:
+            return
         request = cls._instances[request_id]
         request._result = result  # pylint: disable=protected-access
         request._event.set()  # pylint: disable=protected-access


### PR DESCRIPTION
This PR handles the case that a `ui.run_javascript` command times out and removes the request from its dictionary before a response arrives after all. Since the timeout is already raised, we can simply ignore the response and early exit.