### PR TITLE
Let `ui.header` update `scrollPaddingTop` more nicely with a custom header.js component

### DIFF
--- a/nicegui/elements/drawer.py
+++ b/nicegui/elements/drawer.py
@@ -1,86 +1,10 @@
 from typing import Literal, Optional
 
-from .context import context
-from .element import Element
-from .elements.mixins.value_element import ValueElement
-from .functions.html import add_body_html
+from ..context import context
+from ..helpers import require_top_level_layout
+from .mixins.value_element import ValueElement
 
 DrawerSides = Literal['left', 'right']
-
-PageStickyPositions = Literal[
-    'top-right',
-    'top-left',
-    'bottom-right',
-    'bottom-left',
-    'top',
-    'right',
-    'bottom',
-    'left',
-]
-
-
-class Header(ValueElement, default_classes='nicegui-header'):
-
-    def __init__(self, *,
-                 value: bool = True,
-                 fixed: bool = True,
-                 bordered: bool = False,
-                 elevated: bool = False,
-                 wrap: bool = True,
-                 add_scroll_padding: bool = True,
-                 ) -> None:
-        """Header
-
-        This element is based on Quasar's `QHeader <https://quasar.dev/layout/header-and-footer#qheader-api>`_ component.
-
-        Like other layout elements, the header can not be nested inside other elements.
-
-        Note: The header is automatically placed above other layout elements in the DOM to improve accessibility.
-        To change the order, use the `move` method.
-
-        :param value: whether the header is already opened (default: `True`)
-        :param fixed: whether the header should be fixed to the top of the page (default: `True`)
-        :param bordered: whether the header should have a border (default: `False`)
-        :param elevated: whether the header should have a shadow (default: `False`)
-        :param wrap: whether the header should wrap its content (default: `True`)
-        :param add_scroll_padding: whether to automatically prevent link targets from being hidden behind the header (default: `True`)
-        """
-        _check_current_slot(self)
-        with context.client.layout:
-            super().__init__(tag='q-header', value=value, on_value_change=None)
-        self._props['bordered'] = bordered
-        self._props['elevated'] = elevated
-        if wrap:
-            self._classes.append('wrap')
-        code = list(self.client.layout.props['view'])
-        code[1] = 'H' if fixed else 'h'
-        self.client.layout.props['view'] = ''.join(code)
-
-        self.move(target_index=0)
-
-        if add_scroll_padding:
-            add_body_html(f'''
-                <script>
-                    window.onload = () => {{
-                        const header = getHtmlElement({self.id});
-                        new ResizeObserver(() => {{
-                            document.documentElement.style.scrollPaddingTop = `${{header.offsetHeight}}px`;
-                        }}).observe(header);
-                    }};
-                </script>
-            ''')
-
-    def toggle(self):
-        """Toggle the header"""
-        self.value = not self.value
-
-    def show(self):
-        """Show the header"""
-        self.value = True
-
-    def hide(self):
-        """Hide the header"""
-        self.value = False
 
 
 class Drawer(ValueElement, default_classes='nicegui-drawer'):
@@ -114,7 +38,7 @@ class Drawer(ValueElement, default_classes='nicegui-drawer'):
         :param top_corner: whether the drawer expands into the top corner (default: `False`)
         :param bottom_corner: whether the drawer expands into the bottom corner (default: `False`)
         """
-        _check_current_slot(self)
+        require_top_level_layout(self)
         with context.client.layout:
             super().__init__(tag='q-drawer', value=value, on_value_change=None)
         self._props['show-if-above'] = value is None
@@ -231,84 +155,3 @@ class RightDrawer(Drawer):
                          elevated=elevated,
                          top_corner=top_corner,
                          bottom_corner=bottom_corner)
-
-
-class Footer(ValueElement, default_classes='nicegui-footer'):
-
-    def __init__(self, *,
-                 value: bool = True,
-                 fixed: bool = True,
-                 bordered: bool = False,
-                 elevated: bool = False,
-                 wrap: bool = True,
-                 ) -> None:
-        """Footer
-
-        This element is based on Quasar's `QFooter <https://quasar.dev/layout/header-and-footer#qfooter-api>`_ component.
-
-        Like other layout elements, the footer can not be nested inside other elements.
-
-        Note: The footer is automatically placed below other layout elements in the DOM to improve accessibility.
-        To change the order, use the `move` method.
-
-        :param value: whether the footer is already opened (default: `True`)
-        :param fixed: whether the footer is fixed or scrolls with the content (default: `True`)
-        :param bordered: whether the footer should have a border (default: `False`)
-        :param elevated: whether the footer should have a shadow (default: `False`)
-        :param wrap: whether the footer should wrap its content (default: `True`)
-        """
-        _check_current_slot(self)
-        with context.client.layout:
-            super().__init__(tag='q-footer', value=value, on_value_change=None)
-        self._props['bordered'] = bordered
-        self._props['elevated'] = elevated
-        if wrap:
-            self._classes.append('wrap')
-        code = list(self.client.layout.props['view'])
-        code[9] = 'F' if fixed else 'f'
-        self.client.layout.props['view'] = ''.join(code)
-
-        self.move(target_index=-1)
-
-    def toggle(self) -> None:
-        """Toggle the footer"""
-        self.value = not self.value
-
-    def show(self) -> None:
-        """Show the footer"""
-        self.value = True
-
-    def hide(self) -> None:
-        """Hide the footer"""
-        self.value = False
-
-
-class PageSticky(Element):
-
-    def __init__(self,
-                 position: PageStickyPositions = 'bottom-right',
-                 x_offset: float = 0,
-                 y_offset: float = 0,
-                 *,
-                 expand: bool = False) -> None:
-        """Page sticky
-
-        This element is based on Quasar's `QPageSticky <https://quasar.dev/layout/page-sticky>`_ component.
-
-        :param position: position on the screen (default: "bottom-right")
-        :param x_offset: horizontal offset (default: 0)
-        :param y_offset: vertical offset (default: 0)
-        :param expand: whether to fully expand instead of shrinking to fit the content (default: ``False``, *added in version 2.1.0*)
-        """
-        super().__init__('q-page-sticky')
-        self._props['position'] = position
-        self._props['offset'] = [x_offset, y_offset]
-        if expand:
-            self._props['expand'] = True
-
-
-def _check_current_slot(element: Element) -> None:
-    parent = context.slot.parent
-    if parent != parent.client.content:
-        raise RuntimeError(f'Found top level layout element "{element.__class__.__name__}" inside element "{parent.__class__.__name__}". '
-                           'Top level layout elements can not be nested but must be direct children of the page content.')

--- a/nicegui/elements/footer.py
+++ b/nicegui/elements/footer.py
@@ -1,0 +1,53 @@
+from ..context import context
+from ..helpers import require_top_level_layout
+from .mixins.value_element import ValueElement
+
+
+class Footer(ValueElement, default_classes='nicegui-footer'):
+
+    def __init__(self, *,
+                 value: bool = True,
+                 fixed: bool = True,
+                 bordered: bool = False,
+                 elevated: bool = False,
+                 wrap: bool = True,
+                 ) -> None:
+        """Footer
+
+        This element is based on Quasar's `QFooter <https://quasar.dev/layout/header-and-footer#qfooter-api>`_ component.
+
+        Like other layout elements, the footer can not be nested inside other elements.
+
+        Note: The footer is automatically placed below other layout elements in the DOM to improve accessibility.
+        To change the order, use the `move` method.
+
+        :param value: whether the footer is already opened (default: `True`)
+        :param fixed: whether the footer is fixed or scrolls with the content (default: `True`)
+        :param bordered: whether the footer should have a border (default: `False`)
+        :param elevated: whether the footer should have a shadow (default: `False`)
+        :param wrap: whether the footer should wrap its content (default: `True`)
+        """
+        require_top_level_layout(self)
+        with context.client.layout:
+            super().__init__(tag='q-footer', value=value, on_value_change=None)
+        self._props['bordered'] = bordered
+        self._props['elevated'] = elevated
+        if wrap:
+            self._classes.append('wrap')
+        code = list(self.client.layout.props['view'])
+        code[9] = 'F' if fixed else 'f'
+        self.client.layout.props['view'] = ''.join(code)
+
+        self.move(target_index=-1)
+
+    def toggle(self) -> None:
+        """Toggle the footer"""
+        self.value = not self.value
+
+    def show(self) -> None:
+        """Show the footer"""
+        self.value = True
+
+    def hide(self) -> None:
+        """Hide the footer"""
+        self.value = False

--- a/nicegui/elements/header.js
+++ b/nicegui/elements/header.js
@@ -1,0 +1,13 @@
+export default {
+  template: `<q-header ref="qRef" v-bind="$attrs"><slot></slot></q-header>`,
+  mounted() {
+    if (this.add_scroll_padding) {
+      new ResizeObserver(() => {
+        document.documentElement.style.scrollPaddingTop = `${this.$el.offsetHeight}px`;
+      }).observe(this.$el);
+    }
+  },
+  props: {
+    add_scroll_padding: Boolean,
+  },
+};

--- a/nicegui/elements/header.py
+++ b/nicegui/elements/header.py
@@ -1,0 +1,68 @@
+from ..context import context
+from ..functions.html import add_body_html
+from ..helpers import require_top_level_layout
+from .mixins.value_element import ValueElement
+
+
+class Header(ValueElement, default_classes='nicegui-header'):
+
+    def __init__(self, *,
+                 value: bool = True,
+                 fixed: bool = True,
+                 bordered: bool = False,
+                 elevated: bool = False,
+                 wrap: bool = True,
+                 add_scroll_padding: bool = True,
+                 ) -> None:
+        """Header
+
+        This element is based on Quasar's `QHeader <https://quasar.dev/layout/header-and-footer#qheader-api>`_ component.
+
+        Like other layout elements, the header can not be nested inside other elements.
+
+        Note: The header is automatically placed above other layout elements in the DOM to improve accessibility.
+        To change the order, use the `move` method.
+
+        :param value: whether the header is already opened (default: `True`)
+        :param fixed: whether the header should be fixed to the top of the page (default: `True`)
+        :param bordered: whether the header should have a border (default: `False`)
+        :param elevated: whether the header should have a shadow (default: `False`)
+        :param wrap: whether the header should wrap its content (default: `True`)
+        :param add_scroll_padding: whether to automatically prevent link targets from being hidden behind the header (default: `True`)
+        """
+        require_top_level_layout(self)
+        with context.client.layout:
+            super().__init__(tag='q-header', value=value, on_value_change=None)
+        self._props['bordered'] = bordered
+        self._props['elevated'] = elevated
+        if wrap:
+            self._classes.append('wrap')
+        code = list(self.client.layout.props['view'])
+        code[1] = 'H' if fixed else 'h'
+        self.client.layout.props['view'] = ''.join(code)
+
+        self.move(target_index=0)
+
+        if add_scroll_padding:
+            add_body_html(f'''
+                <script>
+                    window.onload = () => {{
+                        const header = getHtmlElement({self.id});
+                        new ResizeObserver(() => {{
+                            document.documentElement.style.scrollPaddingTop = `${{header.offsetHeight}}px`;
+                        }}).observe(header);
+                    }};
+                </script>
+            ''')
+
+    def toggle(self):
+        """Toggle the header"""
+        self.value = not self.value
+
+    def show(self):
+        """Show the header"""
+        self.value = True
+
+    def hide(self):
+        """Hide the header"""
+        self.value = False

--- a/nicegui/elements/header.py
+++ b/nicegui/elements/header.py
@@ -1,10 +1,9 @@
 from ..context import context
-from ..functions.html import add_body_html
 from ..helpers import require_top_level_layout
 from .mixins.value_element import ValueElement
 
 
-class Header(ValueElement, default_classes='nicegui-header'):
+class Header(ValueElement, component='header.js', default_classes='nicegui-header'):
 
     def __init__(self, *,
                  value: bool = True,
@@ -32,9 +31,10 @@ class Header(ValueElement, default_classes='nicegui-header'):
         """
         require_top_level_layout(self)
         with context.client.layout:
-            super().__init__(tag='q-header', value=value, on_value_change=None)
+            super().__init__(value=value, on_value_change=None)
         self._props['bordered'] = bordered
         self._props['elevated'] = elevated
+        self._props['add_scroll_padding'] = add_scroll_padding
         if wrap:
             self._classes.append('wrap')
         code = list(self.client.layout.props['view'])
@@ -42,18 +42,6 @@ class Header(ValueElement, default_classes='nicegui-header'):
         self.client.layout.props['view'] = ''.join(code)
 
         self.move(target_index=0)
-
-        if add_scroll_padding:
-            add_body_html(f'''
-                <script>
-                    window.onload = () => {{
-                        const header = getHtmlElement({self.id});
-                        new ResizeObserver(() => {{
-                            document.documentElement.style.scrollPaddingTop = `${{header.offsetHeight}}px`;
-                        }}).observe(header);
-                    }};
-                </script>
-            ''')
 
     def toggle(self):
         """Toggle the header"""

--- a/nicegui/elements/page_sticky.py
+++ b/nicegui/elements/page_sticky.py
@@ -1,0 +1,38 @@
+from typing import Literal
+
+from ..element import Element
+
+PageStickyPositions = Literal[
+    'top-right',
+    'top-left',
+    'bottom-right',
+    'bottom-left',
+    'top',
+    'right',
+    'bottom',
+    'left',
+]
+
+
+class PageSticky(Element):
+
+    def __init__(self,
+                 position: PageStickyPositions = 'bottom-right',
+                 x_offset: float = 0,
+                 y_offset: float = 0,
+                 *,
+                 expand: bool = False) -> None:
+        """Page sticky
+
+        This element is based on Quasar's `QPageSticky <https://quasar.dev/layout/page-sticky>`_ component.
+
+        :param position: position on the screen (default: "bottom-right")
+        :param x_offset: horizontal offset (default: 0)
+        :param y_offset: vertical offset (default: 0)
+        :param expand: whether to fully expand instead of shrinking to fit the content (default: ``False``, *added in version 2.1.0*)
+        """
+        super().__init__('q-page-sticky')
+        self._props['position'] = position
+        self._props['offset'] = [x_offset, y_offset]
+        if expand:
+            self._props['expand'] = True

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import functools
 import hashlib
@@ -10,9 +12,13 @@ import webbrowser
 from collections.abc import Callable
 from inspect import Parameter, signature
 from pathlib import Path
-from typing import Any, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Set, Tuple, Union
 
+from .context import context
 from .logging import log
+
+if TYPE_CHECKING:
+    from .element import Element
 
 _shown_warnings: Set[str] = set()
 
@@ -120,3 +126,13 @@ def kebab_to_camel_case(string: str) -> str:
 def event_type_to_camel_case(string: str) -> str:
     """Convert an event type string to camelCase."""
     return '.'.join(kebab_to_camel_case(part) if part != '-' else part for part in string.split('.'))
+
+
+def require_top_level_layout(element: Element) -> None:
+    """Check if the element is a top level layout element."""
+    parent = context.slot.parent
+    if parent != parent.client.content:
+        raise RuntimeError(
+            f'Found top level layout element "{element.__class__.__name__}" inside element "{parent.__class__.__name__}". '
+            'Top level layout elements can not be nested but must be direct children of the page content.',
+        )

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -154,11 +154,16 @@ from .elements.context_menu import ContextMenu as context_menu
 from .elements.dark_mode import DarkMode as dark_mode
 from .elements.date import Date as date
 from .elements.dialog import Dialog as dialog
+from .elements.drawer import Drawer as drawer
+from .elements.drawer import LeftDrawer as left_drawer
+from .elements.drawer import RightDrawer as right_drawer
 from .elements.echart import EChart as echart
 from .elements.editor import Editor as editor
 from .elements.expansion import Expansion as expansion
+from .elements.footer import Footer as footer
 from .elements.fullscreen import Fullscreen as fullscreen
 from .elements.grid import Grid as grid
+from .elements.header import Header as header
 from .elements.highchart import highchart
 from .elements.html import Html as html
 from .elements.icon import Icon as icon
@@ -185,6 +190,7 @@ from .elements.menu import MenuItem as menu_item
 from .elements.mermaid import Mermaid as mermaid
 from .elements.notification import Notification as notification
 from .elements.number import Number as number
+from .elements.page_sticky import PageSticky as page_sticky
 from .elements.pagination import Pagination as pagination
 from .elements.plotly import Plotly as plotly
 from .elements.progress import CircularProgress as circular_progress
@@ -240,11 +246,5 @@ from .functions.refreshable import refreshable, refreshable_method, state
 from .functions.style import add_css, add_sass, add_scss
 from .functions.update import update
 from .page import page
-from .page_layout import Drawer as drawer
-from .page_layout import Footer as footer
-from .page_layout import Header as header
-from .page_layout import LeftDrawer as left_drawer
-from .page_layout import PageSticky as page_sticky
-from .page_layout import RightDrawer as right_drawer
 from .ui_run import run
 from .ui_run_with import run_with


### PR DESCRIPTION
### Motivation

In https://github.com/zauberzeug/nicegui/issues/4912#issuecomment-3035026068 we noticed that `ui.header` is adding code blocks to the HTML body which are not cleaned up when recreating the header. This is concerning in single-page applications where one might want to countlessly recreate the whole UI including page layout elements.

### Implementation

1. This PR splits the old page_layout.py into separate files for the individual elements.
2. A custom header.js component takes care of creating the resize observer if needed.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
