### PR TITLE
Drop `check_interval` for `Client.disconnected()`

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -195,13 +195,14 @@ class Client:
             await asyncio.sleep(check_interval)
         self.is_waiting_for_connection = False
 
-    async def disconnected(self, check_interval: float = 0.1) -> None:
+    async def disconnected(self) -> None:
         """Block execution until the client disconnects."""
         if not self.has_socket_connection:
             await self.connected()
         self.is_waiting_for_disconnect = True
-        while self.id in self.instances:
-            await asyncio.sleep(check_interval)
+        disconnect_event = asyncio.Event()
+        self.on_disconnect(lambda _: disconnect_event.set())
+        await disconnect_event.wait()
         self.is_waiting_for_disconnect = False
 
     def run_javascript(self, code: str, *, timeout: float = 1.0) -> AwaitableResponse:


### PR DESCRIPTION
### Motivation

We basically had "war on polling based solution" since #4466 (the good-ol days). This brings it to `Client.disconnected()`. Now it doesn't poll. 

### Implementation

In this implementation, I use `on_disconnect`. Not sure if it is necessarily the same as `while self.id in self.instances:`, though. Tests pass, so that's one thing. 

Will it cause trouble, if many calls to `Client.disconnected()`, and we add a lot of lambdas to `Client.disconnect_handlers`?

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
