### PR TITLE
Generalize `js_handler` with Auto-Return-Value-Intercept (ARVI)

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -4,7 +4,7 @@ import inspect
 import re
 from copy import copy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Optional, Sequence, Union, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Optional, Sequence, Union, cast
 
 from typing_extensions import Self
 
@@ -320,26 +320,6 @@ class Element(Visibility):
             Tooltip(text)
         return self
 
-    @overload
-    def on(self,
-           type: str,  # pylint: disable=redefined-builtin
-           *,
-           js_handler: Optional[str] = None,
-           ) -> Self:
-        ...
-
-    @overload
-    def on(self,
-           type: str,  # pylint: disable=redefined-builtin
-           handler: Optional[events.Handler[events.GenericEventArguments]] = None,
-           args: Union[None, Sequence[str], Sequence[Optional[Sequence[str]]]] = None,
-           *,
-           throttle: float = 0.0,
-           leading_events: bool = True,
-           trailing_events: bool = True,
-           ) -> Self:
-        ...
-
     def on(self,
            type: str,  # pylint: disable=redefined-builtin
            handler: Optional[events.Handler[events.GenericEventArguments]] = None,
@@ -360,8 +340,10 @@ class Element(Visibility):
         :param trailing_events: whether to trigger the event handler after the last event occurrence (default: `True`)
         :param js_handler: JavaScript code that is executed upon occurrence of the event, e.g. `(evt) => alert(evt)` (default: `None`)
         """
-        if handler and js_handler:
-            raise ValueError('Either handler or js_handler can be specified, but not both')
+        if args and js_handler:
+            raise ValueError('''args and js_handler never coexist.
+- If you intend to use js_handler solo without handler, then args is never involved.
+- If you intend to use js_handler with handler, then pick either args or js_handler for your filtering needs.''')
 
         if handler or js_handler:
             listener = EventListener(

--- a/nicegui/event_listener.py
+++ b/nicegui/event_listener.py
@@ -41,4 +41,5 @@ class EventListener:
             'leading_events': self.leading_events,
             'trailing_events': self.trailing_events,
             'js_handler': self.js_handler,
+            'handler': self.handler is not None,
         }

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -178,16 +178,22 @@ function renderRecursively(elements, id) {
     event.specials.forEach((s) => (event_name += s[0].toLocaleUpperCase() + s.substring(1)));
 
     let handler;
-    if (event.js_handler) {
+    if (!event.handler) {
       handler = eval(event.js_handler);
     } else {
       handler = (...args) => {
+        if (event.js_handler) {
+          processed_args = [JSON.stringify(eval(event.js_handler)(...args))];
+          console.log("js_eval_args_update", args);
+        } else {
+          processed_args = stringifyEventArgs(args, event.args);
+        }
         const emitter = () =>
           window.socket?.emit("event", {
             id: id,
             client_id: window.clientId,
             listener_id: event.listener_id,
-            args: stringifyEventArgs(args, event.args),
+            args: processed_args,
           });
         const delayed_emitter = () => {
           if (window.did_handshake) emitter();


### PR DESCRIPTION
This PR should end the saga of PR #4689, PR #4618, while addressing 5 issue / discussions / feature request (#3762, #4611, #4606, #4577, and #4589) as stated in https://github.com/zauberzeug/nicegui/pull/4618#issuecomment-2845918657

#### Background

The crux of the issue is, we want to be able to return custom values which are only possible to be extracted via JavaScript and/or too deep in nested property which `args` does not handle. Stuff gets pretty complex and case-by-case, so read up those 7 referenced items above!

#### Established Requirements

We debated a long time over the API design, and we needed the following requirements: 

- Avoid adding extra parameters whenever possible
  - Option `js_transform = "(e) => e.offsetY"` was eliminated 
- JavaScript transformations should be as easy to add as `"(e) => e.offsetY"`
  - Option `js_handler = "(e) => {defaultHandler(e.offsetY)}"` was eliminated 
- Must be as clear and minimize confusion
  - Option "shoehorning `args`", as well as all other above options, were eliminated

This PR illustrates the idea at https://github.com/zauberzeug/nicegui/pull/4689#issuecomment-2887683005 to comply with all of the aforementioned requirements. 

- Avoid adding extra parameters whenever possible
  - Yes
- JavaScript transformations should be as easy to add as `"(e) => e.offsetY"`
  - `js_handler = "(e) => e.offsetY"`
- Must be as clear and minimize confusion
  - I think so???

#### Logic behind this PR

The keyword is **ARVI**, which stands for Auto-Return-Value-Intercept. It means we intercept the `js_handler`'s return value, if and only if Python-side `handler` is attached. 

As a recap from https://github.com/zauberzeug/nicegui/pull/4689#issuecomment-2887683005: 

- `.on('blah', handler=python_handler, js_handler='(e) => e.event.button')`
  - Since we pass both `handler` and `js_handler`, we now **do** care about the return value, and if there is a return value, we pass to `defaultHandler` right away. 
- `.on('blah', js_handler='(e) => e.event.button')`
  - Old behaviour. `js_handler` doesn't care about return value. 
- `.on('blah', handler=python_handler)`
  - Old behaviour 🙄

#### Notable implementation details

- **`args` and `js_handler` remain mutally exclusive**. 
  - Makes no sense otherwise. You wanna filter twice?
- Logic check `if (event.js_handler) {` changed safely to `if (!event.handler) {`
  - Because no handler + code is even executed => js_handler must be present
  - Since we have a `if handler or js_handler:` on Python-side

#### Remaining to-do 

- [ ] Persuading @falkoschindler
- [ ] Documentation
- [ ] Pytest