### PR TITLE
Let `Client.delete()` do not cause KeyError if called multiple times

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -353,7 +353,8 @@ class Client:
         """
         self.remove_all_elements()
         self.outbox.stop()
-        del Client.instances[self.id]
+        if self.id in Client.instances:
+            del Client.instances[self.id]
         self._deleted = True
 
     def check_existence(self) -> None:


### PR DESCRIPTION
### Motivation

Fixes #5119. As discussed in https://github.com/zauberzeug/nicegui/issues/5119#issuecomment-3277041615, `Client.delete()` may get called twice, if within a prune, the client disconnects. 

### Implementation

This code follows https://github.com/zauberzeug/nicegui/issues/5090#issuecomment-3240147134 and https://github.com/zauberzeug/nicegui/issues/1826#issuecomment-3275126149 and modifies it so that should `Client.delete()` can be called as many times on the same client, resolving the problem. 

Could be considered a breaking change, but I don't see how a `Client.delete()` which _sometimes errors out_ is helpful, really. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
