### PR TITLE
[WIP] internalization support

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,6 +52,21 @@ def _documentation_detail_page(name: str) -> Optional[RedirectResponse]:
         return RedirectResponse(documentation.redirects[name])
     raise HTTPException(404, f'documentation for "{name}" could not be found')
 
+# Debug page for setting the language
+
+
+@ui.page('/set_language')
+def _set_language() -> None:
+    my_input = ui.input('Language', placeholder='en')
+
+    def set_language():
+        app.storage.user['language'] = my_input.value
+        ui.navigate.reload()
+
+    ui.button('Set Language', on_click=set_language)
+
+    ui.label(f"Current Language: {app.storage.user.get('language', 'en')}")
+
 
 @app.get('/status')
 def _status():

--- a/website/documentation/content/doc/api.py
+++ b/website/documentation/content/doc/api.py
@@ -104,6 +104,8 @@ def demo(*args, **kwargs) -> Callable[[Callable], Callable]:
                 page.title = f'ui.*{ui_name}*'
             elif app_name:
                 page.title = f'app.*{app_name}*'
+        print('Title:', title_)
+        print('Description:', description)
         page.parts.append(DocumentationPart(
             title=title_,
             description=description,

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -18,14 +18,14 @@ from ...style import subheading
 
 doc.title('*NiceGUI* Documentation', 'Reference, Demos and more')
 
-doc.text('Overview', '''
+doc.text('Overview<!--TRANSLATEID-id1-->', '''
     NiceGUI is an open-source Python library to write graphical user interfaces which run in the browser.
     It has a very gentle learning curve while still offering the option for advanced customizations.
     NiceGUI follows a backend-first philosophy:
     It handles all the web development details.
     You can focus on writing Python code.
     This makes it ideal for a wide range of projects including short
-    scripts, dashboards, robotics projects, IoT solutions, smart home automation, and machine learning.
+    scripts, dashboards, robotics projects, IoT solutions, smart home automation, and machine learning.<!--TRANSLATEID-id2-->
 ''')
 
 doc.text('How to use this guide', '''

--- a/website/documentation/i18n.py
+++ b/website/documentation/i18n.py
@@ -1,0 +1,75 @@
+# ruff: noqa: RUF001
+
+import re
+
+from nicegui import app
+
+mydict = {
+    'id1': {
+        'en': 'Overview',
+        'cn': '概述',
+        'jp': '概要',
+        'de': 'Überblick',
+    },
+
+    'id2': {
+        'en': '''NiceGUI is an open-source Python library to write graphical user interfaces which run in the browser.
+    It has a very gentle learning curve while still offering the option for advanced customizations.
+    NiceGUI follows a backend-first philosophy:
+    It handles all the web development details.
+    You can focus on writing Python code.
+    This makes it ideal for a wide range of projects including short
+    scripts, dashboards, robotics projects, IoT solutions, smart home automation, and machine learning.''',
+        'cn': '''NiceGUI 是一个开源的 Python 库，用于编写在浏览器中运行的图形用户界面。
+    它具有非常温和的学习曲线，同时仍然提供高级自定义的选项。
+    NiceGUI 遵循后端优先的理念：
+    它处理所有 Web 开发的细节。
+    您可以专注于编写 Python 代码。
+    这使它非常适合广泛的项目，包括短脚本、仪表板、机器人项目、物联网解决方案、智能家居自动化和机器学习。''',
+        'jp': '''NiceGUIは、ブラウザで実行されるグラフィカルユーザーインターフェイスを作成するためのオープンソースのPythonライブラリです。
+    非常に緩やかな学習曲線を持ちながら、高度なカスタマイズのオプションも提供しています。
+    NiceGUIはバックエンドファーストの哲学に従っています。
+    すべてのWeb開発の詳細を処理します。
+    Pythonコードの記述に集中できます。
+    これにより、短いスクリプト、ダッシュボード、ロボティクスプロジェクト、IoTソリューション、スマートホームオートメーション、機械学習など、幅広いプロジェクトに最適です。''',
+        'de': '''NiceGUI ist eine Open-Source-Python-Bibliothek zur Erstellung grafischer Benutzeroberflächen, die im Browser ausgeführt werden.
+    Sie hat eine sehr sanfte Lernkurve und bietet dennoch die Möglichkeit zu erweiterten Anpassungen.
+    NiceGUI folgt einer Backend-First-Philosophie:
+    Es kümmert sich um alle Details der Webentwicklung.
+    Sie können sich auf das Schreiben von Python-Code konzentrieren.
+    Dies macht es ideal für eine Vielzahl von Projekten, darunter kurze
+    Skripte, Dashboards, Robotikprojekte, IoT-Lösungen, Smart-Home-Automatisierung und maschinelles Lernen.''',
+    },
+}
+
+
+def i18nify(text: str):
+    try:
+        language = app.storage.user['language']
+    except Exception as e:
+        print('Error getting language:', e)
+        language = 'en'
+    return i18nify_language(text, language=language)
+
+
+def i18nify_language(text: str, *, language: str = 'en') -> str:
+    """Translate the given text to the specified language."""
+
+    # Look for the HTML tag <!--TRANSLATEID-{uuid}--> in the text using regex
+    print('i18nify_language', text, language)
+    match = re.search(r'<!--TRANSLATEID-([a-zA-Z0-9-]+)-->', text)
+    if not match:
+        return drop_the_tag(text)
+
+    translation_id = match.group(1)
+    if not translation_id or translation_id not in mydict or language not in mydict[translation_id]:
+        return drop_the_tag(text)
+
+    text = mydict[translation_id].get(language, mydict[translation_id][language])
+    return text
+
+
+def drop_the_tag(text: str) -> str:
+    """Remove the HTML tag from the text."""
+    # Remove the HTML tag <!--TRANSLATEID-{uuid}--> from the text
+    return re.sub(r'<!--TRANSLATEID-[a-zA-Z0-9-]+-->', '', text)

--- a/website/documentation/rendering.py
+++ b/website/documentation/rendering.py
@@ -1,4 +1,5 @@
 from nicegui import ui
+from website.documentation.i18n import i18nify
 
 from ..header import add_head_html, add_header
 from ..style import section_heading, subheading
@@ -38,12 +39,12 @@ def render_page(documentation: DocumentationPage, *, with_menu: bool = True) -> 
             if part.title:
                 if part.link_target:
                     ui.link_target(part.link_target)
-                subheading(part.title, link=part.link, major=part.reference is not None)
+                subheading(i18nify(part.title), link=part.link, major=part.reference is not None)
             if part.description:
                 if part.description_format == 'rst':
-                    element = custom_restructured_text(part.description.replace(':param ', ':'))
+                    element = custom_restructured_text(i18nify(part.description).replace(':param ', ':'))
                 else:
-                    element = ui.markdown(part.description)
+                    element = ui.markdown(i18nify(part.description))
                 element.classes('bold-links arrow-links')
                 if ':param' in part.description:
                     element.classes('rst-param-tables')


### PR DESCRIPTION
This PR adds internalization support to the NiceGUI documentation, fix #4025 and generally enables multilingual display, despite our documentation created and defined using Python only. 

Compared to others libraries which use Markdown, architecturally it is more of a challenge, but we also have a bit more ease just because we are maining one codebase. 

Open questions:

- [ ] Is this necessary in the age of AI, where people can have AI translation tools? 
  - [ ] Particularly, can a well-tuned but cheaper LLM (for the batch translation) outperform a non-tuned but more high-quality LLM (used in translation engines, possibly paid)?
- [ ] How to break up the file so that we are reading several small files, not one big Python dictionary, so that maintenence is a bit easier and we don't have Merge Conflict Hell in GitHub? 
- [ ] Tooling such as automatically adding the TRANSLATEID tags, automatically calling LLM for the translation
- [ ] Prompt adjustment for the LLM
- [ ] Ensure decent enough coverage of the documentation website

Results: 

http://127.0.0.1:8080/set_language set the language between:

- `en`: What we have now
- `cn`: What was requested in #4025 
- `jp`: Generally takes more space because spelling terms in Katakana is less space-efficient than English characters
- `de`: Concerned over extremely long words messing up the line breaking. Also Zauberzeug is a German company. As a reminder "Kraftfahrzeug-Haftpflichtversicherung" stands for "motor vehicle liability insurance" 

<img width="401" alt="{3970EE26-CADB-434C-9486-A55D260DC69B}" src="https://github.com/user-attachments/assets/2e9feae6-cbd5-4abf-9477-e80b15d6c0ab" />


<img width="404" alt="{A0974519-2708-4359-B12A-4BBDEDB9A82E}" src="https://github.com/user-attachments/assets/7a0d5e96-12f6-459c-9eec-dfa72c51a4af" />


<img width="405" alt="{2CEDD643-4485-427B-A1D8-566492D7E16F}" src="https://github.com/user-attachments/assets/0321b6ab-8577-47a3-95b8-b573d9590a7f" />

<img width="407" alt="{8B2571A5-3F5B-4168-84ED-F6BE28291EC4}" src="https://github.com/user-attachments/assets/89f4879a-0ed3-477b-95d2-fcfb11c45c9f" />
