### PR TITLE
Reintroduce queue for Mermaid, since parallel rendering = no onclick

### DIFF
--- a/nicegui/elements/mermaid.js
+++ b/nicegui/elements/mermaid.js
@@ -1,5 +1,8 @@
 import mermaid from "mermaid";
 
+let is_running = false;
+const queue = [];
+
 export default {
   template: `<div></div>`,
   data: () => ({
@@ -21,17 +24,23 @@ export default {
     async update(content) {
       if (this.last_content === content) return;
       this.last_content = content;
-      try {
-        const { svg, bindFunctions } = await mermaid.render(this.$el.id + "_mermaid", content);
-        this.$el.innerHTML = svg;
-        bindFunctions?.(this.$el);
-      } catch (error) {
-        const { svg, bindFunctions } = await mermaid.render(this.$el.id + "_mermaid", "error");
-        this.$el.innerHTML = svg;
-        bindFunctions?.(this.$el);
-        const mermaidErrorFormat = { str: error.message, message: error.message, hash: error.name, error };
-        console.error(mermaidErrorFormat);
-        this.$emit("error", mermaidErrorFormat);
+      queue.push({element: this.$el, content: content});
+      if (is_running) return;
+      is_running = true;
+      while (queue.length > 0) {
+        const { element, content } = queue.shift();
+        try {
+          const { svg, bindFunctions } = await mermaid.render(element.id + "_mermaid", content);
+          element.innerHTML = svg;
+          bindFunctions?.(element);
+        } catch (error) {
+          const { svg, bindFunctions } = await mermaid.render(element.id + "_mermaid", "error");
+          element.innerHTML = svg;
+          bindFunctions?.(element);
+          const mermaidErrorFormat = { str: error.message, message: error.message, hash: error.name, error };
+          console.error(mermaidErrorFormat);
+          this.$emit("error", mermaidErrorFormat);
+        }
       }
     },
   },


### PR DESCRIPTION
### Motivation

This PR fix #4852, by reintroducing the rendering queue that we dropped in #4692 because of "unknown reasons". 

### Implementation

- Copy over the `let is_running = false;` and `const queue = [];` from prior to #4692 
- Let GitHub copilot rewrite the rest of the rendering code to respect the queue

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [x] Documentation is not necessary.

I think we should add Pytest to avoid accidentally regressing this in the future, but Mermaid pytest is _really_ not my strong suit, and I'd like to do what I am best at - rapid fixes. 

Also I am not sure if we should hold back the fix, just because of missing pytest. 

### Test code

Stolen from #4852

```py
from nicegui import ui

ui.mermaid('''
    graph LR;
        A --> B;
        click A alert
        click B alert
    ''', config={'securityLevel': 'loose'})

ui.mermaid('''
    graph LR;
        C --> D;
        click C alert
        click D alert
    ''', config={'securityLevel': 'loose'})

ui.run()
```

Before: 

<img width="1280" alt="{2D867831-AA7B-4CD3-8FF7-B0D681EE0F5C}" src="https://github.com/user-attachments/assets/78ecff56-8766-4922-8683-5b7d75ef6784" />

-> No `click`

After: 

<img width="1280" alt="{E35456E5-6B65-4506-8DC9-16FBE7B78FBE}" src="https://github.com/user-attachments/assets/b87a4e15-3c6e-40fb-8d56-db69604d8760" />

-> Yes `click`