### PR TITLE
Use weak references for parent slot to avoid cyclic references

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -76,17 +76,18 @@ class Element(Visibility):
         self._deleted: bool = False
 
         client.elements[self.id] = self
-        self.parent_slot: Optional[Slot] = None
+        self._parent_slot: Optional[weakref.ref[Slot]] = None
         slot_stack = context.slot_stack
         if slot_stack:
-            self.parent_slot = slot_stack[-1]
-            self.parent_slot.children.append(self)
+            parent_slot = slot_stack[-1]
+            parent_slot.children.append(self)
+            self._parent_slot = weakref.ref(parent_slot)
 
         self.tailwind = Tailwind(self)
 
         client.outbox.enqueue_update(self)
-        if self.parent_slot:
-            client.outbox.enqueue_update(self.parent_slot.parent)
+        if self._parent_slot:
+            client.outbox.enqueue_update(parent_slot.parent)
 
     def __init_subclass__(cls, *,
                           component: Union[str, Path, None] = None,
@@ -155,6 +156,20 @@ class Element(Visibility):
         if client is None:
             raise RuntimeError('The client this element belongs to has been deleted.')
         return client
+
+    @property
+    def parent_slot(self) -> Optional[Slot]:
+        """The parent slot of the element."""
+        if self._parent_slot is None:
+            return None
+        parent_slot = self._parent_slot()
+        if parent_slot is None:
+            raise RuntimeError('The parent slot of the element has been deleted.')
+        return parent_slot
+
+    @parent_slot.setter
+    def parent_slot(self, value: Optional[Slot]) -> None:
+        self._parent_slot = weakref.ref(value) if value else None
 
     def add_resource(self, path: Union[str, Path]) -> None:
         """Add a resource to the element.
@@ -455,8 +470,9 @@ class Element(Visibility):
         """
         if include_self:
             yield self
-        if self.parent_slot:
-            yield from self.parent_slot.parent.ancestors(include_self=True)
+        parent_slot = self.parent_slot
+        if parent_slot:
+            yield from parent_slot.parent.ancestors(include_self=True)
 
     def descendants(self, *, include_self: bool = False) -> Iterator[Element]:
         """Iterate over the descendants of the element.
@@ -485,21 +501,24 @@ class Element(Visibility):
         :param target_index: index within the target slot (default: append to the end)
         :param target_slot: slot within the target container (default: default slot)
         """
-        assert self.parent_slot is not None
-        self.parent_slot.children.remove(self)
-        self.parent_slot.parent.update()
-        target_container = target_container or self.parent_slot.parent
+        parent_slot = self.parent_slot
+        assert parent_slot is not None
+        parent_slot.children.remove(self)
+        parent_slot.parent.update()
+        target_container = target_container or parent_slot.parent
 
         if target_slot is None:
-            self.parent_slot = target_container.default_slot
+            parent_slot = target_container.default_slot
+            self.parent_slot = parent_slot
         elif target_slot in target_container.slots:
-            self.parent_slot = target_container.slots[target_slot]
+            parent_slot = target_container.slots[target_slot]
+            self.parent_slot = parent_slot
         else:
             raise ValueError(f'Slot "{target_slot}" does not exist in the target container. '
                              f'Add it first using `add_slot("{target_slot}")`.')
 
-        target_index = target_index if target_index >= 0 else len(self.parent_slot.children)
-        self.parent_slot.children.insert(target_index, self)
+        target_index = target_index if target_index >= 0 else len(parent_slot.children)
+        parent_slot.children.insert(target_index, self)
 
         target_container.update()
 
@@ -512,14 +531,16 @@ class Element(Visibility):
             children = list(self)
             element = children[element]
         self.client.remove_elements(element.descendants(include_self=True))
-        assert element.parent_slot is not None
-        element.parent_slot.children.remove(element)
+        parent_slot = element.parent_slot
+        assert parent_slot is not None
+        parent_slot.children.remove(element)
         self.update()
 
     def delete(self) -> None:
         """Delete the element and all its children."""
-        assert self.parent_slot is not None
-        self.parent_slot.parent.remove(self)
+        parent_slot = self.parent_slot
+        assert parent_slot is not None
+        parent_slot.parent.remove(self)
 
     def _handle_delete(self) -> None:
         """Called when the element is deleted.

--- a/nicegui/elements/timer.py
+++ b/nicegui/elements/timer.py
@@ -40,8 +40,9 @@ class Timer(BaseTimer, Element, component='timer.js'):
     def _cleanup(self) -> None:
         super()._cleanup()
         if not self._deleted:
-            assert self.parent_slot
-            self.parent_slot.parent.remove(self)
+            parent_slot = self.parent_slot
+            assert parent_slot is not None
+            parent_slot.parent.remove(self)
 
     def set_visibility(self, visible: bool) -> None:
         raise NotImplementedError('Use `activate()`, `deactivate()` or `cancel()`. See #3670 for more information.')

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -345,7 +345,7 @@ def test_update_before_client_connection(screen: Screen):
     screen.should_contain('Hello again!')
 
 
-def test_no_cyclic_references(screen: Screen):
+def test_no_cyclic_references_when_deleting_elements(screen: Screen):
     elements: weakref.WeakSet = weakref.WeakSet()
 
     with ui.card() as card:
@@ -358,3 +358,18 @@ def test_no_cyclic_references(screen: Screen):
     assert len(elements) == 0, 'all elements should be deleted immediately'
 
     screen.open('/')
+
+
+def test_no_cyclic_references_when_deleting_clients(screen: Screen):
+    labels = weakref.WeakSet()
+
+    @ui.page('/')
+    def main():
+        labels.add(ui.label())
+
+    screen.open('/')
+    assert len(labels) == 1
+
+    screen.close()
+    screen.wait(3.0)
+    assert len(labels) == 0


### PR DESCRIPTION
### Motivation

In #5052 we noticed that there are still cyclic references between elements and their parent slots. To reduce work for the garbage collector and use much cheaper reference counting, we should avoid such cycles if possible.

### Implementation

Similar to other weak references, this PR introduces a private attribute `self._parent_slot` and a public property `self.parent_slot`. Internal access to the parent slot is optimized to reduce the number of dereferentiations.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary): I'm not sure how because we'd need to disconnected the client and wait.
- [x] Documentation has been added (or is not necessary).
