### PR TITLE
Handle breaking change of pywebview's dialog type

### DIFF
--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -123,7 +123,7 @@ try:
 
         async def create_file_dialog(  # type: ignore # pylint: disable=invalid-overridden-method
             self,
-            dialog_type: int = webview.OPEN_DIALOG,
+            dialog_type: int = webview.FileDialog.OPEN if hasattr(webview, 'FileDialog') else webview.OPEN_DIALOG,
             directory: str = '',
             allow_multiple: bool = False,
             save_filename: str = '',


### PR DESCRIPTION
### Motivation

In https://github.com/zauberzeug/nicegui/discussions/283#discussioncomment-14166928 @jmmlp noticed that is broken with pywebview 6.0+. As it turns out, pywebview deprecated `webview.OPEN_DIALOG` and replaced it with `webview.FileDialog.OPEN`. To show a deprecation warning to the user, `webview.OPEN_DIALOG` is now a function which can't be pickled, causing an exception when calling `create_file_dialog` without passing a valid `dialog_type`.

### Implementation

This PR checks if the new `webview.FileDialog.OPEN` exists and only uses the old `webview.OPEN_DIALOG` as a fallback. This way NiceGUI works with pywebview 5.4 and 6.0.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
