### PR TITLE
Let configure UI framework other than Quasar

### DIFF
--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -18,7 +18,7 @@ from ..observables import ObservableSet
 from ..server import Server
 from ..staticfiles import CacheControlledStaticFiles
 from ..storage import Storage
-from .app_config import AppConfig
+from .app_config import DEFAULT_APP_CONFIGURATOR, AppConfig
 from .range_response import get_range_response
 
 
@@ -300,3 +300,14 @@ class App(FastAPI):
         for client in Client.instances.values():
             if client.page.path == path:
                 yield client
+
+    def configure_vue_ui_framework(self, config_script: str = DEFAULT_APP_CONFIGURATOR):
+        """Configure the UI framework used with the Vue app.
+        This is used to set up the UI framework (e.g. Quasar) with the provided configuration.
+
+        :param config_script: JavaScript code to configure the UI framework (default: DEFAULT_APP_CONFIGURATOR)
+
+        Note: the config_script should be a format string of JavaScript code that will be executed in the browser.
+        It will be called with `.format(config=json.dumps({...})` to populate the configuration.
+        """
+        self.config.ui_framework_config_script = config_script

--- a/nicegui/app/app_config.py
+++ b/nicegui/app/app_config.py
@@ -5,6 +5,12 @@ from typing import Dict, List, Literal, Optional, Union
 from ..dataclasses import KWONLY_SLOTS
 from ..language import Language
 
+DEFAULT_APP_CONFIGURATOR = '''
+app.use(Quasar, {{config: {config}}});
+Quasar.lang.set(Quasar.lang[language.replace('-', '')]);
+Quasar.Dark.set(dark === null ? "auto" : dark);
+'''
+
 
 @dataclass(**KWONLY_SLOTS)
 class AppConfig:
@@ -23,6 +29,7 @@ class AppConfig:
                 'skipHijack': False,
             },
         })
+    ui_framework_config_script: str = field(default_factory=lambda: DEFAULT_APP_CONFIGURATOR)
 
     reload: bool = field(init=False)
     title: str = field(init=False)

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -155,7 +155,7 @@ class Client:
                 'imports': json.dumps(imports),
                 'js_imports': '\n'.join(js_imports),
                 'js_imports_urls': js_imports_urls,
-                'quasar_config': json.dumps(core.app.config.quasar_config),
+                'ui_framework_config_script': core.app.config.ui_framework_config_script.format(config=json.dumps(core.app.config.quasar_config)),
                 'title': self.resolve_title(),
                 'viewport': self.page.resolve_viewport(),
                 'favicon_url': get_favicon_url(self.page, prefix),

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -436,8 +436,6 @@ function createApp(elements, options) {
         });
       }
     },
-  }).use(Quasar, {
-    config: options.quasarConfig,
   }));
 }
 

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -51,15 +51,14 @@
         query: {{ socket_io_js_query_params | safe }},
         extraHeaders: {{ socket_io_js_extra_headers | safe }},
         transports: {{ socket_io_js_transports | safe }},
-        quasarConfig: {{ quasar_config | safe }},
       });
+      const dark = {{ dark }};
+      const language = "{{ language }}";
+      {{ ui_framework_config_script | safe }}
 
       {{ js_imports | safe }}
       {{ vue_scripts | safe }}
 
-      const dark = {{ dark }};
-      Quasar.lang.set(Quasar.lang["{{ language }}".replace('-', '')]);
-      Quasar.Dark.set(dark === None ? "auto" : dark);
       {% if tailwind %}
       if (dark !== None) tailwind.config.darkMode = "class";
       if (dark === True) document.body.classList.add("dark");


### PR DESCRIPTION
### Motivation

In direct response to #4858 and #3818, this PR attempts at decoupling NiceGUI from Quasar at the browser-side Vue app configuration level, such that we can then assess which UI frameworks can work with NiceGUI, and then take a shot at creating native elements in Python. 

We are beginning a new project, preliminarily named NFM: NiceGUI Framework Multiverse

### Implementation

- Rip out Quasar in NiceGUI's `createApp`
- Introduce the concept of `ui_framework_config_script`, which defaults to `DEFAULT_APP_CONFIGURATOR`, that we can override to not interact with `Quasar` but another UI framework in `app.use` and other configuration and bootstrapping
- Set the above by `app.configure_vue_ui_framework`, which could be userspace code (if they urgently want another UI framework), another library's code, or even in an optional package of NiceGUI library

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).

### Results

I don't have a lot of time (it's 4am around where I am right now!) but I did get Element Plus working: 

```py
from nicegui import ui, app

ui.add_body_html('''
<link rel="stylesheet" href="//unpkg.com/element-plus/dist/index.css" />
<script defer src="//unpkg.com/element-plus"></script>
''', shared=True)

app.configure_vue_ui_framework('''
app.use(ElementPlus);
''')

with ui.element('el-button'):
    ui.html('I am a button from Element Plus')

ui.run()
```

<img width="1280" alt="{93B8D525-9EB4-4F81-8CBE-0EC54C3E5A32}" src="https://github.com/user-attachments/assets/810bc958-9bef-42f3-b807-adbee7e541e2" />

-> No `el-button`, instead we have `button`, since Element Plus loaded in properly. 

**Your mileage may vary with other UI frameworks!!!**

My intention: Merge this, since this doesn't break the existing code, and then we can work from here on out. 