### PR TITLE
Skip ES module shim for modern browsers entirely, ~10% faster page load (CPU-bound)

### DIFF
--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -21,7 +21,7 @@
     {% endfor %}
   </head>
   <body>
-    <script src="{{ prefix | safe }}/_nicegui/{{version}}/static/es-module-shims.js"></script>
+    <script nomodule src="{{ prefix | safe }}/_nicegui/{{version}}/static/es-module-shims.js"></script>
     <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/socket.io.min.js"></script>
     {% if tailwind %}
     <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/tailwindcss.min.js"></script>


### PR DESCRIPTION
### Motivation

First, I discovered the `nomodule` attribute of `script` completely by accident in #4761. I pitched that it can speed up page load, but never got around to testing it. I was going on a trip back then. 

I promptly forgot about it. 😅

Until #4798 where we discovered the importance of applying a CPU throttle to make speed issues show themselves, and I was reminded of the topic, and proceeded to implement it and benchmark it. I found a significant speed increase. 

### Implementation

Simply set `nomodule` to the ES module shim. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Results showcase: 

Low-tier mobile speed throttling (8.5x on my machine), no need disable cache and network throttling (we want to show **only** JS execution time)

Before: 

![image](https://github.com/user-attachments/assets/0ac20df4-60a3-49b5-8a17-21057811a069)

After: 

![image](https://github.com/user-attachments/assets/e044ddcf-2516-45aa-a872-04f7b2dc1d1b)

Finish: 7.71s -> 6.97s (Difference: -0.74s, Percentage Difference: -9.60%)
DOMContentLoaded: 6.48s -> 5.85s (Difference: -0.63s, Percentage Difference: -9.72%)
Load: 7.57s -> 6.82s (Difference: -0.75s, Percentage Difference: -9.91%)

### Potential impacts

We can no longer use the functionalities that ES Module Shims offer to us

- `importShim.getImportMap()`
- `importShim.addImportMap(importMap);`
- Shim import `importShim('/path/to/module.js').then(x => console.log(x));`
- Dynamically injecting import map like
```js
document.head.appendChild(Object.assign(document.createElement('script'), {
  type: 'importmap',
  innerHTML: JSON.stringify({ imports: { x: './y.js' } }),
}));
```

I doubt they are useful, since if your browser doesn't support ES Module, ES Module Shims does **not** magically make NiceGUI run with better compatibility. Notably, `ui.markdown` with Mermaid diagram always breaks. 