### PR TITLE
Get ruff happy after tightning the single-quote rules

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -34,19 +34,19 @@ templates = Jinja2Templates(Path(__file__).parent / 'templates')
 
 class Client:
     page_routes: ClassVar[Dict[Callable[..., Any], str]] = {}
-    """Maps page builders to their routes."""
+    '''Maps page builders to their routes.'''
 
     instances: ClassVar[Dict[str, Client]] = {}
-    """Maps client IDs to clients."""
+    '''Maps client IDs to clients.'''
 
     auto_index_client: Client
-    """The client that is used to render the auto-index page."""
+    '''The client that is used to render the auto-index page.'''
 
     shared_head_html = ''
-    """HTML to be inserted in the <head> of every page template."""
+    '''HTML to be inserted in the <head> of every page template.'''
 
     shared_body_html = ''
-    """HTML to be inserted in the <body> of every page template."""
+    '''HTML to be inserted in the <body> of every page template.'''
 
     def __init__(self, page: page, *, request: Optional[Request]) -> None:
         self.request: Optional[Request] = request

--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -9,15 +9,15 @@ from ...events import GenericEventArguments, Handler, ValueChangeEventArguments,
 
 class ValueElement(Element):
     VALUE_PROP: str = 'model-value'
-    """Name of the prop that holds the value of the element"""
+    '''Name of the prop that holds the value of the element'''
 
     LOOPBACK: Optional[bool] = True
-    """Whether to set the new value directly on the client or after getting an update from the server.
+    '''Whether to set the new value directly on the client or after getting an update from the server.
 
     - ``True``: The value is updated by sending a change event to the server which responds with an update.
     - ``False``: The value is updated by setting the VALUE_PROP directly on the client.
     - ``None``: The value is updated automatically by the Vue element.
-    """
+    '''
 
     value = BindableProperty(
         on_change=lambda sender, value: cast(Self, sender)._handle_value_change(value))  # pylint: disable=protected-access

--- a/nicegui/slot.py
+++ b/nicegui/slot.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 class Slot:
     stacks: ClassVar[Dict[int, List[Slot]]] = {}
-    """Maps asyncio task IDs to slot stacks, which keep track of the current slot in each task."""
+    '''Maps asyncio task IDs to slot stacks, which keep track of the current slot in each task.'''
 
     def __init__(self, parent: Element, name: str, template: Optional[str] = None) -> None:
         self.name = name

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -49,19 +49,19 @@ def set_storage_secret(storage_secret: Optional[str] = None) -> None:
 
 class Storage:
     secret: Optional[str] = None
-    """Secret key for session storage."""
+    '''Secret key for session storage.'''
 
     path = Path(os.environ.get('NICEGUI_STORAGE_PATH', '.nicegui')).resolve()
-    """Path to use for local persistence. Defaults to ".nicegui"."""
+    '''Path to use for local persistence. Defaults to ".nicegui".'''
 
     redis_url = os.environ.get('NICEGUI_REDIS_URL', None)
-    """URL to use for shared persistent storage via Redis. Defaults to None, which means local file storage is used."""
+    '''URL to use for shared persistent storage via Redis. Defaults to None, which means local file storage is used.'''
 
     redis_key_prefix = os.environ.get('NICEGUI_REDIS_KEY_PREFIX', 'nicegui:')
-    """Prefix for Redis keys. Defaults to "nicegui:"."""
+    '''Prefix for Redis keys. Defaults to "nicegui:".'''
 
     max_tab_storage_age: float = timedelta(days=30).total_seconds()
-    """Maximum age in seconds before tab storage is automatically purged. Defaults to 30 days."""
+    '''Maximum age in seconds before tab storage is automatically purged. Defaults to 30 days.'''
 
     def __init__(self) -> None:
         self._general = Storage._create_persistent_dict('general')

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -3,7 +3,7 @@ from nicegui.testing import Screen
 
 
 def test_local_target_linking_on_sub_pages(screen: Screen):
-    '''The issue arose when using <base> tag for reverse-proxy path handling. See https://github.com/zauberzeug/nicegui/pull/188#issuecomment-1336313925'''
+    """The issue arose when using <base> tag for reverse-proxy path handling. See https://github.com/zauberzeug/nicegui/pull/188#issuecomment-1336313925"""
     @ui.page('/sub')
     def main():
         ui.link('goto target', '#target').style('margin-bottom: 600px')

--- a/tests/test_serving_files.py
+++ b/tests/test_serving_files.py
@@ -92,11 +92,11 @@ def test_auto_serving_file_from_image_source(screen: Screen):
     img = screen.find_by_tag('img')
     assert '/_nicegui/auto/static/' in img.get_attribute('src')
     screen.wait(0.5)
-    assert screen.selenium.execute_script("""
+    assert screen.selenium.execute_script('''
     return arguments[0].complete &&
         typeof arguments[0].naturalWidth != "undefined" &&
         arguments[0].naturalWidth > 0
-    """, img), 'image should load successfully'
+    ''', img), 'image should load successfully'
 
 
 def test_auto_serving_file_from_video_source(screen: Screen):


### PR DESCRIPTION
### Motivation

This PR fix #4787 by changing our code around how Ruff and flake8 works, such that it does not complain on GitHub Actions. 

### Implementation

The code is made simply by: 
- `pre-commit run --all-files`
- Commiting whatever was changed

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Special notes

As noted in https://github.com/zauberzeug/nicegui/issues/4787#issuecomment-2905344451, I personally believe only 1 out of 3 siutations, that it is our firm mistake. Other cases, I think its not so much. I think "docstring-like comments made with double-quote strings" is fine for clarity, while "docstring made with single-quote strings" is negotiable. 

But, without merging this PR or some other substitute to get Ruff happy, contributors's action runs will always fail, which is **a massive pain**, so I would prefer that we maybe merge this before we discuss whether we should and how to loosen Ruff rules a bit