### PR TITLE
allow props() to take a dict or list without quotes

### DIFF
--- a/nicegui/props.py
+++ b/nicegui/props.py
@@ -9,30 +9,45 @@ if TYPE_CHECKING:
     from .element import Element
 
 PROPS_PATTERN = re.compile(r'''
-# Match a key-value pair optionally followed by whitespace or end of string
-([:\w\-]+)          # Capture group 1: Key
-(?:                 # Optional non-capturing group for value
-    =               # Match the equal sign
-    (?:             # Non-capturing group for value options
-        (           # Capture group 2: Value enclosed in double quotes
-            "       # Match  double quote
-            [^"\\]* # Match any character except quotes or backslashes zero or more times
-            (?:\\.[^"\\]*)*  # Match any escaped character followed by any character except quotes or backslashes zero or more times
-            "       # Match the closing quote
+# Match a key or key-value pair optionally followed by whitespace or end of string
+# The value can be unquoted, or enclosed in quotes, or square or curly brackets
+(?P<key>[:\w\-]+)           # Capture group 1: Key
+(                           # Optional non-capturing group for value
+    =                       # An equals sign
+    (                       # followed by one of ...
+        (?P<double>         # a value enclosed in double quotes
+            "                   # Match double quote
+            [^"\\]*             # Match any character except quotes or backslashes zero or more times
+            (\\.[^"\\]*)*       # Match any escaped character followed by any character except quotes or backslashes zero or more times
+            "                   # Match the closing quote
         )
-        |
-        (           # Capture group 3: Value enclosed in single quotes
-            '       # Match a single quote
-            [^'\\]* # Match any character except quotes or backslashes zero or more times
-            (?:\\.[^'\\]*)*  # Match any escaped character followed by any character except quotes or backslashes zero or more times
-            '       # Match the closing quote
+        |                   # or
+        (?P<single>         # a value enclosed in single quotes
+            '                   # Match a single quote
+            [^'\\]*             # Match any character except quotes or backslashes zero or more times
+            (\\.[^'\\]*)*       # Match any escaped character followed by any character except quotes or backslashes zero or more times
+            '                   # Match the closing quote
         )
-        |           # Or
-        ([\w\-.,%:\/=?&]+)  # Capture group 4: Value without quotes
+        |                   # or
+        (?P<square>         # a value enclosed in square brackets
+            \[                  # Match the opening [
+            [^\]\\]*            # Match any character except a ] or backslashes zero or more times
+            (\\.[^\]\\]*)*      # Match any escaped character followed by any character except ] or backslashes zero or more times
+            \]                  # Match the closing ]
+        )
+        |                   # or
+        (?P<curly>          # a value enclosed in curly braces
+            \{                  # Match the opening {
+            [^\}\\]*            # Match any character except } or backslashes zero or more times
+            (\\.[^\}\\]*)*      # Match any escaped character followed by any character except ] or backslashes zero or more times
+            \}                  # Match the closing }
+        )
+        |                   # or, as a final alternative ....
+        (?P<unquoted>[\w\-.,%:\/=?&]+)  # a value without quotes
     )
-)?                  # End of optional non-capturing group for value
-(?:$|\s)            # Match end of string or whitespace
-''', re.VERBOSE)
+)?                          # End of optional non-capturing group for value
+($|\s)                      # Match end of string or whitespace
+''',re.VERBOSE,)
 
 T = TypeVar('T', bound='Element')
 
@@ -88,16 +103,35 @@ class Props(dict, Generic[T]):
         return element
 
     @staticmethod
-    def parse(text: Optional[str]) -> Dict[str, Any]:
+    def parse(text: Optional[str] = None) -> Dict[str, Any]:
         """Parse a string of props into a dictionary."""
-        dictionary = {}
+        props = {}
         for match in PROPS_PATTERN.finditer(text or ''):
-            key = match.group(1)
-            value = match.group(2) or match.group(3) or match.group(4)
-            if value is None:
-                dictionary[key] = True
+            # Extract match groups as a dictionary
+            match_groups = match.groupdict()
+            key = match_groups['key']
+
+            # Check value groups in priority order
+            value_groups = ['single', 'double', 'square', 'curly']
+            value_match = None
+
+            # Find the first non-None value group match
+            for group in value_groups:
+                if match_groups[group] is not None:
+                    value_match = match_groups[group]
+                    break
+
+            # Determine value based on matched content
+            if value_match:
+                # Safely evaluate Python literals (strings, numbers, etc.)
+                value = ast.literal_eval(value_match)
+            elif match_groups['unquoted'] is not None:
+                # Handle unquoted values (e.g., key=value)
+                value = match_groups['unquoted']
             else:
-                if (value.startswith("'") and value.endswith("'")) or (value.startswith('"') and value.endswith('"')):
-                    value = ast.literal_eval(value)
-                dictionary[key] = value
-        return dictionary
+                # Default for props without explicit values (e.g., key)
+                value = True
+
+            props[key] = value
+
+        return props

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -76,6 +76,12 @@ def test_style_parsing(value: Optional[str], expected: Dict[str, str]):
     ("input-style='{ color: #ff0000 }'", {'input-style': '{ color: #ff0000 }'}),
     ("""input-style='{ myquote: "quote" }'""", {'input-style': '{ myquote: "quote" }'}),
     ('filename=foo=bar.txt', {'filename': 'foo=bar.txt'}),
+    ('array=["one"]', {'array': ['one']}),
+    ('array=["one", "two"]', {'array': ['one', 'two']}),
+    ('''object={'one': "foo"} baz''', {'object': {'one': 'foo'}, 'baz': True}),
+    ('''object={'one': "foo", "two": "bar"}''', {'object': {'one': 'foo', 'two': 'bar'}}),
+
+
 ])
 def test_props_parsing(value: Optional[str], expected: Dict[str, str]):
     assert Props.parse(value) == expected


### PR DESCRIPTION
Occasionally, props can be an javascript array or object, eg the style props for [QScrollArea](https://quasar.dev/vue-components/scroll-area/).  It is not obvious how to set these props with NiceGui. Neither the docs nor the examples help very much, but there is some information in #457 and #706.  There are quite a lot of quotes involved!

Whilst it is possible to add to the `_props` list directly, this is not obvious, and feels like a bit of a hack.

This PR allows a list or dict to be passed to `Element.props()` in what feels like an intuitive fashion. It also updates the `PROPS_PATTERN` regex in `props.py` to use named capture groups, so the logic is clearer 

Includes additional pytests.  All existing tests pass.

Now its easy to make beautiful scrollbars like this 😉 :

![scroll](https://github.com/user-attachments/assets/ce24c761-6441-45e8-b1ac-3ba175c7af0d)


```python
from nicegui import ui

with ui.scroll_area() as scroll:
    for i in range(10):
        ui.label("Commodo nostrud aliquip ad ad consequat aliquip reprehenderit ut. Ea in id est nostrud anim est" 
                    "amet. Minim commodo fugiat ullamco tempor nisi. Nulla consectetur eiusmod tempor mollit.Enim "
                    "exercitation ea culpa aliquip et elit nulla cupidatat id reprehenderit voluptate. Incididunt "
                    "ullamco do ipsum amet qui tempor fugiat ut. Officia esse ea anim magna minim id quis consequat "
                    "labore ad pariatur culpa. Sit ullamco minim velit aliquip ut pariatur irure. Laborum cillum est "
                    "tempor mollit incididunt id eu mollit elit incididunt ad minim. Aute exercitation ad non "
                    "adipisicing. Exercitation commodo et Lorem eiusmod proident elit sit minim laborum enim anim"
                    "ullamco non nostrud. \n")
    
scroll.props('thumb-style={"background": "linear-gradient(0deg, blue 0%, green 100%)", "borderRadius": "5px", "opacity": 1}')
scroll.props('visible bar-style={"background": "linear-gradient(0deg, red 0%, yellow 100%)", "borderRadius": "5px", "opacity": 1}')

ui.run()
```

