### PR TITLE
Remove wait_for2 dependency

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import gzip
 import json
 import logging
@@ -225,7 +226,7 @@ class Air:
         self.connecting = True
         try:
             if self.relay.connected:
-                await helpers.wait_for(self.disconnect(), timeout=5)
+                await asyncio.wait_for(self.disconnect(), timeout=5)
             self.log.debug('Connecting...')
             await self.relay.connect(
                 f'{RELAY_HOST}?device_token={self.token}',

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -7,11 +7,8 @@ import struct
 import threading
 import time
 import webbrowser
-from collections.abc import Awaitable
 from pathlib import Path
 from typing import Any, Optional, Set, Tuple, Union
-
-import wait_for2
 
 from .logging import log
 
@@ -113,12 +110,3 @@ def kebab_to_camel_case(string: str) -> str:
 def event_type_to_camel_case(string: str) -> str:
     """Convert an event type string to camelCase."""
     return '.'.join(kebab_to_camel_case(part) if part != '-' else part for part in string.split('.'))
-
-
-async def wait_for(fut: Awaitable, timeout: Optional[float] = None) -> None:
-    """Wait for a future to complete.
-
-    This function is a wrapper around ``wait_for2.wait_for`` which is a drop-in replacement for ``asyncio.wait_for``.
-    It can be removed once we drop support for older versions than Python 3.13 which fixes ``asyncio.wait_for``.
-    """
-    return await wait_for2.wait_for(fut, timeout)

--- a/nicegui/javascript_request.py
+++ b/nicegui/javascript_request.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import asyncio
 from typing import Any, ClassVar, Dict
 
-from . import helpers
-
 
 class JavaScriptRequest:
     _instances: ClassVar[Dict[str, JavaScriptRequest]] = {}
@@ -27,7 +25,7 @@ class JavaScriptRequest:
 
     def __await__(self) -> Any:
         try:
-            yield from helpers.wait_for(self._event.wait(), self.timeout).__await__()
+            yield from asyncio.wait_for(self._event.wait(), self.timeout).__await__()
         except asyncio.TimeoutError as e:
             raise TimeoutError(f'JavaScript did not respond within {self.timeout:.1f} s') from e
         else:

--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -5,7 +5,7 @@ import time
 from collections import deque
 from typing import TYPE_CHECKING, Any, Deque, Dict, Optional, Tuple
 
-from . import background_tasks, core, helpers
+from . import background_tasks, core
 
 if TYPE_CHECKING:
     from .client import Client
@@ -72,7 +72,7 @@ class Outbox:
             try:
                 if not self._enqueue_event.is_set():
                     try:
-                        await helpers.wait_for(self._enqueue_event.wait(), timeout=1.0)
+                        await asyncio.wait_for(self._enqueue_event.wait(), timeout=1.0)
                     except (TimeoutError, asyncio.TimeoutError):
                         continue
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3952,17 +3952,6 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "s
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"GraalVM\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
 [[package]]
-name = "wait-for2"
-version = "0.3.2"
-description = "Asyncio wait_for that can handle simultaneous cancellation and future completion."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "wait_for2-0.3.2.tar.gz", hash = "sha256:93863026dc35f3471104ecf7de1f4a0b31f4c8b12a2241c0d6ee26dcc0c2092a"},
-]
-
-[[package]]
 name = "watchdog"
 version = "4.0.2"
 description = "Filesystem events monitoring"
@@ -4408,4 +4397,4 @@ sass = ["libsass"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8"
-content-hash = "fd49862eeebd95f8eb1fe6d09e3a98ee41c2d1003f54b616745e8a30df33ae71"
+content-hash = "f43d79075a6b85c874c493c1b888c22ea0ba72e55d8a42c85fc59d8fd4be73fd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ urllib3 = ">=1.26.18,!=2.0.0,!=2.0.1,!=2.0.2,!=2.0.3,!=2.0.4,!=2.0.5,!=2.0.6,!=2
 certifi = ">=2024.07.04" # https://github.com/zauberzeug/nicegui/security/dependabot/35
 redis = { version = ">=4.0.0", optional = true }
 h11 = ">=0.16.0" # https://github.com/zauberzeug/nicegui/security/dependabot/45
-wait_for2 = ">=0.3.2"
+
 
 [tool.poetry.extras]
 native = ["pywebview"]
@@ -124,7 +124,7 @@ module = [
     "sass",
     "socketio.*",
     "vbuild",
-    "wait_for2",
+
     "webview.*", # can be removed with next pywebview release
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ certifi = ">=2024.07.04" # https://github.com/zauberzeug/nicegui/security/depend
 redis = { version = ">=4.0.0", optional = true }
 h11 = ">=0.16.0" # https://github.com/zauberzeug/nicegui/security/dependabot/45
 
-
 [tool.poetry.extras]
 native = ["pywebview"]
 plotly = ["plotly"]
@@ -124,7 +123,6 @@ module = [
     "sass",
     "socketio.*",
     "vbuild",
-
     "webview.*", # can be removed with next pywebview release
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
### Motivation

I introduced the `wait_for2` package in #4641 because it fixed cancellation in test tear downs. But further modifications to the code seems to have made the package obsolete again.

### Implementation

I removed the dependency and the helper. Now ~~`asyncio.wait_for2`~~  `asyncio.wait_for` can be used directly again.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] New Pytests are not necessary
- [x] Documentation is not necessary
