### PR TITLE
Defer non-critical JS for slightly faster page load under CPU+Network simultaneous bottleneck

### DIFF
--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -24,19 +24,19 @@
     <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/es-module-shims.js"></script>
     <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/socket.io.min.js"></script>
     {% if tailwind %}
-    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/tailwindcss.min.js"></script>
+    <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/tailwindcss.min.js"></script>
     {% endif %}
     <!-- prevent Prettier from removing this line -->
     {% if prod_js %}
-    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/vue.global.prod.js"></script>
-    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/quasar.umd.prod.js"></script>
+    <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/vue.global.prod.js"></script>
+    <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/quasar.umd.prod.js"></script>
     {% else %}
-    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/vue.global.js"></script>
-    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/quasar.umd.js"></script>
+    <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/vue.global.js"></script>
+    <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/quasar.umd.js"></script>
     {% endif %}
-    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/nicegui.js"></script>
+    <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/nicegui.js"></script>
 
-    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/lang/{{ language }}.umd.prod.js"></script>
+    <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/lang/{{ language }}.umd.prod.js"></script>
     {{ body_html | safe }}
 
     <div id="app"></div>

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -22,7 +22,7 @@
   </head>
   <body>
     <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/es-module-shims.js"></script>
-    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/socket.io.min.js"></script>
+    <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/socket.io.min.js"></script>
     {% if tailwind %}
     <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/tailwindcss.min.js"></script>
     {% endif %}


### PR DESCRIPTION
### Motivation

Still in the mood of speed improvement. 

So I was reading https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script again... 

Basically, loading behaviour wise, there's 3 valid options: 

![image](https://github.com/user-attachments/assets/f00c9eae-3b58-4fba-8985-043371e3cab4)

1. Normal script
2. Defer script
3. Async script

(Don't think about defer async. It has been mentioned that if async is set, ["If the attribute is specified with the defer attribute, the element will act as if only the async attribute is specified"](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#:~:text=If%20the%20attribute%20is%20specified%20with%20the%20defer%20attribute%2C%20the%20element%20will%20act%20as%20if%20only%20the%20async%20attribute%20is%20specified), meaning async + defer => async). 

I then took a look at the script situation in NiceGUI: 

1. No script in head
2. Body's empty, no elements
3. Main script is a `<script type="module">`, which is ["defer by default"](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#:~:text=scripts%20%E2%80%94%20they-,defer%20by%20default,-.)

Then I thought: **Can I have the rest of the NiceGUI's scripts be defer as well, since they need to run before the main script only, and not any earlier. We don't need to block up the parser while those scripts load?**

And yes, indeed, there is performance uplift.  

### Implementation

- Change the scripts from normal scripts to defer scripts. 
  - Left the ES module shim in-tact since that probably has to load ASAP. 
  - Left Socket.IO in-tact because we'd have to move it anyways if we adapt #4756 
  - Both instances, maybe `defer` would make it even faster, or it would break things. I'll see when I have time. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

-> No need pytest and documentation. As long as existing tests don't break, Id be happy

### Results showcase

Using Fast 4G profile, 4x CPU slowdown. 

Before: 

![image](https://github.com/user-attachments/assets/33218a83-f4c6-4033-bab2-0e4eb3de0501)

After: 

![image](https://github.com/user-attachments/assets/365557c0-9b61-43c7-8ead-76092ce9b5ff)

Finish: 6.47s -> 5.99s
DOMContentLoaded: 4.69s -> 4.38s
Load: 5.69s -> 5.18s

About save 5s. 

Reference: 4G network latency 165ms. I am not saying that we are saving 3x the network latency, but it just puts things into perspective. 

Worthy of note: 

- _No performance uplift_ if network is not slowed down and only CPU slowdown, since the network request would complete in an instant, and we didn't really block the parser for much. 
- _No performance uplift_ if CPU is not slowed down and only network slowdown, since the parsing would complete in an instant, and we can't block the parser if completes in a blink of the eye. 
- **Only notice performance uplift** if you apply BOTH network slowdown and CPU slowdown. 

May want to test with more slowdown and Slow 4G later. 3G's too much. 
