### PR TITLE
Add flake8-quotes information to pyproject.toml for ruff fixable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,12 @@ target-version = "py38"
 indent-width = 4
 line-length = 120
 
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single"
+multiline-quotes = "single"
+docstring-quotes = "double"
+avoid-escape = true
+
 [tool.ruff.lint]
 # See complete list: https://docs.astral.sh/ruff/rules/
 select = [
@@ -148,10 +154,12 @@ select = [
     "UP", # pyupgrade
     "RUF", # ruff
     "PL", # pylint
+    "Q" # flake8-quotes
 ]
 fixable = [
     "I",  # isort
     "RUF022", # `__all__` is not sorted
+    "Q000"  # quote style
 ]
 ignore = [
     "E501", # line too long


### PR DESCRIPTION
### Motivation

I kept having "problems" with using " instead of ' for strings when commiting changes. As we're currently using ruff for some fixing

```toml
fixable = [
    "I",  # isort
    "RUF022", # `__all__` is not sorted
]
```
and
```json
  "[python]": {
    "editor.defaultFormatter": "ms-python.autopep8",
    "editor.codeActionsOnSave": {
      "source.fixAll.ruff": "always"
    }
  }
```

Adding quote fixing to the fixable list would automatically fix this and we'll have less build-errors when commiting.

In an earlier PR I made (https://github.com/zauberzeug/nicegui/pull/4368) we come to the conclusion to not use ruff for the formating but some time after fixable got added so I don't see any problems adding ruff's quote fixing there as it only will fix the quotes.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
