### PR TITLE
Make binding transform functions optional

### DIFF
--- a/nicegui/elements/mixins/content_element.py
+++ b/nicegui/elements/mixins/content_element.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, cast
+from typing import Any, Callable, Optional, cast
 
 from typing_extensions import Self
 
@@ -19,7 +19,7 @@ class ContentElement(Element):
     def bind_content_to(self,
                         target_object: Any,
                         target_name: str = 'content',
-                        forward: Callable[..., Any] = lambda x: x,
+                        forward: Optional[Callable[[Any], Any]] = None,
                         ) -> Self:
         """Bind the content of this element to the target object's target_name property.
 
@@ -28,7 +28,7 @@ class ContentElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
         """
         bind_to(self, 'content', target_object, target_name, forward)
         return self
@@ -36,7 +36,7 @@ class ContentElement(Element):
     def bind_content_from(self,
                           target_object: Any,
                           target_name: str = 'content',
-                          backward: Callable[..., Any] = lambda x: x,
+                          backward: Optional[Callable[[Any], Any]] = None,
                           ) -> Self:
         """Bind the content of this element from the target object's target_name property.
 
@@ -45,7 +45,7 @@ class ContentElement(Element):
 
         :param target_object: The object to bind from.
         :param target_name: The name of the property to bind from.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind_from(self, 'content', target_object, target_name, backward)
         return self
@@ -53,8 +53,8 @@ class ContentElement(Element):
     def bind_content(self,
                      target_object: Any,
                      target_name: str = 'content', *,
-                     forward: Callable[..., Any] = lambda x: x,
-                     backward: Callable[..., Any] = lambda x: x,
+                     forward: Optional[Callable[[Any], Any]] = None,
+                     backward: Optional[Callable[[Any], Any]] = None,
                      ) -> Self:
         """Bind the content of this element to the target object's target_name property.
 
@@ -64,8 +64,8 @@ class ContentElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind(self, 'content', target_object, target_name, forward=forward, backward=backward)
         return self

--- a/nicegui/elements/mixins/disableable_element.py
+++ b/nicegui/elements/mixins/disableable_element.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, cast
+from typing import Any, Callable, Optional, cast
 
 from typing_extensions import Self
 
@@ -33,7 +33,7 @@ class DisableableElement(Element):
     def bind_enabled_to(self,
                         target_object: Any,
                         target_name: str = 'enabled',
-                        forward: Callable[..., Any] = lambda x: x,
+                        forward: Optional[Callable[[Any], Any]] = None,
                         ) -> Self:
         """Bind the enabled state of this element to the target object's target_name property.
 
@@ -42,7 +42,7 @@ class DisableableElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
         """
         bind_to(self, 'enabled', target_object, target_name, forward)
         return self
@@ -50,7 +50,7 @@ class DisableableElement(Element):
     def bind_enabled_from(self,
                           target_object: Any,
                           target_name: str = 'enabled',
-                          backward: Callable[..., Any] = lambda x: x,
+                          backward: Optional[Callable[[Any], Any]] = None,
                           ) -> Self:
         """Bind the enabled state of this element from the target object's target_name property.
 
@@ -59,7 +59,7 @@ class DisableableElement(Element):
 
         :param target_object: The object to bind from.
         :param target_name: The name of the property to bind from.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind_from(self, 'enabled', target_object, target_name, backward)
         return self
@@ -67,8 +67,8 @@ class DisableableElement(Element):
     def bind_enabled(self,
                      target_object: Any,
                      target_name: str = 'enabled', *,
-                     forward: Callable[..., Any] = lambda x: x,
-                     backward: Callable[..., Any] = lambda x: x,
+                     forward: Optional[Callable[[Any], Any]] = None,
+                     backward: Optional[Callable[[Any], Any]] = None,
                      ) -> Self:
         """Bind the enabled state of this element to the target object's target_name property.
 
@@ -78,8 +78,8 @@ class DisableableElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind(self, 'enabled', target_object, target_name, forward=forward, backward=backward)
         return self

--- a/nicegui/elements/mixins/filter_element.py
+++ b/nicegui/elements/mixins/filter_element.py
@@ -19,7 +19,7 @@ class FilterElement(Element):
     def bind_filter_to(self,
                        target_object: Any,
                        target_name: str = 'filter',
-                       forward: Callable[..., Any] = lambda x: x,
+                       forward: Optional[Callable[[Any], Any]] = None,
                        ) -> Self:
         """Bind the filter of this element to the target object's target_name property.
 
@@ -28,7 +28,7 @@ class FilterElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
         """
         bind_to(self, 'filter', target_object, target_name, forward)
         return self
@@ -36,7 +36,7 @@ class FilterElement(Element):
     def bind_filter_from(self,
                          target_object: Any,
                          target_name: str = 'filter',
-                         backward: Callable[..., Any] = lambda x: x,
+                         backward: Optional[Callable[[Any], Any]] = None,
                          ) -> Self:
         """Bind the filter of this element from the target object's target_name property.
 
@@ -45,7 +45,7 @@ class FilterElement(Element):
 
         :param target_object: The object to bind from.
         :param target_name: The name of the property to bind from.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind_from(self, 'filter', target_object, target_name, backward)
         return self
@@ -53,8 +53,8 @@ class FilterElement(Element):
     def bind_filter(self,
                     target_object: Any,
                     target_name: str = 'filter', *,
-                    forward: Callable[..., Any] = lambda x: x,
-                    backward: Callable[..., Any] = lambda x: x,
+                    forward: Optional[Callable[[Any], Any]] = None,
+                    backward: Optional[Callable[[Any], Any]] = None,
                     ) -> Self:
         """Bind the filter of this element to the target object's target_name property.
 
@@ -64,8 +64,8 @@ class FilterElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind(self, 'filter', target_object, target_name, forward=forward, backward=backward)
         return self

--- a/nicegui/elements/mixins/icon_element.py
+++ b/nicegui/elements/mixins/icon_element.py
@@ -19,7 +19,7 @@ class IconElement(Element):
     def bind_icon_to(self,
                      target_object: Any,
                      target_name: str = 'icon',
-                     forward: Callable[..., Any] = lambda x: x,
+                     forward: Optional[Callable[[Any], Any]] = None,
                      ) -> Self:
         """Bind the icon of this element to the target object's target_name property.
 
@@ -28,7 +28,7 @@ class IconElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
         """
         bind_to(self, 'icon', target_object, target_name, forward)
         return self
@@ -36,7 +36,7 @@ class IconElement(Element):
     def bind_icon_from(self,
                        target_object: Any,
                        target_name: str = 'icon',
-                       backward: Callable[..., Any] = lambda x: x,
+                       backward: Optional[Callable[[Any], Any]] = None,
                        ) -> Self:
         """Bind the icon of this element from the target object's target_name property.
 
@@ -45,7 +45,7 @@ class IconElement(Element):
 
         :param target_object: The object to bind from.
         :param target_name: The name of the property to bind from.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind_from(self, 'icon', target_object, target_name, backward)
         return self
@@ -53,8 +53,8 @@ class IconElement(Element):
     def bind_icon(self,
                   target_object: Any,
                   target_name: str = 'icon', *,
-                  forward: Callable[..., Any] = lambda x: x,
-                  backward: Callable[..., Any] = lambda x: x,
+                  forward: Optional[Callable[[Any], Any]] = None,
+                  backward: Optional[Callable[[Any], Any]] = None,
                   ) -> Self:
         """Bind the icon of this element to the target object's target_name property.
 
@@ -64,8 +64,8 @@ class IconElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind(self, 'icon', target_object, target_name, forward=forward, backward=backward)
         return self

--- a/nicegui/elements/mixins/label_element.py
+++ b/nicegui/elements/mixins/label_element.py
@@ -19,7 +19,7 @@ class LabelElement(Element):
     def bind_label_to(self,
                       target_object: Any,
                       target_name: str = 'label',
-                      forward: Callable[..., Any] = lambda x: x,
+                      forward: Optional[Callable[[Any], Any]] = None,
                       ) -> Self:
         """Bind the label of this element to the target object's target_name property.
 
@@ -28,7 +28,7 @@ class LabelElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
         """
         bind_to(self, 'label', target_object, target_name, forward)
         return self
@@ -36,7 +36,7 @@ class LabelElement(Element):
     def bind_label_from(self,
                         target_object: Any,
                         target_name: str = 'label',
-                        backward: Callable[..., Any] = lambda x: x,
+                        backward: Optional[Callable[[Any], Any]] = None,
                         ) -> Self:
         """Bind the label of this element from the target object's target_name property.
 
@@ -45,7 +45,7 @@ class LabelElement(Element):
 
         :param target_object: The object to bind from.
         :param target_name: The name of the property to bind from.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind_from(self, 'label', target_object, target_name, backward)
         return self
@@ -53,8 +53,8 @@ class LabelElement(Element):
     def bind_label(self,
                    target_object: Any,
                    target_name: str = 'label', *,
-                   forward: Callable[..., Any] = lambda x: x,
-                   backward: Callable[..., Any] = lambda x: x,
+                   forward: Optional[Callable[[Any], Any]] = None,
+                   backward: Optional[Callable[[Any], Any]] = None,
                    ) -> Self:
         """Bind the label of this element to the target object's target_name property.
 
@@ -64,8 +64,8 @@ class LabelElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind(self, 'label', target_object, target_name, forward=forward, backward=backward)
         return self

--- a/nicegui/elements/mixins/name_element.py
+++ b/nicegui/elements/mixins/name_element.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, cast
+from typing import Any, Callable, Optional, cast
 
 from typing_extensions import Self
 
@@ -18,7 +18,7 @@ class NameElement(Element):
     def bind_name_to(self,
                      target_object: Any,
                      target_name: str = 'name',
-                     forward: Callable[..., Any] = lambda x: x,
+                     forward: Optional[Callable[[Any], Any]] = None,
                      ) -> Self:
         """Bind the name of this element to the target object's target_name property.
 
@@ -27,7 +27,7 @@ class NameElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
         """
         bind_to(self, 'name', target_object, target_name, forward)
         return self
@@ -35,7 +35,7 @@ class NameElement(Element):
     def bind_name_from(self,
                        target_object: Any,
                        target_name: str = 'name',
-                       backward: Callable[..., Any] = lambda x: x,
+                       backward: Optional[Callable[[Any], Any]] = None,
                        ) -> Self:
         """Bind the name of this element from the target object's target_name property.
 
@@ -44,7 +44,7 @@ class NameElement(Element):
 
         :param target_object: The object to bind from.
         :param target_name: The name of the property to bind from.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind_from(self, 'name', target_object, target_name, backward)
         return self
@@ -52,8 +52,8 @@ class NameElement(Element):
     def bind_name(self,
                   target_object: Any,
                   target_name: str = 'name', *,
-                  forward: Callable[..., Any] = lambda x: x,
-                  backward: Callable[..., Any] = lambda x: x,
+                  forward: Optional[Callable[[Any], Any]] = None,
+                  backward: Optional[Callable[[Any], Any]] = None,
                   ) -> Self:
         """Bind the name of this element to the target object's target_name property.
 
@@ -63,8 +63,8 @@ class NameElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind(self, 'name', target_object, target_name, forward=forward, backward=backward)
         return self

--- a/nicegui/elements/mixins/selectable_element.py
+++ b/nicegui/elements/mixins/selectable_element.py
@@ -39,7 +39,7 @@ class SelectableElement(Element):
     def bind_selected_to(self,
                          target_object: Any,
                          target_name: str = 'selected',
-                         forward: Callable[..., Any] = lambda x: x,
+                         forward: Optional[Callable[[Any], Any]] = None,
                          ) -> Self:
         """Bind the selection state of this element to the target object's target_name property.
 
@@ -48,7 +48,7 @@ class SelectableElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
         """
         bind_to(self, 'selected', target_object, target_name, forward)
         return self
@@ -56,7 +56,7 @@ class SelectableElement(Element):
     def bind_selected_from(self,
                            target_object: Any,
                            target_name: str = 'selected',
-                           backward: Callable[..., Any] = lambda x: x,
+                           backward: Optional[Callable[[Any], Any]] = None,
                            ) -> Self:
         """Bind the selection state of this element from the target object's target_name property.
 
@@ -65,7 +65,7 @@ class SelectableElement(Element):
 
         :param target_object: The object to bind from.
         :param target_name: The name of the property to bind from.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind_from(self, 'selected', target_object, target_name, backward)
         return self
@@ -73,8 +73,8 @@ class SelectableElement(Element):
     def bind_selected(self,
                       target_object: Any,
                       target_name: str = 'selected', *,
-                      forward: Callable[..., Any] = lambda x: x,
-                      backward: Callable[..., Any] = lambda x: x,
+                      forward: Optional[Callable[[Any], Any]] = None,
+                      backward: Optional[Callable[[Any], Any]] = None,
                       ) -> Self:
         """Bind the selection state of this element to the target object's target_name property.
 
@@ -84,8 +84,8 @@ class SelectableElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind(self, 'selected', target_object, target_name, forward=forward, backward=backward)
         return self

--- a/nicegui/elements/mixins/source_element.py
+++ b/nicegui/elements/mixins/source_element.py
@@ -24,7 +24,7 @@ class SourceElement(Element):
     def bind_source_to(self,
                        target_object: Any,
                        target_name: str = 'source',
-                       forward: Callable[..., Any] = lambda x: x,
+                       forward: Optional[Callable[[Any], Any]] = None,
                        ) -> Self:
         """Bind the source of this element to the target object's target_name property.
 
@@ -33,7 +33,7 @@ class SourceElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
         """
         bind_to(self, 'source', target_object, target_name, forward)
         return self
@@ -41,7 +41,7 @@ class SourceElement(Element):
     def bind_source_from(self,
                          target_object: Any,
                          target_name: str = 'source',
-                         backward: Callable[..., Any] = lambda x: x,
+                         backward: Optional[Callable[[Any], Any]] = None,
                          ) -> Self:
         """Bind the source of this element from the target object's target_name property.
 
@@ -50,7 +50,7 @@ class SourceElement(Element):
 
         :param target_object: The object to bind from.
         :param target_name: The name of the property to bind from.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind_from(self, 'source', target_object, target_name, backward)
         return self
@@ -58,8 +58,8 @@ class SourceElement(Element):
     def bind_source(self,
                     target_object: Any,
                     target_name: str = 'source', *,
-                    forward: Callable[..., Any] = lambda x: x,
-                    backward: Callable[..., Any] = lambda x: x,
+                    forward: Optional[Callable[[Any], Any]] = None,
+                    backward: Optional[Callable[[Any], Any]] = None,
                     ) -> Self:
         """Bind the source of this element to the target object's target_name property.
 
@@ -69,8 +69,8 @@ class SourceElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind(self, 'source', target_object, target_name, forward=forward, backward=backward)
         return self

--- a/nicegui/elements/mixins/text_element.py
+++ b/nicegui/elements/mixins/text_element.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, cast
+from typing import Any, Callable, Optional, cast
 
 from typing_extensions import Self
 
@@ -18,7 +18,7 @@ class TextElement(Element):
     def bind_text_to(self,
                      target_object: Any,
                      target_name: str = 'text',
-                     forward: Callable[..., Any] = lambda x: x,
+                     forward: Optional[Callable[[Any], Any]] = None,
                      ) -> Self:
         """Bind the text of this element to the target object's target_name property.
 
@@ -27,7 +27,7 @@ class TextElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
         """
         bind_to(self, 'text', target_object, target_name, forward)
         return self
@@ -35,7 +35,7 @@ class TextElement(Element):
     def bind_text_from(self,
                        target_object: Any,
                        target_name: str = 'text',
-                       backward: Callable[..., Any] = lambda x: x,
+                       backward: Optional[Callable[[Any], Any]] = None,
                        ) -> Self:
         """Bind the text of this element from the target object's target_name property.
 
@@ -44,7 +44,7 @@ class TextElement(Element):
 
         :param target_object: The object to bind from.
         :param target_name: The name of the property to bind from.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind_from(self, 'text', target_object, target_name, backward)
         return self
@@ -52,8 +52,8 @@ class TextElement(Element):
     def bind_text(self,
                   target_object: Any,
                   target_name: str = 'text', *,
-                  forward: Callable[..., Any] = lambda x: x,
-                  backward: Callable[..., Any] = lambda x: x,
+                  forward: Optional[Callable[[Any], Any]] = None,
+                  backward: Optional[Callable[[Any], Any]] = None,
                   ) -> Self:
         """Bind the text of this element to the target object's target_name property.
 
@@ -63,8 +63,8 @@ class TextElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind(self, 'text', target_object, target_name, forward=forward, backward=backward)
         return self

--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -49,7 +49,7 @@ class ValueElement(Element):
     def bind_value_to(self,
                       target_object: Any,
                       target_name: str = 'value',
-                      forward: Callable[..., Any] = lambda x: x,
+                      forward: Optional[Callable[[Any], Any]] = None,
                       ) -> Self:
         """Bind the value of this element to the target object's target_name property.
 
@@ -58,7 +58,7 @@ class ValueElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
         """
         bind_to(self, 'value', target_object, target_name, forward)
         return self
@@ -66,7 +66,7 @@ class ValueElement(Element):
     def bind_value_from(self,
                         target_object: Any,
                         target_name: str = 'value',
-                        backward: Callable[..., Any] = lambda x: x,
+                        backward: Optional[Callable[[Any], Any]] = None,
                         ) -> Self:
         """Bind the value of this element from the target object's target_name property.
 
@@ -75,7 +75,7 @@ class ValueElement(Element):
 
         :param target_object: The object to bind from.
         :param target_name: The name of the property to bind from.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind_from(self, 'value', target_object, target_name, backward)
         return self
@@ -83,8 +83,8 @@ class ValueElement(Element):
     def bind_value(self,
                    target_object: Any,
                    target_name: str = 'value', *,
-                   forward: Callable[..., Any] = lambda x: x,
-                   backward: Callable[..., Any] = lambda x: x,
+                   forward: Optional[Callable[[Any], Any]] = None,
+                   backward: Optional[Callable[[Any], Any]] = None,
                    ) -> Self:
         """Bind the value of this element to the target object's target_name property.
 
@@ -94,8 +94,8 @@ class ValueElement(Element):
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         """
         bind(self, 'value', target_object, target_name, forward=forward, backward=backward)
         return self

--- a/nicegui/elements/mixins/visibility.py
+++ b/nicegui/elements/mixins/visibility.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 from typing_extensions import Self
 
@@ -27,7 +27,7 @@ class Visibility:
     def bind_visibility_to(self,
                            target_object: Any,
                            target_name: str = 'visible',
-                           forward: Callable[..., Any] = lambda x: x,
+                           forward: Optional[Callable[[Any], Any]] = None,
                            ) -> Self:
         """Bind the visibility of this element to the target object's target_name property.
 
@@ -36,7 +36,7 @@ class Visibility:
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
         """
         bind_to(self, 'visible', target_object, target_name, forward)
         return self
@@ -44,7 +44,7 @@ class Visibility:
     def bind_visibility_from(self,
                              target_object: Any,
                              target_name: str = 'visible',
-                             backward: Callable[..., Any] = lambda x: x, *,
+                             backward: Optional[Callable[[Any], Any]] = None, *,
                              value: Any = None) -> Self:
         """Bind the visibility of this element from the target object's target_name property.
 
@@ -53,7 +53,7 @@ class Visibility:
 
         :param target_object: The object to bind from.
         :param target_name: The name of the property to bind from.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         :param value: If specified, the element will be visible only when the target value is equal to this value.
         """
         if value is not None:
@@ -65,8 +65,8 @@ class Visibility:
     def bind_visibility(self,
                         target_object: Any,
                         target_name: str = 'visible', *,
-                        forward: Callable[..., Any] = lambda x: x,
-                        backward: Callable[..., Any] = lambda x: x,
+                        forward: Optional[Callable[[Any], Any]] = None,
+                        backward: Optional[Callable[[Any], Any]] = None,
                         value: Any = None,
                         ) -> Self:
         """Bind the visibility of this element to the target object's target_name property.
@@ -77,8 +77,8 @@ class Visibility:
 
         :param target_object: The object to bind to.
         :param target_name: The name of the property to bind to.
-        :param forward: A function to apply to the value before applying it to the target.
-        :param backward: A function to apply to the value before applying it to this element.
+        :param forward: A function to apply to the value before applying it to the target (default: identity).
+        :param backward: A function to apply to the value before applying it to this element (default: identity).
         :param value: If specified, the element will be visible only when the target value is equal to this value.
         """
         if value is not None:


### PR DESCRIPTION
### Motivation

I noticed that the `bind_to` and `bind_from` functions in the binding module require the user to specify transform functions - in contrast to the two-way `bind` which defaults to identity functions `lambda x: x`. (Note that the user usually uses special binding methods like `bind_value` or `bind_text`, so this deficit remained unnoticed for a while.)
Apart from that it would be more efficient to allow `transform=None` and skip the function call in this case.

### Implementation

This PR makes all binding transform functions `Optional` and sets the default `None`. The docstrings are updated to mention the default behavior.
When using transform functions in binding.py, the possible is value `None` is handled with an extra if-condition.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
