### PR TITLE
Introduce Mermaid `on_node_click` using a no-markdown solution

### DIFF
--- a/nicegui/elements/mermaid.js
+++ b/nicegui/elements/mermaid.js
@@ -9,7 +9,17 @@ export default {
     this.initialize();
     this.update(this.content);
   },
+  beforeUnmount() {
+    this.clearHandler();
+  },
   methods: {
+    getHandlerName() {
+      return `nodeClick_${this.clickInstance}`;
+    },
+    clearHandler() {
+      const handlerName = this.getHandlerName();
+      if (window[handlerName]) delete window[handlerName];
+    },
     initialize() {
       try {
         mermaid.initialize(this.config || {});
@@ -25,6 +35,22 @@ export default {
         const { svg, bindFunctions } = await mermaid.render(this.$el.id + "_mermaid", content);
         this.$el.innerHTML = svg;
         bindFunctions?.(this.$el);
+
+        if (this.clickInstance) {
+          const handlerName = this.getHandlerName();
+          window[handlerName] = (nodeId, nodeText) => {
+            this.$emit("nodeClick", {
+              node: this.getNodeName(nodeId),
+              nodeId,
+              nodeText,
+            });
+          };
+
+          this.$nextTick(() => {
+            this.attachClickHandlers(this.getHandlerName());
+          });
+        };
+
       } catch (error) {
         const { svg, bindFunctions } = await mermaid.render(this.$el.id + "_mermaid", "error");
         this.$el.innerHTML = svg;
@@ -34,9 +60,32 @@ export default {
         this.$emit("error", mermaidErrorFormat);
       }
     },
+    attachClickHandlers(handlerName) {
+      const clickables = this.$el.querySelectorAll("g.node.clickable");
+      clickables.forEach(node => {
+        node.removeAttribute("onclick");
+        node.onclick = null;
+
+        const newNode = node.cloneNode(true);
+        node.parentNode.replaceChild(newNode, node);
+
+        const nodeText = newNode.textContent.trim();
+        newNode.addEventListener("click", () => {
+          window[handlerName](newNode.id, nodeText);
+        });
+      });
+    },
+    getNodeName(domId) {
+      if (!domId) return undefined;
+      const parts = domId.split("-");
+      if (parts.length >= 3) return parts.slice(1, -1).join("-");
+      if (parts.length === 2) return parts[1];
+      return domId;
+    },
   },
   props: {
     config: Object,
     content: String,
+    clickInstance: Number,
   },
 };

--- a/nicegui/elements/mermaid.py
+++ b/nicegui/elements/mermaid.py
@@ -1,6 +1,4 @@
-import re
-from datetime import datetime
-from typing import Dict, Match, Optional, Tuple
+from typing import Dict, Optional
 
 from ..events import GenericEventArguments, Handler
 from .mixins.content_element import ContentElement
@@ -32,7 +30,6 @@ class Mermaid(ContentElement,
             :param config: configuration dictionary to be passed to ``mermaid.initialize()``
             :param on_node_click: callback that is invoked when a node is clicked, applies ``{'securityLevel': 'loose'}`` automatically
             """
-        content, timestamp = self._update_click_handler(content)
 
         super().__init__(content=content)
 
@@ -41,20 +38,8 @@ class Mermaid(ContentElement,
         if on_node_click:
             self.on('nodeClick', on_node_click)
             self._props['config']['securityLevel'] = 'loose'
-            self._props['clickInstance'] = timestamp
+            self._props['clickInstance'] = True
 
     def _handle_content_change(self, content: str) -> None:
         self._props[self.CONTENT_PROP] = content.strip()
         self.run_method('update', content.strip())
-
-    def _update_click_handler(self, content: str) -> Tuple[str, int]:
-        pattern = r'click\s+(\w+)\s+(?:call\s+)?nodeClick(\([^)]*\))?'
-
-        dt = datetime.now()
-        timestamp = int(dt.timestamp())
-
-        def repl(m: Match[str]) -> str:
-            node = m.group(1)
-            return f'click {node} call nodeClick_c{timestamp}()'
-
-        return re.sub(pattern, repl, content), timestamp

--- a/nicegui/elements/mermaid.py
+++ b/nicegui/elements/mermaid.py
@@ -1,5 +1,8 @@
-from typing import Dict, Optional
+import re
+from datetime import datetime
+from typing import Dict, Match, Optional
 
+from ..events import GenericEventArguments, Handler
 from .mixins.content_element import ContentElement
 
 
@@ -11,26 +14,47 @@ class Mermaid(ContentElement,
               ]):
     CONTENT_PROP = 'content'
 
-    def __init__(self, content: str, config: Optional[Dict] = None) -> None:
+    def __init__(self, content: str, config: Optional[Dict] = None, on_node_click: Optional[Handler[GenericEventArguments]] = None) -> None:
         """Mermaid Diagrams
 
-        Renders diagrams and charts written in the Markdown-inspired `Mermaid <https://mermaid.js.org/>`_ language.
-        The mermaid syntax can also be used inside Markdown elements by providing the extension string 'mermaid' to the ``ui.markdown`` element.
+            Renders diagrams and charts written in the Markdown-inspired `Mermaid <https://mermaid.js.org/>`_ language.
+            The mermaid syntax can also be used inside Markdown elements by providing the extension string 'mermaid' to the ``ui.markdown`` element.
 
-        The optional configuration dictionary is passed directly to mermaid before the first diagram is rendered.
-        This can be used to set such options as
+            The optional configuration dictionary is passed directly to mermaid before the first diagram is rendered.
+            This can be used to set such options as
 
-            ``{'securityLevel': 'loose', ...}`` - allow running JavaScript when a node is clicked
-            ``{'logLevel': 'info', ...}`` - log debug info to the console
+                ``{'securityLevel': 'loose', ...}`` - allow running JavaScript when a node is clicked, applied automatically when `on_node_clicked` is specified
+                ``{'logLevel': 'info', ...}`` - log debug info to the console
 
-        Refer to the Mermaid documentation for the ``mermaid.initialize()`` method for a full list of options.
+            Refer to the Mermaid documentation for the ``mermaid.initialize()`` method for a full list of options.
 
-        :param content: the Mermaid content to be displayed
-        :param config: configuration dictionary to be passed to ``mermaid.initialize()``
-        """
+            :param content: the Mermaid content to be displayed
+            :param config: configuration dictionary to be passed to ``mermaid.initialize()``
+            :param on_node_click: callback that is invoked when a node is clicked, applies ``{'securityLevel': 'loose'}`` automatically
+            """
+        content, timestamp = self._update_click_handler(content)
+
         super().__init__(content=content)
-        self._props['config'] = config
+
+        self._props['config'] = config or {}
+
+        if on_node_click:
+            self.on('nodeClick', on_node_click)
+            self._props['config']['securityLevel'] = 'loose'
+            self._props['clickInstance'] = timestamp
 
     def _handle_content_change(self, content: str) -> None:
         self._props[self.CONTENT_PROP] = content.strip()
         self.run_method('update', content.strip())
+
+    def _update_click_handler(self, content: str) -> str:
+        pattern = r'click\s+(\w+)\s+(?:call\s+)?nodeClick(\([^)]*\))?'
+
+        dt = datetime.now()
+        timestamp = int(dt.timestamp())
+
+        def repl(m: Match[str]) -> str:
+            node = m.group(1)
+            return f'click {node} call nodeClick_c{timestamp}()'
+
+        return re.sub(pattern, repl, content), timestamp

--- a/nicegui/elements/mermaid.py
+++ b/nicegui/elements/mermaid.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime
-from typing import Dict, Match, Optional
+from typing import Dict, Match, Optional, Tuple
 
 from ..events import GenericEventArguments, Handler
 from .mixins.content_element import ContentElement
@@ -47,7 +47,7 @@ class Mermaid(ContentElement,
         self._props[self.CONTENT_PROP] = content.strip()
         self.run_method('update', content.strip())
 
-    def _update_click_handler(self, content: str) -> str:
+    def _update_click_handler(self, content: str) -> Tuple[str, int]:
         pattern = r'click\s+(\w+)\s+(?:call\s+)?nodeClick(\([^)]*\))?'
 
         dt = datetime.now()

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -84,30 +84,14 @@ def test_error(screen: Screen):
 def test_click_mermaid_node(screen: Screen):
     ui.mermaid('''
         flowchart TD;
-
-            X;
-            click X call document.write("Clicked X")
-    ''', config={'securityLevel': security_level})
-
-    ui.mermaid('''
-        flowchart TD;
-            Y;
-            click Y call document.write("Clicked Y")
-    ''', config={'securityLevel': security_level})
-
-    ui.mermaid('''
-        flowchart TD;
-            Z;
-            click Z call document.write("Clicked Z")
-    ''', config={'securityLevel': security_level})
+            A[Node A];
+            B[Node B];
+    ''', on_node_click=lambda e: label.set_text(str(e.args['nodeText'])))
+    label = ui.label('')
 
     screen.open('/')
-    screen.click('Y')
-    screen.wait(0.5)
-    screen.should_not_contain('Clicked X')
-    screen.should_not_contain('Clicked Z')
-    if security_level == 'loose':
-        screen.should_contain('Clicked Y')
-    else:
-        screen.should_not_contain('Clicked Y')
+    screen.click('Node A')
+    assert 'Node A' in label.text
 
+    screen.click('Node B')
+    assert 'Node B' in label.text

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -1,4 +1,3 @@
-import pytest
 from selenium.webdriver.common.by import By
 
 from nicegui import ui
@@ -82,18 +81,19 @@ def test_error(screen: Screen):
     screen.should_contain('Parse error on line 3')
 
 
-@pytest.mark.parametrize('security_level', ['loose', 'strict'])
-def test_click_mermaid_node(security_level: str, screen: Screen):
+def test_click_mermaid_node(screen: Screen):
     ui.mermaid('''
         flowchart TD;
-            A;
-            click A call document.write("Success")
-    ''', config={'securityLevel': security_level})
+            A[Node A];
+            B[Node B];
+            click A call nodeClick()
+            click B call nodeClick()
+    ''', on_node_click=lambda e: label.set_text(str(e.args)))
+    label = ui.label('')
 
     screen.open('/')
-    screen.click('A')
-    screen.wait(0.5)
-    if security_level == 'loose':
-        screen.should_contain('Success')
-    else:
-        screen.should_not_contain('Success')
+    screen.click('Node A')
+    assert 'A' in label.text
+
+    screen.click('Node B')
+    assert 'Node B' in label.text

--- a/website/documentation/content/mermaid_documentation.py
+++ b/website/documentation/content/mermaid_documentation.py
@@ -14,17 +14,19 @@ def main_demo() -> None:
     list(ui.context.client.elements.values())[-1].props['config'] = {'securityLevel': 'loose'}  # HACK: for click_demo
 
 
-@doc.demo('Handle click events', '''
-    You can register to click events by adding a `click` directive to a node and emitting a custom event.
-    Make sure to set the `securityLevel` to `loose` in the `config` parameter to allow JavaScript execution.
+@doc.demo('Handle node events', '''
+    You can register to click events by adding a `click` directive to a node to call `nodeClick()`, this will trigger the callback defined at `on_node_click`.
+    When a callback is specified the `config` is updated to include ``{"securityLevel": "loose"}`` to allow JavaScript execution.
 ''')
 def click_demo() -> None:
     ui.mermaid('''
     graph LR;
-        A((Click me!));
-        click A call emitEvent("mermaid_click", "You clicked me!")
-    ''', config={'securityLevel': 'loose'})
-    ui.on('mermaid_click', lambda e: ui.notify(e.args))
+        A((Click Me));
+        B((Or Click Me));
+        A --> B;
+        click A call nodeClick()
+        click B call nodeClick()
+    ''', on_node_click=lambda e: ui.notify(e.args))
 
 
 @doc.demo('Handle errors', '''

--- a/website/documentation/content/mermaid_documentation.py
+++ b/website/documentation/content/mermaid_documentation.py
@@ -15,7 +15,7 @@ def main_demo() -> None:
 
 
 @doc.demo('Handle node events', '''
-    You can register to click events by adding a `click` directive to a node to call `nodeClick()`, this will trigger the callback defined at `on_node_click`.
+    You can register to click events by adding a callback to the `on_node_click` parameter.
     When a callback is specified the `config` is updated to include ``{"securityLevel": "loose"}`` to allow JavaScript execution.
 ''')
 def click_demo() -> None:
@@ -24,8 +24,6 @@ def click_demo() -> None:
         A((Click Me));
         B((Or Click Me));
         A --> B;
-        click A call nodeClick()
-        click B call nodeClick()
     ''', on_node_click=lambda e: ui.notify(e.args))
 
 


### PR DESCRIPTION
### Motivation

This PR introduces another alternative way of adding node click events to Mermaid diagrams without use of the global `emitEvent`.

The method was first raised in #4845 and demonstrated in #4862. This implementation differs to the previous working demonstration by ensuring the rendering queue is included as per #4852 and #4853.

### Implementation

This approach bypasses Mermaid's own `click` event methods - the adding of `click <nodeName> call <func(params)>` to the markdown - by attaching a handler directing to the node DOM elements. The method utilizes `querySelectorAll` to identify the nodes within each diagram based on html tag and class names.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

![454577347-5bc288bb-d98f-49be-ac4c-84e57ff24152](https://github.com/user-attachments/assets/da103fc3-8cdf-4d89-b359-3f6c54bc4b4d)

### The Pros, Cons, and Inbetweens

#### Pros
- No requirement for declaring click events in Mermaid
- No confusion about Mermaid's click syntax
- No placeholder handlers in markdown
- No unique event handlers
- Returns consistent data, both within itself (each trigger has the same arguments) and as expected from a NiceGUI element
- Returns node name, node html id, and node text
- Adds protection against double-triggers by preventing multiple event handlers being attached
- Works with multiple diagrams on the same page
- Works where multiple diagrams share similar node names
- Doesn't stop or prevent traditional Mermaid click events if defined in the markdown
- Adds the ability for further functionality through node html id

#### Cons
- Relies on finding g.node with a query selector, leading to potential breaking changes from Mermaid (unlikely)
- Relies on extracting node name from its html id, leading to potential breaking changes from Mermaid (unlikely)
- Currently only works with diagrams with g.node like 'graph', 'state', and 'class' (though these are also the most popular diagram types)

#### Inbetweens
- Ability to add additional query selectors to support other diagram types that even Mermaid doesn't support click events for
- Adds click events in a manner that doesn't match Mermaid documentation

### The Extra Functionality
#### Mermaid click events still work

Because no changes are made to the markdown or the Mermaid click definitions, they still work with existing methods and as per the Mermaid documentation.

```python

from nicegui import ui

ui.mermaid('''
    graph LR;
        A --> B;
        click A alert
    ''', on_node_click=lambda e: ui.notify(e))

ui.run()
```
![454578200-a7540950-1652-41e9-b633-47cde690464a](https://github.com/user-attachments/assets/0e3d4a1d-28f0-43c8-8e44-f0c24c5eadf4)

#### You can reference the nodes in the DOM directly

Because we have the node html id (and not just the node name) we can reference it directly and make changes.

```python

from nicegui import ui

node_styles = {}

def style_node(e):
    node_id = e.args['nodeId']
    node_el = ui.query(f'#{node_id} rect')
    
    if node_id not in node_styles:
        node_styles[node_id] = True
    else:
        node_styles[node_id] = not node_styles[node_id]
    
    if node_styles[node_id]:
        node_el.style(add='fill: yellow;')
    else:
        node_el.style(remove='fill: yellow;')

    e.args['state'] = node_styles[node_id]
    ui.notify(e)

ui.mermaid('''
    graph LR;
        A --> B;
    ''', on_node_click=lambda e: style_node(e))
    
ui.run()
```
![454584526-1f342412-761a-4419-a8a0-e694d429c33c](https://github.com/user-attachments/assets/4979cde4-c5ad-4cef-93d5-4183eea0bcbf)
