### PR TITLE
Browser Data Store: Retransmission Avoidance (-40% for docs page alone)

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from fastapi import HTTPException, Request
 from fastapi.responses import RedirectResponse
 from starlette.middleware.sessions import SessionMiddleware
 
-from nicegui import app, ui
+from nicegui import app, json, ui
 from website import anti_scroll_hack, documentation, fly, imprint_privacy, main_page, svg
 
 # session middleware is required for demo in documentation
@@ -24,6 +24,7 @@ app.add_static_file(local_file=svg.PATH / 'logo_square.png', url_path='/logo_squ
 
 documentation.build_search_index()
 documentation.build_tree()
+app.browser_data_store['side_tree_hierarchy'] = json.dumps(documentation.tree.nodes)
 
 
 @app.post('/dark_mode')

--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -5,7 +5,7 @@ import signal
 import urllib
 from enum import Enum
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Iterator, List, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional, Union
 
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import FileResponse
@@ -45,6 +45,7 @@ class App(FastAPI):
         self._connect_handlers: List[Union[Callable[..., Any], Awaitable]] = []
         self._disconnect_handlers: List[Union[Callable[..., Any], Awaitable]] = []
         self._exception_handlers: List[Callable[..., Any]] = [log.exception]
+        self.browser_data_store: Dict[str, str] = {}
 
     @property
     def is_starting(self) -> bool:

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -53,6 +53,11 @@ def is_file(path: Optional[Union[str, Path]]) -> bool:
         return False
 
 
+def hash_data_store_entry(entry: str) -> str:
+    """Hashes the data store entry, which must be a string."""
+    return hashlib.sha256(entry.encode('utf-8')).hexdigest()
+
+
 def hash_file_path(path: Path, *, max_time: Optional[float] = None) -> str:
     """Hash the given path based on its string representation and optionally the last modification time of given files."""
     hasher = hashlib.sha256(path.as_posix().encode())

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -45,7 +45,9 @@
       <span>{{ translations.trying_to_reconnect }}</span>
     </div>
     <script type="module">
-      const app = createApp(parseElements(String.raw`{{ elements | safe }}`), {
+      updateBrowserDataStore(String.raw`{{ filtered_browser_data_store | safe }}`);
+
+      const app = createApp(parseElements(String.raw`{{ elements | safe }}`, "{{browser_data_store_token}}"), {
         version: "{{ version }}",
         prefix: "{{ prefix | safe }}",
         query: {{ socket_io_js_query_params | safe }},

--- a/website/documentation/rendering.py
+++ b/website/documentation/rendering.py
@@ -19,7 +19,8 @@ def render_page(documentation: DocumentationPage, *, with_menu: bool = True) -> 
         with ui.left_drawer() \
                 .classes('column no-wrap gap-1 bg-[#eee] dark:bg-[#1b1b1b] mt-[-20px] px-8 py-20') \
                 .style('height: calc(100% + 20px) !important') as menu:
-            tree = ui.tree(nodes, label_key='title').classes('w-full').props('accordion no-connectors')
+            tree = ui.tree(ui.context.client.fetch_dict_from_browser_data_store('side_tree_hierarchy'),
+                           label_key='title').classes('w-full').props('accordion no-connectors')
             tree.add_slot('default-header', '''
                 <a :href="'/documentation/' + props.node.id" onclick="event.stopPropagation()">{{ props.node.title }}</a>
             ''')

--- a/website/svg.py
+++ b/website/svg.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from nicegui import ui
+from nicegui import app, ui
 
 PATH = Path(__file__).parent / 'static'
 HAPPY_FACE_SVG = (PATH / 'happy_face.svg').read_text(encoding='utf-8')
@@ -9,25 +9,33 @@ GITHUB_SVG = (PATH / 'github.svg').read_text(encoding='utf-8')
 DISCORD_SVG = (PATH / 'discord.svg').read_text(encoding='utf-8')
 REDDIT_SVG = (PATH / 'reddit.svg').read_text(encoding='utf-8')
 
+app.browser_data_store['happy_face_svg'] = HAPPY_FACE_SVG
+app.browser_data_store['nicegui_word_svg'] = NICEGUI_WORD_SVG
+app.browser_data_store['github_svg'] = GITHUB_SVG
+app.browser_data_store['discord_svg'] = DISCORD_SVG
+app.browser_data_store['reddit_svg'] = REDDIT_SVG
+
+app.browser_data_store['half_happy_face_svg'] = HAPPY_FACE_SVG.replace(
+    'viewBox="0 0 62.44 71.74"', 'viewBox="31.22 0 31.22 71.74"')
+
 
 def face(half: bool = False) -> ui.html:
-    code = HAPPY_FACE_SVG
     if half:
-        code = code.replace('viewBox="0 0 62.44 71.74"', 'viewBox="31.22 0 31.22 71.74"')
-    return ui.html(code)
+        return ui.html(ui.context.client.fetch_string_from_browser_data_store('half_happy_face_svg'))
+    return ui.html(ui.context.client.fetch_string_from_browser_data_store('happy_face_svg'))
 
 
 def word() -> ui.html:
-    return ui.html(NICEGUI_WORD_SVG)
+    return ui.html(ui.context.client.fetch_string_from_browser_data_store('nicegui_word_svg'))
 
 
 def github() -> ui.html:
-    return ui.html(GITHUB_SVG)
+    return ui.html(ui.context.client.fetch_string_from_browser_data_store('github_svg'))
 
 
 def discord() -> ui.html:
-    return ui.html(DISCORD_SVG)
+    return ui.html(ui.context.client.fetch_string_from_browser_data_store('discord_svg'))
 
 
 def reddit() -> ui.html:
-    return ui.html(REDDIT_SVG)
+    return ui.html(ui.context.client.fetch_string_from_browser_data_store('reddit_svg'))


### PR DESCRIPTION
### Motivation

As outlined in #4794, I felt that the NiceGUI site became more sluggish after #4732. Be it true or not, I found that over 30% of the page's content data is the sidebar hierarchy, which is sent again and again on every page load. 

This PR introduces a two new mechanisms: 

- Browser Data Store (at `app.browser_data_store`): 
  - **[User usage]** which the user can write strings (strings only, for ease of hashing) to, 
  - **[End result]** that they can **rest assured NiceGUI will help them keep synchronized** with what is in the browser's `localStorage`
- Fetch from Browser Data Store: (at `client.fetch_xxx_from_browser_data_store`, where `xxx` can be `string`, `list`, or `dict`), 
  - **[User usage]** which the user can use as a placeholder of the large amount of data, 
  - **[End result]** and upon `nicegui.js` `parseElements`, it will replace such placeholders with _whatever's in the corresponding Browser Data Store key_, achieving the outcome of **retransmission avoidance**. 

Real motivation: @falkoschindler ["I'm not sure how this can work in general."](https://github.com/zauberzeug/nicegui/discussions/4794#discussioncomment-13270220) You know I like to challenge the impossible. 

### Implementation

#### Browser Data Store synchronization routine: 

- If populated, browser sends cookie `nicegui_data_store` with the keys it has and the hash of those values to the server on every request. 
- Server inspects such cookie if present, checks the hash, and sends only the keys it needs to send to update the browser with the latest data from the Browser Data Store. 
- Browser receives the data from `updateBrowserDataStore` and updates `nicegui_data_store` such that next request (if nothing has changed) it gets to save a re-transmission. 

Notably: 
- Server also sends value `None` (which is `null` in JSON-form) so as to delete old keys. 

#### Fetch from Browser Data Store routine:

- To avoid plain-text injection, the fetching is triggered with a random token in `client.browser_data_store_token` which is also transmitted to the browser. In such a manner, people who control the arbitrary input to elements (e.g. `ui.label(user_provided_input)` can NOT trigger the fetch, since they don't know the random token. 
  - For injection to occur, the `user_provided_input` must read `ui.context.client.browser_data_store_token` dynamically on client creation, which is impossible for a string / dict / list. 
- `nicegui.js` `parseElements` `JSON.parse` is passed with a custom `reviver`, which detects for these values and replace them (using Python notation for clarity):
  - If it finds **string** `"BDS-TOKEN-sometoken:long_string"`, it replaces the string with the value of key `long_string` in localStorage
  - If it finds **list** `["BDS-TOKEN-sometoken", "long_string"]`, it replaces the list with the JSON-decoded value of key `long_string` in localStorage
  - If it finds **dict** `{"BDS-TOKEN-sometoken": "long_string"}`, it replaces the dict with the JSON-decoded value of key `long_string` in localStorage

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).

-> We need to think about whether we need pytest. Documentation seems necessary but I'd like to get someone else to look at the idea before doing documentation, since this idea is quite big!

### Results showcase

Before: 

<img width="701" alt="image" src="https://github.com/user-attachments/assets/a1c6b592-3897-4b96-a1e0-6155db549e01" />

-> 30.3 KB

After: 

<img width="701" alt="image" src="https://github.com/user-attachments/assets/568f1662-c532-4508-bf5a-642cac44b174" />

-> 18.3 KB
