### PR TITLE
Switch to Jsdelivr CDN for downloading NPM packages

### DIFF
--- a/npm.json
+++ b/npm.json
@@ -2,49 +2,48 @@
   "vue": {
     "destination": "nicegui/static",
     "keep": [
-      "package/dist/vue\\.global(\\.prod)?\\.js"
+      "dist/vue\\.global(\\.prod)?\\.js"
     ],
     "rename": {
-      "package/dist": ".."
+      "dist": ".."
     },
     "version": "3.4.38"
   },
   "quasar": {
     "destination": "nicegui/static",
     "keep": [
-      "package/dist/quasar\\.umd(\\.prod)?\\.js",
-      "package/dist/quasar(\\.prod)?\\.css",
-      "package/dist/lang/.*\\.umd\\.prod\\.js"
+      "dist/quasar\\.umd(\\.prod)?\\.js",
+      "dist/quasar(\\.prod)?\\.css",
+      "dist/lang/.*\\.umd\\.prod\\.js"
     ],
     "rename": {
-      "package/dist": ".."
+      "dist": ".."
     },
     "version": "2.16.9"
   },
   "tailwindcss": {
     "destination": "nicegui/static",
     "keep": [],
-    "download": "https://cdn.tailwindcss.com",
     "rename": "../tailwindcss.min.js",
     "version": "3.4.10"
   },
   "socket.io": {
     "destination": "nicegui/static",
     "keep": [
-      "package/client-dist/socket\\.io\\.min\\.js(\\.map)?"
+      "client-dist/socket\\.io\\.min\\.js(\\.map)?"
     ],
     "rename": {
-      "package/client-dist": ".."
+      "client-dist": ".."
     },
     "version": "4.7.5"
   },
   "es-module-shims": {
     "destination": "nicegui/static",
     "keep": [
-      "package/dist/es-module-shims\\.js"
+      "dist/es-module-shims\\.js"
     ],
     "rename": {
-      "package/dist": ".."
+      "dist": ".."
     },
     "version": "1.10.0"
   },
@@ -52,78 +51,78 @@
     "package": "ag-grid-community",
     "destination": "nicegui/elements/lib",
     "keep": [
-      "package/dist/ag-grid-community(\\.min)?\\.js"
+      "dist/ag-grid-community(\\.min)?\\.js"
     ],
     "rename": {
-      "package/dist/": ""
+      "dist/": ""
     },
     "version": "32.1.0"
   },
   "echarts": {
     "destination": "nicegui/elements/lib",
     "keep": [
-      "package/dist/echarts\\.min\\.js",
-      "package/dist/echarts\\.js\\.map"
+      "dist/echarts\\.min\\.js",
+      "dist/echarts\\.js\\.map"
     ],
     "rename": {
-      "package/dist/": ""
+      "dist/": ""
     },
     "version": "5.5.1"
   },
   "echarts-gl": {
     "destination": "nicegui/elements/lib",
     "keep": [
-      "package/dist/echarts-gl\\.min\\.js",
-      "package/dist/echarts-gl\\.js\\.map"
+      "dist/echarts-gl\\.min\\.js",
+      "dist/echarts-gl\\.js\\.map"
     ],
     "rename": {
-      "package/dist/": ""
+      "dist/": ""
     },
     "version": "2.0.9"
   },
   "leaflet": {
     "destination": "nicegui/elements/lib/leaflet",
     "keep": [
-      "package/dist/leaflet\\.css",
-      "package/dist/leaflet\\.js",
-      "package/dist/leaflet\\.js\\.map",
-      "package/dist/images/.*"
+      "dist/leaflet\\.css",
+      "dist/leaflet\\.js",
+      "dist/leaflet\\.js\\.map",
+      "dist/images/.*"
     ],
     "rename": {
-      "package/dist/": ""
+      "dist/": ""
     },
     "version": "1.9.4"
   },
   "leaflet-draw": {
     "destination": "nicegui/elements/lib/leaflet",
     "keep": [
-      "package/dist/leaflet\\.draw\\.css",
-      "package/dist/leaflet\\.draw\\.js",
-      "package/dist/images/.*"
+      "dist/leaflet\\.draw\\.css",
+      "dist/leaflet\\.draw\\.js",
+      "dist/images/.*"
     ],
     "rename": {
-      "package/dist/": ""
+      "dist/": ""
     },
     "version": "1.0.4"
   },
   "mermaid": {
     "destination": "nicegui/elements/lib",
     "keep": [
-      "package/dist/mermaid.esm.min\\.mjs",
-      "package/dist/chunks/mermaid.esm.min/.*\\.mjs"
+      "dist/mermaid.esm.min\\.mjs",
+      "dist/chunks/mermaid.esm.min/.*\\.mjs"
     ],
     "rename": {
-      "package/dist/": ""
+      "dist/": ""
     },
     "version": "11.0.2"
   },
   "nipplejs": {
     "destination": "nicegui/elements/lib",
     "keep": [
-      "package/dist/nipplejs(\\.min)?\\.js"
+      "dist/nipplejs(\\.min)?\\.js"
     ],
     "rename": {
-      "package/dist/": ""
+      "dist/": ""
     },
     "version": "0.10.2"
   },
@@ -131,33 +130,33 @@
     "package": "plotly.js",
     "destination": "nicegui/elements/lib",
     "keep": [
-      "package/dist/plotly(\\.min)?\\.js"
+      "dist/plotly(\\.min)?\\.js"
     ],
     "rename": {
-      "package/dist/": ""
+      "dist/": ""
     },
     "version": "2.35.0"
   },
   "three": {
     "destination": "nicegui/elements/lib",
     "keep": [
-      "package/build/three\\.module\\.js",
-      "package/examples/jsm/renderers/CSS2DRenderer(\\.min)?\\.js",
-      "package/examples/jsm/renderers/CSS3DRenderer(\\.min)?\\.js",
-      "package/examples/jsm/controls/OrbitControls(\\.min)?\\.js",
-      "package/examples/jsm/controls/DragControls(\\.min)?\\.js",
-      "package/examples/jsm/loaders/STLLoader(\\.min)?\\.js",
-      "package/examples/jsm/loaders/GLTFLoader(\\.min)?\\.js",
-      "package/examples/jsm/libs/tween\\.module(\\.min)?\\.js",
-      "package/examples/jsm/utils/BufferGeometryUtils(\\.min)?\\.js"
+      "build/three\\.module\\.js",
+      "examples/jsm/renderers/CSS2DRenderer(\\.min)?\\.js",
+      "examples/jsm/renderers/CSS3DRenderer(\\.min)?\\.js",
+      "examples/jsm/controls/OrbitControls(\\.min)?\\.js",
+      "examples/jsm/controls/DragControls(\\.min)?\\.js",
+      "examples/jsm/loaders/STLLoader(\\.min)?\\.js",
+      "examples/jsm/loaders/GLTFLoader(\\.min)?\\.js",
+      "examples/jsm/libs/tween\\.module(\\.min)?\\.js",
+      "examples/jsm/utils/BufferGeometryUtils(\\.min)?\\.js"
     ],
     "rename": {
-      "package/build/": "",
-      "package/examples/jsm/renderers/": "modules/",
-      "package/examples/jsm/controls/": "modules/",
-      "package/examples/jsm/loaders/": "modules/",
-      "package/examples/jsm/libs/": "modules/",
-      "package/examples/jsm/utils/": "modules/"
+      "build/": "",
+      "examples/jsm/renderers/": "modules/",
+      "examples/jsm/controls/": "modules/",
+      "examples/jsm/loaders/": "modules/",
+      "examples/jsm/libs/": "modules/",
+      "examples/jsm/utils/": "modules/"
     },
     "version": "0.168.0"
   },
@@ -165,22 +164,19 @@
     "package": "@tweenjs/tween.js",
     "destination": "nicegui/elements/lib",
     "keep": [
-      "package/dist/tween\\.umd(\\.min)?\\.js"
+      "dist/tween\\.umd(\\.min)?\\.js"
     ],
     "rename": {
-      "package/dist/": ""
+      "dist/": ""
     },
     "version": "25.0.0"
   },
   "vanilla-jsoneditor": {
     "destination": "nicegui/elements/lib",
     "keep": [
-      "package/standalone\\.js",
-      "package/standalone\\.js\\.map"
+      "standalone\\.js",
+      "standalone\\.js\\.map"
     ],
-    "rename": {
-      "package/": ""
-    },
     "version": "0.23.8"
   }
 }

--- a/npm.py
+++ b/npm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Update dependencies according to npm.json configurations using the NPM packagist.
+"""Update dependencies according to npm.json configurations using jsDelivr CDN.
 
 npm.json file is a JSON object key => dependency.
 
@@ -13,8 +13,6 @@ npm.json file is a JSON object key => dependency.
 """
 import json
 import re
-import shutil
-import tarfile
 import tempfile
 from argparse import ArgumentParser
 from pathlib import Path
@@ -36,11 +34,6 @@ def prepare(path: Path) -> Path:
     return path
 
 
-def cleanup(path: Path) -> Path:
-    shutil.rmtree(path, ignore_errors=True)
-    return path
-
-
 def url_to_filename(url: str) -> str:
     return re.sub(r'[^a-zA-Z0-9]', '_', url)
 
@@ -51,6 +44,40 @@ def download_buffered(url: str) -> Path:
         response = httpx.get(url, headers={'User-Agent': 'Mozilla/5.0'}, timeout=3)
         filepath.write_bytes(response.content)
     return filepath
+
+
+def get_package_info_from_jsdelivr(pkg_name: str) -> dict:
+    path = download_buffered(f'https://data.jsdelivr.com/v1/package/npm/{pkg_name}')
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def get_package_files_from_jsdelivr(pkg_name: str, version: str) -> dict:
+    path = download_buffered(f'https://data.jsdelivr.com/v1/package/npm/{pkg_name}@{version}')
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def download_file_from_jsdelivr(pkg_name: str, version: str, filepath: str) -> bytes:
+    return download_buffered(f'https://cdn.jsdelivr.net/npm/{pkg_name}@{version}/{filepath}').read_bytes()
+
+
+def find_matching_files(files_dict: dict, pattern: str) -> list[str]:
+    matches = []
+
+    def traverse(files_list, current_path=''):
+        for file_info in files_list:
+            if file_info['type'] == 'file':
+                full_path = f"{current_path}/{file_info['name']}" if current_path else file_info['name']
+                if re.match(f'^{pattern}$', full_path):
+                    matches.append(full_path)
+            elif file_info['type'] == 'directory':
+                new_path = f"{current_path}/{file_info['name']}" if current_path else file_info['name']
+                if 'files' in file_info:
+                    traverse(file_info['files'], new_path)
+
+    if 'files' in files_dict:
+        traverse(files_dict['files'])
+
+    return matches
 
 
 DEPENDENCIES = (root_path / 'DEPENDENCIES.md').open('w', encoding='utf-8')
@@ -64,95 +91,82 @@ KNOWN_LICENSES = {
     'BSD-3-Clause': 'https://opensource.org/licenses/BSD-3-Clause',
 }
 
-# Create a hidden folder to work in.
-tmp = cleanup(root_path / '.npm')
-
 dependencies: dict[str, dict] = json.loads((root_path / 'npm.json').read_text(encoding='utf-8'))
 for key, dependency in dependencies.items():
     if names is not None and key not in names:
         continue
 
-    # Reset destination folder.
     destination = prepare(root_path / dependency['destination'] / key)
 
-    # Get package info from NPM.
-    package_name = dependency.get('package', key)
-    npm_data = json.loads(download_buffered(f'https://registry.npmjs.org/{package_name}').read_text(encoding='utf-8'))
-    npm_version = dependency.get('version') or dependency.get('version', npm_data['dist-tags']['latest'])
-    npm_tarball = npm_data['versions'][npm_version]['dist']['tarball']
-    license_ = 'UNKNOWN'
-    if 'license' in npm_data['versions'][npm_version]:
-        license_ = npm_data['versions'][npm_version]['license']
-    elif package_name == 'echarts-gl':
-        license_ = 'BSD-3-Clause'
-    print(f'{key}: {npm_version} - {npm_tarball} ({license_})')
-    DEPENDENCIES.write(f'- {key}: {npm_version} ([{license_}]({KNOWN_LICENSES.get(license_, license_)}))\n')
+    try:
+        package_name = dependency.get('package', key)
+        package_info = get_package_info_from_jsdelivr(package_name)
+        npm_version = dependency.get('version') or package_info['tags']['latest']
+        files_info = get_package_files_from_jsdelivr(package_name, npm_version)
 
-    # Handle the special case of tailwind. Hopefully remove this soon.
-    if 'download' in dependency:
-        download_path = download_buffered(dependency['download'])
-        content = download_path.read_text(encoding='utf-8')
-        MSG = (
-            'console.warn("cdn.tailwindcss.com should not be used in production. '
-            'To use Tailwind CSS in production, install it as a PostCSS plugin or use the Tailwind CLI: '
-            'https://tailwindcss.com/docs/installation");'
-        )
-        if MSG not in content:
-            raise ValueError(f'Expected to find "{MSG}" in {download_path}')
-        content = content.replace(MSG, '')
-        prepare(destination / dependency['rename']).write_text(content, encoding='utf-8')
+        license_ = 'UNKNOWN'
+        try:
+            package_json_content = download_file_from_jsdelivr(package_name, npm_version, 'package.json')
+            package_json = json.loads(package_json_content.decode('utf-8'))
+            if 'license' in package_json:
+                license_ = package_json['license']
+            elif package_name == 'echarts-gl':
+                license_ = 'BSD-3-Clause'
+        except Exception:
+            if package_name == 'echarts-gl':
+                license_ = 'BSD-3-Clause'
 
-    # Download and extract.
-    tgz_file = prepare(Path(tmp, key, f'{key}.tgz'))
-    tgz_download = download_buffered(npm_tarball)
-    shutil.copyfile(tgz_download, tgz_file)
-    with tarfile.open(tgz_file) as archive:
-        to_be_extracted: list[tarfile.TarInfo] = []
-        for tarinfo in archive.getmembers():
-            for keep in dependency['keep']:
-                if re.match(f'^{keep}$', tarinfo.name):
-                    to_be_extracted.append(tarinfo)  # TODO: simpler?
+        jsdelivr_url = f'https://cdn.jsdelivr.net/npm/{package_name}@{npm_version}/'
+        print(f'{key}: {npm_version} - {jsdelivr_url} ({license_})')
+        DEPENDENCIES.write(f'- {key}: {npm_version} ([{license_}]({KNOWN_LICENSES.get(license_, license_)}))\n')
 
-        archive.extractall(members=to_be_extracted, path=Path(tmp, key))
+        for keep_pattern in dependency['keep']:
+            matching_files = find_matching_files(files_info, keep_pattern)
 
-        for extracted in to_be_extracted:
-            filename: str = extracted.name
-            for rename in dependency['rename']:
-                filename = filename.replace(rename, dependency['rename'][rename])
+            for file_path in matching_files:
+                try:
+                    file_content = download_file_from_jsdelivr(package_name, npm_version, file_path)
 
-            newfile = prepare(Path(destination, filename))
-            if newfile.exists():
-                newfile.unlink()
-            Path(tmp, key, extracted.name).rename(newfile)
+                    filename = file_path
+                    for rename_from, rename_to in dependency.get('rename', {}).items():
+                        filename = filename.replace(rename_from, rename_to)
 
-            if 'GLTFLoader' in filename:
-                content = newfile.read_text(encoding='utf-8')
-                MSG = '../utils/BufferGeometryUtils.js'
-                if MSG not in content:
-                    raise ValueError(f'Expected to find "{MSG}" in {filename}')
-                content = content.replace(MSG, 'BufferGeometryUtils')
-                newfile.write_text(content, encoding='utf-8')
+                    newfile = prepare(Path(destination, filename))
+                    if newfile.exists():
+                        newfile.unlink()
 
-            if 'DragControls.js' in filename:
-                content = newfile.read_text(encoding='utf-8')
-                MSG = '_selected = findGroup( _intersections[ 0 ].object )'
-                if MSG not in content:
-                    raise ValueError(f'Expected to find "{MSG}" in {filename}')
-                content = content.replace(MSG, MSG + ' || _intersections[ 0 ].object')
-                newfile.write_text(content, encoding='utf-8')
+                    newfile.write_bytes(file_content)
 
-            if 'mermaid.esm.min.mjs' in filename:
-                content = newfile.read_text(encoding='utf-8')
-                content = re.sub(r'"\./chunks/mermaid.esm.min/(.*?)\.mjs"', r'"\1"', content)
-                newfile.write_text(content, encoding='utf-8')
+                    if 'GLTFLoader' in filename:
+                        content = newfile.read_text(encoding='utf-8')
+                        MSG = '../utils/BufferGeometryUtils.js'
+                        if MSG in content:
+                            content = content.replace(MSG, 'BufferGeometryUtils')
+                            newfile.write_text(content, encoding='utf-8')
+
+                    if 'DragControls.js' in filename:
+                        content = newfile.read_text(encoding='utf-8')
+                        MSG = '_selected = findGroup( _intersections[ 0 ].object )'
+                        if MSG in content:
+                            content = content.replace(MSG, MSG + ' || _intersections[ 0 ].object')
+                            newfile.write_text(content, encoding='utf-8')
+
+                    if 'mermaid.esm.min.mjs' in filename:
+                        content = newfile.read_text(encoding='utf-8')
+                        content = re.sub(r'"\./chunks/mermaid.esm.min/(.*?)\.mjs"', r'"\1"', content)
+                        newfile.write_text(content, encoding='utf-8')
+
+                except Exception as e:
+                    print(f'Warning: Failed to download {file_path} for {package_name}: {e}')
+
+    except Exception as e:
+        print(f'Error processing package {package_name}: {e}')
+        continue
 
     try:
-        # Delete destination folder if empty.
         if not any(destination.iterdir()):
             destination.rmdir()
     except Exception:
         pass
 
 temp_dir.cleanup()
-
-cleanup(tmp)


### PR DESCRIPTION
### Motivation

In PR #4749 we couldn't get an ESM for ajv-formats from registry.npmjs.org. So we decided to switch to Jsdelivr.

### Implementation

This PR re-implements parts of npm.py to work with Jsdelivr. The special case for TailwindCSS could be removed.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
