### PR TITLE
Add `on_node_click` functionality to `ui.mermaid` element

### DIFF
--- a/nicegui/elements/mermaid.js
+++ b/nicegui/elements/mermaid.js
@@ -9,7 +9,17 @@ export default {
     this.initialize();
     this.update(this.content);
   },
+  beforeUnmount() {
+    this.clearHandler();
+  },
   methods: {
+    getHandlerName() {
+      return `nodeClick_${this.clickInstance}`;
+    },
+    clearHandler() {
+      const handlerName = this.getHandlerName();
+      if (window[handlerName]) delete window[handlerName];
+    },
     initialize() {
       try {
         mermaid.initialize(this.config || {});
@@ -25,6 +35,22 @@ export default {
         const { svg, bindFunctions } = await mermaid.render(this.$el.id + "_mermaid", content);
         this.$el.innerHTML = svg;
         bindFunctions?.(this.$el);
+
+        if (this.clickInstance) {
+          const handlerName = this.getHandlerName();
+          window[handlerName] = (nodeId, nodeText) => {
+            this.$emit("nodeClick", {
+              node: this.getNodeName(nodeId),
+              nodeId,
+              nodeText,
+            });
+          };
+
+          this.$nextTick(() => {
+            this.attachClickHandlers(this.getHandlerName());
+          });
+        };
+
       } catch (error) {
         const { svg, bindFunctions } = await mermaid.render(this.$el.id + "_mermaid", "error");
         this.$el.innerHTML = svg;
@@ -34,9 +60,32 @@ export default {
         this.$emit("error", mermaidErrorFormat);
       }
     },
+    attachClickHandlers(handlerName) {
+      const clickables = this.$el.querySelectorAll("g.node.clickable");
+      clickables.forEach(node => {
+        node.removeAttribute("onclick");
+        node.onclick = null;
+
+        const newNode = node.cloneNode(true);
+        node.parentNode.replaceChild(newNode, node);
+
+        const nodeText = newNode.textContent.trim();
+        newNode.addEventListener("click", () => {
+          window[handlerName](newNode.id, nodeText);
+        });
+      });
+    },
+    getNodeName(domId) {
+      if (!domId) return undefined;
+      const parts = domId.split("-");
+      if (parts.length >= 3) return parts.slice(1, -1).join("-");
+      if (parts.length === 2) return parts[1];
+      return domId;
+    },
   },
   props: {
     config: Object,
     content: String,
+    clickInstance: Number,
   },
 };

--- a/nicegui/elements/mermaid.py
+++ b/nicegui/elements/mermaid.py
@@ -1,5 +1,8 @@
-from typing import Dict, Optional
+import re
+from datetime import datetime
+from typing import Dict, Match, Optional
 
+from ..events import GenericEventArguments, Handler
 from .mixins.content_element import ContentElement
 
 
@@ -11,26 +14,47 @@ class Mermaid(ContentElement,
               ]):
     CONTENT_PROP = 'content'
 
-    def __init__(self, content: str, config: Optional[Dict] = None) -> None:
+    def __init__(self, content: str, config: Optional[Dict] = None, on_node_click: Optional[Handler[GenericEventArguments]] = None) -> None:
         """Mermaid Diagrams
 
-        Renders diagrams and charts written in the Markdown-inspired `Mermaid <https://mermaid.js.org/>`_ language.
-        The mermaid syntax can also be used inside Markdown elements by providing the extension string 'mermaid' to the ``ui.markdown`` element.
+            Renders diagrams and charts written in the Markdown-inspired `Mermaid <https://mermaid.js.org/>`_ language.
+            The mermaid syntax can also be used inside Markdown elements by providing the extension string 'mermaid' to the ``ui.markdown`` element.
 
-        The optional configuration dictionary is passed directly to mermaid before the first diagram is rendered.
-        This can be used to set such options as
+            The optional configuration dictionary is passed directly to mermaid before the first diagram is rendered.
+            This can be used to set such options as
 
-            ``{'securityLevel': 'loose', ...}`` - allow running JavaScript when a node is clicked
-            ``{'logLevel': 'info', ...}`` - log debug info to the console
+                ``{'securityLevel': 'loose', ...}`` - allow running JavaScript when a node is clicked, applied automatically when `on_node_clicked` is specified
+                ``{'logLevel': 'info', ...}`` - log debug info to the console
 
-        Refer to the Mermaid documentation for the ``mermaid.initialize()`` method for a full list of options.
+            Refer to the Mermaid documentation for the ``mermaid.initialize()`` method for a full list of options.
 
-        :param content: the Mermaid content to be displayed
-        :param config: configuration dictionary to be passed to ``mermaid.initialize()``
-        """
+            :param content: the Mermaid content to be displayed
+            :param config: configuration dictionary to be passed to ``mermaid.initialize()``
+            :param on_node_click: callback that is invoked when a node is clicked, applies ``{'securityLevel': 'loose'}`` automatically
+            """
+        content, timestamp = self._update_click_handler(content)
+
         super().__init__(content=content)
-        self._props['config'] = config
+
+        self._props['config'] = config or {}
+
+        if on_node_click:
+            self.on('nodeClick', on_node_click)
+            self._props['config']['securityLevel'] = 'loose'
+            self._props['clickInstance'] = timestamp
 
     def _handle_content_change(self, content: str) -> None:
         self._props[self.CONTENT_PROP] = content.strip()
         self.run_method('update', content.strip())
+
+    def _update_click_handler(self, content: str) -> str:
+        pattern = r'click\s+(\w+)\s+(?:call\s+)?nodeClick(\([^)]*\))?'
+
+        dt = datetime.now()
+        timestamp = int(dt.timestamp())
+
+        def repl(m: Match[str]) -> str:
+            node = m.group(1)
+            return f'click {node} call nodeClick_c{timestamp}()'
+
+        return re.sub(pattern, repl, content), timestamp

--- a/nicegui/elements/mermaid.py
+++ b/nicegui/elements/mermaid.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime
-from typing import Dict, Match, Optional
+from typing import Dict, Match, Optional, Tuple
 
 from ..events import GenericEventArguments, Handler
 from .mixins.content_element import ContentElement
@@ -47,7 +47,7 @@ class Mermaid(ContentElement,
         self._props[self.CONTENT_PROP] = content.strip()
         self.run_method('update', content.strip())
 
-    def _update_click_handler(self, content: str) -> str:
+    def _update_click_handler(self, content: str) -> Tuple[str, int]:
         pattern = r'click\s+(\w+)\s+(?:call\s+)?nodeClick(\([^)]*\))?'
 
         dt = datetime.now()

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -1,4 +1,3 @@
-import pytest
 from selenium.webdriver.common.by import By
 
 from nicegui import ui
@@ -82,18 +81,19 @@ def test_error(screen: Screen):
     screen.should_contain('Parse error on line 3')
 
 
-@pytest.mark.parametrize('security_level', ['loose', 'strict'])
-def test_click_mermaid_node(security_level: str, screen: Screen):
+def test_click_mermaid_node(screen: Screen):
     ui.mermaid('''
         flowchart TD;
-            A;
-            click A call document.write("Success")
-    ''', config={'securityLevel': security_level})
+            A[Node A];
+            B[Node B];
+            click A call nodeClick()
+            click B call nodeClick()
+    ''', on_node_click=lambda e: label.set_text(str(e.args)))
+    label = ui.label('')
 
     screen.open('/')
-    screen.click('A')
-    screen.wait(0.5)
-    if security_level == 'loose':
-        screen.should_contain('Success')
-    else:
-        screen.should_not_contain('Success')
+    screen.click('Node A')
+    assert 'A' in label.text
+
+    screen.click('Node B')
+    assert 'Node B' in label.text

--- a/website/documentation/content/mermaid_documentation.py
+++ b/website/documentation/content/mermaid_documentation.py
@@ -14,17 +14,19 @@ def main_demo() -> None:
     list(ui.context.client.elements.values())[-1].props['config'] = {'securityLevel': 'loose'}  # HACK: for click_demo
 
 
-@doc.demo('Handle click events', '''
-    You can register to click events by adding a `click` directive to a node and emitting a custom event.
-    Make sure to set the `securityLevel` to `loose` in the `config` parameter to allow JavaScript execution.
+@doc.demo('Handle node events', '''
+    You can register to click events by adding a `click` directive to a node to call `nodeClick()`, this will trigger the callback defined at `on_node_click`.
+    When a callback is specified the `config` is updated to include ``{"securityLevel": "loose"}`` to allow JavaScript execution.
 ''')
 def click_demo() -> None:
     ui.mermaid('''
     graph LR;
-        A((Click me!));
-        click A call emitEvent("mermaid_click", "You clicked me!")
-    ''', config={'securityLevel': 'loose'})
-    ui.on('mermaid_click', lambda e: ui.notify(e.args))
+        A((Click Me));
+        B((Or Click Me));
+        A --> B;
+        click A call nodeClick()
+        click B call nodeClick()
+    ''', on_node_click=lambda e: ui.notify(e.args))
 
 
 @doc.demo('Handle errors', '''


### PR DESCRIPTION
### Motivation

The current `click` event handler for `ui.mermaid` relies on the global js `emitEvent` function and registering the event with `ui.on(...)`, see https://nicegui.io/documentation/mermaid#handle_click_events, but this differs to most other elements which allow specifying a callback as a parameter when the element is created. 

If applied, this PR will introduce a dedicated `on_node_click` parameter to the `ui.mermaid` element.

### Implementation

A new `on_node_click` parameter has been added to `ui.mermaid`. The user is still required to add a `click {nodeName} call nodeClick()` declaration to their markdown to signal which nodes are to trigger the callback. 

Ensuring that multiple Mermaid diagram instances on the same page all triggered the callback proved difficult. During testing it was found that:
- If multiple diagrams on the same page had overlapping node names this caused a double-trigger on the last diagram and none on the prior. 
- If the `nodeClick()` js function isn't ready when the chart is rendered it can break the diagram resulting in a blank element, refreshing the page resolves this.
- The last Mermaid diagram rendered to a page has `click` js but all prior diagrams were missing this.
- Unless passed as an argument to the js function in the markdown, Mermaid can't return the node id.
- These issues appear to all be at the Mermaid api level. 

To overcome these issues: 
- The markdown `content` is inspected and altered prior to sending to the javascript component to ensure that the `nodeClick()` function name is unique to each diagram, a timestamp is used to do this. Each diagram then has it's own caller attached to the instance without the user needing to manage this.
- The `content` needs to be updated with the unique function name prior to the first initial js load. If done afterwards it triggers a `content` refresh which breaks the diagram.
- Mermaid's own `click` js events, generated when a click reference is added to the markdown, are removed (if they exist) and replaced with a new `click` js event.
- The node id can be extracted from the nodes DOM element.

This is a fully working implementation but it is by no means perfect and there are definitely improvements & efficiencies to be found. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Key Discussion Points

- Is there a better way to generate unique function names? Although this implementation works it doesn't feel right to alter the markdown secretly.
- Originally I used the elements 'id' to create the unique function names but this isn't available before `super()`. If the content is updated after `super()` it triggers an element refresh and this resulted in a broken diagram. Is there a better way to handle this situation?

### Test Example

```python
from nicegui import ui

ui.mermaid('''
    graph LR;
        A((Click Me));
        B((Or Click Me));
        A --> B;
        click A call nodeClick()
        click B call nodeClick()
    ''', on_node_click=lambda e: ui.notify(e.args))


ui.mermaid('''
    graph LR;
        A((Click Me 2));
        B((Or Click Me 2));
        A --> B;
        click A call nodeClick()
        click B call nodeClick()
    ''', on_node_click=lambda e: ui.notify(e.args))

ui.run()
```