### PR TITLE
Fix bad navigation of relative urls

### DIFF
--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 from ..client import Client
 from ..context import context
 from ..element import Element
+from ..elements.sub_pages import SubPages
 from .javascript import run_javascript
 
 
@@ -68,7 +69,8 @@ class Navigate:
         else:
             raise TypeError(f'Invalid target type: {type(target)}')
 
-        if not new_tab and isinstance(target, str) and not bool(urlparse(target).netloc):
+        if not new_tab and isinstance(target, str) and not bool(urlparse(target).netloc) and \
+                any(isinstance(el, SubPages) for el in context.client.elements.values()):
             context.client.sub_pages_router._handle_navigate(path)  # pylint: disable=protected-access
             return
 

--- a/nicegui/sub_pages_router.py
+++ b/nicegui/sub_pages_router.py
@@ -61,8 +61,11 @@ class SubPagesRouter:
         # NOTE: keep a reference to the client because _handle_open clears the slots so that context.client does not work anymore
         client = context.client
         if (
-            self._handle_open(path) or  # path is handled by `ui.sub_pages`
-            not self._other_page_builder_matches_path(path, client)  # `ui.sub_pages` is still responsible
+            any(isinstance(el, SubPages) for el in client.layout.descendants()) and
+            (
+                self._handle_open(path) or  # path is handled by `ui.sub_pages`
+                not self._other_page_builder_matches_path(path, client)  # `ui.sub_pages` is still responsible
+            )
         ):
             client.run_javascript(f'''
                 const fullPath = (window.path_prefix || '') + "{self.current_path}";

--- a/nicegui/sub_pages_router.py
+++ b/nicegui/sub_pages_router.py
@@ -61,11 +61,8 @@ class SubPagesRouter:
         # NOTE: keep a reference to the client because _handle_open clears the slots so that context.client does not work anymore
         client = context.client
         if (
-            any(isinstance(el, SubPages) for el in client.layout.descendants()) and
-            (
-                self._handle_open(path) or  # path is handled by `ui.sub_pages`
-                not self._other_page_builder_matches_path(path, client)  # `ui.sub_pages` is still responsible
-            )
+            self._handle_open(path) or  # path is handled by `ui.sub_pages`
+            not self._other_page_builder_matches_path(path, client)  # `ui.sub_pages` is still responsible
         ):
             client.run_javascript(f'''
                 const fullPath = (window.path_prefix || '') + "{self.current_path}";

--- a/tests/test_navigate.py
+++ b/tests/test_navigate.py
@@ -48,7 +48,7 @@ def test_navigate_to_relative_url(screen: Screen):
     @ui.page('/test_page')
     def test_page():
         ui.label('Test page')
-        ui.button('Back', on_click=ui.navigate.to('/'))
+        ui.button('Back', on_click=ui.navigate.back)
 
     screen.open('/')
     screen.click('Go relative')

--- a/tests/test_navigate.py
+++ b/tests/test_navigate.py
@@ -53,7 +53,8 @@ def test_navigate_to_relative_url(screen: Screen):
     screen.open('/')
     screen.click('Go relative')
     screen.wait(0.2)
-    assert '/test_page' in screen.selenium.current_url
+    assert screen.selenium.current_url == f'http://localhost:{Screen.PORT}/test_page'
+
     screen.click('Back')
     screen.wait(0.2)
-    assert '/' in screen.selenium.current_url
+    assert screen.selenium.current_url == f'http://localhost:{Screen.PORT}/'

--- a/tests/test_navigate.py
+++ b/tests/test_navigate.py
@@ -38,3 +38,22 @@ def test_navigate_to_absolute_url(screen: Screen):
     screen.click('Go external')
     screen.wait(1.0)
     assert external_url in screen.selenium.current_url
+
+
+def test_navigate_to_relative_url(screen: Screen):
+    @ui.page('/')
+    def page():
+        ui.button('Go relative', on_click=lambda: ui.navigate.to('/test_page'))
+
+    @ui.page('/test_page')
+    def test_page():
+        ui.label('Test page')
+        ui.button('Back', on_click=ui.navigate.to('/'))
+
+    screen.open('/')
+    screen.click('Go relative')
+    screen.wait(0.2)
+    assert '/test_page' in screen.selenium.current_url
+    screen.click('Back')
+    screen.wait(0.2)
+    assert '/' in screen.selenium.current_url


### PR DESCRIPTION
### Motivation

In #5023, @MicaelJarniac reported that the google oauth example is broken. But the problem is much larger. All relative navigations do not work if you use page builder but not the new `ui.sub_pages`. We fixed absolute urls in #4999. But relative urls are also problematic.

### Implementation

This PR fixes #5023 by ensuring sub pages router only handles navigation if there are ui.sub_pages elements.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
