### PR TITLE
Implementation of `q-btn-toggle` (ui.button_toggle)

### DIFF
--- a/nicegui/elements/button_toggle.py
+++ b/nicegui/elements/button_toggle.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict, List, Optional, Union
+
+from nicegui.elements.mixins.value_element import ValueElement
+from nicegui.events import Handler, ValueChangeEventArguments
+
+
+class ButtonToggle(ValueElement):
+
+    def __init__(
+        self,
+        options: Union[List[str], List[Dict[str, Any]]],
+        *,
+        value: Optional[str] = None,
+        on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+        **kwargs,
+    ) -> None:
+        """Button Toggle
+
+        A button toggle group component that maintains a selected value.
+        This element is based on Quasar's `QBtnToggle <https://quasar.dev/vue-components/button-toggle>`_ component.
+
+        Args:
+            options: List of options. Can be strings or dicts with 'label' and 'value' keys
+            value: Initial selected value (default: None)
+            on_change: Callback function that receives the new value when changed
+            **kwargs: Additional props to pass to the underlying q-btn-toggle
+        """
+        # Process options to ensure they have the right format
+        processed_options = []
+        for option in options:
+            if isinstance(option, str):
+                processed_options.append({'label': option, 'value': option})
+            elif isinstance(option, dict):
+                if 'label' in option and 'value' in option:
+                    processed_options.append(option)
+                else:
+                    # If missing label or value, use the option as both
+                    label = option.get('label', str(option.get('value', option)))
+                    value_key = option.get('value', label)
+                    processed_options.append({'label': label, 'value': value_key})
+            else:
+                # Convert other types to string
+                str_option = str(option)
+                processed_options.append({'label': str_option, 'value': str_option})
+
+        super().__init__(tag='q-btn-toggle', value=value, on_value_change=on_change)
+        self._props['options'] = processed_options
+        self._props.update(kwargs)

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -10,6 +10,7 @@ __all__ = [
     'badge',
     'button',
     'button_group',
+    'button_toggle',
     'card',
     'card_actions',
     'card_section',
@@ -136,6 +137,7 @@ from .elements.badge import Badge as badge
 from .elements.button import Button as button
 from .elements.button_dropdown import DropdownButton as dropdown_button
 from .elements.button_group import ButtonGroup as button_group
+from .elements.button_toggle import ButtonToggle as button_toggle
 from .elements.card import Card as card
 from .elements.card import CardActions as card_actions
 from .elements.card import CardSection as card_section

--- a/tests/test_button_toggle.py
+++ b/tests/test_button_toggle.py
@@ -1,0 +1,65 @@
+from nicegui import ui
+from nicegui.testing import Screen
+
+
+def test_button_toggle(screen: Screen):
+    result_label = ui.label()
+    toggle = ui.button_toggle(['Option A', 'Option B', 'Option C'],
+                             value='Option A',
+                             on_change=lambda e: result_label.set_text(f'Selected: {e.value}'))
+
+    screen.open('/')
+    screen.should_contain('Selected: Option A')  # Initial value should be displayed
+
+    # Test clicking different options
+    screen.click('Option B')
+    screen.should_contain('Selected: Option B')
+
+    screen.click('Option C')
+    screen.should_contain('Selected: Option C')
+
+    # Test clicking the same option again (should remain selected)
+    screen.click('Option C')
+    screen.should_contain('Selected: Option C')
+
+
+def test_button_toggle_with_dict_options(screen: Screen):
+    result_label = ui.label()
+    toggle = ui.button_toggle([
+        {'label': 'Today', 'value': '1d'},
+        {'label': 'This Week', 'value': '7d'},
+        {'label': 'This Month', 'value': '30d'},
+    ], value='7d', on_change=lambda e: result_label.set_text(f'Selected: {e.value}'))
+
+    screen.open('/')
+    screen.should_contain('Selected: 7d')  # Initial value
+
+    screen.click('Today')
+    screen.should_contain('Selected: 1d')
+
+    screen.click('This Month')
+    screen.should_contain('Selected: 30d')
+
+
+def test_button_toggle_programmatic_control(screen: Screen):
+    result_label = ui.label()
+    toggle = ui.button_toggle(['Red', 'Green', 'Blue'],
+                             value='Red',
+                             on_change=lambda e: result_label.set_text(f'Selected: {e.value}'))
+
+    ui.button('Set Green', on_click=lambda: toggle.set_value('Green'))
+    ui.button('Set Blue', on_click=lambda: toggle.set_value('Blue'))
+
+    screen.open('/')
+    screen.should_contain('Selected: Red')  # Initial value
+
+    # Test programmatic value setting
+    screen.click('Set Green')
+    screen.should_contain('Selected: Green')
+
+    screen.click('Set Blue')
+    screen.should_contain('Selected: Blue')
+
+    # Test manual clicking after programmatic change
+    screen.click('Red')
+    screen.should_contain('Selected: Red')

--- a/tests/test_button_toggle.py
+++ b/tests/test_button_toggle.py
@@ -3,7 +3,7 @@ from nicegui.testing import Screen
 
 
 def test_button_toggle(screen: Screen):
-    result_label = ui.label()
+    result_label = ui.label('Selected: Option A')  # Initialize with the initial value
     ui.button_toggle(['Option A', 'Option B', 'Option C'],
                              value='Option A',
                              on_change=lambda e: result_label.set_text(f'Selected: {e.value}'))
@@ -24,7 +24,7 @@ def test_button_toggle(screen: Screen):
 
 
 def test_button_toggle_with_dict_options(screen: Screen):
-    result_label = ui.label()
+    result_label = ui.label('Selected: 7d')  # Initialize with the initial value
     ui.button_toggle([
         {'label': 'Today', 'value': '1d'},
         {'label': 'This Week', 'value': '7d'},
@@ -42,7 +42,7 @@ def test_button_toggle_with_dict_options(screen: Screen):
 
 
 def test_button_toggle_programmatic_control(screen: Screen):
-    result_label = ui.label()
+    result_label = ui.label('Selected: Red')  # Initialize with the initial value
     toggle = ui.button_toggle(['Red', 'Green', 'Blue'],
                              value='Red',
                              on_change=lambda e: result_label.set_text(f'Selected: {e.value}'))

--- a/tests/test_button_toggle.py
+++ b/tests/test_button_toggle.py
@@ -4,7 +4,7 @@ from nicegui.testing import Screen
 
 def test_button_toggle(screen: Screen):
     result_label = ui.label()
-    toggle = ui.button_toggle(['Option A', 'Option B', 'Option C'],
+    ui.button_toggle(['Option A', 'Option B', 'Option C'],
                              value='Option A',
                              on_change=lambda e: result_label.set_text(f'Selected: {e.value}'))
 
@@ -25,7 +25,7 @@ def test_button_toggle(screen: Screen):
 
 def test_button_toggle_with_dict_options(screen: Screen):
     result_label = ui.label()
-    toggle = ui.button_toggle([
+    ui.button_toggle([
         {'label': 'Today', 'value': '1d'},
         {'label': 'This Week', 'value': '7d'},
         {'label': 'This Month', 'value': '30d'},

--- a/website/documentation/content/button_toggle_documentation.py
+++ b/website/documentation/content/button_toggle_documentation.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+from nicegui import ui
+
+from . import doc
+
+
+# Demo the ButtonToggle component
+@doc.demo(ui.button_toggle)
+def main_demo() -> None:
+    toggle = ui.button_toggle(['Option A', 'Option B', 'Option C'], value='Option A')
+    ui.label().bind_text_from(toggle, 'value', lambda v: f'Selected: {v}')
+
+
+@doc.demo('Custom labels and values', '''
+    You can provide options as dictionaries with separate labels and values.
+''')
+def dict_options() -> None:
+    toggle = ui.button_toggle([
+        {'label': 'Today', 'value': '1d'},
+        {'label': 'This Week', 'value': '7d'},
+        {'label': 'This Month', 'value': '30d'},
+    ], value='7d').props('dense')
+    ui.label().bind_text_from(toggle, 'value', lambda v: f'Selected: {v}')
+
+
+@doc.demo('Toggle styling', '''
+    You can apply the same styling options to a toggle as to a button, like "flat", "outline", "push", ...
+''')
+def styling() -> None:
+    toggle = ui.button_toggle(['Small', 'Medium', 'Large'], value='Medium') \
+        .props('color=secondary toggle-color=positive size=lg flat')
+    ui.label().bind_text_from(toggle, 'value', lambda v: f'Selected: {v}')
+
+
+@doc.demo('Programmatic control', '''
+    You can programmatically change the selected value and get notified of changes.
+''')
+def programmatic_control() -> None:
+    toggle = ui.button_toggle(['Red', 'Green', 'Blue'], value='Red',
+                       on_change=lambda e: ui.notify(f'Selection changed to: {e.value}'))
+
+    with ui.row().classes('gap-2 mt-2'):
+        ui.button('Set to Green', on_click=lambda: toggle.set_value('Green'))
+        ui.button('Set to Blue', on_click=lambda: toggle.set_value('Blue'))
+        ui.button('Get Value', on_click=lambda: ui.notify(f'Current value: {toggle.value}'))
+
+
+doc.reference(ui.button_toggle)

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -205,6 +205,7 @@ def map_of_nicegui():
             - [`ui.badge`](/documentation/badge)
             - [`ui.button`](/documentation/button)
             - [`ui.button_group`](/documentation/button_group)
+            - [`ui.button_toggle`](/documentation/button_toggle)
             - [`ui.card`](/documentation/card), `ui.card_actions`, `ui.card_section`
             - [`ui.carousel`](/documentation/carousel), `ui.carousel_slide`
             - [`ui.chat_message`](/documentation/chat_message)

--- a/website/documentation/content/section_controls.py
+++ b/website/documentation/content/section_controls.py
@@ -3,6 +3,7 @@ from . import (
     button_documentation,
     button_dropdown_documentation,
     button_group_documentation,
+    button_toggle_documentation,
     checkbox_documentation,
     codemirror_documentation,
     chip_documentation,
@@ -30,6 +31,7 @@ doc.title('*Controls*')
 
 doc.intro(button_documentation)
 doc.intro(button_group_documentation)
+doc.intro(button_toggle_documentation)
 doc.intro(button_dropdown_documentation)
 doc.intro(badge_documentation)
 doc.intro(chip_documentation)


### PR DESCRIPTION
### Motivation

Implements quasars [q-btn-toggle](https://quasar.dev/vue-components/button-toggle)

### Implementation

Follow similar implementation as `ui.button_group` but it is a value element.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Example
```py
from nicegui import ui


# Demo the ButtonToggle component
@ui.page("/")
def main():
    ui.label("ui.button_toggle Component Demo").classes("text-2xl font-bold mb-4")

    # Example 1: Simple string options
    ui.label("Example 1: Simple options").classes("text-lg font-semibold mt-4 mb-2")
    toggle1 = ui.button_toggle(
        options=["Option A", "Option B", "Option C"],
        value="Option A",
        on_change=lambda e: result1.set_text(f"Selected: {e.value}"),
    )
    result1 = ui.label("Selected: Option A").classes("mt-2")

    # Example 2: Dict options with different labels and values
    ui.label("Example 2: Custom labels and values").classes(
        "text-lg font-semibold mt-4 mb-2"
    )
    toggle2 = ui.button_toggle(
        options=[
            {"label": "Today", "value": "1d"},
            {"label": "This Week", "value": "7d"},
            {"label": "This Month", "value": "30d"},
        ],
        value="7d",
        on_change=lambda e: result2.set_text(f"Selected: {e.value}"),
    ).props("dense")
    result2 = ui.label("Selected: 7d").classes("mt-2")
```
