### PR TITLE
Make ui.sub_pages navigation aware of url fragments

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -23,6 +23,7 @@ from .javascript_request import JavaScriptRequest
 from .logging import log
 from .observables import ObservableDict
 from .outbox import Outbox
+from .sub_pages_router import SubPagesRouter
 from .translations import translations
 from .version import __version__
 
@@ -87,6 +88,9 @@ class Client:
         self.disconnect_handlers: List[Union[Callable[..., Any], Awaitable]] = []
 
         self._temporary_socket_id: Optional[str] = None
+
+        with self:
+            self.sub_pages_router = SubPagesRouter(request)
 
     @property
     def is_auto_index_client(self) -> bool:

--- a/nicegui/elements/sub_pages.js
+++ b/nicegui/elements/sub_pages.js
@@ -1,45 +1,50 @@
+window.addEventListener("popstate", (event) =>
+  emitEvent(
+    "sub_pages_open",
+    event.state?.page || window.location.pathname + window.location.search + window.location.hash
+  )
+);
+window.addEventListener("pushstate", (event) =>
+  emitEvent(
+    "sub_pages_open",
+    event.state?.page || window.location.pathname + window.location.search + window.location.hash
+  )
+);
+document.addEventListener("click", (e) => {
+  const a = e.target.closest("a[href]");
+  if (a && a.target !== "_blank" && !a.hasAttribute("download")) {
+    const href = a.getAttribute("href");
+    if (href.startsWith("/")) {
+      e.preventDefault();
+
+      const currentPath = window.location.pathname + window.location.search + window.location.hash;
+      const targetUrl = new URL(href, window.location.origin);
+      const targetPath = targetUrl.pathname + targetUrl.search;
+
+      if (currentPath === targetPath && targetUrl.hash) {
+        // Same page, different fragment - handle directly
+        const fragmentName = targetUrl.hash.substring(1);
+        let target = document.getElementById(fragmentName);
+        if (!target) {
+          target = document.querySelector(`a[name="${fragmentName}"]`);
+        }
+        if (target) {
+          target.scrollIntoView({ behavior: "smooth" });
+          // Update URL without triggering page reload
+          history.pushState({ page: href }, "", (window.path_prefix || "") + href);
+          return;
+        }
+      }
+
+      emitEvent("sub_pages_navigate", href);
+    }
+  }
+});
 export default {
   template: `
     <div>
       <slot></slot>
     </div>
   `,
-  mounted() {
-    window.addEventListener("popstate", (event) =>
-      this.$emit("open", event.state?.page || window.location.pathname + window.location.search + window.location.hash)
-    );
-    window.addEventListener("pushstate", (event) =>
-      this.$emit("open", event.state?.page || window.location.pathname + window.location.search + window.location.hash)
-    );
-    document.addEventListener("click", (e) => {
-      const a = e.target.closest("a[href]");
-      if (a && a.target !== "_blank" && !a.hasAttribute("download")) {
-        const href = a.getAttribute("href");
-        if (href.startsWith("/")) {
-          e.preventDefault();
-
-          const currentPath = window.location.pathname + window.location.search;
-          const targetUrl = new URL(href, window.location.origin);
-          const targetPath = targetUrl.pathname + targetUrl.search;
-
-          if (currentPath === targetPath && targetUrl.hash) {
-            // Same page, different fragment - handle directly
-            const fragmentName = targetUrl.hash.substring(1);
-            let target = document.getElementById(fragmentName);
-            if (!target) {
-              target = document.querySelector(`a[name="${fragmentName}"]`);
-            }
-            if (target) {
-              target.scrollIntoView({ behavior: "smooth" });
-              // Update URL without triggering page reload
-              history.pushState({ page: href }, "", (window.path_prefix || "") + href);
-              return;
-            }
-          }
-
-          this.$emit("navigate", href);
-        }
-      }
-    });
-  },
+  mounted() {},
 };

--- a/nicegui/elements/sub_pages.js
+++ b/nicegui/elements/sub_pages.js
@@ -6,10 +6,10 @@ export default {
   `,
   mounted() {
     window.addEventListener("popstate", (event) =>
-      this.$emit("open", event.state?.page || window.location.pathname + window.location.search)
+      this.$emit("open", event.state?.page || window.location.pathname + window.location.search + window.location.hash)
     );
     window.addEventListener("pushstate", (event) =>
-      this.$emit("open", event.state?.page || window.location.pathname + window.location.search)
+      this.$emit("open", event.state?.page || window.location.pathname + window.location.search + window.location.hash)
     );
     document.addEventListener("click", (e) => {
       const a = e.target.closest("a[href]");
@@ -17,6 +17,26 @@ export default {
         const href = a.getAttribute("href");
         if (href.startsWith("/")) {
           e.preventDefault();
+
+          const currentPath = window.location.pathname + window.location.search;
+          const targetUrl = new URL(href, window.location.origin);
+          const targetPath = targetUrl.pathname + targetUrl.search;
+
+          if (currentPath === targetPath && targetUrl.hash) {
+            // Same page, different fragment - handle directly
+            const fragmentName = targetUrl.hash.substring(1);
+            let target = document.getElementById(fragmentName);
+            if (!target) {
+              target = document.querySelector(`a[name="${fragmentName}"]`);
+            }
+            if (target) {
+              target.scrollIntoView({ behavior: "smooth" });
+              // Update URL without triggering page reload
+              history.pushState({ page: href }, "", (window.path_prefix || "") + href);
+              return;
+            }
+          }
+
           this.$emit("navigate", href);
         }
       }

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import re
-from typing import Any, Callable, Dict, List, Optional, Set, cast
+from typing import Any, Callable, Dict, Optional, Set
 from urllib.parse import urlparse
 
 from starlette.datastructures import QueryParams
 from typing_extensions import Self
 
 from .. import background_tasks
-from ..binding import BindableProperty, bind, bind_from, bind_to
 from ..context import context
 from ..element import Element
 from ..elements.label import Label
@@ -18,10 +17,13 @@ from ..page_args import PageArgs, RouteMatch
 
 
 class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-pages'):
-    path = BindableProperty(
-        on_change=lambda sender, path: cast(SubPages, sender)._handle_path_change(path))  # pylint: disable=protected-access
-
-    def __init__(self, routes: Optional[Dict[str, Callable]] = None, *, root_path: Optional[str] = None, data: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(
+        self,
+            routes: Optional[Dict[str, Callable]] = None,
+            *,
+            root_path: Optional[str] = None,
+            data: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Sub Pages
 
         Create a sub pages element to handle client-side routing within a page.
@@ -31,16 +33,15 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         :param data: optional dictionary with arbitrary data to be passed to sub-page functions
         """
         super().__init__()
+        self._router = context.client.sub_pages_router
         self._routes = routes or {}
-        self._root_path = root_path
+        parent_sub_pages_element = next((el for el in self.ancestors() if isinstance(el, SubPages)), None)
+        self._root_path = parent_sub_pages_element.full_path if parent_sub_pages_element else root_path
         self._data = data or {}
-        self.path = '/'
         self._active_tasks: Set[asyncio.Task] = set()
-        self._send_update_on_path_change = True  # standard pattern like for other elements
-        self._handle_routes_change()
-        if self._is_root:
-            self.on('open', lambda e: self._show_page_and_update_browser_url(e.args))
-            self.on('navigate', lambda e: self._handle_navigate(e.args))
+        self._send_update_on_path_change = True
+        self._path: Optional[str] = None
+        self.show()
 
     def add(self, path: str, page: Callable) -> Self:
         """Add a new route to the sub pages.
@@ -51,145 +52,112 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         :return: self for method chaining
         """
         self._routes[path] = page
-        self._handle_routes_change()
+        self.show()
         return self
 
-    def show(self, full_path: str) -> Optional[RouteMatch]:
+    def show(self) -> Optional[RouteMatch]:
         """Show the page for the given path.
 
         :param full_path: the path to navigate to (can be empty string for root path; trailing slash is ignored)
+                         If None, the path will be calculated automatically from the current router state
         :return: the RouteMatch object if a route was found and shown, None otherwise
         """
+        match_result = self._find_matching_path()
+        if match_result is not None and match_result.full_url == self._path:
+            self._scroll_to_fragment(match_result.fragment)
+            return match_result
         self._cancel_active_tasks()
         self.clear()
-
-        match_result = self._match_route(full_path)
-        if match_result is None:
-            with self:
-                Label(f'404: sub page {full_path} not found')
-            return None
-
-        self._send_update_on_path_change = False
-        self.path = match_result.path
-        self._send_update_on_path_change = True
         with self:
-            self._place_content(match_result)
-
-        if match_result.fragment:
-            run_javascript(f'''
-                setTimeout(() => {{
-                    let target = document.getElementById("{match_result.fragment}");
-                    if (target)
-                        target.scrollIntoView({{ behavior: "smooth" }});
-                    else
-                        if (target = document.querySelector('a[name="{match_result.fragment}"]'))
-                            target.scrollIntoView({{ behavior: "smooth" }});
-                }}, 100);
-            ''')
-
-        child_sub_pages = SubPages.find_child(self)
-        if child_sub_pages:
-            child_sub_pages.show(full_path[len(match_result.path):])
-
+            if match_result is None:
+                self._show_404()
+                return None
+            self._send_update_on_path_change = False
+            self._path = match_result.full_url
+            self._send_update_on_path_change = True
+            self._show_page(match_result)
         return match_result
 
+    def _show_page(self, match: RouteMatch) -> None:
+        kwargs = PageArgs.build_kwargs(match, self, self._data)
+        result = match.builder(**kwargs)
+        self._scroll_to_fragment(match.fragment)
+        if asyncio.iscoroutine(result):
+            async def background_task():
+                with self:
+                    await result
+            task = background_tasks.create(background_task(), name=f'building sub_page {match.pattern}')
+            self._active_tasks.add(task)
+            task.add_done_callback(self._active_tasks.discard)
+
+    def _show_404(self) -> None:
+        """Show a 404 error message."""
+        with self:
+            Label(f'404: sub page {self._router.current_path} not found')
+
+    @property
+    def full_path(self) -> str:
+        """Get the full path of this SubPages element."""
+        return f'{self._root_path or ""}{self._path or ""}'
+
+    def _find_matching_path(self) -> Optional[RouteMatch]:
+        match: Optional[RouteMatch] = None
+        segments = self._router.current_path.split('/')
+        while segments:
+            path = '/'.join(segments)
+            if not path:
+                break
+            match = self._match_route(path[len(self._root_path or ''):])
+            if match is not None:
+                break
+            segments.pop()
+
+        return match
+
     def _cancel_active_tasks(self) -> None:
-        """Cancel all active async tasks for this SubPages instance."""
         for task in self._active_tasks:
             if not task.done() and not task.cancelled():
                 task.cancel()
         self._active_tasks.clear()
 
-    def _show_page_and_update_browser_url(self, path: str) -> Optional[RouteMatch]:
-        """Show the page and update browser URL.
-
-        :param path: the path to navigate to
-        :return: the RouteMatch object if successful, None if no route was found
-        """
-        match_result = self.show(path)
-        if match_result is None:
-            return None
-
-        # Build full path including root_path
-        if match_result.path == '/' and self._root_path:
-            full_path = self._root_path
-        else:
-            full_path = f'{self._root_path or ""}{match_result.path}'
-
-        if match_result.query_params:
-            full_path += '?' + str(match_result.query_params)
-
-        fragment = f'#{match_result.fragment}' if match_result.fragment else ''
-
-        run_javascript(f'''
-            const fullPath = (window.path_prefix || '') + "{full_path}" + "{fragment}";
-            if (window.location.pathname + window.location.search + window.location.hash !== fullPath) {{
-                history.pushState({{page: "{path}"}}, "", fullPath);
-            }}
-        ''')
-        return match_result
-
-    def _match_route(self, full_path: str) -> Optional[RouteMatch]:
-        """Find the first matching route for a full path (including query params and fragments) with segment dropping.
-
-        :return: RouteMatch object if found, None otherwise
-        """
-        parsed_url = urlparse(full_path)
-        path_only = parsed_url.path
+    def _match_route(self, path: str) -> Optional[RouteMatch]:
+        parsed_url = urlparse(path)
+        path_only = parsed_url.path.rstrip('/')
         query_params = QueryParams(parsed_url.query) if parsed_url.query else QueryParams()
         fragment = parsed_url.fragment
+        if path_only == '':
+            path_only = '/'
 
-        normalized_path = self._normalize_path(path_only)
-        segments = normalized_path.split('/')
-        while segments:
-            sub_path = '/'.join(segments)
-            for route, builder in self._routes.items():
-                matches = self._match_path(route, sub_path)
-                if matches is not None:
-                    return RouteMatch(
-                        path=sub_path,
-                        pattern=route,
-                        builder=builder,
-                        parameters=matches,
-                        query_params=query_params,
-                        fragment=fragment
-                    )
-            segments.pop()
+        for route, builder in self._routes.items():
+            parameters = self._match_path(route, path_only)
+            if parameters is not None:
+                return RouteMatch(
+                    path=path_only,
+                    pattern=route,
+                    builder=builder,
+                    parameters=parameters,
+                    query_params=query_params,
+                    fragment=fragment,
+                )
         return None
 
-    def _handle_routes_change(self) -> None:
-        if self._is_root:
-            assert context.client.request
-            path = str(context.client.request.url.path)
-            if context.client.request.url.query:
-                path += '?' + context.client.request.url.query
-            if context.client.request.url.fragment:
-                path += '#' + context.client.request.url.fragment
-            self._show_page_and_update_browser_url(path)
-
-    def _handle_navigate(self, path: str) -> None:
-        """Handle navigate event from link clicks."""
-        if not self._try_navigate_to(path):
-            context.client.open(path)
-
-    def _normalize_path(self, path: str) -> str:
-        """Normalize the path by trimming root path and handling trailing slashes."""
-        if self._root_path is not None:
-            root = self._root_path.rstrip('/')
-            if path.startswith(root):
-                path = path[len(root):]
-        if path.endswith('/') and path != '/':
-            path = path[:-1]
-        if path == '':
-            path = '/'
-        return path
+    def _scroll_to_fragment(self, fragment: str) -> None:
+        if fragment:
+            run_javascript(f'''
+                console.log('scrolling to fragment', "{fragment}");
+                setTimeout(() => {{
+                    console.log('scrolled to fragment', "{fragment}");
+                    let target = document.getElementById("{fragment}");
+                    if (target)
+                        target.scrollIntoView({{ behavior: "smooth" }});
+                    else
+                        if (target = document.querySelector('a[name="{fragment}"]'))
+                            target.scrollIntoView({{ behavior: "smooth" }});
+                }}, 100);
+            ''')
 
     @staticmethod
     def _match_path(pattern: str, path: str) -> Optional[Dict[str, str]]:
-        """Match a path pattern against an actual path and extract parameters noted with {param} placeholders.
-
-        :return: empty dict for exact matches, parameter dict for parameterized matches, None for no match.
-        """
         if '{' not in pattern:
             return {} if pattern == path else None
 
@@ -208,122 +176,3 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
             if isinstance(parent, SubPages):
                 return False
         return True
-
-    def _place_content(self, route_match: RouteMatch) -> None:
-        kwargs = PageArgs.build_kwargs(route_match, self, self._data)
-        result = route_match.builder(**kwargs)
-
-        if asyncio.iscoroutine(result):
-            async def background_task():
-                with self:
-                    await result
-            task = background_tasks.create(background_task(), name=f'building sub_page {route_match.pattern}')
-            self._active_tasks.add(task)
-            task.add_done_callback(self._active_tasks.discard)
-
-    def _try_navigate_to(self, path: str) -> bool:
-        """Try to handle navigation through ``ui.sub_pages`` system.
-
-        :param path: the path to navigate to
-        :return: ``True`` if handled by ``ui.sub_pages``, ``False`` otherwise
-        """
-        return self._show_page_and_update_browser_url(path) is not None
-
-    @staticmethod
-    def try_navigate_to(path: str) -> bool:
-        """Try to handle navigation through ``ui.sub_pages`` system.
-
-        :param path: the path to navigate to
-        :return: ``True`` if handled by ``ui.sub_pages``, ``False`` otherwise
-        """
-        handled_by_sub_pages = False
-        for sub_page in SubPages.find_roots(context.client.content):
-            if sub_page._try_navigate_to(path):  # pylint: disable=protected-access
-                handled_by_sub_pages = True
-        return handled_by_sub_pages
-
-    @staticmethod
-    def find_roots(element: Element) -> List[SubPages]:
-        """Find all root ``ui.sub_pages`` elements in an element tree.
-
-        :param element: the element to search from
-        :return: list of all root ``ui.sub_pages`` elements found
-        """
-        return [el for el in element.descendants(include_self=True) if isinstance(el, SubPages) and el._is_root]  # pylint: disable=protected-access
-
-    @staticmethod
-    def find_child(element: Element) -> Optional[SubPages]:
-        """Find child ``ui.sub_pages`` element, ensuring only one exists per level.
-
-        :return: the ``ui.sub_pages`` element if found, ``None`` otherwise
-        """
-        return next((el for el in element.descendants() if isinstance(el, SubPages)), None)
-
-    def bind_path_to(self,
-                     target_object: Any,
-                     target_name: str = 'path',
-                     forward: Callable[..., Any] = lambda x: x,
-                     ) -> Self:
-        """Bind the path of this element to the target object's target_name property.
-
-        The binding works one way only, from this element to the target.
-        The update happens immediately and whenever the path changes.
-
-        :param target_object: The object to bind to.
-        :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the path before applying it to the target.
-        """
-        bind_to(self, 'path', target_object, target_name, forward)
-        return self
-
-    def bind_path_from(self,
-                       target_object: Any,
-                       target_name: str = 'path',
-                       backward: Callable[..., Any] = lambda x: x,
-                       ) -> Self:
-        """Bind the path of this element from the target object's target_name property.
-
-        The binding works one way only, from the target to this element.
-        The update happens immediately and whenever the path changes.
-
-        :param target_object: The object to bind from.
-        :param target_name: The name of the property to bind from.
-        :param backward: A function to apply to the path before applying it to this element.
-        """
-        bind_from(self, 'path', target_object, target_name, backward)
-        return self
-
-    def bind_path(self,
-                  target_object: Any,
-                  target_name: str = 'path', *,
-                  forward: Callable[..., Any] = lambda x: x,
-                  backward: Callable[..., Any] = lambda x: x,
-                  ) -> Self:
-        """Bind the path of this element to the target object's target_name property.
-
-        The binding works both ways, from this element to the target and from the target to this element.
-        The update happens immediately and whenever the path changes.
-        The backward binding takes precedence for the initial synchronization.
-
-        :param target_object: The object to bind to.
-        :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the path before applying it to the target.
-        :param backward: A function to apply to the path before applying it to this element.
-        """
-        bind(self, 'path', target_object, target_name, forward=forward, backward=backward)
-        return self
-
-    def set_path(self, path: str) -> None:
-        """Set the path of this element.
-
-        :param path: The new path.
-        """
-        self.path = path
-
-    def _handle_path_change(self, path: str) -> None:
-        """Called when the path changes.
-
-        :param path: The new path.
-        """
-        if self._is_root and self._send_update_on_path_change:
-            self._show_page_and_update_browser_url(f'{self._root_path or ""}{path}')

--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -3,7 +3,6 @@ from typing import Any, Callable, Union
 from ..client import Client
 from ..context import context
 from ..element import Element
-from ..elements.sub_pages import SubPages
 from .javascript import run_javascript
 
 
@@ -69,8 +68,8 @@ class Navigate:
             raise TypeError(f'Invalid target type: {type(target)}')
 
         if not new_tab and isinstance(target, str):
-            if SubPages.try_navigate_to(path):
-                return
+            context.client.sub_pages_router._handle_navigate(path)  # pylint: disable=protected-access
+            return
 
         context.client.open(path, new_tab)
 

--- a/nicegui/page_args.py
+++ b/nicegui/page_args.py
@@ -25,6 +25,8 @@ class RouteMatch:
     '''The extracted parameters (name -> value) from the path (e.g., ``{"id": "123"}``)'''
     query_params: QueryParams
     '''The query parameters from the URL'''
+    fragment: str
+    '''The URL fragment (e.g., "section" from "#section")'''
 
 
 @dataclass(**KWONLY_SLOTS)

--- a/nicegui/page_args.py
+++ b/nicegui/page_args.py
@@ -28,6 +28,17 @@ class RouteMatch:
     fragment: str
     '''The URL fragment (e.g., "section" from "#section")'''
 
+    @property
+    def full_url(self) -> str:
+        """Get the complete URL including path and query parameters, but excluding fragment.
+
+        Fragments should not trigger page rebuilds, only scrolling behavior.
+        """
+        url = self.path
+        if self.query_params:
+            url += '?' + str(self.query_params)
+        return url
+
 
 @dataclass(**KWONLY_SLOTS)
 class PageArgs:

--- a/nicegui/sub_pages_router.py
+++ b/nicegui/sub_pages_router.py
@@ -1,0 +1,51 @@
+from typing import Callable, List, Optional
+
+from fastapi import Request
+
+from .context import context
+from .elements.sub_pages import SubPages
+from .functions.javascript import run_javascript
+from .functions.on import on
+
+
+class SubPagesRouter:
+    def __init__(self, request: Optional[Request]) -> None:
+        on('sub_pages_open', lambda event: self._handle_open(event.args))
+        on('sub_pages_navigate', lambda event: self._handle_navigate(event.args))
+
+        if request is not None:
+            path = str(request.url.path)
+            if request.url.query:
+                path += '?' + request.url.query
+            if request.url.fragment:
+                path += '#' + request.url.fragment
+            self.current_path = path
+        else:
+            self.current_path = '/'
+
+        self.on_path_changed: List[Callable[[str], None]] = []
+
+    def _handle_open(self, path: str) -> bool:
+        self.current_path = path
+        for callback in self.on_path_changed:
+            callback(path)
+        updated = False
+        for sub_pages in tuple(el for el in context.client.layout.descendants() if isinstance(el, SubPages)):
+            try:
+                if sub_pages.show() is not None:
+                    updated = True
+            except ValueError:
+                pass
+        return updated
+
+    def _handle_navigate(self, path: str) -> None:
+        updated = self._handle_open(path)
+        if not updated:
+            context.client.open(path, new_tab=False)
+            return
+        run_javascript(f'''
+            const fullPath = (window.path_prefix || '') + "{self.current_path}";
+            if (window.location.pathname + window.location.search + window.location.hash !== fullPath) {{
+                history.pushState({{page: "{self.current_path}"}}, "", fullPath);
+            }}
+        ''')

--- a/website/documentation/content/sub_pages_documentation.py
+++ b/website/documentation/content/sub_pages_documentation.py
@@ -139,28 +139,6 @@ def adding_sub_pages_demo() -> None:
     pages.add('/other', lambda: other(footer))
 
 
-@doc.demo('Binding the Path', '''
-    The `ui.sub_pages` element has a `path` property which can be bound to.
-''')
-def binding_to_sub_pages_demo():
-    # @ui.page('/')
-    # @ui.page('/{_:path}') # NOTE: our page should catch all paths
-    # def index():
-    #     toggle = ui.toggle(['/', '/other'], value='/')
-    #     ui.sub_pages({'/': main, '/{name}': main}) \
-    #         .bind_path(toggle, 'value')
-    #     ui.label().bind_text_from(pages, 'path')
-
-    def main(name: str = 'main'):
-        ui.label(name).classes('font-bold')
-
-    # END OF DEMO
-    toggle = ui.toggle(['/', '/other'], value='/')
-    pages = ui.sub_pages({'/': main, '/{name}': main}, root_path='/documentation/sub_pages') \
-        .bind_path(toggle, 'value')
-    ui.label().bind_text_from(pages, 'path')
-
-
 @doc.demo('Using PageArgs', '''
           By type-hinting the parameter as `PageArgs`, the sub page builder function gets unified access to
           query parameters, path parameters, and more.


### PR DESCRIPTION
### Motivation

Sub-pages in NiceGUI didn't support URL fragments (e.g., `/page#section`), preventing users from:
- Linking directly to specific sections within sub-pages
- Using `ui.link_target()` elements for in-page navigation
- Proper scroll positioning when navigating with fragments

### Implementation

Building on top of #4905 the implementation was straight forward. Only remark might be the rather large addition to `sub_pages.js` which handles the "same page scrolling" which can and should be fully on the browser side.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
