### PR TITLE
Add a `ui.button_dropdown.on_click` method for registering click event handlers

### DIFF
--- a/nicegui/elements/button_dropdown.py
+++ b/nicegui/elements/button_dropdown.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from typing_extensions import Self
+
 from ..events import ClickEventArguments, Handler, ValueChangeEventArguments, handle_event
 from .mixins.color_elements import BackgroundColorElement
 from .mixins.disableable_element import DisableableElement
@@ -48,7 +50,12 @@ class DropdownButton(IconElement, TextElement, DisableableElement, BackgroundCol
             self._props['split'] = True
 
         if on_click:
-            self.on('click', lambda _: handle_event(on_click, ClickEventArguments(sender=self, client=self.client)), [])
+            self.on_click(on_click)
+
+    def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
+        """Add a callback to be invoked when the dropdown button is clicked."""
+        self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
+        return self
 
     def _text_to_model_text(self, text: str) -> None:
         self._props['label'] = text

--- a/nicegui/elements/button_dropdown.py
+++ b/nicegui/elements/button_dropdown.py
@@ -53,7 +53,10 @@ class DropdownButton(IconElement, TextElement, DisableableElement, BackgroundCol
             self.on_click(on_click)
 
     def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
-        """Add a callback to be invoked when the dropdown button is clicked."""
+        """Add a callback to be invoked when the dropdown button is clicked.
+
+        **Added in version 2.22.0**
+        """
         self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
         return self
 


### PR DESCRIPTION
### Motivation

Today I noticed that `ui.button_dropdown` doesn't have an `on_click` method for registering click handlers like other clickable elements with an `on_click` parameter.

### Implementation

This PR adds this method in complete analogy to `ui.button`.
The initializer now calls the new method instead of repeating the implementation.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
