### PR TITLE
Mermaid `on_node_click`, with `{handler}` drop-in approach

### DIFF
--- a/nicegui/elements/mermaid.js
+++ b/nicegui/elements/mermaid.js
@@ -20,6 +20,11 @@ export default {
         console.error(error);
         this.$emit("error", error);
       }
+      if (this.function_name) {
+        window[this.function_name] = (node, param) => {
+          this.$emit("nodeClicked", {node: node, param: param});
+        }
+      }
     },
     async update(content) {
       if (this.last_content === content) return;
@@ -48,5 +53,6 @@ export default {
   props: {
     config: Object,
     content: String,
+    function_name: String,
   },
 };

--- a/nicegui/elements/mermaid.py
+++ b/nicegui/elements/mermaid.py
@@ -1,5 +1,8 @@
+import uuid
 from typing import Dict, Optional
 
+from ..events import GenericEventArguments, Handler
+from ..logging import log
 from .mixins.content_element import ContentElement
 
 
@@ -11,7 +14,7 @@ class Mermaid(ContentElement,
               ]):
     CONTENT_PROP = 'content'
 
-    def __init__(self, content: str, config: Optional[Dict] = None) -> None:
+    def __init__(self, content: str, config: Optional[Dict] = None, *, on_node_click: Optional[Handler[GenericEventArguments]] = None) -> None:
         """Mermaid Diagrams
 
         Renders diagrams and charts written in the Markdown-inspired `Mermaid <https://mermaid.js.org/>`_ language.
@@ -25,12 +28,31 @@ class Mermaid(ContentElement,
 
         Refer to the Mermaid documentation for the ``mermaid.initialize()`` method for a full list of options.
 
-        :param content: the Mermaid content to be displayed
+        :param content: the Mermaid content to be displayed. If ``on_node_click`` is passed, expect lines such as ``click A {handler}()``, where ``{handler}`` is a placeholder for the JavaScript function defined by NiceGUI to handle node clicks.
         :param config: configuration dictionary to be passed to ``mermaid.initialize()``
+        :param on_node_click: a callback function that will be called when a node is clicked. The function should accept an event argument
         """
-        super().__init__(content=content)
-        self._props['config'] = config
+        function_name = f'mermaid_click_handler_{uuid.uuid4().hex}' if on_node_click else None
+        super().__init__(content=self._format_content(content, function_name))
+        self._props['config'] = config if config is not None else {}
+
+        if on_node_click is not None:
+            self.on('nodeClicked', on_node_click)
+            self._props['config']['securityLevel'] = 'loose'
+            self._props['function_name'] = function_name
 
     def _handle_content_change(self, content: str) -> None:
-        self._props[self.CONTENT_PROP] = content.strip()
-        self.run_method('update', content.strip())
+        content_final = self._format_content(content, self._props.get('function_name'))
+        self._props[self.CONTENT_PROP] = content_final
+        self.run_method('update', content_final)
+
+    @staticmethod
+    def _format_content(content: str, function_name: Optional[str]) -> str:
+        content_final = content.strip()
+        if function_name is not None:
+            try:
+                content_final = content_final.format(handler=function_name)
+            except KeyError:
+                log.warning(
+                    'Mermaid content does not contain {handler} placeholder, but node click functionality is enabled. Please add {handler} to the content string.')
+        return content_final


### PR DESCRIPTION
### Motivation

@thetableman, I feel sorry for pushing back against #4845, so I spent about 2 hours to code what I think could work to let Mermaid have node click functionality, with a minimally-sketchy code change. Notably, I used string format instead of regex, so the change NiceGUI is making should be obvious and understandable to everyone. 

### Implementation

If we desire to add `on_node_click` for Mermaid: 
- Setup function `mermaid_click_handler_SOMEUUID` (since `this` is not available), . 
- Instead of using regex, which are less predictable and a bit of a black box, I use string format (formatting against `{handler}`) and replace that with the actual function name

Shows up clearly in the IDE as well: 

<img width="323" alt="{562E07C9-AB7D-46E6-8BD8-D01AB95B5D1D}" src="https://github.com/user-attachments/assets/88f0b0e5-3ccf-441b-a65c-ef5cc7dd5d59" />

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).

_Pytest pending. Documentation pending. I'm tired TBH._ 

### Test script

```py
from nicegui import ui


@ui.page('/')
def main_page():
    ui.mermaid('''
        graph LR;
            A --> B;
            B --> C;
            click A {handler}
            click B call {handler}()
            click C call {handler}("C", "C some args")
        ''', on_node_click=lambda e: ui.notify(e))


ui.run()
```

### Result

<img width="640" alt="{BA0717C3-3735-48B0-9FC0-2ACCE953FEA3}" src="https://github.com/user-attachments/assets/dbc3234e-c0f8-4805-b433-43e7824717b3" />
