### PR TITLE
Always load ESM module shims, but async

### DIFF
--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -21,7 +21,7 @@
     {% endfor %}
   </head>
   <body>
-    <script nomodule src="{{ prefix | safe }}/_nicegui/{{version}}/static/es-module-shims.js"></script>
+    <script async src="{{ prefix | safe }}/_nicegui/{{version}}/static/es-module-shims.js"></script>
     <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/socket.io.min.js"></script>
     {% if tailwind %}
     <script defer src="{{ prefix | safe }}/_nicegui/{{version}}/static/tailwindcss.min.js"></script>


### PR DESCRIPTION
### Motivation

Introducing the "nomodule" attribute in PR #4801 causes problems like #3935 or #5020 in some old browsers or webkits which don't understand "nomodule".

### Implementation

This PR removes the "nomodule" attribute, but adds "async" as recommended by the shim. This way the shims are loaded in the background and don't slow down the rendering.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
