### PR TITLE
Website: Faster search page

### DIFF
--- a/website/search.py
+++ b/website/search.py
@@ -56,7 +56,7 @@ class Search:
     def handle_input(self, e: events.ValueChangeEventArguments) -> None:
         async def handle_input() -> None:
             with self.results:
-                results = await ui.run_javascript(f'return window.fuse.search("{e.value}").map(result => result.refIndex).slice(0, 100)', timeout=6)
+                results = await ui.run_javascript(f'return window.fuse.search("{e.value}").map(result => result.refIndex).slice(0, (window.innerWidth > 610) ? 100: 25)', timeout=6)
                 self.results.clear()
                 with ui.list().props('bordered separator'):
                     for index in results:

--- a/website/search.py
+++ b/website/search.py
@@ -56,7 +56,7 @@ class Search:
     def handle_input(self, e: events.ValueChangeEventArguments) -> None:
         async def handle_input() -> None:
             with self.results:
-                results = await ui.run_javascript(f'return window.fuse.search("{e.value}").map(result => result.refIndex).slice(0, (window.innerWidth > 610) ? 100: 25)', timeout=6)
+                results = await ui.run_javascript(f'return window.fuse.search("{e.value}", {{limit: (window.innerWidth > 610) ? 100: 25}}).map(result => result.refIndex)', timeout=6)
                 self.results.clear()
                 with ui.list().props('bordered separator'):
                     for index in results:


### PR DESCRIPTION
This PR speeds up the documentation search page in the following ways: 

- Client, who is responsible* for running Fuse.js fuzzy search, needs to send back the indices only, not the entire content. 
  - This saves unnecessary uplink bandwidth from client to server. Messages went from 37KB to 0.5KB. 
- When the page is narrow, an indicator which means the page is on mobile clients, return 25 (a quarter of the original) results
  - According to Lighthouse, the benchmark for page speed, mobile browsers are a quarter as fast as desktop browsers, so I chose the value from there. 
- Let Fuse.js do the limiting of results, instead of us `.slice`
  - Theoreticlly slightly faster, since Fuse.js doesn't have to sort the entire list and provide a big return object. 

As far as what I can tell, the search results before and after this PR are exactly the same. 

*tried to find a Python substitute but came up dry...