### PR TITLE
`ui.code` drop `on_connect` by defining class using JS dynamically

### DIFF
--- a/nicegui/elements/code.py
+++ b/nicegui/elements/code.py
@@ -25,7 +25,7 @@ class Code(ContentElement, default_classes='nicegui-code'):
         super().__init__(content=remove_indentation(content))
 
         with self:
-            self.markdown = markdown().classes('overflow-auto') \
+            self.markdown = markdown().classes('overflow-auto nicegui-invisible-if-no-clipboard') \
                 .bind_content_from(self, 'content', lambda content: f'```{language}\n{content}\n```')
             self.copy_button = button(icon='content_copy', on_click=self.show_checkmark) \
                 .props('round flat size=sm').classes('absolute right-2 top-2 opacity-20 hover:opacity-80') \
@@ -34,10 +34,6 @@ class Code(ContentElement, default_classes='nicegui-code'):
         self._last_scroll: float = 0.0
         self.markdown.on('scroll', self._handle_scroll)
         timer(0.1, self._update_copy_button)
-
-        self.client.on_connect(lambda: self.client.run_javascript(f'''
-            if (!navigator.clipboard) getHtmlElement({self.copy_button.id}).style.display = 'none';
-        '''))
 
     async def show_checkmark(self) -> None:
         """Show a checkmark icon for 3 seconds."""

--- a/nicegui/elements/code.py
+++ b/nicegui/elements/code.py
@@ -25,10 +25,10 @@ class Code(ContentElement, default_classes='nicegui-code'):
         super().__init__(content=remove_indentation(content))
 
         with self:
-            self.markdown = markdown().classes('overflow-auto nicegui-invisible-if-no-clipboard') \
+            self.markdown = markdown().classes('overflow-auto') \
                 .bind_content_from(self, 'content', lambda content: f'```{language}\n{content}\n```')
             self.copy_button = button(icon='content_copy', on_click=self.show_checkmark) \
-                .props('round flat size=sm').classes('absolute right-2 top-2 opacity-20 hover:opacity-80') \
+                .props('round flat size=sm').classes('absolute right-2 top-2 opacity-20 hover:opacity-80 nicegui-invisible-if-no-clipboard') \
                 .on('click', js_handler=f'() => navigator.clipboard.writeText({json.dumps(self.content)})')
 
         self._last_scroll: float = 0.0

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -449,3 +449,11 @@ for (let sheet of document.styleSheets) {
     }
   }
 }
+
+// if no clipboard, we set class nicegui-invisible-if-no-clipboard class, display:none
+if (!navigator.clipboard) {
+  const style = document.createElement("style");
+  style.innerHTML = ".nicegui-invisible-if-no-clipboard { display: none; }";
+  document.head.appendChild(style);
+  document.documentElement.classList.add("nicegui-invisible-if-no-clipboard");
+}

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -450,9 +450,11 @@ for (let sheet of document.styleSheets) {
   }
 }
 
-// if no clipboard, we set class nicegui-invisible-if-no-clipboard class, display:none
-if (!navigator.clipboard) {
-  const style = document.createElement("style");
-  style.innerHTML = ".nicegui-invisible-if-no-clipboard { display: none; }";
-  document.head.appendChild(style);
-}
+// Run after body loaded: if no clipboard, set class nicegui-invisible-if-no-clipboard to display:none
+window.addEventListener('DOMContentLoaded', () => {
+  if (!navigator.clipboard) {
+    const style = document.createElement("style");
+    style.innerHTML = ".nicegui-invisible-if-no-clipboard { display: none; }";
+    document.head.appendChild(style);
+  }
+});

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -455,5 +455,4 @@ if (!navigator.clipboard) {
   const style = document.createElement("style");
   style.innerHTML = ".nicegui-invisible-if-no-clipboard { display: none; }";
   document.head.appendChild(style);
-  document.documentElement.classList.add("nicegui-invisible-if-no-clipboard");
 }


### PR DESCRIPTION
### Motivation

This PR fix #4912 by not using `self.client.on_connect`, which is know to cause memory leak as it adds a lambda to `Client.connect_handlers` list, but that lambda is never deleted at all. 

### Implementation

To achieve the original functionality of "hide copy button if no `navigator.clipboard`, this PR defines `nicegui-invisible-if-no-clipboard` dynamically via JS in `nicegui.js`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are impossible? (how can we test for memory leak?)
- [x] Documentation is not necessary. 
