### PR TITLE
Drop auto-index pages in favour of streamlined usage of SPAs via positional root parameter in ui.run

### DIFF
--- a/nicegui/core.py
+++ b/nicegui/core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 from socketio import AsyncServer
 
@@ -13,3 +13,4 @@ app: App
 sio: AsyncServer
 loop: Optional[asyncio.AbstractEventLoop] = None
 air: Optional[Air] = None
+spa: Optional[Callable] = None

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -2,7 +2,7 @@ import multiprocessing
 import os
 import sys
 from pathlib import Path
-from typing import Any, List, Literal, Optional, Tuple, TypedDict, Union
+from typing import Any, Callable, List, Literal, Optional, Tuple, TypedDict, Union
 
 from fastapi.middleware.gzip import GZipMiddleware
 from starlette.routing import Route
@@ -45,7 +45,7 @@ class DocsConfig(TypedDict):
     license_info: Optional[LicenseInfoDict]
 
 
-def run(*,
+def run(root: Optional[Callable] = None, *,
         host: Optional[str] = None,
         port: Optional[int] = None,
         title: str = 'NiceGUI',
@@ -126,6 +126,7 @@ def run(*,
         prod_js=prod_js,
         show_welcome_message=show_welcome_message,
     )
+    core.spa = root
     core.app.config.endpoint_documentation = endpoint_documentation
     if not helpers.is_pytest():
         core.app.add_middleware(GZipMiddleware)


### PR DESCRIPTION
### Motivation

As discussed in #4964, we could streamline the the setup of NiceGUI as an SPA by providing a positional `root` parameter in `ui.run`. The basic pattern becomes so simple that we do not need auto-index pages anymore 🎉

### Implementation

This PR implements an idea form @falkoschindler and me while discussing #4964: by evaluating the `root` builder function in the FastAPI default 404 handler we do not need to register catch-all FastAPI routes at all. Thereby any other defined FastAPI routes take precedence. Only if the FastAPI routing fails we route the path to the `root` builder function passed via `ui.run`.  A basic (already working) example looks like this:

```py
from nicegui import ui

def root():
    ui.link('Go to main page', '/')
    ui.link('Go to other page', '/other')
    ui.sub_pages({
        '/': main,
        '/other': other,
    })

def main():
    ui.label('Main page content')

def other():
    ui.label('Another page content')

@ui.page('/test')
def test():
    ui.label('Test page content')

ui.run(root)
```

Of course that only works when auto-index page does not register a `/` page on it's own.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] The implementation is complete.
  - [ ] remove all auto-index client related code
  - [ ] provide support for async root pages
  - [ ] inject required parameters into root page similar to what ui.sub_pages does
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).
