### PR TITLE
Support shared client for routed page

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -48,7 +48,7 @@ class Client:
     shared_body_html = ''
     """HTML to be inserted in the <body> of every page template."""
 
-    def __init__(self, page: page, *, request: Optional[Request]) -> None:
+    def __init__(self, page: page, *, request: Optional[Request], shared: bool = False) -> None:
         self.request: Optional[Request] = request
         self.id = str(uuid.uuid4())
         self.created = time.time()
@@ -60,7 +60,7 @@ class Client:
         self.is_waiting_for_connection: bool = False
         self.is_waiting_for_disconnect: bool = False
         self.environ: Optional[Dict[str, Any]] = None
-        self.shared = request is None
+        self.shared = shared or (request is None)
         self.on_air = False
         self._num_connections: defaultdict[str, int] = defaultdict(int)
         self._delete_tasks: Dict[str, asyncio.Task] = {}


### PR DESCRIPTION
This PR adds `shared_client` option to `@ui.page`, allowing those pages to have a shared client and thus shared state, just like the auto-index page, unlocking more possibilities on how NiceGUI can be used. 

#### Backstory on the auto-index page and the shared client

Previously, I have mentioned that I don't really see a use for the auto-index page, and even expressed intent to drop the functionality. 

Particularly, even @rodja mentioned that "The auto-index page makes NiceGUI code base (and many new features) so much more complicated to implement."

After observing the polls and comments at #4472, I changed my mind, and now think the auto-index page has its merits in select applications. 

However, it is in my opinion that, to achieve first-class (maybe second-class, but at least better than what it is now) support for a shared client, I think it is unsustainable, that for each NiceGUI application to be limited to one and one only. 

Therefore, this PR opens the floodgate to creating larger-scale applications where shared states matter. 

#### Advantages brought about by this PR

Consider https://github.com/falkoschindler/nicedeck. If I uderstand correctly, there can only be 1 set of slide decks. 

If I want to enable a platform for hosting multiple slide decks, tough luck. It would be impossible for NiceGUI without this PR. 

This could also be potential useful in creating massive dashboards systems (think: bus arrival screen display), IoT applications, Real-time chat, and online games. 

#### To-do

- [ ] Assess pros and cons
- [ ] Block off functions which doesn't work in the new shared-client page
- [ ] Test more throughly on other elements and functions

#### Test code

<details>
<summary> 3 kinds of page, each with ui.notify on button press </summary>

```py
from nicegui import ui


def menu():
    ui.link('Shared client', '/shared_client')
    ui.link('Non-shared client', '/non_shared_client')
    ui.link('Auto-index page', '/')
    ui.button('Spawn notification', on_click=lambda: ui.notify(f'Hello world Client {ui.context.client.id}'))


@ui.page('/shared_client', shared_client=True)
def shared_client():
    menu()
    ui.label('This page uses a shared client')
    ui.label(ui.context.client.id)


@ui.page('/non_shared_client')
def non_shared_client():
    menu()
    ui.label('This page does not use a shared client')
    ui.label(ui.context.client.id)


menu()
ui.label('This is the auto-index page, so it uses a shared client implicitly')
ui.label(ui.context.client.id)

ui.run()
```

</details>

<img width="640" alt="{EFD12EB5-6693-431C-9C4A-EFA004DC4917}" src="https://github.com/user-attachments/assets/cd639624-bb45-4d72-94d3-772d2caaca4b" />


