### PR TITLE
Use ui.sub_pages to greatly speed up the documentation

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from fastapi.responses import RedirectResponse
 from starlette.middleware.sessions import SessionMiddleware
 
 from nicegui import app, ui
-from website import anti_scroll_hack, documentation, fly, imprint_privacy, main_page, svg
+from website import anti_scroll_hack, documentation, fly, header, imprint_privacy, main_page, svg
 
 # session middleware is required for demo in documentation
 app.add_middleware(SessionMiddleware, secret_key=os.environ.get('NICEGUI_SECRET_KEY', ''))
@@ -32,28 +32,61 @@ async def _post_dark_mode(request: Request) -> None:
 
 
 @ui.page('/')
+@ui.page('{path:path}')
 def _main_page() -> None:
-    main_page.create()
+    ui.context.client.content.classes('p-0 gap-0')
+    header.add_head_html()
+    with ui.left_drawer() \
+        .classes('column no-wrap gap-1 bg-[#eee] dark:bg-[#1b1b1b] mt-[-20px] px-8 py-20') \
+            .style('height: calc(100% + 20px) !important') as menu:
+        tree = ui.tree(documentation.tree.nodes, label_key='title').classes('w-full').props('accordion no-connectors')
+        tree.add_slot('default-header', '''
+                <a :href="'/documentation/' + props.node.id" onclick="event.stopPropagation()">{{ props.node.title }}</a>
+            ''')
+    header.add_header(menu)
+
+    window_state = {'is_desktop': None}
+    ui.on('is_desktop', lambda v: window_state.update(is_desktop=v.args))
+    ui.add_head_html('''<script>
+            const mq = window.matchMedia('(min-width: 1024px)')
+            mq.addEventListener('change', e => emitEvent('is_desktop', e.matches))
+            window.addEventListener('load', () => {
+                emitEvent('is_desktop', mq.matches)
+            })
+        </script>''')
+
+    def _show_menu(path: str) -> bool:
+        if path.startswith('/documentation/'):
+            return window_state['is_desktop'] if window_state['is_desktop'] is not None else menu.value
+        else:
+            return False
+
+    ui.sub_pages({
+        '/': main_page.create,
+        '/documentation': _documentation_page,
+        '/documentation/{name}': lambda name: _documentation_detail_page(name, menu, tree),
+        '/imprint_privacy': imprint_privacy.create,
+    }).classes('mx-auto').bind_path_to(menu, 'value', _show_menu)
 
 
-@ui.page('/documentation')
 def _documentation_page() -> None:
-    documentation.render_page(documentation.registry[''], with_menu=False)
+    documentation.render_page(documentation.registry[''])
 
 
-@ui.page('/documentation/{name}/{_:path}')
-def _documentation_detail_page(name: str) -> Optional[RedirectResponse]:
+def _documentation_detail_page(name: str, menu: ui.left_drawer, tree: ui.tree) -> Optional[RedirectResponse]:
+    tree.expand(documentation.rendering._ancestor_nodes(name))
+    ui.run_javascript(f'''
+        Array.from(getHtmlElement({tree.id}).getElementsByTagName("a"))
+            .find(el => el.innerText.trim() === "{(documentation.registry[name].parts[0].title or '').replace('*', '')}")
+            .scrollIntoView({{block: "center"}});
+    ''')
+
     if name in documentation.registry:
         documentation.render_page(documentation.registry[name])
         return None
     if name in documentation.redirects:
         return RedirectResponse(documentation.redirects[name])
     raise HTTPException(404, f'documentation for "{name}" could not be found')
-
-
-@ui.page('/imprint_privacy')
-def _imprint_privacy() -> None:
-    imprint_privacy.create()
 
 
 @app.get('/status')

--- a/website/documentation/rendering.py
+++ b/website/documentation/rendering.py
@@ -2,7 +2,6 @@ from typing import List
 
 from nicegui import ui
 
-from ..header import add_head_html, add_header
 from ..style import section_heading, subheading
 from .content import DocumentationPage
 from .custom_restructured_text import CustomRestructuredText as custom_restructured_text
@@ -11,31 +10,11 @@ from .reference import generate_class_doc
 from .tree import nodes
 
 
-def render_page(documentation: DocumentationPage, *, with_menu: bool = True) -> None:
+def render_page(documentation: DocumentationPage) -> None:
     """Render the documentation."""
 
-    # menu
-    if with_menu:
-        with ui.left_drawer() \
-                .classes('column no-wrap gap-1 bg-[#eee] dark:bg-[#1b1b1b] mt-[-20px] px-8 py-20') \
-                .style('height: calc(100% + 20px) !important') as menu:
-            tree = ui.tree(nodes, label_key='title').classes('w-full').props('accordion no-connectors')
-            tree.add_slot('default-header', '''
-                <a :href="'/documentation/' + props.node.id" onclick="event.stopPropagation()">{{ props.node.title }}</a>
-            ''')
-            tree.expand(_ancestor_nodes(documentation.name))
-            ui.run_javascript(f'''
-                Array.from(getHtmlElement({tree.id}).getElementsByTagName("a"))
-                    .find(el => el.innerText.trim() === "{(documentation.parts[0].title or '').replace('*', '')}")
-                    .scrollIntoView({{block: "center"}});
-            ''')
-    else:
-        menu = None
+    ui.run_javascript('window.scrollTo({top: 0, left: 0, behavior: "instant"});')
 
-    # header
-    add_head_html()
-    add_header(menu)
-    ui.add_css('html {scroll-behavior: auto}')
     title = (documentation.title or '').replace('*', '')
     ui.page_title('NiceGUI' if not title else title if title.split()[0] == 'NiceGUI' else f'{title} | NiceGUI')
 

--- a/website/header.py
+++ b/website/header.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import Optional
 
 from nicegui import app, ui
 
@@ -22,7 +21,7 @@ def add_head_html() -> None:
         )
 
 
-def add_header(menu: Optional[ui.left_drawer] = None) -> None:
+def add_header(menu: ui.left_drawer) -> None:
     """Create the page header."""
     menu_items = {
         'Installation': '/#installation',
@@ -42,8 +41,7 @@ def add_header(menu: Optional[ui.left_drawer] = None) -> None:
     with ui.header() \
             .classes('items-center duration-200 p-0 px-4 no-wrap') \
             .style('box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1)'):
-        if menu:
-            ui.button(on_click=menu.toggle, icon='menu').props('flat color=white round').classes('lg:hidden')
+        ui.button(on_click=menu.toggle, icon='menu').props('flat color=white round').classes('lg:hidden')
         with ui.link(target='/').classes('row gap-4 items-center no-wrap mr-auto'):
             svg.face().classes('w-8 stroke-white stroke-2 max-[610px]:hidden')
             svg.word().classes('w-24')

--- a/website/main_page.py
+++ b/website/main_page.py
@@ -5,7 +5,6 @@ from nicegui import ui
 
 from . import documentation, example_card, svg
 from .examples import examples
-from .header import add_head_html, add_header
 from .style import example_link, features, heading, link_target, section_heading, subtitle, title
 
 SPONSORS = json.loads((Path(__file__).parent / 'sponsors.json').read_text(encoding='utf-8'))
@@ -13,10 +12,6 @@ SPONSORS = json.loads((Path(__file__).parent / 'sponsors.json').read_text(encodi
 
 def create() -> None:
     """Create the content of the main page."""
-    ui.context.client.content.classes('p-0 gap-0')
-    add_head_html()
-    add_header()
-
     with ui.row().classes('w-full h-screen items-center gap-8 pr-4 no-wrap into-section'):
         svg.face(half=True).classes('stroke-black dark:stroke-white w-[200px] md:w-[230px] lg:w-[300px]')
         with ui.column().classes('gap-4 md:gap-8 pt-32'):


### PR DESCRIPTION
### Motivation

The documentation currently use @ui.page declarations. Due to http and socketio handshakes, content transfer and Quasar app loading, these have a noticeable delay when switching from one page to the next.

### Implementation

This PR uses the new `ui.sub_page` element from #4821 to implement the whole documentation as a single page application. A major difficulty was the left-drawer implementation for the element tree. To decide wether it should be opened or closed is tricky because non-desktop sized screens should never open it automatically. To make it work, I had to send the media breakpoint information to the backend via a custom javascript event.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] The implementation is complete.
  - [ ] fix styling of index page for ultra-wide screens
  - [ ] add url-fragment capabilities to `ui.sub_pages` (in a separate PR)
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
