### PR TITLE
Fix: Corrected how space key press is checked in the class KeyboardKey of events.py file

### DIFF
--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -249,7 +249,7 @@ class KeyboardKey:
     @property
     def space(self) -> bool:
         """Whether the key is the space key."""
-        return self.name == 'Space'
+        return self.name == ' '
 
     @property
     def page_up(self) -> bool:


### PR DESCRIPTION
### Motivation
Fix for issue [KeyEventArguments.key.space is incorrect #4878](https://github.com/zauberzeug/nicegui/issues/4878)
<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation
in events.py, class KeyboardKey replaced the following:
    @property
    def space(self) -> bool:
        """Whether the key is the space key."""
        return self.name == 'Space'

with this:
    @property
    def space(self) -> bool:
        """Whether the key is the space key."""
        return self.name == ' '

***Note***: We could use `return self.code == 'Space'` as well, but it would be inconsistent with the rest of the class which always uses `return self.name == value`

<!-- What is the concept behind the implementation? How does it work? -->
<!-- Include any important technical decisions or trade-offs made -->

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
