### PR TITLE
move websocket initialization code to create hook

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -331,7 +331,8 @@ function createApp(elements, options) {
     render() {
       return renderRecursively(this.elements, 0);
     },
-    beforeCreate() {
+    created() {
+      mounted_app = this;
       window.documentId = createRandomUUID();
       window.clientId = options.query.client_id;
       const url = window.location.protocol === "https:" ? "wss://" : "ws://" + window.location.host;
@@ -434,9 +435,6 @@ function createApp(elements, options) {
           }
         });
       }
-    },
-    mounted() {
-      mounted_app = this;
     },
   }).use(Quasar, {
     config: options.quasarConfig,


### PR DESCRIPTION
Part of an effort to have custom vue component emit an `init` type event led to investigating how NiceGUI app component uses `mounted` hook to initialize websocket, which runs after subcomponent hooks. 

In order for the component to emit and have server receive, sub components can now use window.socket with a `connect` handler (or potentially other types of events?) 

This moves the socket initialization code to `beforeCreate()`, but leaves `mounted_app = this` in the mounted hook.

Early vibe testing is that the functionality I have that is invoked by custom component init calls is now much faster than waiting for everything to mount and then being able to either invoke the function via a `run_method` server call, or polling for socket availability.