### PR TITLE
Add dynamic icon color to ColorInput in preview mode

### DIFF
--- a/nicegui/elements/color_input.py
+++ b/nicegui/elements/color_input.py
@@ -1,3 +1,4 @@
+import re
 from colorsys import rgb_to_yiq
 from typing import Any, Optional
 
@@ -7,6 +8,9 @@ from .color_picker import ColorPicker as color_picker
 from .mixins.disableable_element import DisableableElement
 from .mixins.label_element import LabelElement
 from .mixins.value_element import ValueElement
+
+HEX_COLOR_PATTERN_6 = re.compile(r'^#([0-9a-fA-F]{6})$')
+HEX_COLOR_PATTERN_3 = re.compile(r'^#([0-9a-fA-F]{3})$')
 
 
 class ColorInput(LabelElement, ValueElement, DisableableElement):
@@ -55,12 +59,18 @@ class ColorInput(LabelElement, ValueElement, DisableableElement):
         if not self.preview:
             return
 
-        color = (self.value or '#ffffff').split(';', 1)[0]
-        r = int(color[1:3], 16) / 255
-        g = int(color[3:5], 16) / 255
-        b = int(color[5:7], 16) / 255
+        color = self.value.strip()
+        if HEX_COLOR_PATTERN_6.match(color):
+            r = int(color[1:3], 16) / 255
+            g = int(color[3:5], 16) / 255
+            b = int(color[5:7], 16) / 255
+        elif HEX_COLOR_PATTERN_3.match(color):
+            r = int(color[1], 16) / 15
+            g = int(color[2], 16) / 15
+            b = int(color[3], 16) / 15
+        else:
+            self.button.style('background-color: transparent').props(remove='color')
+            return
         luminance = rgb_to_yiq(r, g, b)[0]
         icon_color = 'grey-10' if luminance > 0.5 else 'grey-3'
-
-        self.button.style(f'background-color: {color};') \
-            .props(f'color="{icon_color}"')
+        self.button.style(f'background-color: {color}').props(f'color="{icon_color}"')


### PR DESCRIPTION
### Motivation

When passing `preview=True` to `ColorInput`, the button icon and background are separated by adding a shadow. If applied, this PR modifies this behavior to changing the icon color dynamically based on the button background color.

|Before|After|
|--|--|
|<img width="50" height="50" alt="before_dark" src="https://github.com/user-attachments/assets/2ba0cfa9-6c00-48f6-8a15-0667e7c71117" /> <img width="50" height="50" alt="before_light" src="https://github.com/user-attachments/assets/3feab7e4-47f2-4dfe-90cc-2833e31f0daa" /> | <img width="50" height="50" alt="after_light" src="https://github.com/user-attachments/assets/64e300e0-e3d5-47ee-a5e9-9fb72f32b231" /> <img width="50" height="50" alt="after_dark" src="https://github.com/user-attachments/assets/8391350c-deb3-4d39-93e2-782d0c528aec" />|

### Implementation

The implementation uses the `rgb_to_yiq` function from the `colorsys` module from Python's standard library to calculate the luminance of the chosen color. The YIQ color space slightly biases the choice towards a white icon for vivid colors.

### Progress

- [X] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [X] The implementation is complete.
- [X] Pytests have been added (or are not necessary).
- [X] Documentation has been added (or is not necessary).

---

Feature request: #4965