### PR TITLE
Force Vue re-render on late event registration

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -392,7 +392,6 @@ function createApp(elements, options) {
 
             const oldTypes = new Set((this.elements[id]?.events || []).map(ev => ev.type));
             if (element.events?.some(e => !oldTypes.has(e.type))) {
-              console.log("Re-rendering element " + id + " because of new events");
               delete this.elements[id];
               needAwaitNextTick = true;
             }

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -385,6 +385,21 @@ function createApp(elements, options) {
             .map(([_, element]) => loadDependencies(element, options.prefix, options.version));
           await Promise.all(loadPromises);
 
+          let needAwaitNextTick = false;
+
+          for (const [id, element] of Object.entries(msg)) {
+            if (element === null) continue;
+
+            const oldTypes = new Set((this.elements[id]?.events || []).map(ev => ev.type));
+            if (element.events?.some(e => !oldTypes.has(e.type))) {
+              console.log("Re-rendering element " + id + " because of new events");
+              delete this.elements[id];
+              needAwaitNextTick = true;
+            }
+          }
+
+          if (needAwaitNextTick) await this.$nextTick();
+
           for (const [id, element] of Object.entries(msg)) {
             if (element === null) {
               delete this.elements[id];

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -206,3 +206,18 @@ def test_delegated_event_with_argument_filtering(screen: Screen) -> None:
     screen.click('Item B')
     screen.click('Item C')
     assert ids == ['A', 'B', 'C']
+
+
+async def test_late_event_registration(screen: Screen):
+    events = []
+
+    @ui.page('/')
+    async def page():
+        a_input = ui.input('A')
+        await ui.context.client.connected()
+        a_input.on('keydown', lambda _: events.append('A'), [])
+
+    screen.open('/')
+    await asyncio.sleep(1)  # wait for the page to load and the event to be attached
+    screen.selenium.find_element(By.XPATH, '//*[@aria-label="A"]').send_keys('x')
+    assert events == ['A']


### PR DESCRIPTION
### Motivation

This PR fix #4154, enabling late event registration like:

```py
@ui.page('/')
async def page():
    ui.label('This is a test for late event handling')
    i = ui.input()
    await ui.context.client.connected()
    i.on('keydown', ui.notify)
```

<img width="640" alt="{A7397251-83CE-4739-93CB-0EB4690EA8D5}" src="https://github.com/user-attachments/assets/e6aab177-614f-4c61-b076-18113670a3de" />

As you can see, `i.on('keydown', ui.notify)` was ran after the client was connected, so it must be sent via Socket.IO and client-side shall register the event after initial render. Before, it doesn't work, as mentioned in #4154 somewhere. Now, with this PR, it works. 

### Implementation

Before we process the list of elements, we do a check to see if there are any new events sent in by the server. 
- If there is, then:
  - We remove that element from Vue's `this.elements`
  - We mark that we need to `await this.$nextTick();`
  - We proceed to `await this.$nextTick();` to force the Vue to render without that element
    - Do it ONCE only, for performance
  - In such a way, when we process the list of elements as usual, Vue will be like 
    - "hey I haven't seen this element before, let me render it"
- If there is none, then fine, do nothing. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

I don't think this needs documentation. ~~Thinking about how to Pytest this.~~ Pytest done


