### PR TITLE
Strip path prefixes in sub pages router

### DIFF
--- a/nicegui/sub_pages_router.py
+++ b/nicegui/sub_pages_router.py
@@ -22,7 +22,14 @@ class SubPagesRouter:
         on('sub_pages_navigate', lambda event: self._handle_navigate(event.args))
 
         if request is not None:
+            forwarded_prefix = request.headers.get('X-Forwarded-Prefix', '')
+            root = _normalize(request.scope.get('root_path', ''))
+            combined = _normalize((forwarded_prefix or '') + (root or ''))
             path = request.url.path
+            for p in (combined, root):
+                if p and (path == p or path.startswith(p + '/')):
+                    path = path[len(p):] or '/'
+                    break
             if request.url.query:
                 path += '?' + request.url.query
             # NOTE: we do not use request.url.fragment because browsers do not send it to the server
@@ -110,3 +117,7 @@ class SubPagesRouter:
                 sub_pages._set_match(None)  # pylint: disable=protected-access
                 has_404 = True
         return not has_404
+
+
+def _normalize(p: str) -> str:
+    return p[:-1] if p and p != '/' and p.endswith('/') else p


### PR DESCRIPTION
### Motivation

In #5106, @SirTaros described unexpected path behaviour when opening `ui.sub_pages` with an url path which has some kind of prefix. Either through `mount_path` parameter (asgi routing) or `x-forwarded-prefix` (proxy routing).

### Implementation

Because Proxies often (not always) strip the external prefix it worked in most cases. The bug is fixed stripping the x-forwarded-prefix and the sub-mount scope from `request.url.path` before using it in `ui.sub_pages_router`.

Reproduction (with `mount_path`):

```py
import uvicorn
from fastapi import FastAPI
from nicegui import ui

fastapi_app = FastAPI()

@ui.page('/')
@ui.page('/{_:path}')
def router():
    ui.sub_pages({
        '/': home,
        '/other': other,
    })

def other():
    ui.label('Other Site')
    ui.link('Go to home', '/')

def home():
    ui.label('Home Site')
    ui.link('Go to other', '/other')

ui.run_with(fastapi_app, mount_path='/mount/')

if __name__ == '__main__':
    uvicorn.run('main:fastapi_app', log_level='warning', reload=True)
```

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are to complicated to build, but I manually tested
   - [x] the reproduction shown above (derived from #5106)
   - [x] the combination of #5063 and #5106
   - [x] #5083 with and without NiceGUI On Air
- [x] Documentation is not necessary.
