### PR TITLE
Add None to the return type of WindowProxy.create_file_dialog

### DIFF
--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -128,7 +128,7 @@ try:
             allow_multiple: bool = False,
             save_filename: str = '',
             file_types: Tuple[str, ...] = (),
-        ) -> Tuple[str, ...]:
+        ) -> Tuple[str, ...] | None:
             return await self._request(
                 dialog_type=dialog_type,
                 directory=directory,

--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -128,7 +128,7 @@ try:
             allow_multiple: bool = False,
             save_filename: str = '',
             file_types: Tuple[str, ...] = (),
-        ) -> Tuple[str, ...] | None:
+        ) -> Optional[Tuple[str, ...]]:
             return await self._request(
                 dialog_type=dialog_type,
                 directory=directory,


### PR DESCRIPTION
### Motivation

Addresses issue #4953 where [WindowProxy.create_file_dialog](/zauberzeug/nicegui/blob/main/nicegui/native/native.py#L124) incorrectly does not have `None` in the signature for its return type.

### Implementation

`None` was added to the existing signature of [WindowProxy.create_file_dialog](/zauberzeug/nicegui/blob/main/nicegui/native/native.py#L124).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
