### PR TITLE
Feat: `ui.parallax` based on `ui.image` and Quasar Parallax

### DIFF
--- a/nicegui/elements/image.js
+++ b/nicegui/elements/image.js
@@ -1,6 +1,7 @@
 export default {
   template: `
-    <q-img
+    <component
+      :is="is_parallax ? 'q-parallax' : 'q-img'"
       ref="qRef"
       v-bind="$attrs"
       :src="computed_src"
@@ -8,11 +9,15 @@ export default {
       <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
         <slot :name="slot" v-bind="slotProps || {}" />
       </template>
-    </q-img>
+    </component>
   `,
   props: {
     src: String,
     t: String,
+    is_parallax: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: function () {
     return {
@@ -20,7 +25,7 @@ export default {
     };
   },
   mounted() {
-    setTimeout(() => this.compute_src(), 0); // NOTE: wait for window.path_prefix to be set in app.mounted()
+    setTimeout(() => this.compute_src(), 0);
   },
   updated() {
     this.compute_src();

--- a/nicegui/elements/image.js
+++ b/nicegui/elements/image.js
@@ -25,7 +25,7 @@ export default {
     };
   },
   mounted() {
-    setTimeout(() => this.compute_src(), 0);
+    setTimeout(() => this.compute_src(), 0); // NOTE: wait for window.path_prefix to be set in app.mounted()
   },
   updated() {
     this.compute_src();

--- a/nicegui/elements/parallax.py
+++ b/nicegui/elements/parallax.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from typing import Union
+
+from .. import optional_features
+from .image import Image
+
+try:
+    from PIL.Image import Image as PIL_Image
+    optional_features.register('pillow')
+except ImportError:
+    pass
+
+
+class Parallax(Image, component='image.js'):
+    def __init__(self, source: Union[str, Path, 'PIL_Image'] = '', *,
+                 height: int = 500,
+                 speed: float = 1.0) -> None:
+        """Parallax Image
+
+        Displays an image with a parallax effect.
+        This element is based on Quasar's `Parallax <https://quasar.dev/vue-components/parallax>`_ component.
+
+        :param source: the source of the image; can be a URL, local file path, a base64 string or a PIL image
+        :param height: the height of the parallax image in pixels (default: 500)
+        :param speed: the speed (0 to 1) of the parallax effect (default: 1.0)
+        """
+        super().__init__(source=source)
+        self._props['height'] = height
+        self._props['speed'] = speed
+        self._props['is_parallax'] = True

--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -225,6 +225,9 @@
 .nicegui-leaflet video.leaflet-image-layer {
   max-width: none; /* HACK: make the video show up */
 }
+.q-parallax__media>img,.q-parallax__media>video {
+  max-width: none; /* HACK: make the parallax image cover the screen as it should */
+}
 .nicegui-log {
   padding: 0.5rem;
   scroll-padding-bottom: 0.5rem;

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -78,6 +78,7 @@ __all__ = [
     'page_sticky',
     'page_title',
     'pagination',
+    'parallax',
     'plotly',
     'pyplot',
     'query',
@@ -186,6 +187,7 @@ from .elements.mermaid import Mermaid as mermaid
 from .elements.notification import Notification as notification
 from .elements.number import Number as number
 from .elements.pagination import Pagination as pagination
+from .elements.parallax import Parallax as parallax
 from .elements.plotly import Plotly as plotly
 from .elements.progress import CircularProgress as circular_progress
 from .elements.progress import LinearProgress as linear_progress

--- a/website/documentation/content/parallax_documentation.py
+++ b/website/documentation/content/parallax_documentation.py
@@ -1,0 +1,23 @@
+from nicegui import ui
+
+from . import doc
+
+
+@doc.auto_execute
+@doc.demo(ui.parallax)
+def main_demo() -> None:
+    @ui.page('/parallax_demo')
+    def parallax_demo():
+        ui.label('Dummy text...').classes('border h-screen w-full')
+
+        with ui.parallax('https://cdn.quasar.dev/img/parallax2.jpg', height=300, speed=0.5) as parallax:
+            ui.label('Text').classes('text-white')
+
+        ui.label('Dummy text...').classes('border h-screen w-full')
+
+    # END OF DEMO
+
+    ui.link('Go to parallax demo', '/parallax_demo')
+
+
+doc.reference(ui.parallax)

--- a/website/documentation/content/section_audiovisual_elements.py
+++ b/website/documentation/content/section_audiovisual_elements.py
@@ -7,6 +7,7 @@ from . import (
     icon_documentation,
     image_documentation,
     interactive_image_documentation,
+    parallax_documentation,
     video_documentation,
 )
 
@@ -34,6 +35,7 @@ def captions_and_overlays_demo():
 
 
 doc.intro(interactive_image_documentation)
+doc.intro(parallax_documentation)
 doc.intro(audio_documentation)
 doc.intro(video_documentation)
 doc.intro(icon_documentation)


### PR DESCRIPTION
### Motivation

Addresses https://github.com/orgs/zauberzeug/projects/6/views/1?pane=issue&itemId=82939987, about having to use `ui.element('q-parallax')`

### Implementation

- `ui.parallax` is super similar to `ui.image`, to the point we can get away with `class Parallax(Image, component='image.js'):`
  - Add a prop, `is_parallax`, for `image.js` to serve both the normal `ui.image` element and the `ui.parallax` element
- Documentation-wise, open another page, otherwise no scroll = no parallax

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

-> I don't think we need pytest for this one? 
