### PR TITLE
Fix the development container to keep working with Python 3.8

### DIFF
--- a/development.dockerfile
+++ b/development.dockerfile
@@ -1,12 +1,21 @@
-FROM python:3.11-slim
+FROM python:3.8-slim
 
 RUN apt update && apt install curl build-essential -y
 
+# The next few lines are the original command commented out
+# but kept in the file to quickly swap back once development.dockerfile
+# is upgraded to use python 3.11.
+
+
 # We use Poetry for dependency management
-RUN curl -sSL https://install.python-poetry.org | python3 - && \
-    cd /usr/local/bin && \
-    ln -s ~/.local/bin/poetry && \
-    poetry config virtualenvs.create false
+#RUN curl -sSL https://install.python-poetry.org | python3 - && \
+#    cd /usr/local/bin && \
+#    ln -s ~/.local/bin/poetry && \
+#    poetry config virtualenvs.create fals
+
+# pin the last seed packages that still support 3.8
+RUN python -m pip install --upgrade "pip<25" "setuptools<80" wheel
+RUN python -m pip install "virtualenv<20.31" "poetry==1.8.5" && poetry config virtualenvs.create false
 
 WORKDIR /app
 

--- a/development.dockerfile
+++ b/development.dockerfile
@@ -2,20 +2,10 @@ FROM python:3.8-slim
 
 RUN apt update && apt install curl build-essential -y
 
-# The next few lines are the original command commented out
-# but kept in the file to quickly swap back once development.dockerfile
-# is upgraded to use python 3.11.
-
-
-# We use Poetry for dependency management
-#RUN curl -sSL https://install.python-poetry.org | python3 - && \
-#    cd /usr/local/bin && \
-#    ln -s ~/.local/bin/poetry && \
-#    poetry config virtualenvs.create fals
-
-# pin the last seed packages that still support 3.8
-RUN python -m pip install --upgrade "pip<25" "setuptools<80" wheel
-RUN python -m pip install "virtualenv<20.31" "poetry~=1.8" && poetry config virtualenvs.create false
+# keep toolchain compatible with Python 3.8
+RUN python -m pip install --no-cache-dir --upgrade "virtualenv<20.31" "pip<25" "setuptools<80" wheel \
+    && python -m pip install --no-cache-dir "poetry~=1.8" \
+    && poetry config virtualenvs.create false
 
 WORKDIR /app
 

--- a/development.dockerfile
+++ b/development.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.11-slim
 
 RUN apt update && apt install curl build-essential -y
 

--- a/development.dockerfile
+++ b/development.dockerfile
@@ -15,7 +15,7 @@ RUN apt update && apt install curl build-essential -y
 
 # pin the last seed packages that still support 3.8
 RUN python -m pip install --upgrade "pip<25" "setuptools<80" wheel
-RUN python -m pip install "virtualenv<20.31" "poetry==1.8.5" && poetry config virtualenvs.create false
+RUN python -m pip install "virtualenv<20.31" "poetry~=1.8" && poetry config virtualenvs.create false
 
 WORKDIR /app
 


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
This PR solves the problem of the development container not building. Specifically, `poetry` was failing during the install.

<!-- Please provide relevant links to corresponding issues and feature requests. -->
I posted about it [here](https://discord.com/channels/1089836369431498784/1377358120279609405) in the NiceGUI Discord. (If necessary, I can edit this PR and/or add screenshots of the old behavior.)

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->
It's literally a two character change `3.8` to `3.11`
<!-- Include any important technical decisions or trade-offs made -->

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
