### PR TITLE
Avoid duplicate values in `ui.select` in "add-unique" mode

### DIFF
--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -93,6 +93,14 @@ class Select(LabelElement, ValidationElement, ChoiceElement, DisableableElement,
             if e.args is None:
                 return []
             else:
+                if self._props.get('new-value-mode') == 'add-unique':
+                    # handle issue #4896: eliminate duplicate arguments
+                    for arg1 in [a for a in e.args if isinstance(a, str)]:
+                        for arg2 in [a for a in e.args if isinstance(a, dict)]:
+                            if arg1 == arg2['label']:
+                                e.args.remove(arg1)
+                                e.args.remove(arg2)
+                                break
                 args = [self._values[arg['value']] if isinstance(arg, dict) else arg for arg in e.args]
                 for arg in e.args:
                     if isinstance(arg, str):

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -89,6 +89,7 @@ class Select(LabelElement, ValidationElement, ChoiceElement, DisableableElement,
         return self._is_showing_popup
 
     def _event_args_to_value(self, e: GenericEventArguments) -> Any:
+        # pylint: disable=too-many-nested-blocks
         if self.multiple:
             if e.args is None:
                 return []

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -100,7 +100,6 @@ class Select(LabelElement, ValidationElement, ChoiceElement, DisableableElement,
                         for arg2 in [a for a in e.args if isinstance(a, dict)]:
                             if arg1 == arg2['label']:
                                 e.args.remove(arg1)
-                                e.args.remove(arg2)
                                 break
                 args = [self._values[arg['value']] if isinstance(arg, dict) else arg for arg in e.args]
                 for arg in e.args:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -132,7 +132,7 @@ def test_add_new_values(screen:  Screen, option_dict: bool, multiple: bool, new_
             screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd'}" if option_dict else
                                   "options = ['a', 'b', 'c', 'd', 'd']")
         elif new_value_mode == 'add-unique':
-            screen.should_contain("value = ['a', 'd', 'd']" if multiple else 'value = d')
+            screen.should_contain("value = ['a']" if multiple else 'value = d')
             screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd'}" if option_dict else
                                   "options = ['a', 'b', 'c', 'd']")
         elif new_value_mode == 'toggle':

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -132,7 +132,7 @@ def test_add_new_values(screen:  Screen, option_dict: bool, multiple: bool, new_
             screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd'}" if option_dict else
                                   "options = ['a', 'b', 'c', 'd', 'd']")
         elif new_value_mode == 'add-unique':
-            screen.should_contain("value = ['a']" if multiple else 'value = d')
+            screen.should_contain("value = ['a', 'd']" if multiple else 'value = d')
             screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd'}" if option_dict else
                                   "options = ['a', 'b', 'c', 'd']")
         elif new_value_mode == 'toggle':


### PR DESCRIPTION
### Motivation

In #4896 we noticed that there is a way to get duplicate values in `ui.select` even when using the "add-unique" mode:

```py
label = ui.label()
ui.select([], new_value_mode='add-unique', multiple=True).props('use-chips') \
    .bind_value_to(label, 'text', lambda x: ', '.join(x))
```

1. Type "abc"
2. Press Enter
3. Type "abc"
4. Close the popup by clicking on the arrow
5. Press Enter

### Implementation

By analyzing the received event arguments containing the existing selection `{"value": 0, "label": "abc"}` as well as the typed input `"abc"`, we can find and eliminate such duplicates before treating them as new values.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been updated.
- [x] Documentation is not necessary.
