### PR TITLE
Clean up dependencies in pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -408,7 +408,7 @@ version = "3.4.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de"},
     {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176"},
@@ -3385,7 +3385,7 @@ version = "2.32.4"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c"},
     {file = "requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"},
@@ -3819,7 +3819,7 @@ version = "2.2.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
 markers = "python_version == \"3.8\""
 files = [
     {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
@@ -3841,7 +3841,7 @@ version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["dev"]
 markers = "python_version >= \"3.9\""
 files = [
     {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
@@ -4420,4 +4420,4 @@ sass = ["libsass"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8"
-content-hash = "ffe9ba78e0412d800856f36a6f97bfeb7930e768b01e3e87a1f3fabf4599cca0"
+content-hash = "725e82c8da6187e56fc6f1bd28f2e24df538b487f417a47cb4f3bdf27fa8a950"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,28 +20,26 @@ starlette = [
 uvicorn = {extras = ["standard"], version = ">=0.22.0"}
 fastapi = ">=0.109.1"
 python-socketio = {extras = ["asyncio-client"], version = ">=5.10.0"} # version min: see https://github.com/zauberzeug/nicegui/issues/1809
-python-engineio = ">=4.12.0"  # https://github.com/zauberzeug/nicegui/issues/4602
 vbuild = ">=0.8.2"
-watchfiles = ">=0.18.1"
 jinja2 = "^3.1.6" # https://github.com/zauberzeug/nicegui/security/dependabot/44
 python-multipart = ">=0.0.18"
 orjson = {version = ">=3.9.15", markers = "platform_machine != 'i386' and platform_machine != 'i686'"} # https://github.com/zauberzeug/nicegui/security/dependabot/29, orjson does not support 32bit
 itsdangerous = "^2.1.2"
 aiofiles = ">=23.1.0"
+httpx = ">=0.24.0"
+ifaddr = ">=0.2.0"
+docutils = ">=0.19.0"
 pywebview = { version = "^5.0.1", optional = true }
 plotly = { version = ">=5.13,<7.0", optional = true }
 matplotlib = { version = "^3.5.0", optional = true }
-httpx = ">=0.24.0"
 nicegui-highcharts = { version = "^2.0.2", optional = true }
-ifaddr = ">=0.2.0"
-aiohttp = ">=3.10.2" # https://github.com/zauberzeug/nicegui/security/dependabot/36
 libsass = { version = "^0.23.0", optional = true }
-docutils = ">=0.19.0"
-requests = ">=2.32.4" # https://github.com/zauberzeug/nicegui/security/dependabot/46
-urllib3 = ">=1.26.18,!=2.0.0,!=2.0.1,!=2.0.2,!=2.0.3,!=2.0.4,!=2.0.5,!=2.0.6,!=2.0.7,!=2.1.0,!=2.2.0,!=2.2.1" # https://github.com/zauberzeug/nicegui/security/dependabot/34
-certifi = ">=2024.07.04" # https://github.com/zauberzeug/nicegui/security/dependabot/35
 redis = { version = ">=4.0.0", optional = true }
-h11 = ">=0.16.0" # https://github.com/zauberzeug/nicegui/security/dependabot/45
+watchfiles = ">=0.18.1" # transitive, used by uvicorn
+h11 = ">=0.16.0" # transitive, pinned to https://github.com/zauberzeug/nicegui/security/dependabot/45
+python-engineio = ">=4.12.0"  # transitive, pinned to address https://github.com/zauberzeug/nicegui/issues/4602
+aiohttp = ">=3.10.2" # transitive, pinned to address https://github.com/zauberzeug/nicegui/security/dependabot/36
+certifi = ">=2024.07.04" # transitive, pinned to address https://github.com/zauberzeug/nicegui/security/dependabot/35
 
 [tool.poetry.extras]
 native = ["pywebview"]
@@ -50,6 +48,7 @@ matplotlib = ["matplotlib"]
 highcharts = ["nicegui-highcharts"]
 sass = ["libsass"]
 redis = ["redis"]
+
 [tool.poetry.group.dev.dependencies]
 autopep8 = ">=1.5.7,<3.0.0"
 debugpy = "^1.3.0"
@@ -57,6 +56,8 @@ pytest-selenium = "^4.1.0"
 pytest-asyncio = ">=0.23.0"
 pytest-watcher = "^0.4.2"
 pytest = "^8.2.2"
+requests = ">=2.32.4" # https://github.com/zauberzeug/nicegui/security/dependabot/46
+urllib3 = ">=1.26.18,!=2.0.0,!=2.0.1,!=2.0.2,!=2.0.3,!=2.0.4,!=2.0.5,!=2.0.6,!=2.0.7,!=2.1.0,!=2.2.0,!=2.2.1" # transitive, pinned to address https://github.com/zauberzeug/nicegui/security/dependabot/34
 itsdangerous = "^2.1.2" # required by SessionMiddleware (see https://fastapi.tiangolo.com/?h=itsdangerous#optional-dependencies)
 pandas = [
     {version = "^2.0.0", python = "<3.13"},


### PR DESCRIPTION
### Motivation

In #4917 we noticed that some dependencies are not needed for the main package and can be moved to the dev group.

### Implementation

This PR
- moves the requests and urllib3 packages to the section of dev dependencies,
- moves transitive packages to the bottom and marks them as such with a comment,
- updates the lock file.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] Do we still need itsdangerous (in pyproject and Docker files)? FastAPI doesn't mention it anymore.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
