### PR TITLE
Warn if non-relative, since cross-origin download has many problems

### DIFF
--- a/nicegui/functions/download.py
+++ b/nicegui/functions/download.py
@@ -3,6 +3,7 @@ from typing import Optional, Union
 
 from .. import core, helpers
 from ..context import context
+from ..logging import log
 
 
 class Download:
@@ -55,6 +56,14 @@ class Download:
         :param filename: name of the file to download (default: name of the file on the server)
         :param media_type: media type of the file to download (default: "")
         """
+        is_relative = url.startswith('/') or url.startswith('./') or url.startswith('../')
+        if not is_relative:
+            log.warning(f'ui.download.from_url: You have initiated a cross-origin download from {url}.')
+            log.warning('If cross-origin, browser ignores the instruction to start a download, and tries to view the file in a new tab if possible (such as images, PDFs, etc.). \n'
+                        'Incidentally, download may work for some file types (such as .zip, .db, etc.), but it is not guaranteed to work for all file types.\n')
+            if filename is not None or media_type != '':
+                log.warning(
+                    'Moreover, browser ignores filename and media_type parameters, respecting the origin server\'s headers instead.')
         context.client.download(url, filename, media_type)
 
     def content(self, content: Union[bytes, str], filename: Optional[str] = None, media_type: str = '') -> None:

--- a/nicegui/functions/download.py
+++ b/nicegui/functions/download.py
@@ -58,13 +58,17 @@ class Download:
         """
         is_relative = url.startswith('/') or url.startswith('./') or url.startswith('../')
         if not is_relative:
-            log.warning(f'ui.download.from_url: You have initiated a cross-origin download from {url}.')
-            log.warning('If cross-origin, browser ignores the instruction to start a download, and tries to view the file in a new tab if possible (such as images, PDFs, etc.). \n'
-                        'Incidentally, download may work for some file types (such as .zip, .db, etc.), but it is not guaranteed to work for all file types.')
+            log.warning(
+                f'You have initiated a cross-origin download from {url} using `ui.download.from_url`.\n'
+                'The browser ignores the download instruction and tries to view the file in a new tab if possible, '
+                'such as images, PDFs, etc.\n'
+                'Therefore, the download may only work for some file types such as .zip, .db, etc.',
+            )
             if filename is not None or media_type != '':
-                log.warning(
-                    'Moreover, browser ignores filename and media_type parameters, respecting the origin server\'s headers instead.')
-            log.warning('\nIt is best to change to a relative URL if you control the downloaded content. \nOr, if you insist, use `ui.navigate.to(url, new_tab=True)` instead. \n')
+                log.warning('Moreover, the browser ignores filename and media_type parameters, '
+                            "respecting the origin server's headers instead.")
+            log.warning('It is best to change to a relative URL if you control the downloaded content.\n'
+                        'Or, if you insist, use `ui.navigate.to(url, new_tab=True)` instead.')
         context.client.download(url, filename, media_type)
 
     def content(self, content: Union[bytes, str], filename: Optional[str] = None, media_type: str = '') -> None:

--- a/nicegui/functions/download.py
+++ b/nicegui/functions/download.py
@@ -64,7 +64,7 @@ class Download:
             if filename is not None or media_type != '':
                 log.warning(
                     'Moreover, browser ignores filename and media_type parameters, respecting the origin server\'s headers instead.')
-            log.warning('\nIf you insist, use `ui.navigate.to(url, new_tab=True)` instead. \n')
+            log.warning('\nIt is best to change to a relative URL if you control the downloaded content. \nOr, if you insist, use `ui.navigate.to(url, new_tab=True)` instead. \n')
         context.client.download(url, filename, media_type)
 
     def content(self, content: Union[bytes, str], filename: Optional[str] = None, media_type: str = '') -> None:

--- a/nicegui/functions/download.py
+++ b/nicegui/functions/download.py
@@ -60,10 +60,11 @@ class Download:
         if not is_relative:
             log.warning(f'ui.download.from_url: You have initiated a cross-origin download from {url}.')
             log.warning('If cross-origin, browser ignores the instruction to start a download, and tries to view the file in a new tab if possible (such as images, PDFs, etc.). \n'
-                        'Incidentally, download may work for some file types (such as .zip, .db, etc.), but it is not guaranteed to work for all file types.\n')
+                        'Incidentally, download may work for some file types (such as .zip, .db, etc.), but it is not guaranteed to work for all file types.')
             if filename is not None or media_type != '':
                 log.warning(
                     'Moreover, browser ignores filename and media_type parameters, respecting the origin server\'s headers instead.')
+            log.warning('\nIf you insist, use `ui.navigate.to(url, new_tab=True)` instead. \n')
         context.client.download(url, filename, media_type)
 
     def content(self, content: Union[bytes, str], filename: Optional[str] = None, media_type: str = '') -> None:

--- a/nicegui/functions/download.py
+++ b/nicegui/functions/download.py
@@ -19,7 +19,7 @@ class Download:
 
         Function to trigger the download of a file, URL or bytes.
 
-        :param src: target URL, local path of a file or raw data which should be downloaded
+        :param src: relative target URL, local path of a file or raw data which should be downloaded
         :param filename: name of the file to download (default: name of the file on the server)
         :param media_type: media type of the file to download (default: "")
         """
@@ -46,11 +46,22 @@ class Download:
         context.client.download(src, filename, media_type)
 
     def from_url(self, url: str, filename: Optional[str] = None, media_type: str = '') -> None:
-        """Download from a URL
+        """Download from a relative URL
 
-        Function to trigger the download from a URL.
+        Function to trigger the download from a relative URL.
+
+        Note:
+        This function is intended to be used with relative URLs only.
+        For absolute URLs, the browser ignores the download instruction and tries to view the file in a new tab
+        if possible, such as images, PDFs, etc.
+        Therefore, the download may only work for some file types such as .zip, .db, etc.
+        Furthermore, the browser ignores filename and media_type parameters,
+        respecting the origin server's headers instead.
+        Either replace the absolute URL with a relative one, or use ``ui.navigate.to(url, new_tab=True)`` instead.
 
         *Added in version 2.14.0*
+
+        *Updated in version 2.19.0: Added warning for cross-origin downloads*
 
         :param url: URL
         :param filename: name of the file to download (default: name of the file on the server)
@@ -58,17 +69,8 @@ class Download:
         """
         is_relative = url.startswith('/') or url.startswith('./') or url.startswith('../')
         if not is_relative:
-            log.warning(
-                f'You have initiated a cross-origin download from {url} using `ui.download.from_url`.\n'
-                'The browser ignores the download instruction and tries to view the file in a new tab if possible, '
-                'such as images, PDFs, etc.\n'
-                'Therefore, the download may only work for some file types such as .zip, .db, etc.',
-            )
-            if filename is not None or media_type != '':
-                log.warning('Moreover, the browser ignores filename and media_type parameters, '
-                            "respecting the origin server's headers instead.")
-            log.warning('It is best to change to a relative URL if you control the downloaded content.\n'
-                        'Or, if you insist, use `ui.navigate.to(url, new_tab=True)` instead.')
+            log.warning('Using `ui.download.from_url` with absolute URLs is not recommended.\n'
+                        'Please refer to the documentation for more details.')
         context.client.download(url, filename, media_type)
 
     def content(self, content: Union[bytes, str], filename: Optional[str] = None, media_type: str = '') -> None:

--- a/website/documentation/content/download_documentation.py
+++ b/website/documentation/content/download_documentation.py
@@ -6,13 +6,13 @@ from . import doc
 @doc.demo(ui.download)
 def main_demo() -> None:
     ui.button('Local file', on_click=lambda: ui.download.file('main.py'))
-    ui.button('From URL', on_click=lambda: ui.download.from_url('https://nicegui.io/logo.png'))
+    ui.button('From URL', on_click=lambda: ui.download.from_url('/logo.png'))
     ui.button('Content', on_click=lambda: ui.download.content('Hello World', 'hello.txt'))
 
 
 @doc.demo(ui.download.from_url)
 def from_url_demo() -> None:
-    ui.button('Download', on_click=lambda: ui.download.from_url('https://nicegui.io/logo.png'))
+    ui.button('Download', on_click=lambda: ui.download.from_url('/logo.png'))
 
 
 @doc.demo(ui.download.content)


### PR DESCRIPTION
This PR fix #4723 to avoid a common pitfall that is cross-origin download on the browser-side. 

Due to browser security reasons outlined https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#download, if it is cross-origin, then the browser ignores the `download` and thus `filename` and `media_type` alike. 

The conclusion from #4723 appears to be, there is no legitimate use for running `ui.download.from_url` from a cross-origin URL. Since it'll only work as the user expected only if: 
- Server responds a file type the browser can't otherwise open a new tab,
- User did not pass filename (which would otherwise be ignored). 

Thus, it is recommended that either: 
- User change their code to relative URL
- Or if they insist, simply use `ui.navigate.to` with `new_tab = True` (https://nicegui.io/documentation/navigate#ui_navigate_to_(formerly_ui_open))