### PR TITLE
Provide autocompletion hints for ui.codemirror()

### DIFF
--- a/nicegui/elements/codemirror.py
+++ b/nicegui/elements/codemirror.py
@@ -301,11 +301,11 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
         return self._props['theme']
 
     @theme.setter
-    def theme(self, theme: str) -> None:
+    def theme(self, theme: SUPPORTED_THEMES) -> None:
         self._props['theme'] = theme
         self.update()
 
-    def set_theme(self, theme: str) -> None:
+    def set_theme(self, theme: SUPPORTED_THEMES) -> None:
         """Sets the theme of the editor."""
         self._props['theme'] = theme
         self.update()
@@ -321,11 +321,11 @@ class CodeMirror(ValueElement, DisableableElement, component='codemirror.js', de
         return self._props['language']
 
     @language.setter
-    def language(self, language: Optional[str]) -> None:
+    def language(self, language: Optional[SUPPORTED_LANGUAGES] = None) -> None:
         self._props['language'] = language
         self.update()
 
-    def set_language(self, language: Optional[str]) -> None:
+    def set_language(self, language: Optional[SUPPORTED_LANGUAGES] = None) -> None:
         """Sets the language of the editor (case-insensitive)."""
         self._props['language'] = language
         self.update()


### PR DESCRIPTION
This PR optimizes the syntax hints for the `set_language()` and `set_theme()` methods in `ui.codemirror()`.  

I noticed there are two Literal types in [codemirror.py](https://github.com/zauberzeug/nicegui/blob/main/nicegui/elements/codemirror.py), which define the supported languages and themes for codemirror.  

However, when calling `set_language()`, I found `language: Optional[str]`. I believe changing it to `language: Optional[SUPPORTED_LANGUAGES] = None` would provide a better IDE autocompletion experience.  

This was the motivation behind my improvements to this method.  

I also took the opportunity to modify the `set_theme()` method so that it can benefit from similar syntax autocompletion.

## Before
![image](https://github.com/user-attachments/assets/4df99f8b-c198-40f5-9e8e-a3d7d7f74482)
![image](https://github.com/user-attachments/assets/9bf46e34-074a-4cee-b2e2-3367fe3068b7)

## After
![image](https://github.com/user-attachments/assets/b1da0a03-191f-464d-a242-2c93074262fb)
![image](https://github.com/user-attachments/assets/e6c23cfc-cecd-4464-a463-21aea91ded14)