### PR TITLE
Move Socket.IO initialization all the way to head + Pre-Mount Message Caching

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -296,79 +296,9 @@ async function loadDependencies(element, prefix, version) {
   }
 }
 
-function createRandomUUID() {
-  try {
-    return crypto.randomUUID();
-  } catch (e) {
-    // https://stackoverflow.com/a/2117523/3419103
-    return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
-      (+c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))).toString(16)
-    );
-  }
-}
-
-const OLD_TAB_ID = sessionStorage.__nicegui_tab_closed === "false" ? sessionStorage.__nicegui_tab_id : null;
-const TAB_ID =
-  !sessionStorage.__nicegui_tab_id || sessionStorage.__nicegui_tab_closed === "false"
-    ? (sessionStorage.__nicegui_tab_id = createRandomUUID())
-    : sessionStorage.__nicegui_tab_id;
-sessionStorage.__nicegui_tab_closed = "false";
-window.onbeforeunload = function () {
-  sessionStorage.__nicegui_tab_closed = "true";
-};
-
 function createApp(elements, options) {
   Object.entries(elements).forEach(([_, element]) => replaceUndefinedAttributes(element));
   setInterval(() => ack(), 3000);
-
-  let handleConnect = () => {
-    const args = {
-      client_id: window.clientId,
-      document_id: window.documentId,
-      tab_id: TAB_ID,
-      old_tab_id: OLD_TAB_ID,
-      next_message_id: window.nextMessageId,
-    };
-    window.socket.emit("handshake", args, (ok) => {
-      if (!ok) {
-        console.log("reloading because handshake failed for clientId " + window.clientId);
-        window.location.reload();
-      }
-      document.getElementById("popup").ariaHidden = true;
-    });
-    window.did_handshake = true;
-  }
-
-  // Initialize window variables needed for socket communication
-  window.documentId = createRandomUUID();
-  window.clientId = options.query.client_id;
-  window.path_prefix = options.prefix;
-  window.nextMessageId = options.query.next_message_id;
-  window.ackedMessageId = -1;
-
-  // Initialize Socket.IO early
-  const url = window.location.protocol === "https:" ? "wss://" : "ws://" + window.location.host;
-  window.socket = io(url, {
-    path: `${options.prefix}/_nicegui_ws/socket.io`,
-    query: options.query,
-    extraHeaders: options.extraHeaders,
-    transports: options.transports,
-  });
-  window.did_handshake = false;
-
-  // Queue for messages received before the app is mounted
-  let premountMessageQueue = [];
-  const catchAllHandler = (event, ...args) => {
-    if (args.length > 0 && args[0]._id !== undefined) {
-      const message_id = args[0]._id;
-      if (message_id < window.nextMessageId) return;
-      window.nextMessageId = message_id + 1;
-      delete args[0]._id;
-    }
-    premountMessageQueue.push({ event, args });
-  };
-  window.socket.onAny(catchAllHandler); // onAny does not cover "connect", though
-  window.socket.on("connect", handleConnect);
 
   return (app = Vue.createApp({
     data() {
@@ -383,7 +313,7 @@ function createApp(elements, options) {
       mounted_app = this;
 
       // Remove temporary catch-all handler
-      window.socket.offAny(catchAllHandler);
+      window.socket.offAny(window.catchAllHandler);
 
       // Define message handlers
       const messageHandlers = {
@@ -435,11 +365,11 @@ function createApp(elements, options) {
         notify: (msg) => Quasar.Notify.create(msg),
       };
 
-      console.log("Run premount messages", JSON.stringify(premountMessageQueue));
+      console.log("Run premount messages", JSON.stringify(window.premountMessageQueue));
 
       // Process queued messages that were received before the app was mounted
-      while (premountMessageQueue.length > 0) {
-        const { event, args } = premountMessageQueue.shift();
+      while (window.premountMessageQueue.length > 0) {
+        const { event, args } = window.premountMessageQueue.shift();
         const handler = messageHandlers[event];
         if (!handler) {
           console.warn(`No handler for event '${event}'`);

--- a/nicegui/static/nicegui_head.js
+++ b/nicegui/static/nicegui_head.js
@@ -1,0 +1,68 @@
+function createRandomUUID() {
+  try {
+    return crypto.randomUUID();
+  } catch (e) {
+    // https://stackoverflow.com/a/2117523/3419103
+    return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
+      (+c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))).toString(16)
+    );
+  }
+}
+const OLD_TAB_ID = sessionStorage.__nicegui_tab_closed === "false" ? sessionStorage.__nicegui_tab_id : null;
+const TAB_ID =
+  !sessionStorage.__nicegui_tab_id || sessionStorage.__nicegui_tab_closed === "false"
+    ? (sessionStorage.__nicegui_tab_id = createRandomUUID())
+    : sessionStorage.__nicegui_tab_id;
+sessionStorage.__nicegui_tab_closed = "false";
+window.onbeforeunload = function () {
+  sessionStorage.__nicegui_tab_closed = "true";
+};
+function initSocketIO(options) {
+  // Initialize window variables needed for socket communication
+  window.documentId = createRandomUUID();
+  window.clientId = options.query.client_id;
+  window.path_prefix = options.prefix;
+  window.nextMessageId = options.query.next_message_id;
+  window.ackedMessageId = -1;
+  // Initialize Socket.IO early
+  const url = window.location.protocol === "https:" ? "wss://" : "ws://" + window.location.host;
+  window.socket = io(url, {
+    path: `${options.prefix}/_nicegui_ws/socket.io`,
+    query: options.query,
+    extraHeaders: options.extraHeaders,
+    transports: options.transports,
+  });
+  window.did_handshake = false;
+  console.log("Socket.IO connected");
+  // Queue for messages received before the app is mounted
+  window.premountMessageQueue = [];
+  window.catchAllHandler = (event, ...args) => {
+    if (args.length > 0 && args[0]._id !== undefined) {
+      const message_id = args[0]._id;
+      if (message_id < window.nextMessageId) return;
+      window.nextMessageId = message_id + 1;
+      delete args[0]._id;
+    }
+    premountMessageQueue.push({ event, args });
+  };
+  window.socket.onAny(window.catchAllHandler); // onAny does not cover "connect", though
+  window.socket.on("connect", handleConnect);
+}
+function handleConnect() {
+  if (window.documentId === undefined) { throw new Error("documentId is undefined. You're calling this too early!"); }
+  const args = {
+    client_id: window.clientId,
+    document_id: window.documentId,
+    tab_id: TAB_ID,
+    old_tab_id: OLD_TAB_ID,
+    next_message_id: window.nextMessageId,
+  };
+  window.socket.emit("handshake", args, (ok) => {
+    if (!ok) {
+      console.log("reloading because handshake failed for clientId " + window.clientId);
+      window.location.reload();
+    }
+    // document.getElementById("popup").ariaHidden = true;
+  });
+  window.did_handshake = true;
+}

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -4,6 +4,26 @@
     <title>{{ title }}</title>
     <meta name="viewport" content="{{ viewport }}" />
     <link href="{{ favicon_url }}" rel="shortcut icon" />
+    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/socket.io.min.js" fetchpriority="high"></script>
+    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/nicegui_head.js" fetchpriority="high"></script>
+    <script>
+      console.log('before initSocketIO');
+      console.time('initSocketIO');
+      window.nicegui_options = {
+        version: "{{ version }}",
+        prefix: "{{ prefix | safe }}",
+        query: {{ socket_io_js_query_params | safe }},
+        extraHeaders: {{ socket_io_js_extra_headers | safe }},
+        transports: {{ socket_io_js_transports | safe }},
+        quasarConfig: {{ quasar_config | safe }},
+      }
+      initSocketIO(window.nicegui_options);
+      console.timeEnd('initSocketIO');
+      console.log('initSocketIO');
+      window.socket.on('connect', () => {
+        console.log('connected_debug');
+      });
+    </script>
     <link href="{{ prefix | safe }}/_nicegui/{{version}}/static/nicegui.css" rel="stylesheet" type="text/css" />
     <link href="{{ prefix | safe }}/_nicegui/{{version}}/static/fonts.css" rel="stylesheet" type="text/css" />
     {% if prod_js %}
@@ -19,20 +39,6 @@
     {% for url in js_imports_urls %}
     <link rel="modulepreload" href="{{ url }}" />
     {% endfor %}
-    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/socket.io.min.js"></script>
-    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/nicegui_head.js"></script>
-    <script>
-      window.nicegui_options = {
-        version: "{{ version }}",
-        prefix: "{{ prefix | safe }}",
-        query: {{ socket_io_js_query_params | safe }},
-        extraHeaders: {{ socket_io_js_extra_headers | safe }},
-        transports: {{ socket_io_js_transports | safe }},
-        quasarConfig: {{ quasar_config | safe }},
-      }
-      initSocketIO(window.nicegui_options);
-      console.log('initSocketIO');
-    </script>
   </head>
   <body>
     <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/es-module-shims.js"></script>

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -20,82 +20,8 @@
     <link rel="modulepreload" href="{{ url }}" />
     {% endfor %}
     <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/socket.io.min.js"></script>
+    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/nicegui_head.js"></script>
     <script>
-      function createRandomUUID() {
-        try {
-          return crypto.randomUUID();
-        } catch (e) {
-          // https://stackoverflow.com/a/2117523/3419103
-          return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
-            (+c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))).toString(16)
-          );
-        }
-      }
-
-      const OLD_TAB_ID = sessionStorage.__nicegui_tab_closed === "false" ? sessionStorage.__nicegui_tab_id : null;
-      const TAB_ID =
-        !sessionStorage.__nicegui_tab_id || sessionStorage.__nicegui_tab_closed === "false"
-          ? (sessionStorage.__nicegui_tab_id = createRandomUUID())
-          : sessionStorage.__nicegui_tab_id;
-      sessionStorage.__nicegui_tab_closed = "false";
-      window.onbeforeunload = function () {
-        sessionStorage.__nicegui_tab_closed = "true";
-      };
-
-      function initSocketIO(options) {
-        // Initialize window variables needed for socket communication
-        window.documentId = createRandomUUID();
-        window.clientId = options.query.client_id;
-        window.path_prefix = options.prefix;
-        window.nextMessageId = options.query.next_message_id;
-        window.ackedMessageId = -1;
-
-        // Initialize Socket.IO early
-        const url = window.location.protocol === "https:" ? "wss://" : "ws://" + window.location.host;
-        window.socket = io(url, {
-          path: `${options.prefix}/_nicegui_ws/socket.io`,
-          query: options.query,
-          extraHeaders: options.extraHeaders,
-          transports: options.transports,
-        });
-        window.did_handshake = false;
-        window.socket.connect();
-        console.log("Socket.IO connected");
-
-        // Queue for messages received before the app is mounted
-        window.premountMessageQueue = [];
-        window.catchAllHandler = (event, ...args) => {
-          if (args.length > 0 && args[0]._id !== undefined) {
-            const message_id = args[0]._id;
-            if (message_id < window.nextMessageId) return;
-            window.nextMessageId = message_id + 1;
-            delete args[0]._id;
-          }
-          premountMessageQueue.push({ event, args });
-        };
-        window.socket.onAny(window.catchAllHandler); // onAny does not cover "connect", though
-        window.socket.on("connect", handleConnect);
-      }
-
-      function handleConnect() {
-        if (window.documentId === undefined) { throw new Error("documentId is undefined. You're calling this too early!"); }
-        const args = {
-          client_id: window.clientId,
-          document_id: window.documentId,
-          tab_id: TAB_ID,
-          old_tab_id: OLD_TAB_ID,
-          next_message_id: window.nextMessageId,
-        };
-        window.socket.emit("handshake", args, (ok) => {
-          if (!ok) {
-            console.log("reloading because handshake failed for clientId " + window.clientId);
-            window.location.reload();
-          }
-          // document.getElementById("popup").ariaHidden = true;
-        });
-        window.did_handshake = true;
-      }
-
       window.nicegui_options = {
         version: "{{ version }}",
         prefix: "{{ prefix | safe }}",
@@ -105,6 +31,7 @@
         quasarConfig: {{ quasar_config | safe }},
       }
       initSocketIO(window.nicegui_options);
+      console.log('initSocketIO');
     </script>
   </head>
   <body>

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -19,10 +19,96 @@
     {% for url in js_imports_urls %}
     <link rel="modulepreload" href="{{ url }}" />
     {% endfor %}
+    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/socket.io.min.js"></script>
+    <script>
+      function createRandomUUID() {
+        try {
+          return crypto.randomUUID();
+        } catch (e) {
+          // https://stackoverflow.com/a/2117523/3419103
+          return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
+            (+c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))).toString(16)
+          );
+        }
+      }
+
+      const OLD_TAB_ID = sessionStorage.__nicegui_tab_closed === "false" ? sessionStorage.__nicegui_tab_id : null;
+      const TAB_ID =
+        !sessionStorage.__nicegui_tab_id || sessionStorage.__nicegui_tab_closed === "false"
+          ? (sessionStorage.__nicegui_tab_id = createRandomUUID())
+          : sessionStorage.__nicegui_tab_id;
+      sessionStorage.__nicegui_tab_closed = "false";
+      window.onbeforeunload = function () {
+        sessionStorage.__nicegui_tab_closed = "true";
+      };
+
+      function initSocketIO(options) {
+        // Initialize window variables needed for socket communication
+        window.documentId = createRandomUUID();
+        window.clientId = options.query.client_id;
+        window.path_prefix = options.prefix;
+        window.nextMessageId = options.query.next_message_id;
+        window.ackedMessageId = -1;
+
+        // Initialize Socket.IO early
+        const url = window.location.protocol === "https:" ? "wss://" : "ws://" + window.location.host;
+        window.socket = io(url, {
+          path: `${options.prefix}/_nicegui_ws/socket.io`,
+          query: options.query,
+          extraHeaders: options.extraHeaders,
+          transports: options.transports,
+        });
+        window.did_handshake = false;
+        window.socket.connect();
+        console.log("Socket.IO connected");
+
+        // Queue for messages received before the app is mounted
+        window.premountMessageQueue = [];
+        window.catchAllHandler = (event, ...args) => {
+          if (args.length > 0 && args[0]._id !== undefined) {
+            const message_id = args[0]._id;
+            if (message_id < window.nextMessageId) return;
+            window.nextMessageId = message_id + 1;
+            delete args[0]._id;
+          }
+          premountMessageQueue.push({ event, args });
+        };
+        window.socket.onAny(window.catchAllHandler); // onAny does not cover "connect", though
+        window.socket.on("connect", handleConnect);
+      }
+
+      function handleConnect() {
+        if (window.documentId === undefined) { throw new Error("documentId is undefined. You're calling this too early!"); }
+        const args = {
+          client_id: window.clientId,
+          document_id: window.documentId,
+          tab_id: TAB_ID,
+          old_tab_id: OLD_TAB_ID,
+          next_message_id: window.nextMessageId,
+        };
+        window.socket.emit("handshake", args, (ok) => {
+          if (!ok) {
+            console.log("reloading because handshake failed for clientId " + window.clientId);
+            window.location.reload();
+          }
+          // document.getElementById("popup").ariaHidden = true;
+        });
+        window.did_handshake = true;
+      }
+
+      window.nicegui_options = {
+        version: "{{ version }}",
+        prefix: "{{ prefix | safe }}",
+        query: {{ socket_io_js_query_params | safe }},
+        extraHeaders: {{ socket_io_js_extra_headers | safe }},
+        transports: {{ socket_io_js_transports | safe }},
+        quasarConfig: {{ quasar_config | safe }},
+      }
+      initSocketIO(window.nicegui_options);
+    </script>
   </head>
   <body>
     <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/es-module-shims.js"></script>
-    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/socket.io.min.js"></script>
     {% if tailwind %}
     <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/tailwindcss.min.js"></script>
     {% endif %}
@@ -45,17 +131,16 @@
       <span>{{ translations.trying_to_reconnect }}</span>
     </div>
     <script type="module">
-      const app = createApp(parseElements(String.raw`{{ elements | safe }}`), {
-        version: "{{ version }}",
-        prefix: "{{ prefix | safe }}",
-        query: {{ socket_io_js_query_params | safe }},
-        extraHeaders: {{ socket_io_js_extra_headers | safe }},
-        transports: {{ socket_io_js_transports | safe }},
-        quasarConfig: {{ quasar_config | safe }},
-      });
+      const app = createApp(parseElements(String.raw`{{ elements | safe }}`), window.nicegui_options);
+      console.log("After createApp");
 
       {{ js_imports | safe }}
+
+      console.log("After js_imports");
+
       {{ vue_scripts | safe }}
+
+      console.log("After vue_scripts");
 
       const dark = {{ dark }};
       Quasar.lang.set(Quasar.lang["{{ language }}".replace('-', '')]);


### PR DESCRIPTION
This PR is a more heavy-handed approach in making sure we establish Socket.IO initialization as soon as possible. It is benchmarked to be at least 50% faster than the current implementation, with higher performance gains under more adverse network connection. 

Before PR: 

![image](https://github.com/user-attachments/assets/cbdb72a9-b7ff-4768-903c-004ed674ba1f)

> "Connected in" time > DOMContentLoaded, since we only establish Socket.IO connection after mounted

After PR: 

<img width="1241" alt="{FA188AE4-E9B2-4588-8118-3FE6CBA9DE94}" src="https://github.com/user-attachments/assets/f054a3ed-72b2-4f53-beb1-1e612f560af3" />

> "Connected in" time < DOMContentLoaded, since we establish Socket.IO connection as early as possible, and that occurs before Vue was loaded in at all. 

Explainer: 

Currently, NiceGUI loads like this: 

- Load in the CSS files in head
- Load in the JS files in body
- `createApp`
- When the app is mounted, setup Socket.IO
- The triple handshake (Engine.IO, Socket.IO, then NiceGUI)
- `await ui.context.client.connected()` finishes

My PR change it to be like this

- Load in the CSS files in head
- **Load in just enough JS to setup Socket.IO with a pre-mount message queue**
- The triple handshake (Engine.IO, Socket.IO, then NiceGUI)
- `await ui.context.client.connected()` finishes
- Load in the JS files in body
- `createApp`
- When the app is mounted, **execute the messages stored in the message queue and re-setup Socket.IO**

Since we begin talking to Socket.IO earlier, we:

- Complete the triple-handshake earlier
- `await ui.context.client.connected()` finishes earlier
- Obtain the messages to be ran after mounted earlier

To-do items: 

- [ ] Heard pytest wasn't too happy about this. Let's fix either pytest or my code! (likely former)
- [ ] Remove debugging `console.log` prints. 

---

PS: #4755 change it to be like this

- Load in the CSS files in head
- Load in the JS files in body
- `createApp`
- When the app is **`beforeCreate`**, setup Socket.IO
- The triple handshake occurs from here (Engine.IO, Socket.IO, then NiceGUI)
- Assign `mounted_app = this;` when app is `mounted` only
- `await ui.context.client.connected()` finishes
