### PR TITLE
Fix deselection of table rows by using the correct row key

### DIFF
--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -82,7 +82,7 @@ class Table(FilterElement, component='table.js'):
                     self.selected.clear()
                 self.selected.extend(e.args['rows'])
             else:
-                self.selected = [row for row in self.selected if row[row_key] not in e.args['keys']]
+                self.selected = [row for row in self.selected if row[self.row_key] not in e.args['keys']]
             self.update()
             arguments = TableSelectionEventArguments(sender=self, client=self.client, selection=self.selected)
             for handler in self._selection_handlers:


### PR DESCRIPTION
### Motivation

Discovered the bug in Issue #4875 where rows in a table can be selected, but not deselected. This is due to the function `handle selection` which refers to the row_key which is given in the initialisation of the table, but if it is assigned afterwards, it does not update in the function. Therefore replacing the row_key with self.row_key, to ensure that the class variable is used.

