### PR TITLE
Eliminates B006 warnings from root-cause

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -88,14 +88,18 @@ class Element(Visibility):
 
     def __init_subclass__(cls, *,
                           component: Union[str, Path, None] = None,
-                          dependencies: List[Union[str, Path]] = [],  # noqa: B006
-                          libraries: List[Union[str, Path]] = [],  # noqa: B006  # DEPRECATED
-                          exposed_libraries: List[Union[str, Path]] = [],  # noqa: B006  # DEPRECATED
-                          extra_libraries: List[Union[str, Path]] = [],  # noqa: B006  # DEPRECATED
+                          dependencies: Optional[List[Union[str, Path]]] = None,
+                          libraries: Optional[List[Union[str, Path]]] = None,  # DEPRECATED
+                          exposed_libraries: Optional[List[Union[str, Path]]] = None,  # DEPRECATED
+                          extra_libraries: Optional[List[Union[str, Path]]] = None,  # DEPRECATED
                           default_classes: Optional[str] = None,
                           default_style: Optional[str] = None,
                           default_props: Optional[str] = None,
                           ) -> None:
+        dependencies = dependencies or []
+        libraries = libraries or []
+        exposed_libraries = exposed_libraries or []
+        extra_libraries = extra_libraries or []
         super().__init_subclass__()
         base = Path(inspect.getfile(cls)).parent
 

--- a/nicegui/elements/aggrid.py
+++ b/nicegui/elements/aggrid.py
@@ -25,7 +25,7 @@ class AgGrid(Element,
 
     def __init__(self,
                  options: Dict, *,
-                 html_columns: List[int] = [],  # noqa: B006
+                 html_columns: Optional[List[int]] = None,
                  theme: Optional[str] = 'balham',
                  auto_size_columns: bool = True,
                  ) -> None:
@@ -40,6 +40,8 @@ class AgGrid(Element,
         :param theme: AG Grid theme (default: "balham")
         :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``True``)
         """
+        if html_columns is None:
+            html_columns = []
         super().__init__()
         self._props['options'] = options
         self._props['html_columns'] = html_columns[:]
@@ -51,10 +53,10 @@ class AgGrid(Element,
     @classmethod
     def from_pandas(cls,
                     df: 'pd.DataFrame', *,
-                    html_columns: List[int] = [],  # noqa: B006
+                    html_columns: Optional[List[int]] = None,
                     theme: Optional[str] = 'balham',
                     auto_size_columns: bool = True,
-                    options: Dict = {}) -> Self:  # noqa: B006
+                    options: Optional[Dict] = None) -> Self:
         """Create an AG Grid from a Pandas DataFrame.
 
         Note:
@@ -70,6 +72,10 @@ class AgGrid(Element,
         :param options: dictionary of additional AG Grid options
         :return: AG Grid element
         """
+        if html_columns is None:
+            html_columns = []
+        if options is None:
+            options = {}
         import pandas as pd  # pylint: disable=import-outside-toplevel
 
         def is_special_dtype(dtype):
@@ -97,10 +103,10 @@ class AgGrid(Element,
     @classmethod
     def from_polars(cls,
                     df: 'pl.DataFrame', *,
-                    html_columns: List[int] = [],  # noqa: B006
+                    html_columns: Optional[List[int]] = None,
                     theme: Optional[str] = 'balham',
                     auto_size_columns: bool = True,
-                    options: Dict = {}) -> Self:  # noqa: B006
+                    options: Optional[Dict] = None) -> Self:
         """Create an AG Grid from a Polars DataFrame.
 
         If the DataFrame contains non-UTF-8 datatypes, they will be converted to strings.
@@ -115,6 +121,10 @@ class AgGrid(Element,
         :param options: dictionary of additional AG Grid options
         :return: AG Grid element
         """
+        if html_columns is None:
+            html_columns = []
+        if options is None:
+            options = {}
         return cls({
             'columnDefs': [{'field': str(col)} for col in df.columns],
             'rowData': df.to_dicts(),

--- a/nicegui/elements/interactive_image.py
+++ b/nicegui/elements/interactive_image.py
@@ -29,7 +29,7 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
                  content: str = '',
                  size: Optional[Tuple[float, float]] = None,
                  on_mouse: Optional[Handler[MouseEventArguments]] = None,
-                 events: List[str] = ['click'],  # noqa: B006
+                 events: Optional[List[str]] = None,
                  cross: Union[bool, str] = False,
                  ) -> None:
         """Interactive Image
@@ -57,6 +57,8 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
         :param events: list of JavaScript events to subscribe to (default: `['click']`)
         :param cross: whether to show crosshairs or a color string (default: `False`)
         """
+        if events is None:
+            events = ['click']
         super().__init__(source=source, content=content)
         self._props['events'] = events[:]
         self._props['cross'] = cross

--- a/nicegui/elements/keyboard.py
+++ b/nicegui/elements/keyboard.py
@@ -22,8 +22,7 @@ class Keyboard(Element, component='keyboard.js'):
                  on_key: Optional[Handler[KeyEventArguments]] = None, *,
                  active: bool = True,
                  repeating: bool = True,
-                 ignore: List[Literal['input', 'select', 'button', 'textarea']] =
-                     ['input', 'select', 'button', 'textarea'],  # noqa: B006
+                 ignore: Optional[List[Literal['input', 'select', 'button', 'textarea']]] = None,
                  ) -> None:
         """Keyboard
 
@@ -60,6 +59,8 @@ class Keyboard(Element, component='keyboard.js'):
         :param repeating: boolean flag indicating whether held keys should be sent repeatedly (default: ``True``)
         :param ignore: ignore keys when one of these element types is focussed (default: ``['input', 'select', 'button', 'textarea']``)
         """
+        if ignore is None:
+            ignore = ['input', 'select', 'button', 'textarea']
         super().__init__()
         self._key_handlers = [on_key] if on_key else []
         self.active = active

--- a/nicegui/elements/leaflet.py
+++ b/nicegui/elements/leaflet.py
@@ -27,7 +27,7 @@ class Leaflet(Element, component='leaflet.js', default_classes='nicegui-leaflet'
                  center: Tuple[float, float] = (0.0, 0.0),
                  zoom: int = 13,
                  *,
-                 options: Dict = {},  # noqa: B006
+                 options: Optional[Dict] = None,
                  draw_control: Union[bool, Dict] = False,
                  hide_drawn_items: bool = False,
                  additional_resources: Optional[List[str]] = None,
@@ -43,6 +43,8 @@ class Leaflet(Element, component='leaflet.js', default_classes='nicegui-leaflet'
         :param hide_drawn_items: whether to hide drawn items on the map (default: False, *added in version 2.0.0*)
         :param additional_resources: additional resources like CSS or JS files to load (default: None, *added in version 2.11.0*)
         """
+        if options is None:
+            options = {}
         super().__init__()
         self.add_resource(Path(__file__).parent / 'lib' / 'leaflet')
 

--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -1,6 +1,6 @@
 import os
 from functools import lru_cache
-from typing import List
+from typing import List, Optional
 
 import markdown2
 from fastapi.responses import PlainTextResponse
@@ -13,7 +13,7 @@ class Markdown(ContentElement, component='markdown.js', default_classes='nicegui
 
     def __init__(self,
                  content: str = '', *,
-                 extras: List[str] = ['fenced-code-blocks', 'tables'],  # noqa: B006
+                 extras: Optional[List[str]] = None,
                  ) -> None:
         """Markdown Element
 
@@ -22,6 +22,8 @@ class Markdown(ContentElement, component='markdown.js', default_classes='nicegui
         :param content: the Markdown content to be displayed
         :param extras: list of `markdown2 extensions <https://github.com/trentm/python-markdown2/wiki/Extras#implemented-extras>`_ (default: `['fenced-code-blocks', 'tables']`)
         """
+        if extras is None:
+            extras = ['fenced-code-blocks', 'tables']
         self.extras = extras[:]
         super().__init__(content=content)
         if 'mermaid' in extras:

--- a/nicegui/elements/scene.py
+++ b/nicegui/elements/scene.py
@@ -77,7 +77,7 @@ class Scene(Element,
                  grid: Union[bool, Tuple[int, int]] = True,
                  camera: Optional[SceneCamera] = None,
                  on_click: Optional[Handler[SceneClickEventArguments]] = None,
-                 click_events: List[str] = ['click', 'dblclick'],  # noqa: B006
+                 click_events: Optional[List[str]] = None,
                  on_drag_start: Optional[Handler[SceneDragEventArguments]] = None,
                  on_drag_end: Optional[Handler[SceneDragEventArguments]] = None,
                  drag_constraints: str = '',
@@ -101,6 +101,8 @@ class Scene(Element,
         :param drag_constraints: comma-separated JavaScript expression for constraining positions of dragged objects (e.g. ``'x = 0, z = y / 2'``)
         :param background_color: background color of the scene (default: "#eee")
         """
+        if click_events is None:
+            click_events = ['click', 'dblclick']
         super().__init__()
         self._props['width'] = width
         self._props['height'] = height


### PR DESCRIPTION
### Motivation

Addresses https://github.com/orgs/zauberzeug/projects/6?pane=issue&itemId=82940985

### Implementation

- I tried `click_events: List[str] = ('click', 'dblclick')`, but that would cause mypy to complain. 
- `click_events: Sequence[str] = ('click', 'dblclick')` could be doable, but we are changing `List` to `Sequence`, not sure if that'd be a breaking change
- Wound up asking Copilot to "no mutable default" and its solution was `click_events: Optional[List[str]] = None` with `if click_events is None:` `click_events = ['click', 'dblclick']`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

Tests are green at https://github.com/evnchn/nicegui/actions/runs/15380276062, but the point about whether this is a breaking change is still worthy. 
