### PR TITLE
Management of Redis client connections in app.storage.user

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ def some_json():
 
 
 @ui.page('/')
-async def root_path():
+async def root_page():
     # use this page to check that app.storage.user behaves as expected '
     ui.label('root page')
     if not app.storage.user.get('root_page_counter'):
@@ -76,7 +76,7 @@ async def root_path():
 
 
 @ui.page('/api/hello')
-async def root_path():
+async def api_hello_page():
     # use this page to that app.storage.user changes are not published to redis
     # check redis before going back to /
     ui.label('api hello page')

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -72,7 +72,7 @@ class Storage:
     '''Maximum age in seconds before tab storage is automatically purged. Defaults to 30 days.'''
 
     ignore_user_storage_uri_prefixes = [uri.strip().strip('\'"') for uri in
-                                        os.environ.get('NICEGUI_STORAGE_USER_IGNORE_URI_PREFIXES', '').strip(
+                                        os.environ.get('NICEGUI_REDIS_USER_STORAGE_IGNORE_URI_PREFIXES', '').strip(
                                             '\'"').split(',') if uri.strip()]
     '''Prefixes we should ignore user storage on -- only applies if redis_url != None'''
 


### PR DESCRIPTION
Related to Issue #4979  -- This pull request contains extra code that needs to be removed if it is to be accepted. It is left this way to help explain and demonstrate the problems and solution. 

@rodja requested specifically, that I put this in, rather than him cloning my fork, or viewing my commits here:

- https://github.com/zauberzeug/nicegui/compare/main...lweighall:nicegui:lw_issue4979_api_path_exclude  (this is my current implementation)
- https://github.com/zauberzeug/nicegui/compare/main...lweighall:nicegui:lw_issue4979_original_implementation_notes (these are my notes on the original code)

As a result it is not yet complete and I am submitting as a draft PR. 

I am used to submitting PR's as complete, but in this case it was specifically requested in Issue #4979. 

### Motivation

NiceGUI creates `app.storage.user = {}` with a new session UUID on every API call via `RequestTrackingMiddleware`, regardless of whether storage is needed. This opens a new Redis pub/sub connection per call, eventually hitting Redis's 10K connection limit and making the entire app unavailable.

**Need:** Better control over Redis client connection creation. `RedisPersistentDict` should use context managers and only create persistent connections when actually needed (existing data or new writes), not on every API call that doesn't use `app.storage.user`.

### Implementation

**Goal:** Improve Redis connection management and allow excluding specific URI prefixes (e.g., `/api`) from storage creation.

**Changes:**
- **storage.py:** Added `NICEGUI_REDIS_USER_STORAGE_IGNORE_URI_PREFIXES` env var (CSV of URI prefixes). `RequestTrackingMiddleware` skips creating `app.storage.user` for matching prefixes and passes `skip_redis_publish=True` to prevent unnecessary connections.

- **redis_persistent_dict.py:** Moved Redis connection from `__init__` to lazy `_init_redis_client()`. Non-pubsub operations now use context managers. Persistent connections only created when `_start_listening()` is called. `close()`/`clear()` skip Redis operations when `skip_redis_publish=True`.

**Documentation:** Need to document `NICEGUI_REDIS_USER_STORAGE_IGNORE_URI_PREFIXES` behavior.

### Progress

- [X] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).
