### PR TITLE
New Element - InputChips

### DIFF
--- a/nicegui/elements/input_chips.js
+++ b/nicegui/elements/input_chips.js
@@ -1,0 +1,9 @@
+export default {
+  template: `
+    <q-select
+      ref="qRef"
+      v-bind="$attrs"
+    >
+    </q-select>
+  `,
+};

--- a/nicegui/elements/input_chips.py
+++ b/nicegui/elements/input_chips.py
@@ -20,12 +20,11 @@ class InputChips(LabelElement, ValidationElement, ValueElement, DisableableEleme
                  use_delimiter: bool = False,
                  validation: Optional[Union[ValidationFunction, ValidationDict]] = None,
                  ) -> None:
-        """Dropdown Selection
+        """Input Chips
 
         This element is based on Quasar's `QSelect <https://quasar.dev/vue-components/select>`_ component.
-
-        The options can be specified as a list of values, or as a dictionary mapping values to labels.
-        After manipulating the options, call `update()` to update the options in the UI.
+        This variant focuses solely on using chips without dropdown menu which is suitable for longer lists.
+        Hence, it acts as an input with list of chips rather than a dropdown of choices.
 
         You can use the `validation` parameter to define a dictionary of validation rules,
         e.g. ``{'Too long!': lambda value: len(value) < 3}``.
@@ -68,7 +67,11 @@ class InputChips(LabelElement, ValidationElement, ValueElement, DisableableEleme
             new_value = next((arg for arg in e.args if isinstance(arg, str)), None)
             split_args = []
             if new_value is not None:
-                split_args = [value.strip() for value in re.split(r'[,;|]+', new_value) if len(value)> 0] if self.use_delimiter else [new_value]
+                split_args = (
+                    [value.strip() for value in re.split(r'[,;|]+', new_value)if len(value)> 0]
+                    if self.use_delimiter
+                    else [new_value]
+                )
 
             args = [arg['label'] for arg in e.args if isinstance(arg, dict)]
             mode = self._props['new-value-mode']

--- a/nicegui/elements/input_chips.py
+++ b/nicegui/elements/input_chips.py
@@ -1,0 +1,92 @@
+import re
+from typing import Any, Literal, Optional, Union
+
+from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
+from .mixins.disableable_element import DisableableElement
+from .mixins.label_element import LabelElement
+from .mixins.validation_element import ValidationDict, ValidationElement, ValidationFunction
+from .mixins.value_element import ValueElement
+
+
+class InputChips(LabelElement, ValidationElement, ValueElement, DisableableElement, component='input_chips.js'):
+
+    def __init__(self,
+                 value: Any = None,
+                 *,
+                 label: Optional[str] = None,
+                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 new_value_mode: Literal['add', 'add-unique', 'toggle'] = 'toggle',
+                 clearable: bool = False,
+                 use_delimiter: bool = False,
+                 validation: Optional[Union[ValidationFunction, ValidationDict]] = None,
+                 ) -> None:
+        """Dropdown Selection
+
+        This element is based on Quasar's `QSelect <https://quasar.dev/vue-components/select>`_ component.
+
+        The options can be specified as a list of values, or as a dictionary mapping values to labels.
+        After manipulating the options, call `update()` to update the options in the UI.
+
+        You can use the `validation` parameter to define a dictionary of validation rules,
+        e.g. ``{'Too long!': lambda value: len(value) < 3}``.
+        The key of the first rule that fails will be displayed as an error message.
+        Alternatively, you can pass a callable that returns an optional error message.
+        To disable the automatic validation on every value change, you can use the `without_auto_validation` method.
+
+        :param value: the initial value
+        :param label: the label to display above the selection
+        :param on_change: callback to execute when selection changes
+        :param new_value_mode: handle new values from user input (default: toggle)
+        :param clearable: whether to add a button to clear the selection
+        :param use_delimiter: whether Separate multiple values by [,;|、،]
+        :param validation: dictionary of validation rules or a callable that returns an optional error message (default: None for no validation)
+        """
+        if value is None:
+            value = []
+        elif not isinstance(value, list):
+            value = [value]
+        else:
+            value = value[:]  # NOTE: avoid modifying the original list which could be the list of options (#3014)
+        super().__init__(label=label, value=value, on_value_change=on_change, validation=validation)
+
+        self._props['new-value-mode'] = new_value_mode
+
+        self.use_delimiter = use_delimiter
+
+        self._props['use-input'] = True
+        self._props['hide-selected'] = False
+        self._props['fill-input'] = True
+        self._props['input-debounce'] = 0
+        self._props['multiple'] = True
+        self._props['hide-dropdown-icon'] = True
+        self._props['clearable'] = clearable
+
+    def _event_args_to_value(self, e: GenericEventArguments) -> Any:
+        if e.args is None:
+            return []
+        else:
+            new_value = next((arg for arg in e.args if isinstance(arg, str)), None)
+            split_args = []
+            if new_value is not None:
+                split_args = [value.strip() for value in re.split(r'[,;|]+', new_value) if len(value)> 0] if self.use_delimiter else [new_value]
+
+            args = [arg['label'] for arg in e.args if isinstance(arg, dict)]
+            mode = self._props['new-value-mode']
+
+
+            for value in split_args:
+                if mode == 'add':
+                    args.append(value)
+                elif mode == 'add-unique':
+                    if value not in args:
+                        args.append(value)
+                elif mode == 'toggle':
+                    if value in args:
+                        args.remove(value)
+                    else:
+                        args.append(value)
+            return args
+
+
+    def _value_to_model_value(self, value: Any) -> Any:
+        return [{'value': ind, 'label': val} for ind, val in enumerate(value or [])]

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -47,6 +47,7 @@ __all__ = [
     'icon',
     'image',
     'input',
+    'input_chips',
     'interactive_image',
     'item',
     'item_label',
@@ -164,6 +165,7 @@ from .elements.html import Html as html
 from .elements.icon import Icon as icon
 from .elements.image import Image as image
 from .elements.input import Input as input  # pylint: disable=redefined-builtin
+from .elements.input_chips import InputChips as input_chips
 from .elements.interactive_image import InteractiveImage as interactive_image
 from .elements.item import Item as item
 from .elements.item import ItemLabel as item_label


### PR DESCRIPTION
### Motivation

Note that #4927 can not be resolved since Quasar framework has same behavior as well. The root cause lies in the dropdown itself which is directly coupled with the behavior of `options`. Setting props `hide-dropdown-icon popup-content-class='hidden' use-chips` does not help either. You may accidentally toggle the first element if a substring is typed in (#4927 shows some clips on this behavior). This will be troublesome in long lists.

`ui.select` is at the moment can be an alias for `Dropdown Selection`. Since options is more or less the backbone of ui.selecct,  making the dropdown optional may break ui.select.

Therefore, I created a new element `InputChips` to overcome the issue for users who want `new_value_mode` and safely use it. Using this element will add values to list with input and removing can be done with chip's clear button rather than dropdown. Having an element like this ready to use would be helpful for myself (because this was exactly what I wanted to create a form) or users like #1649.

### Implementation

- It replaces `ChoiceElement` with `ValueElement` to remove the dependency on options/dropdown and the JS file contains barebones of Qselect.
- It converts the value label dict from Qselect to list of values and compares with the new values. So this simplifies backend work done to keep the values validated according to `new_value_mode` set for the element.
- Unlike my previous PR, `use_delimiter` works for all cases since this only deals with list.

Partly I feel there will be better performance for larger list since this element quickly deals with the list of values in transit while ui.select have to run `_hande_new_value` after. Remember that `_hande_new_value` runs multiple times if `use_delimiter` is True, for cases like 2+ values are added in one go. (Though this will be the case if #4936 or this PR is merged at some point to use `use_delimiter`)

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).

I created this draft PR before starting pytest/docs, to get some opinions/thoughts of this feature whether it will be good addition or not.
