### PR TITLE
Let npm.py run on Windows as well (hopefully same function as old)

### DIFF
--- a/npm.py
+++ b/npm.py
@@ -20,6 +20,9 @@ from pathlib import Path
 from typing import Dict, List
 
 import requests
+import tempfile
+
+temp_dir = tempfile.TemporaryDirectory()
 
 parser = ArgumentParser()
 parser.add_argument('path', default='.', help='path to the root of the repository')
@@ -44,9 +47,7 @@ def url_to_filename(url: str) -> str:
 
 
 def download_buffered(url: str) -> Path:
-    path = Path('/tmp/nicegui_dependencies')
-    path.mkdir(exist_ok=True)
-    filepath = path / url_to_filename(url)
+    filepath = Path(temp_dir.name) / url_to_filename(url)
     if not filepath.exists():
         response = requests.get(url, headers={'User-Agent': 'Mozilla/5.0'}, timeout=3)
         filepath.write_bytes(response.content)
@@ -121,6 +122,8 @@ for key, dependency in dependencies.items():
                 filename = filename.replace(rename, dependency['rename'][rename])
 
             newfile = prepare(Path(destination, filename))
+            if newfile.exists():
+                newfile.unlink()
             Path(tmp, key, extracted.name).rename(newfile)
 
             if 'GLTFLoader' in filename:
@@ -144,8 +147,13 @@ for key, dependency in dependencies.items():
                 content = re.sub(r'"\./chunks/mermaid.esm.min/(.*?)\.mjs"', r'"\1"', content)
                 newfile.write_text(content, encoding='utf-8')
 
-    # Delete destination folder if empty.
-    if not any(destination.iterdir()):
-        destination.rmdir()
+    try:
+        # Delete destination folder if empty.
+        if not any(destination.iterdir()):
+            destination.rmdir()
+    except Exception:
+        pass
+
+temp_dir.cleanup()
 
 cleanup(tmp)

--- a/npm.py
+++ b/npm.py
@@ -15,12 +15,12 @@ import json
 import re
 import shutil
 import tarfile
+import tempfile
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import Dict, List
 
 import requests
-import tempfile
 
 temp_dir = tempfile.TemporaryDirectory()
 


### PR DESCRIPTION
This PR lets npm.py run on Windows as well. It also allows it to be ran repeatedly without throwing errors

Core changes: 
- Use `tempfile.TemporaryDirectory()`
- `unlink` before `rename` so that the old file is overwritten
- Try-except the failing line `if not any(destination.iterdir()):` `destination.rmdir()`

---

Admittedly, this is a minor concern, because by all means you should be on Linux or using a Dev Container, according to the [contributing guide](https://github.com/zauberzeug/nicegui/blob/42d24d40129785038d6fce9c2aafe24c62482478/CONTRIBUTING.md). 

But, both has failed me so far, and so I'm still on Windows. And, I need `npm.py` to work, so as to help out in #4656 and #4520. 

I personally believe that making `npm.py` runnable on cross-platform may speed up development of new elements, as we lower the barrier to custom element development. 

---

It is best to answer the following before we proceed: 

- [ ] What's the purpose of the `if not any(destination.iterdir()):` `destination.rmdir()`? 
  - It seems to always fail on Windows, so I add a try-except
  - But I don't want to just carelessly do that and call it a day
- [x] Is the output on Linux still working? 
  - You may want to grab the `npm.json` with pinned version in #4632, and test. 
  - It's the same on my side, minus Tailwind, which they changed stuff upstream and so we'll never get the exact same copy. 