### PR TITLE
Introduce ui.sub_pages element to allow implementing single page applications (SPAs)

### DIFF
--- a/nicegui/elements/sub_pages.js
+++ b/nicegui/elements/sub_pages.js
@@ -2,11 +2,13 @@ export default {
   template: "<slot></slot>",
   mounted() {
     const initial_path = window.location.pathname;
-    //this.$emit("open", initial_path);
-    // Listen for browser back/forward navigation
     window.addEventListener("popstate", (event) => {
       console.log("popstate", event);
-      this.$emit("route_change", event.state?.page || window.location.pathname);
+      this.$emit("open", event.state?.page || window.location.pathname);
+    });
+    window.addEventListener("pushstate", (event) => {
+      console.log("pushstate", event);
+      this.$emit("open", event.state?.page || window.location.pathname);
     });
 
     document.addEventListener("click", (e) => {

--- a/nicegui/elements/sub_pages.js
+++ b/nicegui/elements/sub_pages.js
@@ -1,5 +1,9 @@
 export default {
-  template: "<slot></slot>",
+  template: `
+    <div class="nicegui-column">
+      <slot></slot>
+    </div>
+  `,
   mounted() {
     const initial_path = window.location.pathname;
     window.addEventListener("popstate", (event) => {

--- a/nicegui/elements/sub_pages.js
+++ b/nicegui/elements/sub_pages.js
@@ -1,0 +1,22 @@
+export default {
+  template: "<slot></slot>",
+  mounted() {
+    const initial_path = window.location.pathname;
+    //this.$emit("open", initial_path);
+    // Listen for browser back/forward navigation
+    window.addEventListener("popstate", (event) => {
+      console.log("popstate", event);
+      this.$emit("route_change", event.state?.page || window.location.pathname);
+    });
+
+    document.addEventListener("click", (e) => {
+      const a = e.target.closest("a[href]");
+      e.preventDefault();
+      if (!a) return;
+      const path = a.getAttribute("href");
+      history.pushState({}, "", path);
+      this.$emit("open", path);
+      console.log("click", path);
+    });
+  },
+};

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -1,0 +1,31 @@
+from asyncio import iscoroutine
+from typing import Callable, Dict, Self
+
+from .. import background_tasks, ui
+from ..element import Element
+
+
+class SubPages(Element, component='sub_pages.js'):
+
+    def __init__(self, routes: Dict[str, Callable]):
+        super().__init__()
+        self._routes = routes
+        self.show(ui.context.client.request.url.path if ui.context.client.request else '/')
+        self.on('open', lambda e: self.show(e.args))
+
+    def add(self, path: str, page: Callable) -> Self:
+        """Add a new route to the sub pages."""
+        self._routes[path] = page
+        return self
+
+    def show(self, path: str):
+        """Show the page for the given path."""
+        if path in self._routes:
+            self.clear()
+            with self:
+                result = self._routes[path]()
+            if iscoroutine(result):
+                async def background_task():
+                    with self:
+                        await result
+                background_tasks.create(background_task(), name=f'sub_pages {path}')

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -1,5 +1,7 @@
+import inspect
+import re
 from asyncio import iscoroutine
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from typing_extensions import Self
 
@@ -36,8 +38,9 @@ class SubPages(Element, component='sub_pages.js'):
             if not sub_path.startswith('/'):
                 sub_path = '/' + sub_path
             for path, builder in self._routes.items():
-                if sub_path == path:
-                    self._replace_content(path, builder)
+                params = self._match_path(path, sub_path)
+                if params is not None:
+                    self._replace_content(path, builder, params)
                     child_sub_pages = find_child_sub_pages(self)
                     if child_sub_pages:
                         child_sub_pages.show(full_path.removeprefix(path))
@@ -47,14 +50,36 @@ class SubPages(Element, component='sub_pages.js'):
             ui.label(f'404: sub page "{full_path}" not found')
         return False
 
-    def _find_base_path(self):
-        parent = self
-        while True:
-            if parent.parent_slot is None:
-                return '/'
-            parent = parent.parent_slot.parent
-            if isinstance(parent, SubPages):
-                return parent._current_path
+    @staticmethod
+    def _match_path(pattern: str, path: str) -> Optional[Dict[str, str]]:
+        """Match a path pattern against an actual path and extract parameters.
+
+        :return: empty dict for exact matches, parameter dict for parameterized matches, None for no match.
+        """
+        if '{' not in pattern:
+            return {} if pattern == path else None
+        regex_pattern = pattern
+        for match in re.finditer(r'\{(\w+)\}', pattern):
+            param_name = match.group(1)
+            regex_pattern = regex_pattern.replace(f'{{{param_name}}}', f'(?P<{param_name}>[^/]+)')
+        regex_pattern = f'^{regex_pattern}$'
+        regex_match = re.match(regex_pattern, path)
+        if regex_match:
+            return regex_match.groupdict()
+        return None
+
+    def _convert_parameter(self, value: str, param_type: type) -> Any:
+        """Convert a string parameter to the specified type."""
+        if param_type is str:
+            return value
+        elif param_type is int:
+            return int(value)
+        elif param_type is float:
+            return float(value)
+        elif param_type is bool:
+            return value.lower() in ('true', '1', 'yes', 'on')
+        else:
+            return value
 
     def _is_root(self) -> bool:
         parent: ui.element = self
@@ -64,10 +89,23 @@ class SubPages(Element, component='sub_pages.js'):
                 return False
         return True
 
-    def _replace_content(self, path: str, builder: Callable):
+    def _replace_content(self, path: str, builder: Callable, params: Optional[Dict[str, str]] = None):
         self.clear()
         with self:
-            result = builder()
+            if params:
+                sig = inspect.signature(builder)
+                converted_params = {}
+                for param_name, param_value in params.items():
+                    if param_name in sig.parameters:
+                        param_info = sig.parameters[param_name]
+                        param_type = param_info.annotation
+                        if param_type != inspect.Parameter.empty:
+                            converted_params[param_name] = self._convert_parameter(param_value, param_type)
+                        else:
+                            converted_params[param_name] = param_value
+                result = builder(**converted_params)
+            else:
+                result = builder()
         if iscoroutine(result):
             async def background_task():
                 with self:

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -1,5 +1,7 @@
 from asyncio import iscoroutine
-from typing import Callable, Dict, Self
+from typing import Callable, Dict
+
+from typing_extensions import Self
 
 from .. import background_tasks, ui
 from ..element import Element
@@ -10,6 +12,8 @@ class SubPages(Element, component='sub_pages.js'):
     def __init__(self, routes: Dict[str, Callable]):
         super().__init__()
         self._routes = routes
+        self._base_path = self._find_base_path()
+        self._current_path = '/'
         self.show(ui.context.client.request.url.path if ui.context.client.request else '/')
         self.on('open', lambda e: self.show(e.args))
 
@@ -18,13 +22,20 @@ class SubPages(Element, component='sub_pages.js'):
         self._routes[path] = page
         return self
 
-    def show(self, path: str):
+    def show(self, full_path: str):
         """Show the page for the given path."""
+        if full_path.startswith(self._base_path):
+            path = full_path[len(self._base_path):]
+            if not path.startswith('/'):
+                path = '/' + path
+        else:
+            path = full_path
         if path in self._routes:
+            self._current_path = path
             self.clear()
             ui.run_javascript(f'''
-                if (window.location.pathname !== "{path}") {{
-                    history.pushState({{page: "{path}"}}, "", "{path}");
+                if (window.location.pathname !== "{full_path}") {{
+                    history.pushState({{page: "{full_path}"}}, "", "{full_path}");
                 }}
             ''')
             with self:
@@ -33,4 +44,18 @@ class SubPages(Element, component='sub_pages.js'):
                 async def background_task():
                     with self:
                         await result
-                background_tasks.create(background_task(), name=f'sub_pages {path}')
+                background_tasks.create(background_task(), name=f'building sub_page {full_path}')
+        else:
+            if any(full_path.startswith(route) for route in self._routes):
+                return
+            with self:
+                ui.label(f'404: sub page "{path}" not found on {self._base_path}')
+
+    def _find_base_path(self):
+        parent = self
+        while True:
+            if parent.parent_slot is None:
+                return '/'
+            parent = parent.parent_slot.parent
+            if isinstance(parent, SubPages):
+                return parent._current_path

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -40,14 +40,26 @@ class SubPages(Element, component='sub_pages.js'):
             for path, builder in self._routes.items():
                 params = self._match_path(path, sub_path)
                 if params is not None:
+                    if sub_path == '/':
+                        remaining_path = full_path
+                    else:
+                        remaining_path = full_path[len(sub_path):]
+                    if not remaining_path:
+                        remaining_path = '/'
+                    if sub_path == '/' and remaining_path == full_path and sub_path != full_path:
+                        continue
                     self._replace_content(path, builder, params)
                     child_sub_pages = find_child_sub_pages(self)
-                    if child_sub_pages:
-                        child_sub_pages.show(full_path.removeprefix(path))
-                    return True
+
+                    if child_sub_pages and remaining_path != sub_path:
+                        if child_sub_pages.show(remaining_path):
+                            return True
+                    elif sub_path == full_path:
+                        return True
             segments.pop()
+        self.clear()
         with self:
-            ui.label(f'404: sub page "{full_path}" not found')
+            ui.label(f'404: sub page {full_path} not found')
         return False
 
     @staticmethod

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -22,6 +22,11 @@ class SubPages(Element, component='sub_pages.js'):
         """Show the page for the given path."""
         if path in self._routes:
             self.clear()
+            ui.run_javascript(f'''
+                if (window.location.pathname !== "{path}") {{
+                    history.pushState({{page: "{path}"}}, "", "{path}");
+                }}
+            ''')
             with self:
                 result = self._routes[path]()
             if iscoroutine(result):

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -107,6 +107,7 @@ __all__ = [
     'step',
     'stepper',
     'stepper_navigation',
+    'sub_pages',
     'switch',
     'tab',
     'tab_panel',
@@ -211,6 +212,7 @@ from .elements.splitter import Splitter as splitter
 from .elements.stepper import Step as step
 from .elements.stepper import Stepper as stepper
 from .elements.stepper import StepperNavigation as stepper_navigation
+from .elements.sub_pages import SubPages as sub_pages
 from .elements.switch import Switch as switch
 from .elements.table import Table as table
 from .elements.tabs import Tab as tab

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -1,8 +1,10 @@
 from nicegui import ui
 from nicegui.testing import Screen
 
+# pylint: disable=missing-function-docstring
 
-def test_switching_between_sub_pages_keeps_other_content(screen: Screen):
+
+def test_switching_between_sub_pages(screen: Screen):
     index_calls = 0
 
     @ui.page('/')
@@ -29,9 +31,19 @@ def test_switching_between_sub_pages_keeps_other_content(screen: Screen):
     screen.should_contain('some text before main content')
     screen.should_contain('goto main')
     screen.should_not_contain('goto other')
+    screen.selenium.back()
+    assert index_calls == 1
+    screen.should_contain('some text before main content')
+    screen.should_contain('goto other')
+    screen.should_not_contain('goto main')
+    screen.selenium.forward()
+    assert index_calls == 1
+    screen.should_contain('some text before main content')
+    screen.should_contain('goto main')
+    screen.should_not_contain('goto other')
 
 
-def test_opening_sub_page(screen: Screen):
+def test_accessing_sub_page_directly(screen: Screen):
     @ui.page('/two')
     @ui.page('/one')
     def index():

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -78,20 +78,19 @@ def test_sub_page_in_sub_page(screen: Screen):
         ui.label('sub')
         ui.link('goto a', '/sub/a')
         ui.link('goto b', '/sub/b')
-        ui.sub_pages(
-            {
-                '/': sub_main,
-                '/a': sub_page1_a,
-                '/b': sub_page1_b
-            })
+        ui.sub_pages({
+            '/': sub_main,
+            '/a': sub_page_a,
+            '/b': sub_page_b
+        })
 
     def sub_main():
         ui.label('sub-main')
 
-    def sub_page1_a():
+    def sub_page_a():
         ui.label('sub-a')
 
-    def sub_page1_b():
+    def sub_page_b():
         ui.label('sub-b')
 
     screen.open('/')

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -44,8 +44,8 @@ def test_switching_between_sub_pages(screen: Screen):
 
 
 def test_accessing_sub_page_directly(screen: Screen):
-    @ui.page('/two')
-    @ui.page('/one')
+    @ui.page('/')
+    @ui.page('/{_:path}')
     def index():
         ui.sub_pages({'/one': sub_page1, '/two': sub_page2})
 
@@ -61,3 +61,52 @@ def test_accessing_sub_page_directly(screen: Screen):
     screen.open('/two')
     screen.should_contain('two')
     screen.should_not_contain('one')
+
+
+def test_sub_page_in_sub_page(screen: Screen):
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index(_):
+        ui.link('goto main', '/')
+        ui.link('goto sub', '/sub')
+        ui.sub_pages({'/': main, '/sub': sub})
+
+    def main():
+        ui.label('main')
+
+    def sub():
+        ui.label('sub')
+        ui.link('goto a', '/sub/a')
+        ui.link('goto b', '/sub/b')
+        ui.sub_pages(
+            {
+                '/': sub_main,
+                '/a': sub_page1_a,
+                '/b': sub_page1_b
+            })
+
+    def sub_main():
+        ui.label('sub-main')
+
+    def sub_page1_a():
+        ui.label('sub-a')
+
+    def sub_page1_b():
+        ui.label('sub-b')
+
+    screen.open('/')
+    screen.should_contain('main')
+    screen.click('goto sub')
+    screen.should_contain('sub-main')
+    screen.click('goto a')
+    screen.should_contain('sub-a')
+    screen.click('goto b')
+    screen.should_contain('sub-b')
+    screen.click('goto main')
+    screen.should_contain('main')
+    screen.should_not_contain('sub-main')
+    screen.should_not_contain('sub-a')
+    screen.should_not_contain('sub-b')
+
+    screen.open('/sub/a')
+    screen.should_contain('sub-a')

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -1,0 +1,51 @@
+from nicegui import ui
+from nicegui.testing import Screen
+
+
+def test_switching_between_sub_pages_keeps_other_content(screen: Screen):
+    index_calls = 0
+
+    @ui.page('/')
+    @ui.page('/other')
+    def index():
+        nonlocal index_calls
+        index_calls += 1
+        ui.label('some text before main content')
+        ui.sub_pages({'/': child, '/other': child2})
+
+    def child():
+        ui.link('goto other', '/other')
+
+    def child2():
+        ui.link('goto main', '/')
+
+    screen.open('/')
+    assert index_calls == 1
+    screen.should_contain('some text before main content')
+    screen.should_contain('goto other')
+    screen.should_not_contain('goto main')
+    screen.click('goto other')
+    assert index_calls == 1
+    screen.should_contain('some text before main content')
+    screen.should_contain('goto main')
+    screen.should_not_contain('goto other')
+
+
+def test_opening_sub_page(screen: Screen):
+    @ui.page('/two')
+    @ui.page('/one')
+    def index():
+        ui.sub_pages({'/one': sub_page1, '/two': sub_page2})
+
+    def sub_page1():
+        ui.label('one')
+
+    def sub_page2():
+        ui.label('two')
+
+    screen.open('/one')
+    screen.should_contain('one')
+    screen.should_not_contain('two')
+    screen.open('/two')
+    screen.should_contain('two')
+    screen.should_not_contain('one')

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -109,3 +109,33 @@ def test_sub_page_in_sub_page(screen: Screen):
 
     screen.open('/sub/a')
     screen.should_contain('sub-a')
+
+
+def test_parameterized_sub_pages(screen: Screen):
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index(_):
+        ui.link('goto main', '/')
+        ui.link('goto one', '/one-1')
+        ui.link('goto two', '/two/two')
+        ui.sub_pages({
+            '/': main,
+            '/one-{idx}': one,
+            '/two/{idx}': two,
+        })
+
+    def main():
+        ui.label('main')
+
+    def one(idx: int):
+        ui.label(f'one-{idx}-{isinstance(idx, int)}')
+
+    def two(idx: str):
+        ui.label(f'two-{idx}')
+
+    screen.open('/')
+    screen.should_contain('main')
+    screen.click('goto one')
+    screen.should_contain('one-1-True')
+    screen.click('goto two')
+    screen.should_contain('two-two')

--- a/tests/test_sub_pages_match_path.py
+++ b/tests/test_sub_pages_match_path.py
@@ -1,0 +1,201 @@
+import re
+
+import pytest
+
+from nicegui.elements.sub_pages import SubPages
+
+# pylint: disable=protected-access
+
+
+def test_exact_match_simple_path():
+    """Test exact matching of simple paths without parameters."""
+    assert SubPages._match_path('/', '/') == {}
+    assert SubPages._match_path('/home', '/home') == {}
+    assert SubPages._match_path('/users', '/users') == {}
+    assert SubPages._match_path('/api/v1', '/api/v1') == {}
+
+
+def test_exact_match_no_match():
+    """Test that non-matching paths return None."""
+    assert SubPages._match_path('/', '/home') is None
+    assert SubPages._match_path('/home', '/') is None
+    assert SubPages._match_path('/users', '/user') is None
+    assert SubPages._match_path('/api/v1', '/api/v2') is None
+    assert SubPages._match_path('/home', '/home/sub') is None
+    assert SubPages._match_path('/home/sub', '/home') is None
+
+
+def test_single_parameter_match():
+    """Test matching patterns with a single parameter."""
+    assert SubPages._match_path('/user/{id}', '/user/123') == {'id': '123'}
+    assert SubPages._match_path('/user/{id}', '/user/abc') == {'id': 'abc'}
+    assert SubPages._match_path('/user/{id}', '/user/test-user') == {'id': 'test-user'}
+    assert SubPages._match_path('/{category}', '/books') == {'category': 'books'}
+    assert SubPages._match_path('/api/{version}', '/api/v1') == {'version': 'v1'}
+
+
+def test_single_parameter_no_match():
+    """Test that single parameter patterns correctly reject non-matches."""
+    assert SubPages._match_path('/user/{id}', '/user/') is None  # Empty parameter
+    assert SubPages._match_path('/user/{id}', '/user') is None   # Missing parameter
+    assert SubPages._match_path('/user/{id}', '/admin/123') is None  # Wrong path
+    assert SubPages._match_path('/user/{id}', '/user/123/edit') is None  # Extra segments
+    assert SubPages._match_path('/{category}', '/') is None  # Empty parameter
+
+
+def test_multiple_parameters_match():
+    """Test matching patterns with multiple parameters."""
+    assert SubPages._match_path('/user/{id}/post/{post_id}', '/user/123/post/456') == {
+        'id': '123', 'post_id': '456'
+    }
+    assert SubPages._match_path('/{category}/{subcategory}', '/books/fiction') == {
+        'category': 'books', 'subcategory': 'fiction'
+    }
+    assert SubPages._match_path('/api/{version}/{endpoint}', '/api/v1/users') == {
+        'version': 'v1', 'endpoint': 'users'
+    }
+    assert SubPages._match_path('/{a}/{b}/{c}', '/x/y/z') == {
+        'a': 'x', 'b': 'y', 'c': 'z'
+    }
+
+
+def test_multiple_parameters_no_match():
+    """Test that multiple parameter patterns correctly reject non-matches."""
+    assert SubPages._match_path('/user/{id}/post/{post_id}', '/user/123/post') is None
+    assert SubPages._match_path('/user/{id}/post/{post_id}', '/user/123') is None
+    assert SubPages._match_path('/user/{id}/post/{post_id}', '/user/123/comment/456') is None
+    assert SubPages._match_path('/{a}/{b}', '/x') is None
+    assert SubPages._match_path('/{a}/{b}', '/x/y/z') is None
+
+
+def test_mixed_static_and_parameter_segments():
+    """Test patterns mixing static segments with parameters."""
+    assert SubPages._match_path('/api/v1/user/{id}', '/api/v1/user/123') == {'id': '123'}
+    assert SubPages._match_path('/static/{dynamic}/more', '/static/test/more') == {'dynamic': 'test'}
+    assert SubPages._match_path('/prefix/{middle}/suffix', '/prefix/value/suffix') == {'middle': 'value'}
+    assert SubPages._match_path('/user/{id}/settings', '/user/123/settings') == {'id': '123'}
+
+
+def test_mixed_static_and_parameter_no_match():
+    """Test that mixed patterns correctly reject non-matches."""
+    assert SubPages._match_path('/api/v1/user/{id}', '/api/v2/user/123') is None
+    assert SubPages._match_path('/static/{dynamic}/more', '/static/test/less') is None
+    assert SubPages._match_path('/user/{id}/settings', '/user/123/profile') is None
+    assert SubPages._match_path('/prefix/{middle}/suffix', '/prefix/value') is None
+
+
+def test_parameter_names_with_underscores_and_numbers():
+    """Test parameter names with valid identifier characters."""
+    assert SubPages._match_path('/user/{user_id}', '/user/123') == {'user_id': '123'}
+    assert SubPages._match_path('/post/{post_id2}', '/post/abc') == {'post_id2': 'abc'}
+    assert SubPages._match_path('/{param1}/{param_2}', '/a/b') == {'param1': 'a', 'param_2': 'b'}
+    # Valid parameter names (Python identifiers)
+    assert SubPages._match_path('/path/{_}', '/path/value') == {'_': 'value'}
+    assert SubPages._match_path('/path/{_param}', '/path/value') == {'_param': 'value'}
+    assert SubPages._match_path('/path/{param_}', '/path/value') == {'param_': 'value'}
+    assert SubPages._match_path('/path/{a1}', '/path/value') == {'a1': 'value'}
+    assert SubPages._match_path('/path/{param123}', '/path/value') == {'param123': 'value'}
+
+
+def test_parameter_values_with_special_characters():
+    """Test that parameter values can contain various characters (except /)."""
+    assert SubPages._match_path('/user/{id}', '/user/123-abc') == {'id': '123-abc'}
+    assert SubPages._match_path('/user/{id}', '/user/test_user') == {'id': 'test_user'}
+    assert SubPages._match_path('/user/{id}', '/user/user@example.com') == {'id': 'user@example.com'}
+    assert SubPages._match_path('/file/{name}', '/file/document.pdf') == {'name': 'document.pdf'}
+    assert SubPages._match_path('/search/{query}', '/search/hello%20world') == {'query': 'hello%20world'}
+
+    # Parameter values cannot contain forward slashes
+    assert SubPages._match_path('/user/{id}', '/user/123/456') is None
+    assert SubPages._match_path('/file/{path}', '/file/folder/file.txt') is None
+
+
+def test_empty_strings_and_edge_cases():
+    """Test edge cases with empty strings and unusual inputs."""
+    assert SubPages._match_path('', '') == {}
+    assert SubPages._match_path('', '/') is None
+    assert SubPages._match_path('/', '') is None
+    assert SubPages._match_path('/user/{id}', '/user/') is None  # Empty parameter
+
+
+def test_case_sensitivity():
+    """Test that matching is case-sensitive."""
+    assert SubPages._match_path('/User', '/user') is None
+    assert SubPages._match_path('/user', '/User') is None
+    assert SubPages._match_path('/user/{ID}', '/user/abc') == {'ID': 'abc'}  # Parameter name is case-sensitive
+
+
+def test_special_characters_in_patterns():
+    """Test that special regex characters in static parts are handled correctly."""
+    # Should match literally
+    assert SubPages._match_path('/api.v1', '/api.v1') == {}
+    assert SubPages._match_path('/search?', '/search?') == {}
+    assert SubPages._match_path('/path[0]', '/path[0]') == {}
+    assert SubPages._match_path('/price$', '/price$') == {}
+    assert SubPages._match_path('/regex*', '/regex*') == {}
+
+    # Should not match due to literal interpretation
+    assert SubPages._match_path('/api.v1', '/apixv1') is None
+    assert SubPages._match_path('/search?', '/search') is None
+
+    # Literal curly braces (not valid parameter syntax)
+    assert SubPages._match_path('/path{', '/path{') == {}
+    assert SubPages._match_path('/path}', '/path}') == {}
+    assert SubPages._match_path('/path{invalid', '/path{invalid') == {}
+    assert SubPages._match_path('/path{', '/path}') is None
+    assert SubPages._match_path('/path}', '/path{') is None
+
+
+def test_invalid_parameter_names():
+    """Test handling of invalid parameter names in patterns."""
+    # Numbers are not valid parameter names - cause regex errors
+    with pytest.raises(re.error):
+        SubPages._match_path('/path{123}', '/path{123}')
+
+    with pytest.raises(re.error):
+        SubPages._match_path('/path{123abc}', '/path{123abc}')
+
+    # Patterns that don't match \w+ are treated as literal text
+    assert SubPages._match_path('/path{param-name}', '/path{param-name}') == {}
+    assert SubPages._match_path('/path{param.name}', '/path{param.name}') == {}
+    assert SubPages._match_path('/path{param space}', '/path{param space}') == {}
+
+    # These should not match if the path is different
+    assert SubPages._match_path('/path{param-name}', '/path{different}') is None
+    assert SubPages._match_path('/path{param.name}', '/path{other.name}') is None
+
+
+def test_adjacent_parameters():
+    """Test patterns with parameters that are adjacent (no static separators)."""
+    # This is an edge case - adjacent parameters without separators
+    result = SubPages._match_path('/{a}{b}', '/xy')
+    # The first parameter will match as much as possible, leaving minimum for the second
+    assert result is not None
+    assert 'a' in result and 'b' in result
+    assert result['a'] + result['b'] == 'xy'
+
+
+def test_real_world_patterns():
+    """Test patterns similar to those used in real applications."""
+    # Blog-style URLs
+    assert SubPages._match_path('/blog/{year}/{month}/{slug}', '/blog/2023/12/my-post') == {
+        'year': '2023', 'month': '12', 'slug': 'my-post'
+    }
+
+    # API endpoints
+    assert SubPages._match_path('/api/v1/users/{user_id}/posts/{post_id}',
+                                '/api/v1/users/123/posts/456') == {
+        'user_id': '123', 'post_id': '456'
+    }
+
+    # File paths
+    assert SubPages._match_path('/files/{category}/{filename}',
+                                '/files/images/photo.jpg') == {
+        'category': 'images', 'filename': 'photo.jpg'
+    }
+
+    # E-commerce
+    assert SubPages._match_path('/shop/{category}/{product_id}',
+                                '/shop/electronics/laptop-123') == {
+        'category': 'electronics', 'product_id': 'laptop-123'
+    }


### PR DESCRIPTION
### Motivation

We already have [an example on how to hand-build a Singe Page Application (SPA)](https://github.com/zauberzeug/nicegui/tree/main/examples/single_page_app). Then, @Alyxion worked out the feature-rich but super large pull request #2811 to integrate SPAs directly into NiceGUI. While working/reviewing the code I came up with this alternative pull request which allows the following SPA syntax:

```py
@ui.page('/')
@ui.page('/{_:path}') # tells FastAPI/Starlette that all path's should land on our SPA
def index():
    ui.label('some text before main content')
    ui.sub_pages({'/': child, '/other': child2})

def child():
    ui.link('goto other', '/other')

def child2():
    ui.link('goto main', '/')
```

Sub pages can also be nested. But only one `ui.sub_pages` element should be used on each hierarchy level.
If a sub page needs to modify content from it's parent, the object is simply passed via lambda:

```py
@ui.page('/')
@ui.page('/{_:path}')
def index():
    title = ui.label()
    ui.sub_pages({
        '/': lambda: child(title),
        '/other': lambda: child2(title)
    })

def child(title: ui.label):
    title.set_text('child title')
    ui.link('goto other', '/other')

def child2(title: ui.label):
    title.set_text('other title')
    ui.link('goto main', '/')
```

Paths to sub pages can contain parameters (not yet fully implemented):

```py
@ui.page('/')
@ui.page('/{_:path}')
def index(_):
    ui.select(label='item', options=['a', 'b', 'c'], on_change=lambda e: ui.navigate.to(f'/{e.value}'))
    ui.sub_pages({'/{item}': main_content})

def main_content(item: str = 'nothing'):
    ui.label(f'item: {item}')
```

Key differences compared to #2811 (@Alyxion's SPA PR)

 - much less code (but obviously also only a fraction of the features)
 - self-explanatory shared state between pages via parameter passing (not `yield` and object storage)
 - just a new UI element `ui.sub_pages` instead of decorators, routers etc. (for custom routing with sub pages, users should derive from `ui.sub_pages` and override 'show()')

### Implementation

I tried to create a PR as small as possible. But adding nested sub pages, async support and path parameters made it a lot more complicated than I originally thought. It is also still far from done.

If you want to dive into this, I recommend looking at `test_sub_pages.py` for examples on how the `ui.sub_pages` api works.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] The implementation is complete.
  - [ ] make `ui.navigate.to` work with sub pages
  - [ ] allow default parameters for sub page functions
  - [ ] ensure only one `ui.sub_pages` is used on each hierarchy level
- [x] Pytests have been added.
- [ ] Documentation has been added.
