### PR TITLE
Add rate limits for hosted website

### DIFF
--- a/fly.dockerfile
+++ b/fly.dockerfile
@@ -28,7 +28,7 @@ COPY pyproject.toml poetry.lock*  ./
 
 RUN poetry install --no-root --extras "plotly matplotlib highcharts sass"
 
-RUN pip install latex2mathml
+RUN pip install latex2mathml slowapi
 
 ADD . .
 

--- a/main.py
+++ b/main.py
@@ -8,10 +8,11 @@ from fastapi.responses import RedirectResponse
 from starlette.middleware.sessions import SessionMiddleware
 
 from nicegui import app, ui
-from website import anti_scroll_hack, documentation, fly, imprint_privacy, main_page, svg
+from website import anti_scroll_hack, documentation, fly, imprint_privacy, main_page, rate_limits, svg
 
 # session middleware is required for demo in documentation
 app.add_middleware(SessionMiddleware, secret_key=os.environ.get('NICEGUI_SECRET_KEY', ''))
+rate_limits.setup()
 
 on_fly = fly.setup()
 anti_scroll_hack.setup()

--- a/website/rate_limits.py
+++ b/website/rate_limits.py
@@ -1,0 +1,20 @@
+try:
+    from slowapi import Limiter, _rate_limit_exceeded_handler
+    from slowapi.errors import RateLimitExceeded
+    from slowapi.middleware import SlowAPIMiddleware
+    from slowapi.util import get_remote_address
+
+    from nicegui import app
+
+    HAS_SLOWAPI = True
+except ImportError:
+    HAS_SLOWAPI = False
+
+
+def setup():
+    if not HAS_SLOWAPI:
+        return
+    limiter = Limiter(key_func=get_remote_address, default_limits=['50/minute', '5/second'])
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_middleware(SlowAPIMiddleware)


### PR DESCRIPTION
### Motivation

https://nicegui.io sometimes sees to much traffic from single users. This can lead to bad experience for everyone else.

### Implementation

This pull request sets rate limits via https://github.com/laurentS/slowapi. I deliberately just made it an optional feature and added the `slowapi` package to our fly.io deployment. If it works we might make it a general feature in NiceGUI. But thats for an eperate PR.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have are not necessary.
- [x] Documentation is not necessary.
