### PR TITLE
Use fly.io autoscaler for https://nicegui.io

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+
+
+def run(cmd: list[str], capture: bool = False) -> str:
+    if capture:
+        return subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
+    subprocess.run(cmd, check=True)
+    return ''
+
+
+try:
+    v = run(['git', 'describe', '--abbrev=0', '--tags', '--match', 'v*'], capture=True).strip()
+    version = v.lstrip('v') or '0.0.0'
+except Exception:
+    version = '0.0.0'
+
+run(['fly', 'deploy', '--wait-timeout', '360', '--build-arg', f'VERSION={version}'])
+
+instances = {
+    'yul': 2,  # Montreal, Quebec (Canada)
+    'iad': 4,  # Washington DC, Virginia (US)
+    'sjc': 2,  # San Jose, California (US)
+    'lax': 2,  # Los Angeles, California (US)
+    'mia': 3,  # Miami, Florida (US)
+    'sea': 2,  # Seattle, Washington (US)
+    'fra': 5,  # Frankfurt, Germany
+    'ams': 2,  # Amsterdam, Netherlands
+    'mad': 1,  # Madrid, Spain
+    'cdg': 2,  # Paris, France
+    'lhr': 2,  # London, England (UK)
+    'otp': 1,  # Bucharest, Romania
+    'jnb': 1,  # Johannesburg, South Africa
+    'bom': 1,  # Mumbai, India
+    'nrt': 4,  # Tokyo, Japan
+    'sin': 2,  # Singapore
+    'hkg': 4,  # Hong Kong
+    'syd': 1,  # Sydney, Australia
+    'gru': 1,  # Sao Paulo, Brazil
+}
+for region, count in instances.items():
+    run(['fly', 'scale', 'count', f'app={count}', '--region', region, '-y'])
+
+# NOTE: pin first machine per region to avoid cold-start latency
+machines_json = run(['fly', 'machines', 'list', '--json'], capture=True)
+machines = json.loads(machines_json)
+pinned = set()
+for m in machines:
+    r = m.get('region', 'unknown')
+    if r in pinned:
+        continue
+    mid = m.get('id')
+    if mid:
+        run(['fly', 'machine', 'update', mid, '--autostop=false', '-y'])
+        print(f'pinned {mid} in {r}')
+        pinned.add(r)

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,2 +1,0 @@
-
-fly deploy --wait-timeout 360 --build-arg VERSION=$(git describe --abbrev=0 --tags --match 'v*' 2>/dev/null | sed 's/^v//' || echo '0.0.0')

--- a/fly.toml
+++ b/fly.toml
@@ -9,7 +9,6 @@ kill_signal = "SIGTERM"
 kill_timeout = "5s"
 swap_size_mb = 2048
 
-
 [build]
   dockerfile = "fly.dockerfile"
 
@@ -23,9 +22,9 @@ swap_size_mb = 2048
   protocol = "tcp"
   internal_port = 8080
   processes = ["app"]
-  auto_stop_machines = false
+  auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 18
+  min_machines_running = 1
 
   [[services.ports]]
     port = 80
@@ -35,9 +34,10 @@ swap_size_mb = 2048
   [[services.ports]]
     port = 443
     handlers = ["tls", "http"]
+
   [services.concurrency]
     type = "requests"
-    hard_limit = 2000
+    hard_limit = 200
     soft_limit = 100
 
   [[services.tcp_checks]]


### PR DESCRIPTION
### Motivation

Managing fly.io instances has been quite a burden. Sometimes it was simpler to keep more instances running than necessary to handle spikes at other times. The fly.io build in auto-scaler could not be used out of the box, because the cold-start of a machine in a region without any instances takes a few seconds (which results in waiting time for the visitor).

### Implementation

The new `deploy.py` keeps one instance per region running by removing it from the autoscaler. With that trick, instances are started and stopped by fly.io on demand without having poor experience for regions with only a few visitors.


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation has been added.
