### PR TITLE
Improve documentation page for `ui.sub_pages`

### DIFF
--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -19,6 +19,7 @@ from ..page_arguments import PageArguments, RouteMatch
 
 
 class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-pages'):
+
     def __init__(self,
                  routes: Optional[Dict[str, Callable]] = None,
                  *,
@@ -203,7 +204,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
                 task.cancel()
         self._active_tasks.clear()
 
-    def _handle_scrolling(self, match, *, behavior: str):
+    def _handle_scrolling(self, match: RouteMatch, *, behavior: str) -> None:
         if match.fragment:
             self._scroll_to_fragment(match.fragment, behavior=behavior)
         elif not self._router.is_initial_request:  # NOTE: the initial path has no fragment; to not interfere with later fragment scrolling, we skip scrolling to top
@@ -216,7 +217,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
             }});
         ''')
 
-    def _scroll_to_top(self, behavior: str) -> None:
+    def _scroll_to_top(self, *, behavior: str) -> None:
         run_javascript(f'''
             requestAnimationFrame(() => {{ window.scrollTo({{top: 0, left: 0, behavior: "{behavior}"}}); }});
         ''')

--- a/website/documentation/content/sub_pages_documentation.py
+++ b/website/documentation/content/sub_pages_documentation.py
@@ -150,8 +150,8 @@ def page_arguments_demo():
     # @ui.page('/')
     # @ui.page('/{_:path}') # NOTE: our page should catch all paths
     # def index():
-    #     ui.link('msg=hello', '/documentation/sub_pages?msg=hello')
-    #     ui.link('msg=world', '/documentation/sub_pages?msg=world')
+    #     ui.link('msg=hello', '/?msg=hello')
+    #     ui.link('msg=world', '/?msg=world')
     #     ui.sub_pages({'/': main})
 
     def main(args: PageArguments):


### PR DESCRIPTION
### Motivation

We noticed that embedded `ui.sub_pages` demos caused the whole documentation page to scroll to the top, which made exploring the demos rather tedious and confusing. Apart from that, navigating to /other/a in one demo caused 404 errors in other demos with no inherent way to get the demo working again.

### Implementation

We decided to stop using real `ui.sub_pages` elements for demos but to mock them with a `FakeSubPages` element. The implementation is pretty straightforward: Initialize it with routes and optional data, create a `link` with a given text and route and call `init` at the place where the subpages should be rendered. A `ui.timer` is used to call both sync and async subpage functions.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
