### PR TITLE
Allow combination of x-forwarded-prefix and root_path

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -131,7 +131,7 @@ class Client:
     def build_response(self, request: Request, status_code: int = 200) -> Response:
         """Build a FastAPI response for the client."""
         self.outbox.updates.clear()
-        prefix = request.headers.get('X-Forwarded-Prefix', request.scope.get('root_path', ''))
+        prefix = request.headers.get('X-Forwarded-Prefix', '') + request.scope.get('root_path', '')
         elements = json.dumps({
             id: element._to_dict() for id, element in self.elements.items()  # pylint: disable=protected-access
         })


### PR DESCRIPTION
### Motivation

In #4930 and #5012 scenarios are presented, where the user has simultaneously `X-Forwarded-Prefix` and `root-path`. This is not yet supported by NiceGUI. In #5038, @twsl created a PR to fix it, but the approach with another middleware has too many unforeseeable side-effects in my opinion. Also @git2212 used GitHub copilot to create a fix in https://github.com/zauberzeug/nicegui/pull/5038. But that code is not a pull request in our repo and the tests look really complicated -- and might not even verify the desired outcome.

### Implementation

The code change is super minimal. It fixes #4930, #5012 and closes #5038. The tricky part is the testing. To verify I did the following:

1. copy [`main.py` from FastAPI example](https://github.com/zauberzeug/nicegui/blob/main/examples/fastapi/main.py) to [Nginx Subpath `app/main.py` example](https://github.com/zauberzeug/nicegui/blob/main/examples/nginx_subpath/app/main.py).
2. add ` port=8080, host='0.0.0.0'` parameters to `uvicorn.run` call in the `main.py` to ensure the nginx proxy can access it
3. add `../../nicegui:/usr/local/lib/python3.11/site-packages/nicegui` as volume mount of the app container in [docker-compose.yml](https://github.com/zauberzeug/nicegui/blob/main/examples/nginx_subpath/docker-compose.yml) to ensure the container runs with my local modifications
4. start with `docker compose up`
5. Access `http://localhost/nicegui/gui`

Without this fix, the page is not shown.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are too complicated.
- [x] Documentation is not necessary.
