### PR TITLE
UserInteraction.click(): Handle radio elements

### DIFF
--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -96,12 +96,10 @@ class UserInteraction(Generic[T]):
                     return self
                 elif isinstance(element, ui.radio):
                     if isinstance(element.options, dict):
-                        target_value = next(
-                            (k for k, v in element.options.items() if v == self.target), ""
-                        )
+                        target_value = next((k for k, v in element.options.items() if v == self.target), '')
                     else:
                         target_value = self.target
-                    element.set_value(target_value)
+                    element.value = target_value
                     return self
 
                 for listener in element._event_listeners.values():  # pylint: disable=protected-access

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -60,17 +60,14 @@ def test_radio_set_options(screen: Screen):
 
 async def test_radio_click_with_user(user: User):
     radio = ui.radio(['A', 'B', 'C'])
-    label = ui.label().bind_text_from(radio, 'value', lambda x: f'Value: {x}')
+    ui.label().bind_text_from(radio, 'value', lambda x: f'Value: {x}')
 
     await user.open('/')
-    radio_interaction = user.find(target='A', kind=ui.radio)
-    radio_interaction.click()
-    assert label.text == 'Value: A'
-    radio_interaction = user.find(target='B', kind=ui.radio)
-    radio_interaction.click()
-    assert label.text == 'Value: B'
+    user.find('A', kind=ui.radio).click()
+    await user.should_see('Value: A')
 
-    # already selected, should not change
-    radio_interaction = user.find(target='B', kind=ui.radio)
-    radio_interaction.click()
-    assert label.text == 'Value: B'
+    user.find('B', kind=ui.radio).click()
+    await user.should_see('Value: B')
+
+    user.find('B', kind=ui.radio).click()  # already selected, should not change
+    await user.should_see('Value: B')


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
Currently, `UserInteraction.click()` does not support `ui.radio` elements. This PR updates it so radio elements work similarly to `ui.select` elements.

<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->
It adds a new section of logic to `UserInteraction.click()` for radio elements.

<!-- Include any important technical decisions or trade-offs made -->

I have not added documentation for this case, but it's so similar to `ui.select` that perhaps no additional documentation is needed. (But I'm happy to add documentation if that would be useful.)

### Progress

- [X] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [X] The implementation is complete.
- [X] Pytests have been added (or are not necessary).
- [X] Documentation has been added (or is not necessary).
