### PR TITLE
Better Redis control for users

### DIFF
--- a/examples/redis_storage/README.md
+++ b/examples/redis_storage/README.md
@@ -1,0 +1,22 @@
+# Using Redis for session storage
+
+NiceGUI can use Redis as the session storage, which is particularly interesting in environments where you want session persistance or there are multiple workers. To make this work, you set environment variables:
+
+## `NICEGUI_REDIS_URL`
+
+This is the only required variable. Setting it to a full Redis server connection string will make NiceGUI switch to Redis for storage
+
+## `NICEGUI_REDIS_PREFIX`
+
+The prefix that will be used on the Redis server for the values set from the NiceGUI server. Default is `nicegui:`. If you have two environments using the same Redis server/cluster, use this prefix to separate them.
+
+## Control how NiceGUI establishes the Redis connection
+
+When NiceGUI starts, and the `NICEGUI_REDIS_URL` is set, it will establish the connection. Sometimes you want to control the arguments for this connection (you can read more on the Python Redis package documentation). The following are defined as environment variables:
+
+- `NICEGUI_REDIS_HEALTH_CHECK_INTERVAL` (default: 10) as connection argument `health_check_interval`
+- `NICEGUI_REDIS_SOCKET_CONNECT_TIMEOUT` (default: 5) as connection argument `socket_connect_timeout`
+- `NICEGUI_REDIS_RETRY_ON_TIMEOUT` (default: True) as connection argument `retry_on_timeout`
+- `NICEGUI_REDIS_SOCKET_KEEPALIVE` (default: True) sa connection argument `socket_keepalive`
+
+All environment values are always strings. The boolean values needed for the two last settings will be interpreted from 0/1 or true/false.

--- a/examples/redis_storage/README.md
+++ b/examples/redis_storage/README.md
@@ -1,6 +1,6 @@
 # Using Redis for session storage
 
-NiceGUI can use Redis as the session storage, which is particularly interesting in environments where you want session persistance or there are multiple workers. To make this work, you set environment variables:
+NiceGUI can use Redis for storage. To make this work, you set environment variables:
 
 ## `NICEGUI_REDIS_URL`
 

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -205,7 +205,9 @@ def run(*,
         return [a.strip() for a in args.split(',')]
 
     if kwargs.get('workers', 1) > 1:
-        raise ValueError('NiceGUI does not support multiple workers yet.')
+        # Check if the NICEGUI_REDIS_URL is set. If not, do not allow multiple workers.
+        if not os.environ.get('NICEGUI_REDIS_URL', None):
+            raise ValueError('NiceGUI does not support multiple workers yet. Please set the NICEGUI_REDIS_URL environment variable.')
 
     # NOTE: The following lines are basically a copy of `uvicorn.run`, but keep a reference to the `server`.
 

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -205,7 +205,7 @@ def run(*,
         return [a.strip() for a in args.split(',')]
 
     if kwargs.get('workers', 1) > 1:
-        raise ValueError('NiceGUI does not support multiple workers yet. Please set the NICEGUI_REDIS_URL environment variable.')
+        raise ValueError('NiceGUI does not support multiple workers yet.')
 
     # NOTE: The following lines are basically a copy of `uvicorn.run`, but keep a reference to the `server`.
 

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -205,9 +205,7 @@ def run(*,
         return [a.strip() for a in args.split(',')]
 
     if kwargs.get('workers', 1) > 1:
-        # Check if the NICEGUI_REDIS_URL is set. If not, do not allow multiple workers.
-        if not os.environ.get('NICEGUI_REDIS_URL', None):
-            raise ValueError('NiceGUI does not support multiple workers yet. Please set the NICEGUI_REDIS_URL environment variable.')
+        raise ValueError('NiceGUI does not support multiple workers yet. Please set the NICEGUI_REDIS_URL environment variable.')
 
     # NOTE: The following lines are basically a copy of `uvicorn.run`, but keep a reference to the `server`.
 

--- a/website/documentation/content/section_configuration_deployment.py
+++ b/website/documentation/content/section_configuration_deployment.py
@@ -112,6 +112,10 @@ doc.text('', '''
     - `RST_CONTENT_CACHE_SIZE` (default: 1000): The maximum number of ReStructuredText content snippets that are cached in memory.
     - `NICEGUI_REDIS_URL` (default: None, means local file storage): The URL of the Redis server to use for shared persistent storage.
     - `NICEGUI_REDIS_KEY_PREFIX` (default: "nicegui:"): The prefix for Redis keys.
+    - `NICEGUI_REDIS_HEALTH_CHECK_INTERVAL` (default: 10): The interval in seconds for the Redis health check.
+    - `NICEGUI_REDIS_SOCKET_CONNECT_TIMEOUT` (default: 5): The timeout in seconds for the Redis socket connection.
+    - `NICEGUI_REDIS_RETRY_ON_TIMEOUT` (default: True): Whether to retry on timeout for the Redis connection.
+    - `NICEGUI_REDIS_SOCKET_KEEPALIVE` (default: True): Whether to keep the Redis socket alive.
 ''')
 def env_var_demo():
     from nicegui.elements import markdown

--- a/website/documentation/content/storage_documentation.py
+++ b/website/documentation/content/storage_documentation.py
@@ -182,13 +182,14 @@ doc.text('Indentation', '''
 
 
 doc.text('Redis storage', '''
-    You can use [Redis](https://redis.io/) for storage as an alternative to the default file storage.
-    This is useful if you have multiple NiceGUI instances and want to share data across them.
+    You can use [Redis](https://redis.io/) or a compatible solution such as Valkey for storage as an alternative
+    to the default file storage. This is useful if you have multiple NiceGUI instances and want to share data across them.
 
     To activate this feature install the `redis` package (`pip install nicegui[redis]`)
     and provide the `NICEGUI_REDIS_URL` environment variable to point to your Redis server.
     Our [Redis storage example](https://github.com/zauberzeug/nicegui/tree/main/examples/redis_storage) shows
-    how you can setup it up with a reverse proxy or load balancer.
+    how you can setup it up with a reverse proxy or load balancer, as well as to define connection
+    parameters for Redis.
 
     Please note that the Redis sync always contains all the data, not only the changed values.
 


### PR DESCRIPTION
### Motivation

This PR adds some more docs to using Redis, as well as allows for the following environment variables to be set to control Redis connection properties:
- `NICEGUI_REDIS_HEALTH_CHECK_INTERVAL` (default: 10) as connection argument `health_check_interval`
- `NICEGUI_REDIS_SOCKET_CONNECT_TIMEOUT` (default: 5) as connection argument `socket_connect_timeout`
- `NICEGUI_REDIS_RETRY_ON_TIMEOUT` (default: True) as connection argument `retry_on_timeout`
- `NICEGUI_REDIS_SOCKET_KEEPALIVE` (default: True) as connection argument `socket_keepalive`

### Implementation

`redis_persistant_dict.py` will check for the variables above and convert strings to booleans

### Progress

If applied, this PR will improve docs on using Redis and allow for more user control in the Redis connection.
