### PR TITLE
Generating multiple values for `ui.select`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,8 @@ jobs:
           poetry run pip install -r tests/requirements.txt
           # try fix issue with importlib_resources
           poetry run pip install importlib-resources
-      - name: test startup
-        run: poetry run ./test_startup.sh
+      # - name: test startup
+      #   run: poetry run ./test_startup.sh
       - name: setup chromedriver
         uses: nanasess/setup-chromedriver@v2.3.0
       - name: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: setup chromedriver
         uses: nanasess/setup-chromedriver@v2.3.0
       - name: pytest
-        run: poetry run pytest
+        run: poetry run pytest tests/test_select.py
 
   slack:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,12 @@ jobs:
           poetry run pip install -r tests/requirements.txt
           # try fix issue with importlib_resources
           poetry run pip install importlib-resources
-      # - name: test startup
-      #   run: poetry run ./test_startup.sh
+      - name: test startup
+        run: poetry run ./test_startup.sh
       - name: setup chromedriver
         uses: nanasess/setup-chromedriver@v2.3.0
       - name: pytest
-        run: poetry run pytest tests/test_select.py
+        run: poetry run pytest
 
   slack:
     needs:

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -1,6 +1,6 @@
+import re
 from collections.abc import Generator, Iterable
 from copy import deepcopy
-import re
 from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Union
 
 from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
@@ -76,7 +76,7 @@ class Select(LabelElement, ValidationElement, ChoiceElement, DisableableElement,
             self._props['new-value-mode'] = new_value_mode
             with_input = True
 
-        self.use_delimiter = use_delimiter if new_value_mode in ("add", "add-unique") else False
+        self.use_delimiter = use_delimiter if new_value_mode in ('add', 'add-unique') else False
 
         if with_input:
             self.original_options = deepcopy(options)
@@ -106,7 +106,7 @@ class Select(LabelElement, ValidationElement, ChoiceElement, DisableableElement,
                     split_args = [value.strip() for value in re.split(r'[,;|、،]+', new_value) if len(value)> 0]
                     e.args.remove(new_value)
                     e.args.extend(split_args)
-                
+
                 if self._props.get('new-value-mode') == 'add-unique':
                     # handle issue #4896: eliminate duplicate arguments
                     for arg1 in [a for a in e.args if isinstance(a, str)]:

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -58,6 +58,10 @@ class Select(LabelElement, ValidationElement, ChoiceElement, DisableableElement,
         :param validation: dictionary of validation rules or a callable that returns an optional error message (default: None for no validation)
         :param key_generator: a callback or iterator to generate a dictionary key for new values
         """
+        self.use_delimiter = use_delimiter if new_value_mode in ('add', 'add-unique') else False
+        if use_delimiter:
+            multiple = True
+
         self.multiple = multiple
         if multiple:
             if value is None:
@@ -75,8 +79,6 @@ class Select(LabelElement, ValidationElement, ChoiceElement, DisableableElement,
                 raise ValueError('new_value_mode "add" is not supported for dict options without key_generator')
             self._props['new-value-mode'] = new_value_mode
             with_input = True
-
-        self.use_delimiter = use_delimiter if new_value_mode in ('add', 'add-unique') else False
 
         if with_input:
             self.original_options = deepcopy(options)

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -110,7 +110,7 @@ class Select(LabelElement, ValidationElement, ChoiceElement, DisableableElement,
                 if self._props.get('new-value-mode') == 'add-unique':
                     # handle issue #4896: eliminate duplicate arguments
                     for arg1 in [a for a in e.args if isinstance(a, str)]:
-                        if any([arg1 == a['label'] for a in e.args if isinstance(a, dict)]) or e.args.count(arg1) > 1:
+                        if any(arg1 == a['label'] for a in e.args if isinstance(a, dict)) or e.args.count(arg1) > 1:
                             e.args.remove(arg1)
 
                 args = [self._values[arg['value']] if isinstance(arg, dict) else arg for arg in e.args]

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -166,9 +166,9 @@ def test_add_new_values_delimited(screen:  Screen, option_dict: bool, new_value_
         screen.find_by_tag('input').send_keys(Keys.ENTER)
         screen.wait(0.5)
     if new_value_mode == 'add':
-        screen.should_contain("value = ['d', 'd', 'f']")
-        screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd', 'f': 'f'}" if option_dict else
-                                "options = ['a', 'b', 'c', 'd', 'd', 'f']")
+        screen.should_contain("value = ['d, d; f']")
+        # screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd', 'f': 'f'}" if option_dict else
+                                # "options = ['a', 'b', 'c', 'd', 'd', 'f']")
     elif new_value_mode == 'add-unique':
         screen.should_contain("value = ['d', 'f']")
         screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'f': 'f'}" if option_dict else

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -158,21 +158,25 @@ def test_add_new_values_delimited(screen:  Screen, option_dict: bool, new_value_
     screen.should_contain('value = []')
     screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C'}" if option_dict else "options = ['a', 'b', 'c']")
 
+
+    screen.find_by_class('q-select').click()
+    screen.wait(0.5)
+    screen.find_all('A' if option_dict else 'a')[-1].click()
+    screen.should_contain("value = ['a']")
+
     for _ in range(2):
-        screen.find_by_tag('input').send_keys(Keys.BACKSPACE + 'd, d; f')
+        screen.find_by_tag('input').send_keys('d, d; f')
         screen.wait(0.5)
         screen.find_by_tag('input').click()
         screen.wait(0.5)
         screen.find_by_tag('input').send_keys(Keys.ENTER)
         screen.wait(0.5)
     if new_value_mode == 'add':
-        print(s.value)
-        print(s.options)
-        screen.should_contain("value = ['d', 'd', 'f']")
+        screen.should_contain("value = ['a', 'd', 'd', 'f']")
         screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd', 'f': 'f'}" if option_dict else
                                 "options = ['a', 'b', 'c', 'd', 'd', 'f']")
     elif new_value_mode == 'add-unique':
-        screen.should_contain("value = ['d', 'f']")
+        screen.should_contain("value = ['a', 'd', 'f']")
         screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'f': 'f'}" if option_dict else
                                 "options = ['a', 'b', 'c', 'd', 'f']")
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -166,9 +166,9 @@ def test_add_new_values_delimited(screen:  Screen, option_dict: bool, new_value_
         screen.find_by_tag('input').send_keys(Keys.ENTER)
         screen.wait(0.5)
     if new_value_mode == 'add':
-        screen.should_contain("value = ['d, d; f']")
-        # screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd', 'f': 'f'}" if option_dict else
-                                # "options = ['a', 'b', 'c', 'd', 'd', 'f']")
+        screen.should_contain("value = ['d', 'f']")
+        screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'f': 'f'}" if option_dict else
+                                "options = ['a', 'b', 'c', 'd', 'f']")
     elif new_value_mode == 'add-unique':
         screen.should_contain("value = ['d', 'f']")
         screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'f': 'f'}" if option_dict else

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -166,11 +166,11 @@ def test_add_new_values_delimited(screen:  Screen, option_dict: bool, new_value_
         screen.find_by_tag('input').send_keys(Keys.ENTER)
         screen.wait(0.5)
     if new_value_mode == 'add':
-        screen.should_contain("value = ['a', 'd', 'd', 'f']")
+        screen.should_contain("value = ['d', 'd', 'f']")
         screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd', 'f': 'f'}" if option_dict else
                                 "options = ['a', 'b', 'c', 'd', 'd', 'f']")
     elif new_value_mode == 'add-unique':
-        screen.should_contain("value = ['a', 'd', 'f']")
+        screen.should_contain("value = ['d', 'f']")
         screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'f': 'f'}" if option_dict else
                                 "options = ['a', 'b', 'c', 'd', 'f']")
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -166,7 +166,7 @@ def test_add_new_values_delimited(screen:  Screen, option_dict: bool, new_value_
         screen.find_by_tag('input').send_keys(Keys.ENTER)
         screen.wait(0.5)
     if new_value_mode == 'add':
-        screen.should_contain("value = ['d', 'd', 'f']")
+        # screen.should_contain("value = ['d', 'd', 'f']")
         screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd', 'f': 'f'}" if option_dict else
                                 "options = ['a', 'b', 'c', 'd', 'd', 'f']")
     elif new_value_mode == 'add-unique':

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -166,7 +166,9 @@ def test_add_new_values_delimited(screen:  Screen, option_dict: bool, new_value_
         screen.find_by_tag('input').send_keys(Keys.ENTER)
         screen.wait(0.5)
     if new_value_mode == 'add':
-        # screen.should_contain("value = ['d', 'd', 'f']")
+        print(s.value)
+        print(s.options)
+        screen.should_contain("value = ['d', 'd', 'f']")
         screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd', 'f': 'f'}" if option_dict else
                                 "options = ['a', 'b', 'c', 'd', 'd', 'f']")
     elif new_value_mode == 'add-unique':

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -132,7 +132,7 @@ def test_add_new_values(screen:  Screen, option_dict: bool, multiple: bool, new_
             screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd'}" if option_dict else
                                   "options = ['a', 'b', 'c', 'd', 'd']")
         elif new_value_mode == 'add-unique':
-            screen.should_contain("value = ['a', 'd', 'd']" if multiple else 'value = d')
+            screen.should_contain("value = ['a', 'd']" if multiple else 'value = d')
             screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd'}" if option_dict else
                                   "options = ['a', 'b', 'c', 'd']")
         elif new_value_mode == 'toggle':
@@ -154,6 +154,9 @@ def test_add_new_values_delimited(screen:  Screen, option_dict: bool, new_value_
     ui.label().bind_text_from(s, 'value', lambda v: f'value = {v}')
     ui.label().bind_text_from(s, 'options', lambda v: f'options = {v}')
 
+    screen.open('/')
+    screen.should_contain('value = []')
+    screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C'}" if option_dict else "options = ['a', 'b', 'c']")
 
     for _ in range(2):
         screen.find_by_tag('input').send_keys(Keys.BACKSPACE + 'd, d; f')

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -150,7 +150,7 @@ def test_add_new_values_delimited(screen:  Screen, option_dict: bool, new_value_
             ui.select(options=options, use_delimiter=True, new_value_mode=new_value_mode)
         return
 
-    s = ui.select(options=options, use_delimiter=True, new_value_mode=new_value_mode)
+    s = ui.select(options=options, use_delimiter=True, multiple=True, new_value_mode=new_value_mode)
     ui.label().bind_text_from(s, 'value', lambda v: f'value = {v}')
     ui.label().bind_text_from(s, 'options', lambda v: f'options = {v}')
 
@@ -158,25 +158,19 @@ def test_add_new_values_delimited(screen:  Screen, option_dict: bool, new_value_
     screen.should_contain('value = []')
     screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C'}" if option_dict else "options = ['a', 'b', 'c']")
 
-
-    screen.find_by_class('q-select').click()
-    screen.wait(0.5)
-    screen.find_all('A' if option_dict else 'a')[-1].click()
-    screen.should_contain("value = ['a']")
-
     for _ in range(2):
-        screen.find_by_tag('input').send_keys('d, d; f')
+        screen.find_by_tag('input').send_keys(Keys.BACKSPACE + 'd, d; f')
         screen.wait(0.5)
         screen.find_by_tag('input').click()
         screen.wait(0.5)
         screen.find_by_tag('input').send_keys(Keys.ENTER)
         screen.wait(0.5)
     if new_value_mode == 'add':
-        screen.should_contain("value = ['a', 'd', 'd', 'f']")
+        screen.should_contain("value = ['d', 'd', 'f']")
         screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd', 'f': 'f'}" if option_dict else
                                 "options = ['a', 'b', 'c', 'd', 'd', 'f']")
     elif new_value_mode == 'add-unique':
-        screen.should_contain("value = ['a', 'd', 'f']")
+        screen.should_contain("value = ['d', 'f']")
         screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'f': 'f'}" if option_dict else
                                 "options = ['a', 'b', 'c', 'd', 'f']")
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -150,7 +150,7 @@ def test_add_new_values_delimited(screen:  Screen, option_dict: bool, new_value_
             ui.select(options=options, use_delimiter=True, new_value_mode=new_value_mode)
         return
 
-    s = ui.select(options=options, use_delimiter=True, multiple=True, new_value_mode=new_value_mode)
+    s = ui.select(options=options, use_delimiter=True, new_value_mode=new_value_mode)
     ui.label().bind_text_from(s, 'value', lambda v: f'value = {v}')
     ui.label().bind_text_from(s, 'options', lambda v: f'options = {v}')
 
@@ -166,9 +166,9 @@ def test_add_new_values_delimited(screen:  Screen, option_dict: bool, new_value_
         screen.find_by_tag('input').send_keys(Keys.ENTER)
         screen.wait(0.5)
     if new_value_mode == 'add':
-        screen.should_contain('value')# = ['d', 'd', 'f']")
-        screen.should_contain('options')# = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd', 'f': 'f'}" if option_dict else
-                                #"options = ['a', 'b', 'c', 'd', 'd', 'f']")
+        screen.should_contain("value = ['d', 'd', 'f']") # Fails for some reason, but works in browser
+        screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd', 'f': 'f'}" if option_dict else
+                                "options = ['a', 'b', 'c', 'd', 'd', 'f']") # Fails for some reason, but works in browser
     elif new_value_mode == 'add-unique':
         screen.should_contain("value = ['d', 'f']")
         screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'f': 'f'}" if option_dict else

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -166,9 +166,9 @@ def test_add_new_values_delimited(screen:  Screen, option_dict: bool, new_value_
         screen.find_by_tag('input').send_keys(Keys.ENTER)
         screen.wait(0.5)
     if new_value_mode == 'add':
-        screen.should_contain("value = ['d', 'f']")
-        screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'f': 'f'}" if option_dict else
-                                "options = ['a', 'b', 'c', 'd', 'f']")
+        screen.should_contain('value')# = ['d', 'd', 'f']")
+        screen.should_contain('options')# = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd', 'f': 'f'}" if option_dict else
+                                #"options = ['a', 'b', 'c', 'd', 'd', 'f']")
     elif new_value_mode == 'add-unique':
         screen.should_contain("value = ['d', 'f']")
         screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'f': 'f'}" if option_dict else


### PR DESCRIPTION
### Motivation

This PR allows users to a value delimited by comma [or one of these `,;|、،`] to split the values. I used the delimiting chars `,;|` from Quasar docs and further included `、` (Chinese and Japanese comma) and `،` (Arabic comma) to the list incase the GUI is used in other language. 

This feature is only available for new_value_mode `add` and `add-unique`.

It also uses #4916 to resolve duplicate values with `add-unique`. Partly improved upon to handle when the value is delimited.

Closes #4931 #4896

### Implementation

- Pretty much splits the value into list of strings before the usual process. And only works if the value is not None (when removing choice condition).

Limitations:

- I excluded `new_value_mode` as None, as input did not allow me to choose, other than using the dropdown as filter.
- I excluded `new_value_mode`'s `toggle` because it will include more for loops to remove the value in pairs which could lead to severe performance degradation on long lists. I found it difficult to toggle (removing in pairs) if duplicate values are involved when split.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).

### Problems I am facing

I could not get the pytest `test_add_new_values_delimited` working for `add-False` condition for some reason while `add-unique` works completely fine. Locally when I test in my browser it shows the expected output (also tried copy pasting to the test as well) but not in pytest.

List of things I tried to make pytest work so far:

- Checked if value is not splitting - It does split
- Checked if `value` or `options` can be seen (excluding list) - It is seen (The only time pytest passed)
- Checked if value/options are behaving like `add-unique` - No it does not give the same result

#4927 has a working video captured from my browser.

I have trouble setting up pytest as well so I had to rely on github actions for the tests. Locally I test by editing `select.py` file. Also, I do not have experience with pytests with nicegui and barely tried my best by mimicking based on #4916.

@falkoschindler Could I please get some assistance with this? I really could not find a reason why this does work.

I didn't know about adding documentation till this PR, will update if needed after fixing up pytests.