### PR TITLE
Preload only documentation pages marked with `@doc.auto_execute`

### DIFF
--- a/website/documentation/content/doc/__init__.py
+++ b/website/documentation/content/doc/__init__.py
@@ -1,6 +1,7 @@
-from .api import demo, extra_column, get_page, intro, part, redirects, reference, registry, text, title, ui
+from .api import demo, extra_column, get_page, intro, part, redirects, reference, registry, text, title, ui, auto_execute
 
 __all__ = [
+    'auto_execute',
     'demo',
     'extra_column',
     'get_page',

--- a/website/documentation/content/doc/__init__.py
+++ b/website/documentation/content/doc/__init__.py
@@ -1,4 +1,17 @@
-from .api import demo, extra_column, get_page, intro, part, redirects, reference, registry, text, title, ui, auto_execute
+from .api import (
+    auto_execute,
+    demo,
+    extra_column,
+    get_page,
+    intro,
+    part,
+    redirects,
+    reference,
+    registry,
+    text,
+    title,
+    ui,
+)
 
 __all__ = [
     'auto_execute',

--- a/website/documentation/content/doc/api.py
+++ b/website/documentation/content/doc/api.py
@@ -21,10 +21,10 @@ registry: Dict[str, DocumentationPage] = {}
 redirects: Dict[str, str] = {}
 
 
-def auto_execute(func):
+def auto_execute(function: Callable) -> Callable:
     """Decorator to automatically execute the function when the module is imported."""
-    func()
-    return func
+    function()
+    return function
 
 
 def get_page(documentation: ModuleType) -> DocumentationPage:

--- a/website/documentation/content/doc/api.py
+++ b/website/documentation/content/doc/api.py
@@ -21,6 +21,12 @@ registry: Dict[str, DocumentationPage] = {}
 redirects: Dict[str, str] = {}
 
 
+def auto_execute(func):
+    """Decorator to automatically execute the function when the module is imported."""
+    func()
+    return func
+
+
 def get_page(documentation: ModuleType) -> DocumentationPage:
     """Return the documentation page for the given documentation module."""
     target_name = _removesuffix(documentation.__name__.split('.')[-1], '_documentation')

--- a/website/documentation/content/element_filter_documentation.py
+++ b/website/documentation/content/element_filter_documentation.py
@@ -60,6 +60,7 @@ def marker_demo() -> None:
     ElementFilter(marker='red strong', local_scope=True).classes('bg-red-600 text-white')
 
 
+@doc.auto_execute
 @doc.demo('Find elements on other pages', '''
     You can use the `app.clients` iterator to apply the element filter to all clients of a specific page.
 ''')

--- a/website/documentation/content/link_documentation.py
+++ b/website/documentation/content/link_documentation.py
@@ -33,6 +33,7 @@ def same_page_links():
         ui.link('Goto B', '#target_B')  # HIDE
 
 
+@doc.auto_execute
 @doc.demo('Links to other pages', '''
     You can link to other pages by providing the link target as path or function reference.
 ''')

--- a/website/documentation/content/page_documentation.py
+++ b/website/documentation/content/page_documentation.py
@@ -3,6 +3,7 @@ from nicegui import ui
 from . import doc
 
 
+@doc.auto_execute
 @doc.demo(ui.page)
 def main_demo() -> None:
     @ui.page('/other_page')
@@ -17,6 +18,7 @@ def main_demo() -> None:
     ui.link('Visit dark page', dark_page)
 
 
+@doc.auto_execute
 @doc.demo('Pages with Path Parameters', '''
     Page routes can contain parameters like [FastAPI](https://fastapi.tiangolo.com/tutorial/path-params/).
     If type-annotated, they are automatically converted to bool, int, float and complex values.
@@ -31,6 +33,7 @@ def page_with_path_parameters_demo():
     ui.link('Say hi to Santa!', '/repeat/Ho! /3')
 
 
+@doc.auto_execute
 @doc.demo('Wait for Client Connection', '''
     To wait for a client connection, you can add a `client` argument to the decorated page function
     and await `client.connected()`.
@@ -52,6 +55,7 @@ def wait_for_connected_demo():
     ui.link('wait for connection', wait_for_connection)
 
 
+@doc.auto_execute
 @doc.demo('Multicasting', '''
     The content on a page is private to the client (the browser tab) and has its own local element context.
     If you want to send updates to _all_ clients of a specific page, you can use the `app.clients` iterator.

--- a/website/documentation/content/page_layout_documentation.py
+++ b/website/documentation/content/page_layout_documentation.py
@@ -3,6 +3,7 @@ from nicegui import ui
 from . import doc
 
 
+@doc.auto_execute
 @doc.demo('Page Layout', '''
     With `ui.header`, `ui.footer`, `ui.left_drawer` and `ui.right_drawer` you can add additional layout elements to a page.
     The `fixed` argument controls whether the element should scroll or stay fixed on the screen.

--- a/website/documentation/content/refreshable_documentation.py
+++ b/website/documentation/content/refreshable_documentation.py
@@ -91,6 +91,7 @@ def reactive_state():
         counter('B')
 
 
+@doc.auto_execute
 @doc.demo('Global scope', '''
     When defining a refreshable function in the global scope,
     every refreshable UI that is created by calling this function will share the same state.
@@ -117,6 +118,7 @@ def global_scope():
              'For accurate results, please run this example locally on your machine.').classes('text-gray-600')
 
 
+@doc.auto_execute
 @doc.demo('Local scope (variant A)', '''
     When defining a refreshable function in a local scope,
     refreshable UI that is created by calling this function will refresh independently.
@@ -138,6 +140,7 @@ def local_scope_a():
     ui.link('Open demo', demo)
 
 
+@doc.auto_execute
 @doc.demo('Local scope (variant B)', '''
     In order to define refreshable UIs with local state outside of page functions,
     you can, e.g., define a class with a refreshable method.
@@ -161,6 +164,7 @@ def local_scope_b():
     ui.link('Open demo', demo)
 
 
+@doc.auto_execute
 @doc.demo('Local scope (variant C)', '''
     As an alternative to the class definition shown above, you can also define the UI function in global scope,
     but apply the `ui.refreshable` decorator inside the page function.

--- a/website/documentation/content/section_pages_routing.py
+++ b/website/documentation/content/section_pages_routing.py
@@ -18,6 +18,7 @@ doc.title('*Pages* & Routing')
 doc.intro(page_documentation)
 
 
+@doc.auto_execute
 @doc.demo('Auto-index page', '''
     Pages created with the `@ui.page` decorator are "private".
     Their content is re-created for each client.
@@ -45,6 +46,7 @@ def auto_index_page():
 doc.intro(page_layout_documentation)
 
 
+@doc.auto_execute
 @doc.demo('Parameter injection', '''
     Thanks to FastAPI, a page function accepts optional parameters to provide
     [path parameters](https://fastapi.tiangolo.com/tutorial/path-params/),
@@ -120,6 +122,7 @@ def add_head_html_demo():
     ui.label('RED').classes('my-red-label')
 
 
+@doc.auto_execute
 @doc.demo('API Responses', '''
     NiceGUI is based on [FastAPI](https://fastapi.tiangolo.com/).
     This means you can use all of FastAPI's features.


### PR DESCRIPTION
### Motivation

First, in #4728, I noticed that documentation demo pages are only available after the corresponding sections have been visited once.

Then, in #4790, @rodja tried his hands on preloading the documentation pages. But he got bugs and tests only pass on 3.12+, which is suspicious. 

Past experience in https://github.com/zauberzeug/nicegui/pull/4671#issuecomment-2848552821 indicate that, if tests fail on old versions only, they may have something to do with asyncio, which there shouldn't if we are simply defining a page. 

I then watched a YouTube video about how a CVE boils down to "Python function decorators execute code as well" https://youtu.be/T2nBvNBzrP8

Then I asked LLM for "python function decorator for executing the function immediately after definition": https://poe.com/s/YoZKe2s8uRpY4uWZEpVo

Seeing light at the end of the tunnel, I proceed with the PR. 

### Implementation

The code boils down to this: 

```py
def auto_execute(func):
    """Decorator to automatically execute the function when the module is imported."""
    func()
    return func
```

This means, if we decorate the function with `@doc.auto_execute`, that function gets executed immediately. 

The idea is simple: Apply this decorator to **only** the demo functions which are simple `@ui.page` wrappers, and we'll go from there. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

Not sure how to Pytest the documentation site, but I have tested every single page and it works. Additionally, the one demo about `@app.get` FastAPI endpoint is also covered. 
