### PR TITLE
Let `ui.table.from_pandas` handle dataframes with lists or intervals

### DIFF
--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -255,7 +255,8 @@ class Table(FilterElement, component='table.js'):
             return (pd.api.types.is_datetime64_any_dtype(dtype) or
                     pd.api.types.is_timedelta64_dtype(dtype) or
                     pd.api.types.is_complex_dtype(dtype) or
-                    isinstance(dtype, pd.PeriodDtype))
+                    pd.api.types.is_object_dtype(dtype) or
+                    isinstance(dtype, (pd.PeriodDtype, pd.IntervalDtype)))
         special_cols = df.columns[df.dtypes.apply(is_special_dtype)]
         if not special_cols.empty:
             df = df.copy()


### PR DESCRIPTION
This PR proposes a solution for #2744 by adding the check `pd.api.types.is_object_dtype(dtype)` to the `is_special_dtype` function. Because `pd.IntervalDtype` came up as another JSON-incompatible datatype, it is added as another exception.

Test script:
```py
ui.table.from_pandas(pd.DataFrame({
    'A': [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
    'B': [1, 2, 3],
    'C': ['a', 'b', 'c'],
    'D': [datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2), datetime.datetime(2021, 1, 3)],
    'E': [datetime.timedelta(days=1), datetime.timedelta(days=2), datetime.timedelta(days=3)],
    'F': [complex(1, 2), complex(3, 4), complex(5, 6)],
    'G': [pd.Period('2014-01'), pd.Period('2014-02'), pd.Period('2014-03')],
    'H': [pd.Interval(1, 2), pd.Interval(3, 4), pd.Interval(5, 6)],
}))
```

<img width="546" alt="Screenshot 2025-05-21 at 11 00 53" src="https://github.com/user-attachments/assets/d89fcd96-b2d7-43f2-bfa7-ccc4f5d2bd35" />

This PR doesn't solve the problem if `ui.table(rows=...)` is called with cells containing lists. But one could argue that this is a more obvious user error while `ui.table.from_pandas` should handle this case behind the scenes.