### PR TITLE
Introduce PageArgs for ui.sub_pages for query parameters and data access

### DIFF
--- a/nicegui/__init__.py
+++ b/nicegui/__init__.py
@@ -5,6 +5,7 @@ from .client import Client
 from .context import context
 from .element_filter import ElementFilter
 from .nicegui import app
+from .page_args import PageArgs
 from .tailwind import Tailwind
 from .version import __version__
 
@@ -13,6 +14,7 @@ __all__ = [
     'App',
     'Client',
     'ElementFilter',
+    'PageArgs',
     'Tailwind',
     '__version__',
     'app',

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -23,6 +23,7 @@ from .javascript_request import JavaScriptRequest
 from .logging import log
 from .observables import ObservableDict
 from .outbox import Outbox
+from .sub_pages_router import SubPagesRouter
 from .translations import translations
 from .version import __version__
 
@@ -87,6 +88,9 @@ class Client:
         self.disconnect_handlers: List[Union[Callable[..., Any], Awaitable]] = []
 
         self._temporary_socket_id: Optional[str] = None
+
+        with self:
+            self.sub_pages_router = SubPagesRouter(request)
 
     @property
     def is_auto_index_client(self) -> bool:

--- a/nicegui/elements/sub_pages.js
+++ b/nicegui/elements/sub_pages.js
@@ -1,25 +1,50 @@
+window.addEventListener("popstate", (event) =>
+  emitEvent(
+    "sub_pages_open",
+    event.state?.page || window.location.pathname + window.location.search + window.location.hash
+  )
+);
+window.addEventListener("pushstate", (event) =>
+  emitEvent(
+    "sub_pages_open",
+    event.state?.page || window.location.pathname + window.location.search + window.location.hash
+  )
+);
+document.addEventListener("click", (e) => {
+  const a = e.target.closest("a[href]");
+  if (a && a.target !== "_blank" && !a.hasAttribute("download")) {
+    const href = a.getAttribute("href");
+    if (href.startsWith("/")) {
+      e.preventDefault();
+
+      const currentPath = window.location.pathname + window.location.search + window.location.hash;
+      const targetUrl = new URL(href, window.location.origin);
+      const targetPath = targetUrl.pathname + targetUrl.search;
+
+      if (currentPath === targetPath && targetUrl.hash) {
+        // Same page, different fragment - handle directly
+        const fragmentName = targetUrl.hash.substring(1);
+        let target = document.getElementById(fragmentName);
+        if (!target) {
+          target = document.querySelector(`a[name="${fragmentName}"]`);
+        }
+        if (target) {
+          target.scrollIntoView({ behavior: "smooth" });
+          // Update URL without triggering page reload
+          history.pushState({ page: href }, "", (window.path_prefix || "") + href);
+          return;
+        }
+      }
+
+      emitEvent("sub_pages_navigate", href);
+    }
+  }
+});
 export default {
   template: `
     <div>
       <slot></slot>
     </div>
   `,
-  mounted() {
-    window.addEventListener("popstate", (event) =>
-      this.$emit("open", event.state?.page || window.location.pathname + window.location.search)
-    );
-    window.addEventListener("pushstate", (event) =>
-      this.$emit("open", event.state?.page || window.location.pathname + window.location.search)
-    );
-    document.addEventListener("click", (e) => {
-      const a = e.target.closest("a[href]");
-      if (a && a.target !== "_blank" && !a.hasAttribute("download")) {
-        const href = a.getAttribute("href");
-        if (href.startsWith("/")) {
-          e.preventDefault();
-          this.$emit("navigate", href);
-        }
-      }
-    });
-  },
+  mounted() {},
 };

--- a/nicegui/elements/sub_pages.js
+++ b/nicegui/elements/sub_pages.js
@@ -5,8 +5,12 @@ export default {
     </div>
   `,
   mounted() {
-    window.addEventListener("popstate", (event) => this.$emit("open", event.state?.page || window.location.pathname));
-    window.addEventListener("pushstate", (event) => this.$emit("open", event.state?.page || window.location.pathname));
+    window.addEventListener("popstate", (event) =>
+      this.$emit("open", event.state?.page || window.location.pathname + window.location.search)
+    );
+    window.addEventListener("pushstate", (event) =>
+      this.$emit("open", event.state?.page || window.location.pathname + window.location.search)
+    );
     document.addEventListener("click", (e) => {
       const a = e.target.closest("a[href]");
       if (a && a.target !== "_blank" && !a.hasAttribute("download")) {

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -195,7 +195,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         for name, param in parameters.items():
             if param.annotation is PageArgs:
                 assert context.client.request
-                kwargs[name] = PageArgs(context.client.request.query_params)
+                kwargs[name] = PageArgs(context.client.request.query_params, self)
             elif route_match.parameters and name in route_match.parameters:
                 kwargs[name] = self._convert_parameter(route_match.parameters[name], param.annotation)
 

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -226,6 +226,8 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
                 kwargs[name] = self._data[name]
             elif route_match.parameters and name in route_match.parameters:
                 kwargs[name] = self._convert_parameter(route_match.parameters[name], param.annotation)
+            elif name in route_match.query_params:
+                kwargs[name] = self._convert_parameter(route_match.query_params[name], param.annotation)
 
         result = route_match.builder(**kwargs)
         if asyncio.iscoroutine(result):

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -216,11 +216,11 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         for name, param in parameters.items():
             if param.annotation is PageArgs:
                 kwargs[name] = PageArgs(
-                    route_match.query_params,
-                    route_match.path,
-                    self,
-                    route_match.parameters or {},
-                    self._data
+                    path=route_match.path,
+                    frame=self,
+                    path_parameters=route_match.parameters or {},
+                    query_parameters=route_match.query_params,
+                    data=self._data
                 )
             elif name in self._data:
                 kwargs[name] = self._data[name]

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -112,7 +112,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         self.show(path)
         run_javascript(f'''
             const fullPath = (window.path_prefix || '') + "{path}";
-            if (window.location.pathname !== fullPath) {{
+            if (window.location.pathname + window.location.search !== fullPath) {{
                 history.pushState({{page: "{path}"}}, "", fullPath);
             }}
         ''')

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -35,17 +35,19 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
     path = BindableProperty(
         on_change=lambda sender, path: cast(SubPages, sender)._handle_path_change(path))  # pylint: disable=protected-access
 
-    def __init__(self, routes: Optional[Dict[str, Callable]] = None, *, root_path: Optional[str] = None) -> None:
+    def __init__(self, routes: Optional[Dict[str, Callable]] = None, *, root_path: Optional[str] = None, data: Optional[Dict[str, Any]] = None) -> None:
         """Sub Pages
 
         Create a sub pages element to handle client-side routing within a page.
 
         :param routes: dictionary mapping sub-page paths to page builder functions
         :param root_path: optional root path to strip from incoming paths (useful for non-root page mounts)
+        :param data: optional dictionary with arbitrary data to be passed to sub-page functions
         """
         super().__init__()
         self._routes = routes or {}
         self._root_path = root_path
+        self._data = data or {}
         self.path = '/'
         self._active_tasks: Set[asyncio.Task] = set()
         self._send_update_on_path_change = True  # standard pattern like for other elements
@@ -198,8 +200,11 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
                 kwargs[name] = PageArgs(
                     context.client.request.query_params,
                     self,
-                    route_match.parameters or {}
+                    route_match.parameters or {},
+                    self._data
                 )
+            elif name in self._data:
+                kwargs[name] = self._data[name]
             elif route_match.parameters and name in route_match.parameters:
                 kwargs[name] = self._convert_parameter(route_match.parameters[name], param.annotation)
 

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -195,7 +195,11 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         for name, param in parameters.items():
             if param.annotation is PageArgs:
                 assert context.client.request
-                kwargs[name] = PageArgs(context.client.request.query_params, self)
+                kwargs[name] = PageArgs(
+                    context.client.request.query_params,
+                    self,
+                    route_match.parameters or {}
+                )
             elif route_match.parameters and name in route_match.parameters:
                 kwargs[name] = self._convert_parameter(route_match.parameters[name], param.annotation)
 

--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -3,7 +3,6 @@ from typing import Any, Callable, Union
 from ..client import Client
 from ..context import context
 from ..element import Element
-from ..elements.sub_pages import SubPages
 from .javascript import run_javascript
 
 
@@ -69,8 +68,8 @@ class Navigate:
             raise TypeError(f'Invalid target type: {type(target)}')
 
         if not new_tab and isinstance(target, str):
-            if SubPages.try_navigate_to(path):
-                return
+            context.client.sub_pages_router._handle_navigate(path)  # pylint: disable=protected-access
+            return
 
         context.client.open(path, new_tab)
 

--- a/nicegui/page_args.py
+++ b/nicegui/page_args.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable, Dict
 
 if TYPE_CHECKING:
     from .elements.sub_pages import SubPages
@@ -9,6 +10,21 @@ if TYPE_CHECKING:
 from starlette.datastructures import QueryParams
 
 from .dataclasses import KWONLY_SLOTS
+
+
+@dataclass(**KWONLY_SLOTS)
+class RouteMatch:
+    """Information about a matched route."""
+    path: str
+    '''The sub-path that actually matched (e.g., "/user/123")'''
+    pattern: str
+    '''The original route pattern (e.g., "/user/{id}")'''
+    builder: Callable
+    '''The function to call to build the page'''
+    parameters: Dict[str, str]
+    '''The extracted parameters (name -> value) from the path (e.g., ``{"id": "123"}``)'''
+    query_params: QueryParams
+    '''The query parameters from the URL'''
 
 
 @dataclass(**KWONLY_SLOTS)
@@ -28,3 +44,60 @@ class PageArgs:
     '''Query parameters from the request URL.'''
     data: dict[str, Any]
     '''Arbitrary data passed to the ui.sub_pages element.'''
+
+    @classmethod
+    def _from_route_match(cls, route_match: RouteMatch, frame: SubPages, data: dict[str, Any]) -> PageArgs:
+        """Create a PageArgs instance from a RouteMatch and SubPages frame.
+
+        :param route_match: The RouteMatch containing path info and parameters
+        :param frame: The SubPages instance currently executing this page
+        :param data: Arbitrary data passed to the sub_pages element
+        :return: A new PageArgs instance
+        """
+        return cls(
+            path=route_match.path,
+            frame=frame,
+            path_parameters=route_match.parameters or {},
+            query_parameters=route_match.query_params,
+            data=data
+        )
+
+    @staticmethod
+    def _convert_parameter(value: str, param_type: type) -> Any:
+        """Convert a string parameter to the specified type (``str``, ``int``, or ``float``).
+
+        :param value: the string value to convert
+        :param param_type: the type to convert to
+        :return: the converted value
+        """
+        if param_type is str or param_type is inspect.Parameter.empty:
+            return value
+        elif param_type is int:
+            return int(value)
+        elif param_type is float:
+            return float(value)
+        return value
+
+    @classmethod
+    def build_kwargs(cls, route_match: RouteMatch, frame: SubPages, data: dict[str, Any]) -> dict[str, Any]:
+        """Build keyword arguments for the route builder function.
+
+        :param route_match: The RouteMatch containing path info and parameters
+        :param frame: The SubPages instance currently executing this page
+        :param data: Arbitrary data passed to the sub_pages element
+        :return: Dictionary of keyword arguments for the builder function
+        """
+        parameters = inspect.signature(route_match.builder).parameters
+        kwargs = {}
+
+        for name, param in parameters.items():
+            if param.annotation is cls:
+                kwargs[name] = cls._from_route_match(route_match, frame, data)
+            elif name in data:
+                kwargs[name] = data[name]
+            elif route_match.parameters and name in route_match.parameters:
+                kwargs[name] = cls._convert_parameter(route_match.parameters[name], param.annotation)
+            elif name in route_match.query_params:
+                kwargs[name] = cls._convert_parameter(route_match.query_params[name], param.annotation)
+
+        return kwargs

--- a/nicegui/page_args.py
+++ b/nicegui/page_args.py
@@ -15,15 +15,17 @@ class PageArgs:
     Can be used as a parameter in sub-page functions and will be automatically injected.
     """
 
-    def __init__(self, query_parameters: QueryParams, frame: SubPages, path_parameters: dict[str, str], data: dict[str, Any]) -> None:
+    def __init__(self, query_parameters: QueryParams, path: str, frame: SubPages, path_parameters: dict[str, str], data: dict[str, Any]) -> None:
         """Initialize PageArgs with query parameters, frame reference, path parameters, and data.
 
         :param query_parameters: Query parameters from the request
+        :param path: Path from the request
         :param frame: Reference to the ui.sub_pages element currently executing
         :param path_parameters: Path parameters extracted from the route pattern
         :param data: Arbitrary data passed to the sub_pages element
         """
         self._query_parameters = query_parameters
+        self._path = path
         self._frame = frame
         self._path_parameters = path_parameters
         self._data = data

--- a/nicegui/page_args.py
+++ b/nicegui/page_args.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -7,57 +8,23 @@ if TYPE_CHECKING:
 
 from starlette.datastructures import QueryParams
 
+from .dataclasses import KWONLY_SLOTS
 
+
+@dataclass(**KWONLY_SLOTS)
 class PageArgs:
     """Container for page arguments like query parameters and path parameters.
 
-    This class provides access to request data for sub-page functions.
-    Can be used as a parameter in sub-page functions and will be automatically injected.
+    This class provides access to request data.
+    It will be automatically injected into a sub-page builder function if the parameter is annotated with ``PageArgs``.
     """
-
-    def __init__(self, query_parameters: QueryParams, path: str, frame: SubPages, path_parameters: dict[str, str], data: dict[str, Any]) -> None:
-        """Initialize PageArgs with query parameters, frame reference, path parameters, and data.
-
-        :param query_parameters: Query parameters from the request
-        :param path: Path from the request
-        :param frame: Reference to the ui.sub_pages element currently executing
-        :param path_parameters: Path parameters extracted from the route pattern
-        :param data: Arbitrary data passed to the sub_pages element
-        """
-        self._query_parameters = query_parameters
-        self._path = path
-        self._frame = frame
-        self._path_parameters = path_parameters
-        self._data = data
-
-    @property
-    def query_parameters(self) -> QueryParams:
-        """Access to query parameters from the request URL.
-
-        :return: QueryParams object containing the query parameters
-        """
-        return self._query_parameters
-
-    @property
-    def frame(self) -> SubPages:
-        """Access to the ui.sub_pages element currently executing this page.
-
-        :return: ui.sub_pages element that is rendering this page
-        """
-        return self._frame
-
-    @property
-    def path_parameters(self) -> dict[str, str]:
-        """Access to path parameters extracted from the route pattern.
-
-        :return: Dictionary containing path parameters as strings
-        """
-        return self._path_parameters
-
-    @property
-    def data(self) -> dict[str, Any]:
-        """Access to arbitrary data passed to the ui.sub_pages element.
-
-        :return: Dictionary containing the data passed to ui.sub_pages
-        """
-        return self._data
+    path: str
+    '''Path from the request.'''
+    frame: SubPages
+    '''Reference to the ui.sub_pages element currently executing this page.'''
+    path_parameters: dict[str, str]
+    '''Path parameters extracted from the route pattern.'''
+    query_parameters: QueryParams
+    '''Query parameters from the request URL.'''
+    data: dict[str, Any]
+    '''Arbitrary data passed to the ui.sub_pages element.'''

--- a/nicegui/page_args.py
+++ b/nicegui/page_args.py
@@ -25,6 +25,19 @@ class RouteMatch:
     '''The extracted parameters (name -> value) from the path (e.g., ``{"id": "123"}``)'''
     query_params: QueryParams
     '''The query parameters from the URL'''
+    fragment: str
+    '''The URL fragment (e.g., "section" from "#section")'''
+
+    @property
+    def full_url(self) -> str:
+        """Get the complete URL including path and query parameters, but excluding fragment.
+
+        Fragments should not trigger page rebuilds, only scrolling behavior.
+        """
+        url = self.path
+        if self.query_params:
+            url += '?' + str(self.query_params)
+        return url
 
 
 @dataclass(**KWONLY_SLOTS)

--- a/nicegui/page_args.py
+++ b/nicegui/page_args.py
@@ -4,12 +4,12 @@ import inspect
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, Union, get_args, get_origin
 
-if TYPE_CHECKING:
-    from .elements.sub_pages import SubPages
-
 from starlette.datastructures import QueryParams
 
 from .dataclasses import KWONLY_SLOTS
+
+if TYPE_CHECKING:
+    from .elements.sub_pages import SubPages
 
 
 @dataclass(**KWONLY_SLOTS)

--- a/nicegui/page_args.py
+++ b/nicegui/page_args.py
@@ -1,7 +1,8 @@
-from typing import TYPE_CHECKING
+from __future__ import annotations
 
-if TYPE_CHECKING:
-    from starlette.datastructures import QueryParams
+from starlette.datastructures import QueryParams
+
+from .elements.sub_pages import SubPages
 
 
 class PageArgs:
@@ -11,17 +12,27 @@ class PageArgs:
     Can be used as a parameter in sub-page functions and will be automatically injected.
     """
 
-    def __init__(self, query_parameters: 'QueryParams') -> None:
-        """Initialize PageArgs with query parameters.
+    def __init__(self, query_parameters: QueryParams, frame: SubPages) -> None:
+        """Initialize PageArgs with query parameters and frame reference.
 
         :param query_parameters: Query parameters from the request
+        :param frame: Reference to the ui.sub_pages element currently executing
         """
         self._query_parameters = query_parameters
+        self._frame = frame
 
     @property
-    def query_parameters(self) -> 'QueryParams':
+    def query_parameters(self) -> QueryParams:
         """Access to query parameters from the request URL.
 
         :return: QueryParams object containing the query parameters
         """
         return self._query_parameters
+
+    @property
+    def frame(self) -> SubPages:
+        """Access to the ui.sub_pages element currently executing this page.
+
+        :return: ui.sub_pages element that is rendering this page
+        """
+        return self._frame

--- a/nicegui/page_args.py
+++ b/nicegui/page_args.py
@@ -1,0 +1,27 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from starlette.datastructures import QueryParams
+
+
+class PageArgs:
+    """Container for page arguments like query parameters.
+
+    This class provides access to request data for sub-page functions.
+    Can be used as a parameter in sub-page functions and will be automatically injected.
+    """
+
+    def __init__(self, query_parameters: 'QueryParams') -> None:
+        """Initialize PageArgs with query parameters.
+
+        :param query_parameters: Query parameters from the request
+        """
+        self._query_parameters = query_parameters
+
+    @property
+    def query_parameters(self) -> 'QueryParams':
+        """Access to query parameters from the request URL.
+
+        :return: QueryParams object containing the query parameters
+        """
+        return self._query_parameters

--- a/nicegui/page_args.py
+++ b/nicegui/page_args.py
@@ -1,25 +1,30 @@
 from __future__ import annotations
 
-from starlette.datastructures import QueryParams
+from typing import TYPE_CHECKING
 
-from .elements.sub_pages import SubPages
+if TYPE_CHECKING:
+    from .elements.sub_pages import SubPages
+
+from starlette.datastructures import QueryParams
 
 
 class PageArgs:
-    """Container for page arguments like query parameters.
+    """Container for page arguments like query parameters and path parameters.
 
     This class provides access to request data for sub-page functions.
     Can be used as a parameter in sub-page functions and will be automatically injected.
     """
 
-    def __init__(self, query_parameters: QueryParams, frame: SubPages) -> None:
-        """Initialize PageArgs with query parameters and frame reference.
+    def __init__(self, query_parameters: QueryParams, frame: SubPages, path_parameters: dict[str, str]) -> None:
+        """Initialize PageArgs with query parameters, frame reference, and path parameters.
 
         :param query_parameters: Query parameters from the request
         :param frame: Reference to the ui.sub_pages element currently executing
+        :param path_parameters: Path parameters extracted from the route pattern
         """
         self._query_parameters = query_parameters
         self._frame = frame
+        self._path_parameters = path_parameters
 
     @property
     def query_parameters(self) -> QueryParams:
@@ -36,3 +41,11 @@ class PageArgs:
         :return: ui.sub_pages element that is rendering this page
         """
         return self._frame
+
+    @property
+    def path_parameters(self) -> dict[str, str]:
+        """Access to path parameters extracted from the route pattern.
+
+        :return: Dictionary containing path parameters as strings
+        """
+        return self._path_parameters

--- a/nicegui/page_args.py
+++ b/nicegui/page_args.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .elements.sub_pages import SubPages
@@ -15,16 +15,18 @@ class PageArgs:
     Can be used as a parameter in sub-page functions and will be automatically injected.
     """
 
-    def __init__(self, query_parameters: QueryParams, frame: SubPages, path_parameters: dict[str, str]) -> None:
-        """Initialize PageArgs with query parameters, frame reference, and path parameters.
+    def __init__(self, query_parameters: QueryParams, frame: SubPages, path_parameters: dict[str, str], data: dict[str, Any]) -> None:
+        """Initialize PageArgs with query parameters, frame reference, path parameters, and data.
 
         :param query_parameters: Query parameters from the request
         :param frame: Reference to the ui.sub_pages element currently executing
         :param path_parameters: Path parameters extracted from the route pattern
+        :param data: Arbitrary data passed to the sub_pages element
         """
         self._query_parameters = query_parameters
         self._frame = frame
         self._path_parameters = path_parameters
+        self._data = data
 
     @property
     def query_parameters(self) -> QueryParams:
@@ -49,3 +51,11 @@ class PageArgs:
         :return: Dictionary containing path parameters as strings
         """
         return self._path_parameters
+
+    @property
+    def data(self) -> dict[str, Any]:
+        """Access to arbitrary data passed to the ui.sub_pages element.
+
+        :return: Dictionary containing the data passed to ui.sub_pages
+        """
+        return self._data

--- a/nicegui/sub_pages_router.py
+++ b/nicegui/sub_pages_router.py
@@ -1,0 +1,51 @@
+from typing import Callable, List, Optional
+
+from fastapi import Request
+
+from .context import context
+from .elements.sub_pages import SubPages
+from .functions.javascript import run_javascript
+from .functions.on import on
+
+
+class SubPagesRouter:
+    def __init__(self, request: Optional[Request]) -> None:
+        on('sub_pages_open', lambda event: self._handle_open(event.args))
+        on('sub_pages_navigate', lambda event: self._handle_navigate(event.args))
+
+        if request is not None:
+            path = str(request.url.path)
+            if request.url.query:
+                path += '?' + request.url.query
+            if request.url.fragment:
+                path += '#' + request.url.fragment
+            self.current_path = path
+        else:
+            self.current_path = '/'
+
+        self.on_path_changed: List[Callable[[str], None]] = []
+
+    def _handle_open(self, path: str) -> bool:
+        self.current_path = path
+        for callback in self.on_path_changed:
+            callback(path)
+        updated = False
+        for sub_pages in tuple(el for el in context.client.layout.descendants() if isinstance(el, SubPages)):
+            try:
+                if sub_pages.show() is not None:
+                    updated = True
+            except ValueError:
+                pass
+        return updated
+
+    def _handle_navigate(self, path: str) -> None:
+        updated = self._handle_open(path)
+        if not updated:
+            context.client.open(path, new_tab=False)
+            return
+        run_javascript(f'''
+            const fullPath = (window.path_prefix || '') + "{self.current_path}";
+            if (window.location.pathname + window.location.search + window.location.hash !== fullPath) {{
+                history.pushState({{page: "{self.current_path}"}}, "", fullPath);
+            }}
+        ''')

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -618,6 +618,14 @@ def test_sub_page_with_query_parameters(screen: Screen):
     screen.should_contain('button=works')
     assert calls == {'index': 1, 'main_content': 3}
 
+    screen.selenium.back()
+    screen.should_contain('link=works')
+    assert calls == {'index': 1, 'main_content': 4}
+
+    screen.selenium.forward()
+    screen.should_contain('button=works')
+    assert calls == {'index': 1, 'main_content': 5}
+
 
 def test_accessing_path_parameters_via_page_args(screen: Screen):
     @ui.page('/')

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -568,11 +568,11 @@ def test_async_sub_pages(screen: Screen):
     def index():
         ui.toggle(['/', '/0.1', '/1.0'], value='/', on_change=lambda e: ui.navigate.to(e.value))
         ui.sub_pages({
-            '/': lambda: main(0),
+            '/': main,
             '/{delay}': lambda delay: main(float(delay)),
         })
 
-    async def main(delay: float):
+    async def main(delay: float = 0):
         ui.label(f'waiting for {delay} sec')
         await asyncio.sleep(delay)
         ui.label(f'after {delay} sec')

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -563,7 +563,7 @@ def test_async_sub_pages(screen: Screen):
     screen.should_not_contain('after 1.0 sec')
 
 
-def test_sub_pages_with_query_parameters(screen: Screen):
+def test_sub_page_with_query_parameters(screen: Screen):
     @ui.page('/')
     def index():
         ui.link('Link to main', '/?link=works')
@@ -581,3 +581,31 @@ def test_sub_pages_with_query_parameters(screen: Screen):
 
     screen.click('Button to main')
     screen.should_contain('button=works')
+
+
+def test_accessing_path_parameters_via_page_args(screen: Screen):
+    @ui.page('/')
+    @ui.page('/{path:path}')
+    def index():
+        ui.link('Link with parameter', '/link')
+        ui.button('Button with parameter', on_click=lambda: ui.navigate.to('/button'))
+        ui.sub_pages({
+            '/': main_content,
+            '/{parameter}': main_content,
+        })
+
+    def main_content(args: PageArgs):
+        param = args.path_parameters.get('parameter', 'none')
+        ui.label(f'param-{param}')
+
+    screen.open('/')
+    screen.should_contain('param-none')
+
+    screen.open('/test')
+    screen.should_contain('param-test')
+
+    screen.click('Link with parameter')
+    screen.should_contain('param-link')
+
+    screen.click('Button with parameter')
+    screen.should_contain('param-button')

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -348,10 +348,10 @@ def test_adding_sub_pages_after_initialization(screen: Screen):
     @ui.page('/sub')
     def index():
         pages = ui.sub_pages()
-        pages.add('/', lambda: main_content(pages))
+        pages.add('/', main_content)
 
-    def main_content(pages: ui.sub_pages):
-        ui.button('Add sub page', on_click=lambda: pages.add('/sub', sub_content))
+    def main_content(args: PageArgs):
+        ui.button('Add sub page', on_click=lambda: args.frame.add('/sub', sub_content))
         ui.button('Go to sub', on_click=lambda: ui.navigate.to('/sub'))
 
     def sub_content():

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -593,23 +593,30 @@ def test_async_sub_pages(screen: Screen):
 
 
 def test_sub_page_with_query_parameters(screen: Screen):
+    calls = {'index': 0, 'main_content': 0}
+
     @ui.page('/')
     def index():
+        calls['index'] += 1
         ui.link('Link to main', '/?link=works')
         ui.button('Button to main', on_click=lambda: ui.navigate.to('/?button=works'))
         ui.sub_pages({'/': main_content})
 
     def main_content(args: PageArgs):
+        calls['main_content'] += 1
         ui.label(str(args.query_parameters))
 
     screen.open('/?query=test')
     screen.should_contain('query=test')
+    assert calls == {'index': 1, 'main_content': 1}
 
     screen.click('Link to main')
     screen.should_contain('link=works')
+    assert calls == {'index': 1, 'main_content': 2}
 
     screen.click('Button to main')
     screen.should_contain('button=works')
+    assert calls == {'index': 1, 'main_content': 3}
 
 
 def test_accessing_path_parameters_via_page_args(screen: Screen):

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 from selenium.webdriver.common.by import By
 
-from nicegui import ui
+from nicegui import PageArgs, ui
 from nicegui.testing import Screen
 
 # pylint: disable=missing-function-docstring
@@ -561,3 +561,23 @@ def test_async_sub_pages(screen: Screen):
     screen.wait(1)
     screen.should_contain('after 0.1 sec')
     screen.should_not_contain('after 1.0 sec')
+
+
+def test_sub_pages_with_query_parameters(screen: Screen):
+    @ui.page('/')
+    def index():
+        ui.link('Link to main', '/?link=works')
+        ui.button('Button to main', on_click=lambda: ui.navigate.to('/?button=works'))
+        ui.sub_pages({'/': main_content})
+
+    def main_content(args: PageArgs):
+        ui.label(str(args.query_parameters))
+
+    screen.open('/?query=test')
+    screen.should_contain('query=test')
+
+    screen.click('Link to main')
+    screen.should_contain('link=works')
+
+    screen.click('Button to main')
+    screen.should_contain('button=works')

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -75,7 +75,7 @@ def test_switching_between_sub_pages(screen: Screen):
     assert path_tracker['path'] == '/b'
 
 
-def test_passing_element_to_sub_page(screen: Screen):
+def test_passing_data_to_sub_page_via_lambda(screen: Screen):
     @ui.page('/')
     @ui.page('/other')
     def index():
@@ -90,6 +90,35 @@ def test_passing_element_to_sub_page(screen: Screen):
         ui.link('Go to other', '/other')
 
     def other(title: ui.label):
+        title.text = 'other title'
+        ui.link('Go to main', '/')
+
+    screen.open('/')
+    screen.should_contain('main title')
+
+    screen.click('Go to other')
+    screen.should_contain('other title')
+
+    screen.click('Go to main')
+    screen.should_contain('main title')
+
+
+def test_passing_data_to_sub_page_via_dict(screen: Screen):
+    @ui.page('/')
+    @ui.page('/other')
+    def index():
+        title = ui.label()
+        ui.sub_pages({
+            '/': main,
+            '/other': other,
+        }, data={'title': title})
+
+    def main(title: ui.label):
+        title.text = 'main title'
+        ui.link('Go to other', '/other')
+
+    def other(args: PageArgs):
+        title: ui.label = args.data['title']
         title.text = 'other title'
         ui.link('Go to main', '/')
 

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -2,9 +2,8 @@ import asyncio
 from typing import Optional
 
 import pytest
-from selenium.webdriver.common.by import By
 
-from nicegui import PageArgs, ui
+from nicegui import PageArgs, background_tasks, ui
 from nicegui.testing import Screen
 
 # pylint: disable=missing-function-docstring
@@ -12,7 +11,6 @@ from nicegui.testing import Screen
 
 def test_switching_between_sub_pages(screen: Screen):
     calls = {'index': 0, 'a': 0, 'b': 0}
-    path_tracker = {'path': '/'}
 
     @ui.page('/')
     @ui.page('/b')
@@ -22,7 +20,7 @@ def test_switching_between_sub_pages(screen: Screen):
         ui.sub_pages({
             '/': sub_page_a,
             '/b': sub_page_b,
-        }).bind_path_to(path_tracker, 'path')
+        })
 
     def sub_page_a():
         calls['a'] += 1
@@ -41,39 +39,35 @@ def test_switching_between_sub_pages(screen: Screen):
     screen.should_contain('Page A')
     screen.should_not_contain('Page B')
     assert calls == {'index': 1, 'a': 1, 'b': 0}
-    assert path_tracker['path'] == '/'
 
     screen.click('Go to B')
     screen.should_contain('Index')
     screen.should_contain('Page B')
     screen.should_not_contain('Page A')
     assert calls == {'index': 1, 'a': 1, 'b': 1}
-    assert path_tracker['path'] == '/b'
 
     screen.selenium.back()
     screen.should_contain('Index')
     screen.should_contain('Page A')
     screen.should_not_contain('Page B')
     assert calls == {'index': 1, 'a': 2, 'b': 1}
-    assert path_tracker['path'] == '/'
 
     screen.selenium.forward()
     screen.should_contain('Index')
     screen.should_contain('Page B')
     screen.should_not_contain('Page A')
     assert calls == {'index': 1, 'a': 2, 'b': 2}
-    assert path_tracker['path'] == '/b'
 
     screen.click('Go to A')
+    screen.should_contain('Page A')
+    assert calls == {'index': 1, 'a': 3, 'b': 2}
     screen.click('Go to B with slash')
     screen.should_contain('Page B')
     assert calls == {'index': 1, 'a': 3, 'b': 3}
-    assert path_tracker['path'] == '/b'
 
     screen.click('Go to B with slash')
     screen.should_contain('Page B')
-    assert calls == {'index': 1, 'a': 3, 'b': 4}
-    assert path_tracker['path'] == '/b'
+    assert calls == {'index': 1, 'a': 3, 'b': 3}, 'no rebuilding if path stays the same'
 
 
 def test_passing_data_to_sub_page_via_lambda(screen: Screen):
@@ -161,38 +155,10 @@ def test_opening_sub_pages_directly(screen: Screen):
     screen.should_not_contain('two')
 
 
-@pytest.mark.parametrize('root', ['/', '/sub'])
-def test_changing_sub_pages_via_binding(screen: Screen, root: str):
-    @ui.page(root)
-    def index():
-        path_input = ui.input('Path', value='/')
-        ui.sub_pages({
-            '/': main,
-            '/other': other,
-        }, root_path=root if root != '/' else None) \
-            .bind_path_from(path_input, 'value')
-
-    def main():
-        ui.label('main page')
-
-    def other():
-        ui.label('other page')
-
-    screen.open(root)
-    screen.should_contain('main page')
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Path"]')
-    element.send_keys('othe')
-    screen.wait(0.3)
-    screen.should_contain(f'404: sub page {root if root != "/" else ""}/othe not found')
-    element.send_keys('r')
-    screen.wait(0.3)
-    screen.should_contain('other page')
-
-
-def test_sub_page_in_sub_page(screen: Screen):
+def test_nested_sub_pages(screen: Screen):
     @ui.page('/')
     @ui.page('/{_:path}')
-    def index(_):
+    def index():
         ui.link('Go to main', '/')
         ui.link('Go to sub', '/sub')
         ui.sub_pages({
@@ -242,6 +208,66 @@ def test_sub_page_in_sub_page(screen: Screen):
 
     screen.open('/sub/a')
     screen.should_contain('sub A page')
+
+
+def test_async_nested_sub_pages(screen: Screen):
+    calls = {
+        'index': 0,
+        'sleep': 0,
+        'sleep_main': 0,
+        'background': 0,
+        'background_main': 0,
+    }
+
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index(_):
+        calls['index'] += 1
+        ui.link('Go to sleep', '/sleep')
+        ui.link('Go to background', '/background')
+        ui.sub_pages({
+            '/sleep': sleep,
+            '/background': background,
+        })
+
+    async def sleep():
+        calls['sleep'] += 1
+        await asyncio.sleep(0.1)
+        ui.sub_pages({'/': sleep_main})
+
+    def background():
+        async def add():
+            await asyncio.sleep(0.05)
+            with content:
+                ui.sub_pages({'/': background_main})
+
+        calls['background'] += 1
+        content = ui.column()
+        background_tasks.create(add(), name='lazy_content')
+
+    def sleep_main():
+        calls['sleep_main'] += 1
+        ui.label('sleep main page')
+
+    def background_main():
+        calls['background_main'] += 1
+        ui.label('background main page')
+
+    screen.open('/sleep')
+    screen.should_contain('sleep main page')
+    assert calls == {'index': 1, 'sleep': 1, 'sleep_main': 1, 'background': 0,  'background_main': 0}
+
+    screen.open('/background')
+    screen.should_contain('background main page')
+    assert calls == {'index': 2, 'sleep': 1, 'sleep_main': 1, 'background': 1, 'background_main': 1}
+
+    screen.click('Go to sleep')
+    screen.should_contain('sleep main page')
+    assert calls == {'index': 2, 'sleep': 2, 'sleep_main': 2, 'background': 1, 'background_main': 1}
+
+    screen.click('Go to background')
+    screen.should_contain('background main page')
+    assert calls == {'index': 2, 'sleep': 2, 'sleep_main': 2, 'background': 2, 'background_main': 2}
 
 
 def test_parameterized_sub_pages(screen: Screen):
@@ -472,10 +498,10 @@ def test_links_pointing_to_path_which_is_not_a_sub_page(screen: Screen):
         ui.sub_pages({'/': main, '/sub': sub})
 
     def main():
-        ui.label('main')
+        ui.label('main page')
 
     def sub():
-        ui.label('sub')
+        ui.label('sub page')
 
     @ui.page('/other')
     def other():
@@ -483,7 +509,7 @@ def test_links_pointing_to_path_which_is_not_a_sub_page(screen: Screen):
 
     screen.open('/')
     screen.click('Go to sub')
-    screen.should_contain('sub')
+    screen.should_contain('sub page')
     assert screen.current_path == '/sub'
 
     screen.click('Go to other')
@@ -708,3 +734,114 @@ def test_page_args_with_optional_parameters(screen: Screen):
     screen.open('/')
     screen.click('Test PageArgs')
     screen.should_contain('path=/user/123, user_id=123, role=admin, app=MyApp')
+
+
+def test_sub_pages_with_url_fragments(screen: Screen):
+    calls = {'index': 0, 'main': 0, 'targets': 0}
+
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index():
+        calls['index'] += 1
+        ui.sub_pages({
+            '/': main,
+            '/page': targets,
+        })
+
+    def main():
+        calls['main'] += 1
+        ui.label('Main page')
+        ui.link('Go to bottom', '/page#bottom')
+
+    def targets():
+        calls['targets'] += 1
+        ui.link_target('top')
+        ui.label('Top target content')
+        ui.link('Go to bottom', '/page#bottom')
+        for i in range(20):
+            ui.label(f'Line {i}').classes('my-5')
+        ui.link_target('bottom')
+        ui.label('Bottom target content')
+        ui.link('Go to top', '/page#top')
+        ui.link('Back to main', '/')
+
+    # Test 1: Direct navigation with fragment should work
+    screen.open('/page#bottom')
+    screen.should_contain('Bottom target content')
+    assert screen.current_path == '/page'
+    screen.wait(1)
+    scroll_y = screen.selenium.execute_script('return window.scrollY')
+    assert scroll_y > 500, 'Expected scrolling to occur for fragment navigation'
+    assert calls == {'index': 1, 'main': 0, 'targets': 1}
+
+    # Test 2: Same-page fragment navigation should not rebuild pages but should work
+    screen.click('Go to top')
+    screen.should_contain('Top target content')
+    screen.wait(1)
+    scroll_y_top = screen.selenium.execute_script('return window.scrollY')
+    assert scroll_y_top < scroll_y, 'Expected scrolling to top to have smaller scroll position'
+    assert calls == {'index': 1, 'main': 0, 'targets': 1}, 'Fragment navigation should not rebuild page'
+
+    # Test 3: Cross-page navigation with fragment
+    screen.click('Back to main')
+    screen.should_contain('Main page')
+    assert screen.current_path == '/'
+    assert calls == {'index': 1, 'main': 1, 'targets': 1}
+
+    # Test 4: Cross-page fragment navigation
+    screen.click('Go to bottom')
+    screen.should_contain('Bottom target content')
+    assert screen.current_path == '/page'
+    screen.wait(1)
+    scroll_y = screen.selenium.execute_script('return window.scrollY')
+    assert scroll_y > 0, 'Expected scrolling after cross-page fragment navigation'
+    assert calls == {'index': 1, 'main': 1, 'targets': 2}
+
+    # Test 5: Fragment navigation again
+    screen.click('Go to top')
+    screen.wait(1)
+    assert calls == {'index': 1, 'main': 1, 'targets': 2}, 'Fragment navigation should not rebuild page'
+
+
+def test_on_path_changed_event(screen: Screen):
+    paths = []
+    calls = {'index': 0, 'main': 0, 'other': 0}
+
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index():
+        calls['index'] += 1
+        ui.sub_pages({
+            '/': main,
+            '/other': other,
+        })
+        ui.context.client.sub_pages_router.on_path_changed.append(paths.append)
+        ui.link('Go to other', '/other')
+
+    def main():
+        calls['main'] += 1
+        ui.label('main page')
+
+    def other():
+        calls['other'] += 1
+        ui.label('other page')
+
+    screen.open('/')
+    screen.should_contain('main page')
+    assert paths == []  # NOTE: initial path is not reported, because the path does not "change" on first load
+    assert calls == {'index': 1, 'main': 1, 'other': 0}
+
+    screen.click('Go to other')
+    screen.should_contain('other page')
+    assert paths == ['/other']
+    assert calls == {'index': 1, 'main': 1, 'other': 1}
+
+    screen.open('/other')
+    screen.should_contain('other page')
+    assert paths == ['/other']
+    assert calls == {'index': 2, 'main': 1, 'other': 2}
+
+    screen.open('/bad_path')
+    screen.should_contain('404: sub page /bad_path not found')
+    assert paths == ['/other']
+    assert calls == {'index': 3, 'main': 1, 'other': 2}

--- a/website/documentation/content/sub_pages_documentation.py
+++ b/website/documentation/content/sub_pages_documentation.py
@@ -38,7 +38,8 @@ def main_demo() -> None:
 
 
 @doc.demo('Passing Parameters to Sub Page', '''
-    If a sub page needs to modify content from its parent, the object can simply be passed in a lambda function.
+    If a sub page needs data from its parent, a dictionary can be passed to the `ui.sub_pages` element.
+    The data will be available as a keyword argument in the sub page function or as `PageArgs` object.
 ''')
 def parameters_demo():
     # @ui.page('/')
@@ -49,9 +50,9 @@ def parameters_demo():
     #         title = ui.label()
     #     ui.separator()
     #     ui.sub_pages({
-    #        '/': lambda: main(title),
-    #        '/other': lambda: other(title),
-    #     })
+    #        '/': main,
+    #        '/other': other,
+    #     }, data={'title': title})
 
     def main(title: ui.label):
         title.text = 'Main page content'
@@ -68,7 +69,7 @@ def parameters_demo():
         ui.label('Title:')
         title = ui.label()
     ui.separator()
-    ui.sub_pages({'/': lambda: main(title), '/other': lambda: other(title)}, root_path='/documentation/sub_pages')
+    ui.sub_pages({'/': main, '/other': other}, root_path='/documentation/sub_pages', data={'title': title})
 
 
 @doc.demo('Async Sub Pages', '''
@@ -159,4 +160,24 @@ def binding_to_sub_pages_demo():
     ui.label().bind_text_from(pages, 'path')
 
 
-doc.reference(ui.sub_pages)
+@doc.demo('Using PageArgs', '''
+          By type-hinting the parameter as `PageArgs`, the sub page builder function gets unified access to
+          query parameters, path parameters, and more.
+''')
+def page_args_demo():
+    from nicegui import PageArgs
+
+    # @ui.page('/')
+    # @ui.page('/{_:path}')
+    # def index():
+    #     ui.link('msg=hello', '/documentation/sub_pages?msg=hello')
+    #     ui.link('msg=world', '/documentation/sub_pages?msg=world')
+    #     ui.sub_pages({'/': main})
+
+    def main(args: PageArgs):
+        ui.label(args.query_parameters.get('msg', 'no message'))
+
+    # END OF DEMO
+    ui.link('msg=hello', '/documentation/sub_pages?msg=hello')
+    ui.link('msg=world', '/documentation/sub_pages?msg=world')
+    ui.sub_pages({'/': main}, root_path='/documentation/sub_pages')

--- a/website/documentation/content/sub_pages_documentation.py
+++ b/website/documentation/content/sub_pages_documentation.py
@@ -139,28 +139,6 @@ def adding_sub_pages_demo() -> None:
     pages.add('/other', lambda: other(footer))
 
 
-@doc.demo('Binding the Path', '''
-    The `ui.sub_pages` element has a `path` property which can be bound to.
-''')
-def binding_to_sub_pages_demo():
-    # @ui.page('/')
-    # @ui.page('/{_:path}') # NOTE: our page should catch all paths
-    # def index():
-    #     toggle = ui.toggle(['/', '/other'], value='/')
-    #     ui.sub_pages({'/': main, '/{name}': main}) \
-    #         .bind_path(toggle, 'value')
-    #     ui.label().bind_text_from(pages, 'path')
-
-    def main(name: str = 'main'):
-        ui.label(name).classes('font-bold')
-
-    # END OF DEMO
-    toggle = ui.toggle(['/', '/other'], value='/')
-    pages = ui.sub_pages({'/': main, '/{name}': main}, root_path='/documentation/sub_pages') \
-        .bind_path(toggle, 'value')
-    ui.label().bind_text_from(pages, 'path')
-
-
 @doc.demo('Using PageArgs', '''
           By type-hinting the parameter as `PageArgs`, the sub page builder function gets unified access to
           query parameters, path parameters, and more.

--- a/website/documentation/content/sub_pages_documentation.py
+++ b/website/documentation/content/sub_pages_documentation.py
@@ -148,7 +148,7 @@ def binding_to_sub_pages_demo():
     # def index():
     #     toggle = ui.toggle(['/', '/other'], value='/')
     #     ui.sub_pages({'/': main, '/{name}': main}) \
-    #         .bind_path_from(toggle, 'value')
+    #         .bind_path(toggle, 'value')
     #     ui.label().bind_text_from(pages, 'path')
 
     def main(name: str = 'main'):
@@ -157,7 +157,7 @@ def binding_to_sub_pages_demo():
     # END OF DEMO
     toggle = ui.toggle(['/', '/other'], value='/')
     pages = ui.sub_pages({'/': main, '/{name}': main}, root_path='/documentation/sub_pages') \
-        .bind_path_from(toggle, 'value')
+        .bind_path(toggle, 'value')
     ui.label().bind_text_from(pages, 'path')
 
 
@@ -169,7 +169,7 @@ def page_args_demo():
     from nicegui import PageArgs
 
     # @ui.page('/')
-    # @ui.page('/{_:path}')
+    # @ui.page('/{_:path}') # NOTE: our page should catch all paths
     # def index():
     #     ui.link('msg=hello', '/documentation/sub_pages?msg=hello')
     #     ui.link('msg=world', '/documentation/sub_pages?msg=world')

--- a/website/documentation/content/sub_pages_documentation.py
+++ b/website/documentation/content/sub_pages_documentation.py
@@ -1,3 +1,4 @@
+from nicegui import PageArgs
 from nicegui import ui
 
 from . import doc
@@ -181,3 +182,8 @@ def page_args_demo():
     ui.link('msg=hello', '/documentation/sub_pages?msg=hello')
     ui.link('msg=world', '/documentation/sub_pages?msg=world')
     ui.sub_pages({'/': main}, root_path='/documentation/sub_pages')
+
+
+doc.reference(ui.sub_pages, title='Reference for ui.sub_pages')
+
+doc.reference(PageArgs, title='Reference for PageArgs')


### PR DESCRIPTION
### Motivation

This PR extends the `ui.sub_pages` functionality from #4821 to support `PageArgs`, enabling sub pages to access query parameters and shared data in a unified style. This is also in preparation for handling url fragments.

### Implementation

- **PageArgs Integration**: Sub page functions can accept a `PageArgs` parameter for unified access to path parameters, query parameters, and shared data
- **Data Sharing**: The `data` parameter in `ui.sub_pages()` allows passing shared objects to sub pages via `PageArgs`
- **Automatic Injection**: As before, builder functions can use type annotated parameter names to automatically receive individual parameters from `PageArgs`.
- **Optional Parameters**: builder functions now also support optional parameters

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
