### PR TITLE
Introduce Event class for sending events between different parts of the code

### DIFF
--- a/nicegui/__init__.py
+++ b/nicegui/__init__.py
@@ -4,6 +4,7 @@ from .app.app import App
 from .client import Client
 from .context import context
 from .element_filter import ElementFilter
+from .event import Event
 from .nicegui import app
 from .page_arguments import PageArguments
 from .version import __version__
@@ -13,6 +14,7 @@ __all__ = [
     'App',
     'Client',
     'ElementFilter',
+    'Event',
     'PageArguments',
     '__version__',
     'app',

--- a/nicegui/event.py
+++ b/nicegui/event.py
@@ -30,7 +30,8 @@ class Callback(Generic[P]):
     def run(self, *args: P.args, **kwargs: P.kwargs) -> Any:
         """Run the callback."""
         with (self.slot and self.slot()) or nullcontext():
-            return self.func(*args, **kwargs) if helpers.expects_arguments(self.func) else self.func()
+            expect_args = helpers.expects_arguments(self.func)
+            return self.func(*args, **kwargs) if expect_args else self.func()  # type: ignore[call-arg]
 
     async def await_result(self, result: Awaitable | AwaitableResponse | asyncio.Task) -> Any:
         """Await the result of the callback."""

--- a/nicegui/event.py
+++ b/nicegui/event.py
@@ -104,7 +104,7 @@ class Event(Generic[P]):
 
 def _invoke_and_forget(callback: Callback, *args: P.args, **kwargs: P.kwargs) -> Any:
     try:
-        result = callback.func(*args, **kwargs)
+        result = callback.func(*args, **kwargs) if helpers.expects_arguments(callback.func) else callback.func()
         if helpers.is_coroutine_function(callback.func):
             if core.loop and core.loop.is_running():
                 background_tasks.create(result, name=f'{callback.filepath}:{callback.line}')
@@ -116,7 +116,7 @@ def _invoke_and_forget(callback: Callback, *args: P.args, **kwargs: P.kwargs) ->
 
 async def _invoke_and_await(callback: Callback, *args: P.args, **kwargs: P.kwargs) -> Any:
     try:
-        result = callback.func(*args, **kwargs)
+        result = callback.func(*args, **kwargs) if helpers.expects_arguments(callback.func) else callback.func()
         if helpers.is_coroutine_function(callback.func):
             result = await result
         return result

--- a/nicegui/event.py
+++ b/nicegui/event.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Generic, ParamSpec
+
+from . import background_tasks, context, core
+
+startup_coroutines: list[Awaitable] = []
+tasks: list[asyncio.Task] = []
+log = logging.getLogger('rosys.event')
+events: list[Event] = []
+
+
+@dataclass(slots=True, kw_only=True)
+class Callback:
+    func: Callable
+    filepath: str
+    line: int
+
+
+P = ParamSpec('P')
+
+
+class Event(Generic[P]):
+
+    def __init__(self) -> None:
+        self.callbacks: list[Callback] = []
+        events.append(self)
+
+    def register(self, callback: Callable[P, Any]) -> Event[P]:
+        """Register a callback for the event.
+
+        Note that the callback should not be used to update UI since it would probably cause a memory leak.
+        Use the ``register_ui`` method instead.
+        """
+        frame = inspect.currentframe()
+        assert frame is not None
+        frame = frame.f_back
+        assert frame is not None
+        self.callbacks.append(Callback(func=callback, filepath=frame.f_code.co_filename, line=frame.f_lineno))
+        return self
+
+    def register_ui(self, callback: Callable[P, Any]) -> Event[P]:
+        """Register a UI callback for the event which will automatically unregister when the client disconnects."""
+        self.register(callback)
+        client = context.client
+
+        async def register_disconnect() -> None:
+            try:
+                await client.connected(timeout=10.0)
+                client.on_disconnect(lambda: self.unregister(callback))
+            except TimeoutError:
+                log.warning('Could not register a disconnect handler for callback %s', callback)
+                self.unregister(callback)
+        background_tasks.create(register_disconnect())
+        return self
+
+    def unregister(self, callback: Callable[P, Any]) -> None:
+        """Unregister a callback from the event."""
+        self.callbacks[:] = [c for c in self.callbacks if c.func != callback]
+
+    async def call(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        """Fire the event and waits asynchronously until all registered callbacks are completed."""
+        results = asyncio.gather(*[_invoke(callback.func, *args, **kwargs) for callback in self.callbacks],
+                                 return_exceptions=True)
+        for result in results:
+            if isinstance(result, Exception):
+                log.exception('Could not call callback %s', result)
+
+    def emit(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        """Fire event without waiting for the callbacks to complete."""
+        for callback in self.callbacks:
+            try:
+                result = callback.func(*args, **kwargs)
+                if isinstance(result, Awaitable):
+                    if core.loop and core.loop.is_running():
+                        name = f'{callback.filepath}:{callback.line}'
+                        tasks.append(background_tasks.create(result, name=name))
+                    else:
+                        startup_coroutines.append(result)
+            except Exception:
+                log.exception('Could not emit callback %s', callback)
+
+    async def emitted(self, timeout: float | None = None) -> Any:
+        """Wait for an event to be fired and return its arguments.
+
+        :param timeout: the maximum time to wait for the event to be fired (default: ``None`` meaning no timeout)
+        """
+        future: asyncio.Future[Any] = asyncio.Future()
+
+        def callback(*args: P.args, **kwargs: P.kwargs) -> None:  # pylint: disable=unused-argument
+            if not future.done():
+                future.set_result(args[0] if len(args) == 1 else args if args else None)
+
+        self.register(callback)
+        try:
+            return await asyncio.wait_for(future, timeout)
+        except TimeoutError as error:
+            raise TimeoutError(f'Timed out waiting for event after {timeout} seconds') from error
+        finally:
+            self.unregister(callback)
+
+    def __await__(self):
+        return self.emitted().__await__()
+
+
+async def _invoke(handler: Callable[P, Any], *args: P.args, **kwargs: P.kwargs) -> Any:
+    result = handler(*args, **kwargs)
+    if isinstance(result, Awaitable):
+        result = await result
+    return result
+
+
+def reset() -> None:
+    """Reset the event system. (Useful for testing.)"""
+    for event in events:
+        event.callbacks.clear()
+    events.clear()
+    for task in tasks:
+        task.cancel()
+    tasks.clear()
+    startup_coroutines.clear()

--- a/nicegui/testing/general_fixtures.py
+++ b/nicegui/testing/general_fixtures.py
@@ -6,7 +6,7 @@ import pytest
 from starlette.routing import Route
 
 import nicegui.storage
-from nicegui import Client, app, binding, core, run, ui
+from nicegui import Client, app, binding, core, event, run, ui
 from nicegui.page import page
 
 # pylint: disable=redefined-outer-name
@@ -51,6 +51,7 @@ def nicegui_reset_globals() -> Generator[None, None, None]:
     yield
 
     app.reset()
+    event.reset()
 
     # restore initial defaults
     for t in element_types:

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -46,5 +46,20 @@ async def test_event_with_async_handler(user: User):
 
     await user.open('/')
     user.find('Click me').click()
-    await asyncio.sleep(0.2)
     await user.should_see('clicked')
+
+
+async def test_event_handler_in_correct_slot(user: User):
+    event = Event()
+    card = None
+
+    @ui.page('/')
+    def page():
+        nonlocal card
+        ui.button('Click me', on_click=event.emit)
+        with ui.card() as card:
+            event.subscribe_ui(lambda: ui.label('clicked'))
+
+    await user.open('/')
+    user.find('Click me').click()
+    assert len(card.default_slot.children) == 1

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -10,7 +10,7 @@ async def test_event(user: User):
     @ui.page('/')
     def page():
         ui.button('Click me', on_click=event.emit)
-        event.subscribe_ui(lambda: ui.notify('clicked'))
+        event.subscribe(lambda: ui.notify('clicked'))
 
     await user.open('/')
     user.find('Click me').click()
@@ -23,8 +23,8 @@ async def test_event_with_args(user: User):
     @ui.page('/')
     def page():
         ui.button('Click me', on_click=lambda: event.emit(42))
-        event.subscribe_ui(lambda: ui.notify('clicked'))
-        event.subscribe_ui(lambda x: ui.notify(f'{x = }'))
+        event.subscribe(lambda: ui.notify('clicked'))
+        event.subscribe(lambda x: ui.notify(f'{x = }'))
 
     await user.open('/')
     user.find('Click me').click()
@@ -39,7 +39,7 @@ async def test_event_with_async_handler(user: User):
     def page():
         ui.button('Click me', on_click=event.emit)
 
-        @event.subscribe_ui
+        @event.subscribe
         async def handler():
             await asyncio.sleep(0.1)
             ui.notify('clicked')
@@ -58,7 +58,7 @@ async def test_event_handler_in_correct_slot(user: User):
         nonlocal card
         ui.button('Click me', on_click=event.emit)
         with ui.card() as card:
-            event.subscribe_ui(lambda: ui.label('clicked'))
+            event.subscribe(lambda: ui.label('clicked'))
 
     await user.open('/')
     user.find('Click me').click()

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -23,10 +23,12 @@ async def test_event_with_args(user: User):
     @ui.page('/')
     def page():
         ui.button('Click me', on_click=lambda: event.emit(42))
+        event.subscribe_ui(lambda: ui.notify('clicked'))
         event.subscribe_ui(lambda x: ui.notify(f'{x = }'))
 
     await user.open('/')
     user.find('Click me').click()
+    await user.should_see('clicked')
     await user.should_see('x = 42')
 
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,48 @@
+import asyncio
+
+from nicegui import Event, ui
+from nicegui.testing import User
+
+
+async def test_event(user: User):
+    event = Event()
+
+    @ui.page('/')
+    def page():
+        ui.button('Click me', on_click=event.emit)
+        event.subscribe_ui(lambda: ui.notify('clicked'))
+
+    await user.open('/')
+    user.find('Click me').click()
+    await user.should_see('clicked')
+
+
+async def test_event_with_args(user: User):
+    event = Event[int]()
+
+    @ui.page('/')
+    def page():
+        ui.button('Click me', on_click=lambda: event.emit(42))
+        event.subscribe_ui(lambda x: ui.notify(f'{x = }'))
+
+    await user.open('/')
+    user.find('Click me').click()
+    await user.should_see('x = 42')
+
+
+async def test_event_with_async_handler(user: User):
+    event = Event()
+
+    @ui.page('/')
+    def page():
+        ui.button('Click me', on_click=event.emit)
+
+        @event.subscribe_ui
+        async def handler():
+            await asyncio.sleep(0.1)
+            ui.notify('clicked')
+
+    await user.open('/')
+    user.find('Click me').click()
+    await asyncio.sleep(0.2)
+    await user.should_see('clicked')

--- a/website/documentation/content/event_documentation.py
+++ b/website/documentation/content/event_documentation.py
@@ -9,10 +9,6 @@ doc.title('Events')
     Events are a powerful tool distribute information between different parts of your code.
     The following demo shows how to define an event, subscribe a callback and emit it.
 
-    Note that there is also a `subscribe` method for non-UI callbacks.
-    But to run the handler in the current UI context and to automatically unsubscribe when the client disconnects,
-    use the `subscribe_ui` method.
-
     Handlers can be synchronous or asynchronous.
     They can also take arguments if the event contains arguments.
 ''')
@@ -20,21 +16,21 @@ def events_demo():
     from nicegui import Event
 
     click = Event()
-    click.subscribe_ui(lambda: ui.notify('clicked'))
+    click.subscribe(lambda: ui.notify('clicked'))
 
     ui.button('Click me', on_click=click.emit)
 
 
 @doc.demo('Events with arguments', '''
     Events can also include arguments.
-    The callback can take use them, but also ignore them if they are not needed.
+    The callback can use them, but also ignore them if they are not needed.
 ''')
 def events_with_arguments():
     from nicegui import Event
 
     answer = Event[int]()
-    answer.subscribe_ui(lambda: ui.notify('Answer found!'))
-    answer.subscribe_ui(lambda x: ui.notify(f'{x = }'))
+    answer.subscribe(lambda: ui.notify('Answer found!'))
+    answer.subscribe(lambda x: ui.notify(f'{x = }'))
 
     ui.button('Answer', on_click=lambda: answer.emit(42))
 
@@ -51,7 +47,7 @@ def emitting_vs_calling_events():
 
     click = Event()
 
-    @click.subscribe_ui
+    @click.subscribe
     async def handler():
         n = ui.notification('Running...')
         await asyncio.sleep(1)

--- a/website/documentation/content/event_documentation.py
+++ b/website/documentation/content/event_documentation.py
@@ -1,0 +1,65 @@
+from nicegui import ui
+
+from . import doc
+
+doc.title('Events')
+
+
+@doc.demo('Subscribing to events', '''
+    Events are a powerful tool distribute information between different parts of your code.
+    The following demo shows how to define an event, subscribe a callback and emit it.
+
+    Note that there is also a `subscribe` method for non-UI callbacks.
+    But to run the handler in the current UI context and to automatically unsubscribe when the client disconnects,
+    use the `subscribe_ui` method.
+
+    Handlers can be synchronous or asynchronous.
+    They can also take arguments if the event contains arguments.
+''')
+def events_demo():
+    from nicegui import Event
+
+    click = Event()
+    click.subscribe_ui(lambda: ui.notify('clicked'))
+
+    ui.button('Click me', on_click=click.emit)
+
+
+@doc.demo('Events with arguments', '''
+    Events can also include arguments.
+    The callback can take use them, but also ignore them if they are not needed.
+''')
+def events_with_arguments():
+    from nicegui import Event
+
+    answer = Event[int]()
+    answer.subscribe_ui(lambda: ui.notify('Answer found!'))
+    answer.subscribe_ui(lambda x: ui.notify(f'{x = }'))
+
+    ui.button('Answer', on_click=lambda: answer.emit(42))
+
+
+@doc.demo('Emitting vs. calling events', '''
+    The `emit` method fires the event without waiting for the subscribed callbacks to complete.
+    If you want to wait for the subscribed callbacks to complete, use the `call` method.
+
+    The following demo shows how to use `call` to reset the button state after the event has been called.
+''')
+def emitting_vs_calling_events():
+    import asyncio
+    from nicegui import Event
+
+    click = Event()
+
+    @click.subscribe_ui
+    async def handler():
+        n = ui.notification('Running...')
+        await asyncio.sleep(1)
+        n.message = 'Done!'
+
+    async def handle_click():
+        button.disable()
+        await click.call()
+        button.enable()
+
+    button = ui.button('Click me', on_click=handle_click)

--- a/website/documentation/content/section_action_events.py
+++ b/website/documentation/content/section_action_events.py
@@ -3,6 +3,7 @@ from nicegui import app, ui
 from . import (
     clipboard_documentation,
     doc,
+    event_documentation,
     generic_events_documentation,
     keyboard_documentation,
     refreshable_documentation,
@@ -104,10 +105,11 @@ def io_bound_demo():
 
 doc.intro(run_javascript_documentation)
 doc.intro(clipboard_documentation)
+doc.intro(event_documentation)
 
 
-@doc.demo('Events', '''
-    You can register coroutines or functions to be called for the following events:
+@doc.demo('Lifecycle events', '''
+    You can register coroutines or functions to be called for the following lifecycle events:
 
     - `app.on_startup`: called when NiceGUI is started or restarted
     - `app.on_shutdown`: called when NiceGUI is shut down or restarted


### PR DESCRIPTION
### Motivation

While working on PR #5005, we noticed that some projects like our ROS2 example might depend on the shared nature of the long-living auto-index client. If there is some kind of "event" in the data model (or hardware controller), they can simply update the UI if there is only one and exactly one client. When switching to page functions, they updating UI becomes more complicated in this scenario.

Therefore we decided to move our event system from [RoSys](https://github.com/zauberzeug/rosys/) to NiceGUI. It provides a simple API to define events, subscribe arbitrary callbacks to them, and to emit/call them if the event happens.

### Implementation

The core implementation is taken from RoSys. But on a second look some details have changed, partly by relaxing some assumptions or because we can make better use of NiceGUI's infrastructure.

- I chose the method names "subscribe" and "subscribe_ui" instead of "register" and "register_ui".
- Callbacks can still be sync or async.
- Callbacks can - but don't have to - receive arguments.
- Callbacks are automatically called within the same slot where they subscribed.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
  - [x] Merge `subscribe` and `subscribe_ui` into a single `subscribe(..., unsubscribe_on_disconnect: bool | None = None)`.
- [x] Pytests have been added.
- [x] Documentation has been added.
