### PR TITLE
Fix Tailwind for `ui.dark_mode` in combination with `ui.run(dark=None)`

### DIFF
--- a/nicegui/elements/dark_mode.js
+++ b/nicegui/elements/dark_mode.js
@@ -8,12 +8,6 @@ export default {
   methods: {
     update() {
       Quasar.Dark.set(this.value === null ? "auto" : this.value);
-      if (window.tailwind) {
-        const mode = this.value === null ? "media" : "class";
-        if (mode !== tailwind.config.darkMode) tailwind.config.darkMode = mode;
-        if (this.value) document.body.classList.add("dark");
-        else document.body.classList.remove("dark");
-      }
     },
   },
   props: {

--- a/nicegui/elements/dark_mode.py
+++ b/nicegui/elements/dark_mode.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-from .. import core, helpers
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.value_element import ValueElement
 
@@ -20,19 +19,6 @@ class DarkMode(ValueElement, component='dark_mode.js'):
         :param on_change: Callback that is invoked when the value changes.
         """
         super().__init__(value=value, on_value_change=on_change)
-
-        # HACK: this is a temporary warning to inform users about issue #3753
-        if core.app.is_started:
-            self._check_for_issue_3753()
-        else:
-            core.app.on_startup(self._check_for_issue_3753)
-
-    def _check_for_issue_3753(self) -> None:
-        if self.client.page.resolve_dark() is None and core.app.config.tailwind:
-            helpers.warn_once(
-                '`ui.dark_mode` is not supported on pages with `dark=None` while running with `tailwind=True` (the default). '
-                'See https://github.com/zauberzeug/nicegui/issues/3753 for more information.'
-            )
 
     def enable(self) -> None:
         """Enable dark mode."""

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -61,8 +61,7 @@
       {{ vue_scripts | safe }}
 
       {% if tailwind %}
-      if (dark !== None) tailwind.config.darkMode = "class";
-      if (dark === True) document.body.classList.add("dark");
+      tailwind.config.darkMode = ["class", "body.body--dark"];
       {% endif %}
 
       app.mount("#app");

--- a/tests/test_dark_mode.py
+++ b/tests/test_dark_mode.py
@@ -12,7 +12,6 @@ def test_dark_mode(screen: Screen):
 
     def assert_dark(value: bool) -> None:
         classes = (screen.find_by_tag('body').get_attribute('class') or '').split()
-        assert ('dark' in classes) == value
         assert ('body--dark' in classes) == value
         assert ('body--light' in classes) != value
 


### PR DESCRIPTION
### Motivation

While working on migrating to Tailwind 4, I learned how to properly configure dark mode to use Quasar's `body.body--dark` class and noticed that we can use it for Tailwind 3 as well. As it turns out, this solves both #3753 as well as #4886. 🎉

### Implementation

This PR configures Tailwind to watch Quasar's `body.body--dark` class:
```js
tailwind.config.darkMode = ["class", "body.body--dark"];
```
This way Tailwind follows Quasar's dark mode precisely and we can remove all other code related to Tailwind's dark mode.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary (or at least very difficult if we want to simulate the system preference).
- [x] Documentation is not necessary.
