### PR TITLE
Remove unnecessary attribute bindings

### DIFF
--- a/nicegui/elements/dialog.js
+++ b/nicegui/elements/dialog.js
@@ -1,6 +1,6 @@
 export default {
   template: `
-    <q-dialog v-bind="$attrs" @show="addClass" @hide="removeClass">
+    <q-dialog @show="addClass" @hide="removeClass">
       <slot />
     </q-dialog>
   `,

--- a/nicegui/elements/editor.js
+++ b/nicegui/elements/editor.js
@@ -1,10 +1,6 @@
 export default {
   template: `
-    <q-editor
-      ref="qRef"
-      v-bind="$attrs"
-      v-model="inputValue"
-    >
+    <q-editor ref="qRef" v-model="inputValue">
       <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
         <slot :name="slot" v-bind="slotProps || {}" />
       </template>

--- a/nicegui/elements/header.js
+++ b/nicegui/elements/header.js
@@ -1,5 +1,5 @@
 export default {
-  template: `<q-header ref="qRef" v-bind="$attrs"><slot></slot></q-header>`,
+  template: `<q-header ref="qRef"><slot></slot></q-header>`,
   mounted() {
     if (this.add_scroll_padding) {
       new ResizeObserver(() => {

--- a/nicegui/elements/image.js
+++ b/nicegui/elements/image.js
@@ -1,10 +1,6 @@
 export default {
   template: `
-    <q-img
-      ref="qRef"
-      v-bind="$attrs"
-      :src="computed_src"
-    >
+    <q-img ref="qRef" :src="computed_src">
       <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
         <slot :name="slot" v-bind="slotProps || {}" />
       </template>

--- a/nicegui/elements/select.js
+++ b/nicegui/elements/select.js
@@ -3,7 +3,6 @@ export default {
   template: `
     <q-select
       ref="qRef"
-      v-bind="$attrs"
       :options="filteredOptions"
       @filter="filterFn"
       @popup-show="addClass"

--- a/nicegui/elements/table.js
+++ b/nicegui/elements/table.js
@@ -2,11 +2,7 @@ import { convertDynamicProperties } from "../../static/utils/dynamic_properties.
 
 export default {
   template: `
-    <q-table
-      ref="qRef"
-      v-bind="$attrs"
-      :columns="convertedColumns"
-    >
+    <q-table ref="qRef" :columns="convertedColumns">
       <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
         <slot :name="slot" v-bind="slotProps || {}" />
       </template>


### PR DESCRIPTION
### Motivation and Implementation

In #5079 @ftesser noticed that "popup-hide" event handlers are called multiple times:

```py
ui.select(['A']).on('popup-hide', ui.notify)
```

This led to an investigation where I learned something new about Vue:

The duplicate "popup-hide" events were caused by Vue 3's fallthrough behavior on single-root components (meaning a single root node in the Vue template): NiceGUI injects listeners from Python `.on()` as props, and with `v-bind="$attrs"` we forwarded the same listeners again to the root, resulting in the handler being attached twice.
Removing `v-bind="$attrs"` on single-root wrappers prevents this duplication because Vue already forwards non-prop attributes and listeners to the root by default.
Only for components with multiple root nodes (e.g. `ui.input`) adding `v-bind="$attrs"` is correct because the handlers are _not_ attached by default in this case.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
