### PR TITLE
Update checkbox value type to support indeterminate state

### DIFF
--- a/nicegui/elements/checkbox.py
+++ b/nicegui/elements/checkbox.py
@@ -8,7 +8,10 @@ from .mixins.value_element import ValueElement
 
 class Checkbox(TextElement, ValueElement, DisableableElement):
 
-    def __init__(self, text: str = '', *, value: Optional[bool] = False, on_change: Optional[Handler[ValueChangeEventArguments]] = None) -> None:
+    def __init__(self,
+                 text: str = '', *,
+                 value: Optional[bool] = False,
+                 on_change: Optional[Handler[ValueChangeEventArguments]] = None) -> None:
         """Checkbox
 
         This element is based on Quasar's `QCheckbox <https://quasar.dev/vue-components/checkbox>`_ component.

--- a/nicegui/elements/switch.py
+++ b/nicegui/elements/switch.py
@@ -8,7 +8,10 @@ from .mixins.value_element import ValueElement
 
 class Switch(TextElement, ValueElement, DisableableElement):
 
-    def __init__(self, text: str = '', *, value: bool = False, on_change: Optional[Handler[ValueChangeEventArguments]] = None) -> None:
+    def __init__(self,
+                 text: str = '', *,
+                 value: Optional[bool] = False,
+                 on_change: Optional[Handler[ValueChangeEventArguments]] = None) -> None:
         """Switch
 
         This element is based on Quasar's `QToggle <https://quasar.dev/vue-components/toggle>`_ component.


### PR DESCRIPTION
### Motivation
The checkbox component already supports `null` value for indeterminate state. This change simplely update type annotation to reflect this behavior.

A simpe example:
```python
from nicegui import ui

checkbox = ui.checkbox("checkbox")

with ui.row():
    ui.button("True", on_click=lambda: setattr(checkbox, "value", True))
    ui.button("False", on_click=lambda: setattr(checkbox, "value", False))
    ui.button("Indet", on_click=lambda: setattr(checkbox, "value", None))

ui.run()
```

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->
<!-- Include any important technical decisions or trade-offs made -->

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
