### PR TITLE
Fix `navigate.to` with "mailto" URLs in the presence of `ui.sub_pages`

### DIFF
--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -69,11 +69,12 @@ class Navigate:
         else:
             raise TypeError(f'Invalid target type: {type(target)}')
 
-        parsed = urlparse(path)
-        if not new_tab and isinstance(target, str) and parsed.scheme == '' and parsed.netloc == '' and \
-                any(isinstance(el, SubPages) for el in context.client.elements.values()):
-            context.client.sub_pages_router._handle_navigate(path)  # pylint: disable=protected-access
-            return
+        if not new_tab and isinstance(target, str):
+            parsed = urlparse(path)
+            if not parsed.scheme and not parsed.netloc and \
+                    any(isinstance(el, SubPages) for el in context.client.elements.values()):
+                context.client.sub_pages_router._handle_navigate(path)  # pylint: disable=protected-access
+                return
 
         context.client.open(path, new_tab)
 

--- a/tests/test_navigate.py
+++ b/tests/test_navigate.py
@@ -62,22 +62,16 @@ def test_navigate_to_relative_url(screen: Screen):
 
 @pytest.mark.parametrize('sub_pages', [False, True])
 def test_navigate_to_mailto_url(screen: Screen, sub_pages: bool):
-    email_link = 'mailto:test@example.com'
-
     @ui.page('/')
     def page():
-        ui.button('Send mail', on_click=lambda: ui.navigate.to(email_link))
+        ui.button('Send mail', on_click=lambda: ui.navigate.to('mailto:test@example.com'))
         if sub_pages:
             ui.sub_pages({'/': lambda: ui.label('sub page')})
 
     screen.open('/')
     # Override window.open to capture calls instead of triggering the system mail client
-    screen.selenium.execute_script(
-        'window.__open_calls = []; window.open = (url, target) => { window.__open_calls.push([url, target]); };'
-    )
+    screen.selenium.execute_script('window.__open_calls = [];'
+                                   'window.open = (url, target) => window.__open_calls.push([url, target]);')
     screen.click('Send mail')
     screen.wait(0.5)
-    calls = screen.selenium.execute_script('return window.__open_calls')
-    assert len(calls) == 1, 'window.open should have been called'
-    assert calls[0][0] == email_link
-    assert calls[0][1] == ('_self')
+    assert screen.selenium.execute_script('return window.__open_calls') == [['mailto:test@example.com', '_self']]


### PR DESCRIPTION
### Motivation

`mailto:` urls do not work with `navigate.to` when a `ui.sub_pages` element is present.

### Implementation

Now, all `scheme` and `netloc` urls are handled by `client.open` instead of sending them to the `sub_pages_router`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
