### PR TITLE
Mermaid `on_node_click`, with `NICEGUI_HANDLER` drop-in approach

### DIFF
--- a/nicegui/elements/mermaid.js
+++ b/nicegui/elements/mermaid.js
@@ -20,8 +20,14 @@ export default {
         console.error(error);
         this.$emit("error", error);
       }
+      if (this.function_name) {
+        window[this.function_name] = (node, param) => {
+          this.$emit("nodeClicked", {node: node, param: param});
+        }
+      }
     },
     async update(content) {
+      content = content.replace(new RegExp(this.function_placeholder, "g"), this.function_name);
       if (this.last_content === content) return;
       this.last_content = content;
       queue.push({ element: this.$el, content: content });
@@ -48,5 +54,10 @@ export default {
   props: {
     config: Object,
     content: String,
+    function_name: String,
+    function_placeholder: {
+      type: String,
+      default: "NICEGUI_HANDLER",
+    },
   },
 };

--- a/nicegui/elements/mermaid.py
+++ b/nicegui/elements/mermaid.py
@@ -1,5 +1,7 @@
+import uuid
 from typing import Dict, Optional
 
+from ..events import GenericEventArguments, Handler
 from .mixins.content_element import ContentElement
 
 
@@ -11,7 +13,9 @@ class Mermaid(ContentElement,
               ]):
     CONTENT_PROP = 'content'
 
-    def __init__(self, content: str, config: Optional[Dict] = None) -> None:
+    def __init__(self, content: str, config: Optional[Dict] = None, *,
+                 on_node_click: Optional[Handler[GenericEventArguments]] = None,
+                 function_placeholder: str = 'NICEGUI_HANDLER') -> None:
         """Mermaid Diagrams
 
         Renders diagrams and charts written in the Markdown-inspired `Mermaid <https://mermaid.js.org/>`_ language.
@@ -25,11 +29,19 @@ class Mermaid(ContentElement,
 
         Refer to the Mermaid documentation for the ``mermaid.initialize()`` method for a full list of options.
 
-        :param content: the Mermaid content to be displayed
+        :param content: the Mermaid content to be displayed. If ``on_node_click`` is passed, expect lines such as ``click A NICEGUI_HANDLER()``, where ``NICEGUI_HANDLER`` is a placeholder for the JavaScript function defined by NiceGUI to handle node clicks.
         :param config: configuration dictionary to be passed to ``mermaid.initialize()``
+        :param on_node_click: a callback function that will be called when a node is clicked. The function should accept an event argument
+        :param function_placeholder: the placeholder string to be used in the content for the click handler function. Defaults to "NICEGUI_HANDLER". Customizing it allows you to avoid conflicts with your Mermaid diagram content.
         """
         super().__init__(content=content)
-        self._props['config'] = config
+        self._props['config'] = config if config is not None else {}
+
+        if on_node_click is not None:
+            self.on('nodeClicked', on_node_click)
+            self._props['config']['securityLevel'] = 'loose'
+            self._props['function_name'] = f'mermaid_click_handler_{uuid.uuid4().hex}' if on_node_click else None
+            self._props['function_placeholder'] = function_placeholder
 
     def _handle_content_change(self, content: str) -> None:
         self._props[self.CONTENT_PROP] = content.strip()


### PR DESCRIPTION
### Motivation

We're trying to add node click functionality to Mermaid diagram without resorting to global `emitEvent`. 

Apparently, #4861 suffers, when you ought to include `{handler}` in your diagram, which you very much could, in:

```py
ui.mermaid('''
    graph LR
        A[trigger] -->|event| B{handler}
''')
```
Source: https://github.com/zauberzeug/nicegui/pull/4861#issuecomment-2967252331

### Implementation

Thought process: 

- So we would like to make customizable what to replace, because `{handler}` is a legit Mermaid syntax. 
- But, since we would allow changing the placeholder text, then we don't need the Python format string's escaping functionality with `{{` and `}}` anymore
- Then, my new proposal is even simplier, with a direct replace against `NICEGUI_HANDLER` norminally, and you can change the placeholder keyword if you ought to have `NICEGUI_HANDLER` in your diagram. 

Implementation follows: 

- Let set `function_placeholder`
- Replace set `function_placeholder` with random initialized function `function_name` which does `this.$emit("nodeClicked", {node: node, param: param})`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).

Pytest and documentation pending, since we're unsure of the idea. 

### Results

```py
from nicegui import ui


@ui.page('/')
def main_page():
    ui.mermaid('''
        graph LR;
            A --> B;
            B --> C;
            click A NICEGUI_HANDLER
            click B call NICEGUI_HANDLER()
            click C call NICEGUI_HANDLER("C", "C some args")
        ''', on_node_click=lambda e: ui.notify(e))

    ui.mermaid('''
        graph LR;
            X(Cannot use format string) --> Y(NICEGUI_HANDLER solution);
            click X MYHANDLER
            click Y call MYHANDLER("Y", "Y some args")
        ''', on_node_click=lambda e: ui.notify(e), function_placeholder='MYHANDLER')


ui.run()
```

![image](https://github.com/user-attachments/assets/4a2424ac-4798-4d1c-94a1-8f64457d648d)
