### PR TITLE
Aggressively cache `search_index.json` since it is cache-busted by version

### DIFF
--- a/website/documentation/search.py
+++ b/website/documentation/search.py
@@ -17,7 +17,9 @@ examples_index: List[Dict[str, str]] = []
 
 @app.get('/static/search_index.json')
 def _get_search_index() -> JSONResponse:
-    return JSONResponse(search_index)
+    response = JSONResponse(search_index)
+    response.headers['Cache-Control'] = 'public, max-age=86400, immutable'
+    return response
 
 
 @app.get('/static/sitewide_index.json')


### PR DESCRIPTION
### Motivation

As brought to light by @falkoschindler in https://github.com/zauberzeug/nicegui/discussions/4794#discussioncomment-13270220, over 60% of the outgoing traffic in the NiceGUI documentation is occupied by the repeated fetching of `search_index.json`. It makes all other optimizations useless if we don't optimize that first. 

Before: 

![image](https://github.com/user-attachments/assets/42c2142b-8f56-413f-8255-6ecee7af6f83)

-> `66.0 KB` for the `search_index.json`

After: 

![image](https://github.com/user-attachments/assets/89701f4e-327f-4f21-966c-4fd0566f951b)

-> `memory cache` for the `search_index.json`

### Implementation

This applies `'public, max-age=86400, immutable'` header to the response. 

It is OK, since we already do cache-busting by version here: 

https://github.com/zauberzeug/nicegui/blob/f9114c9500226bafbd3e70d1a5a193f0ebf34db0/website/search.py#L13

So, _unless we update the documentation midway in the same version_, which never happens in production, it'd be fine. 

There is impact for people developing the NiceGUI documentation, in that they will not receive the latest search index by default, but chances are: 
1. they don't care about how the searching works,
2. if they do, they can Disable Cache in DevTools I guess. 

~IMO people need to re-think if they should continue contributing, if they can't disable cache by themselves.~

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

-> I don't think we need pytest or documentation for this one. 