### PR TITLE
Only start user storage pruning if a storage secret is set

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -137,7 +137,8 @@ async def _startup() -> None:
     app.timer(10, Client.prune_instances, immediate=False)
     app.timer(10, Slot.prune_stacks, immediate=False)
     app.timer(10, prune_tab_storage, immediate=False)
-    app.timer(10, prune_user_storage, immediate=False)
+    if app.storage.secret:
+        app.timer(10, prune_user_storage, immediate=False)
     air.connect()
 
 


### PR DESCRIPTION
### Motivation

@pascalzauberzeug reported in https://github.com/zauberzeug/air-link/issues/29, that pruning is done even if no storage secret is set. Reproduction:

```py
from nicegui import Client, nicegui, ui

async def prune():
    Client.prune_instances(client_age_threshold=0)
    await nicegui.prune_user_storage(force=True)

@ui.page('/')
def page():
    ui.button('Prune', on_click=prune)

ui.run()
```

### Implementation

User storage pruning needs to access the `request.session` which is only allowed when having a `SessionMiddleware`. This middleware is only added if we have a storage secret.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytest would be to complicated.
- [x] Documentation is not necessary.
