### PR TITLE
Add Anywidget Front-End Module spec support with `ui.anywidget()`

### DIFF
--- a/examples/altair/main.py
+++ b/examples/altair/main.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Demonstrates embedding altair charts in NiceGUI.
+
+This shows how to embed altair charts in NiceGUI, and how to synchronize
+NiceGUI elements with charts using ``.bind_*`` (chart -> NiceGUI) and ``on_*``
+callbacks (NiceGUI -> chart).
+"""
+
+import altair as alt
+import numpy as np
+import pandas as pd
+
+from nicegui import ui
+
+
+def create_altair_chart() -> alt.Chart:
+    """Create simple altair chart with slider-based coloring
+
+    Refer to:
+    https://altair-viz.github.io/user_guide/interactions/jupyter_chart.html#accessing-variable-params
+    """
+    rand = np.random.RandomState(42)
+
+    df = pd.DataFrame({
+        'xval': range(100),
+        'yval': rand.randn(100).cumsum()
+    })
+
+    slider = alt.binding_range(min=0, max=100, step=1)
+    cutoff = alt.param(name='cutoff', bind=slider, value=50)
+
+    chart = alt.Chart(df).mark_point().encode(
+        x='xval',
+        y='yval',
+        color=alt.condition(
+            alt.datum.xval < cutoff,
+            alt.value('red'), alt.value('blue')
+        )
+    ).add_params(
+        cutoff
+    )
+    return chart
+
+
+@ui.page('/')
+def page():
+    # Example 1: getting started example from altair documentation
+    # https://altair-viz.github.io/getting_started/starting.html#customizing-your-visualization
+    with ui.card().classes('min-w-200px max-w-300px'):
+        ui.label('Static altair chart').classes('text-xl font-bold')
+
+        data = pd.DataFrame({'a': list('CCCDDDEEE'), 'b': [2, 7, 4, 1, 2, 6, 8, 4, 7]})
+        chart = alt.Chart(data).mark_bar(color='firebrick').encode(
+            alt.Y('a').title('category'),
+            alt.X('average(b)').title('avg(b) by category')
+        )
+        ui.altair(chart)
+
+    # Example 2: altair chart widget with slider synchronized between nicegui & altair
+    # This is the JupyterChart variable params example from the altair documentation:
+    # https://altair-viz.github.io/user_guide/interactions/jupyter_chart.html#accessing-variable-params
+    with ui.card().classes('min-w-200px max-w-300px'):
+        ui.label('Synchronized altair and nicegui sliders').classes('text-xl font-bold')
+        # jchart = AltairChart(create_altair_chart())
+        chart = create_altair_chart()
+        widget = ui.altair(chart, throttle=0.5)
+
+        def update_cutoff(change):
+            # NOTE: as of altair v5.5, there is a JavaScript side bug in altair.JupyterChart
+            # that causes this callback to fail when accessing .changed (only supported in Jupyter):
+            # https://github.com/vega/altair/issues/3868
+            widget._widget.params.cutoff = change.value
+        slider = ui.slider(
+            min=0, max=100, value=widget._widget.params.cutoff, on_change=update_cutoff, throttle=0.2
+        ).bind_value_from(widget._widget, '_params', backward=lambda p: p['cutoff'])
+        ui.label().bind_text_from(slider, 'value', backward=lambda c: f'Cutoff is {c}')
+
+
+ui.run(show=False)

--- a/examples/anywidget/main.py
+++ b/examples/anywidget/main.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Demonstrates embedding anywidget widgets in NiceGUI.
+
+This shows how to embed anywidget widgets in NiceGUI, and how to synchronize
+NiceGUI elements with widgets using ``.bind_*`` (widget -> NiceGUI) and ``on_*``
+callbacks (NiceGUI -> widget).
+
+The example shows how to embed a counter widget and an altair chart widget
+from the getting started examples in anywidget and altair.
+"""
+
+import altair
+import anywidget
+import traitlets
+
+from nicegui import ui
+
+
+class CounterWidget(anywidget.AnyWidget):
+    """Baseline anywidget example"""
+    _esm = '''
+    function render({ model, el }) {
+      let button = document.createElement("button");
+      button.innerHTML = `anywidget count is ${model.get("value")}`;
+      button.addEventListener("click", () => {
+        model.set("value", model.get("value") + 1);
+        model.save_changes();
+      });
+      model.on("change:value", () => {
+        button.innerHTML = `anywidget count is ${model.get("value")}`;
+      });
+      el.classList.add("counter-widget");
+      el.appendChild(button);
+    }
+    export default { render };
+    '''
+    _css = '''
+    .counter-widget button { color: white; font-size: 1.75rem; background-color: #ea580c; padding: 0.5rem 1rem; border: none; border-radius: 0.25rem; }
+    .counter-widget button:hover { background-color: #9a3412; }
+    '''
+    value = traitlets.Int(0).tag(sync=True)
+
+
+class AltairChart(altair.JupyterChart):
+    """
+    This is a wrapper around `altair.JupyterChart` that just adds some console
+    debugging output, and fixes a minor bug with accessing `.changed` (only
+    usable in Jupyter-widget-based environments).
+    """
+    _esm = '''
+import vegaEmbed from "https://esm.sh/vega-embed@v7?deps=vega@6&deps=vega-lite@5.33.0";
+import lodashDebounce from "https://esm.sh/lodash-es@4.17.21/debounce";
+
+// Note: For offline support, the import lines above are removed and the remaining script
+// is bundled using vl-convert's javascript_bundle function. See the documentation of
+// the javascript_bundle function for details on the available imports and their names.
+// If an additional import is required in the future, it will need to be added to vl-convert
+// in order to preserve offline support.
+async function render({ model, el }) {
+    let finalize;
+
+    function showError(error){
+        el.innerHTML = (
+            '<div style="color:red;">'
+            + '<p>JavaScript Error: ' + error.message + '</p>'
+            + "<p>This usually means there's a typo in your chart specification. "
+            + "See the javascript console for the full traceback.</p>"
+            + '</div>'
+        );
+    }
+
+    const reembed = async () => {
+        if (finalize != null) {
+          finalize();
+        }
+
+        model.set("local_tz", Intl.DateTimeFormat().resolvedOptions().timeZone);
+
+        let spec = structuredClone(model.get("spec"));
+        if (spec == null) {
+            // Remove any existing chart and return
+            while (el.firstChild) {
+                el.removeChild(el.lastChild);
+            }
+            model.save_changes();
+            return;
+        }
+        let embedOptions = structuredClone(model.get("embed_options")) ?? undefined;
+
+        let api;
+        try {
+            api = await vegaEmbed(el, spec, embedOptions);
+        } catch (error) {
+            showError(error)
+            return;
+        }
+
+        finalize = api.finalize;
+
+        // Debounce config
+        const wait = model.get("debounce_wait") ?? 10;
+        const debounceOpts = {leading: false, trailing: true};
+        if (model.get("max_wait") ?? true) {
+            debounceOpts["maxWait"] = wait;
+        }
+
+        const initialSelections = {};
+        for (const selectionName of Object.keys(model.get("_vl_selections"))) {
+            const storeName = `${selectionName}_store`;
+            const selectionHandler = (_, value) => {
+                const newSelections = cleanJson(model.get("_vl_selections") ?? {});
+                const store = cleanJson(api.view.data(storeName) ?? []);
+
+                newSelections[selectionName] = {value, store};
+                model.set("_vl_selections", newSelections);
+                model.save_changes();
+            };
+            api.view.addSignalListener(selectionName, lodashDebounce(selectionHandler, wait, debounceOpts));
+
+            initialSelections[selectionName] = {
+                value: cleanJson(api.view.signal(selectionName) ?? {}),
+                store: cleanJson(api.view.data(storeName) ?? [])
+            }
+        }
+        model.set("_vl_selections", initialSelections);
+
+        const initialParams = {};
+        for (const paramName of Object.keys(model.get("_params"))) {
+            const paramHandler = (_, value) => {
+                const newParams = JSON.parse(JSON.stringify(model.get("_params"))) || {};
+                newParams[paramName] = value;
+                model.set("_params", newParams);
+                model.save_changes();
+            };
+            api.view.addSignalListener(paramName, lodashDebounce(paramHandler, wait, debounceOpts));
+
+            initialParams[paramName] = api.view.signal(paramName) ?? null
+        }
+        model.set("_params", initialParams);
+        model.save_changes();
+
+        // Param change callback
+        model.on('change:_params', async (new_params) => {
+            console.log('change:_params', new_params);
+            for (const [param, value] of Object.entries(new_params)) {
+                console.log('change:_params', new_params, param, value);
+                api.view.signal(param, value);
+            }
+            await api.view.runAsync();
+            console.log('change:_params done');
+        });
+
+        // Add signal/data listeners
+        for (const watch of model.get("_js_watch_plan") ?? []) {
+            if (watch.namespace === "data") {
+                const dataHandler = (_, value) => {
+                    model.set("_js_to_py_updates", [{
+                        namespace: "data",
+                        name: watch.name,
+                        scope: watch.scope,
+                        value: cleanJson(value)
+                    }]);
+                    model.save_changes();
+                };
+                addDataListener(api.view, watch.name, watch.scope, lodashDebounce(dataHandler, wait, debounceOpts))
+
+            } else if (watch.namespace === "signal") {
+                const signalHandler = (_, value) => {
+                    model.set("_js_to_py_updates", [{
+                        namespace: "signal",
+                        name: watch.name,
+                        scope: watch.scope,
+                        value: cleanJson(value)
+                    }]);
+                    model.save_changes();
+                };
+
+                addSignalListener(api.view, watch.name, watch.scope, lodashDebounce(signalHandler, wait, debounceOpts))
+            }
+        }
+
+        // Add signal/data updaters
+        model.on('change:_py_to_js_updates', async (updates) => {
+            for (const update of updates.changed._py_to_js_updates ?? []) {
+                if (update.namespace === "signal") {
+                    console.log('change:_py_to_js_updates signal', update.name, update.scope, update.value);
+                    setSignalValue(api.view, update.name, update.scope, update.value);
+                } else if (update.namespace === "data") {
+                    console.log('change:_py_to_js_updates data', update.name, update.scope, update.value);
+                    setDataValue(api.view, update.name, update.scope, update.value);
+                }
+            }
+            await api.view.runAsync();
+        });
+    }
+
+    model.on('change:spec', reembed);
+    model.on('change:embed_options', reembed);
+    model.on('change:debounce_wait', reembed);
+    model.on('change:max_wait', reembed);
+    await reembed();
+}
+
+function cleanJson(data) {
+    return JSON.parse(JSON.stringify(data))
+}
+
+function getNestedRuntime(view, scope) {
+    var runtime = view._runtime;
+    for (const index of scope) {
+        runtime = runtime.subcontext[index];
+    }
+    return runtime
+}
+
+function lookupSignalOp(view, name, scope) {
+    let parent_runtime = getNestedRuntime(view, scope);
+    return parent_runtime.signals[name] ?? null;
+}
+
+function dataRef(view, name, scope) {
+    let parent_runtime = getNestedRuntime(view, scope);
+    return parent_runtime.data[name];
+}
+
+export function setSignalValue(view, name, scope, value) {
+    let signal_op = lookupSignalOp(view, name, scope);
+    view.update(signal_op, value);
+}
+
+export function setDataValue(view, name, scope, value) {
+    let dataset = dataRef(view, name, scope);
+    let changeset = view.changeset().remove(() => true).insert(value)
+    dataset.modified = true;
+    view.pulse(dataset.input, changeset);
+}
+
+export function addSignalListener(view, name, scope, handler) {
+    let signal_op = lookupSignalOp(view, name, scope);
+    return addOperatorListener(
+        view,
+        name,
+        signal_op,
+        handler,
+    );
+}
+
+export function addDataListener(view, name, scope, handler) {
+    let dataset = dataRef(view, name, scope).values;
+    return addOperatorListener(
+        view,
+        name,
+        dataset,
+        handler,
+    );
+}
+
+// Private helpers from Vega for dealing with nested signals/data
+function findOperatorHandler(op, handler) {
+    const h = (op._targets || [])
+        .filter(op => op._update && op._update.handler === handler);
+    return h.length ? h[0] : null;
+}
+
+function addOperatorListener(view, name, op, handler) {
+    let h = findOperatorHandler(op, handler);
+    if (!h) {
+        h = trap(view, () => handler(name, op.value));
+        h.handler = handler;
+        view.on(op, null, h);
+    }
+    return view;
+}
+
+function trap(view, fn) {
+    return !fn ? null : function() {
+        try {
+            fn.apply(this, arguments);
+        } catch (error) {
+            view.error(error);
+        }
+    };
+}
+
+export default { render }
+'''
+
+@ui.page('/')
+def page():
+    ### Example 1: counter widget synchronized with nicegui & anywidget
+    # This is the getting started example from the anywidget documentation:
+    # https://anywidget.dev/en/getting-started/
+    counter = CounterWidget(value=42)
+    anywidget_counter = ui.anywidget(counter)
+
+    def increment_counter():
+        counter.value += 1
+    ui.button(f'NiceGUI count is {counter.value}', on_click=increment_counter).bind_text_from(counter, 'value', backward=lambda c: f'NiceGUI count is {c}')
+
+
+    ### Example 2: altair chart widget synchronized with nicegui & altair
+    # This is the JupyterChart variable params example from the altair documentation:
+    # https://altair-viz.github.io/user_guide/interactions/jupyter_chart.html#accessing-variable-params
+    import altair as alt
+    import numpy as np
+    import pandas as pd
+
+    rand = np.random.RandomState(42)
+
+    df = pd.DataFrame({
+        'xval': range(100),
+        'yval': rand.randn(100).cumsum()
+    })
+
+    slider = alt.binding_range(min=0, max=100, step=1)
+    cutoff = alt.param(name='cutoff', bind=slider, value=50)
+    predicate = alt.datum.xval < 50
+
+    chart = alt.Chart(df).mark_point().encode(
+        x='xval',
+        y='yval',
+        color=alt.when(predicate).then(alt.value('red')).otherwise(alt.value('blue')),
+    ).add_params(
+        cutoff
+    )
+    # jchart = alt.JupyterChart(chart)
+    jchart = AltairChart(chart)
+    ui.anywidget(jchart, throttle=0.2)
+
+    def update_cutoff(change):
+        jchart.params.cutoff = change.value
+    slider = ui.slider(min=0, max=100, value=cutoff.value, on_change=update_cutoff).bind_value_from(jchart, '_params', backward=lambda p: p['cutoff'])
+    ui.label().bind_text_from(slider, 'value', backward=lambda c: f'Cutoff is {c}')
+
+
+
+ui.run(show=False)

--- a/examples/anywidget/main.py
+++ b/examples/anywidget/main.py
@@ -9,7 +9,6 @@ The example shows how to embed a counter widget and an altair chart widget
 from the getting started examples in anywidget and altair.
 """
 
-import altair
 import anywidget
 import traitlets
 
@@ -41,266 +40,12 @@ class CounterWidget(anywidget.AnyWidget):
     value = traitlets.Int(0).tag(sync=True)
 
 
-class AltairChart(altair.JupyterChart):
+def create_altair_chart():
+    """Create simple altair chart with slider-based coloring
+
+    Refer to:
+    https://altair-viz.github.io/user_guide/interactions/jupyter_chart.html#accessing-variable-params
     """
-    This is a wrapper around `altair.JupyterChart` that just adds some console
-    debugging output, and fixes a minor bug with accessing `.changed` (only
-    usable in Jupyter-widget-based environments).
-    """
-    _esm = '''
-import vegaEmbed from "https://esm.sh/vega-embed@v7?deps=vega@6&deps=vega-lite@5.33.0";
-import lodashDebounce from "https://esm.sh/lodash-es@4.17.21/debounce";
-
-// Note: For offline support, the import lines above are removed and the remaining script
-// is bundled using vl-convert's javascript_bundle function. See the documentation of
-// the javascript_bundle function for details on the available imports and their names.
-// If an additional import is required in the future, it will need to be added to vl-convert
-// in order to preserve offline support.
-async function render({ model, el }) {
-    let finalize;
-
-    function showError(error){
-        el.innerHTML = (
-            '<div style="color:red;">'
-            + '<p>JavaScript Error: ' + error.message + '</p>'
-            + "<p>This usually means there's a typo in your chart specification. "
-            + "See the javascript console for the full traceback.</p>"
-            + '</div>'
-        );
-    }
-
-    const reembed = async () => {
-        if (finalize != null) {
-          finalize();
-        }
-
-        model.set("local_tz", Intl.DateTimeFormat().resolvedOptions().timeZone);
-
-        let spec = structuredClone(model.get("spec"));
-        if (spec == null) {
-            // Remove any existing chart and return
-            while (el.firstChild) {
-                el.removeChild(el.lastChild);
-            }
-            model.save_changes();
-            return;
-        }
-        let embedOptions = structuredClone(model.get("embed_options")) ?? undefined;
-
-        let api;
-        try {
-            api = await vegaEmbed(el, spec, embedOptions);
-        } catch (error) {
-            showError(error)
-            return;
-        }
-
-        finalize = api.finalize;
-
-        // Debounce config
-        const wait = model.get("debounce_wait") ?? 10;
-        const debounceOpts = {leading: false, trailing: true};
-        if (model.get("max_wait") ?? true) {
-            debounceOpts["maxWait"] = wait;
-        }
-
-        const initialSelections = {};
-        for (const selectionName of Object.keys(model.get("_vl_selections"))) {
-            const storeName = `${selectionName}_store`;
-            const selectionHandler = (_, value) => {
-                const newSelections = cleanJson(model.get("_vl_selections") ?? {});
-                const store = cleanJson(api.view.data(storeName) ?? []);
-
-                newSelections[selectionName] = {value, store};
-                model.set("_vl_selections", newSelections);
-                model.save_changes();
-            };
-            api.view.addSignalListener(selectionName, lodashDebounce(selectionHandler, wait, debounceOpts));
-
-            initialSelections[selectionName] = {
-                value: cleanJson(api.view.signal(selectionName) ?? {}),
-                store: cleanJson(api.view.data(storeName) ?? [])
-            }
-        }
-        model.set("_vl_selections", initialSelections);
-
-        const initialParams = {};
-        for (const paramName of Object.keys(model.get("_params"))) {
-            const paramHandler = (_, value) => {
-                const newParams = JSON.parse(JSON.stringify(model.get("_params"))) || {};
-                newParams[paramName] = value;
-                model.set("_params", newParams);
-                model.save_changes();
-            };
-            api.view.addSignalListener(paramName, lodashDebounce(paramHandler, wait, debounceOpts));
-
-            initialParams[paramName] = api.view.signal(paramName) ?? null
-        }
-        model.set("_params", initialParams);
-        model.save_changes();
-
-        // Param change callback
-        model.on('change:_params', async (new_params) => {
-            console.log('change:_params', new_params);
-            for (const [param, value] of Object.entries(new_params)) {
-                console.log('change:_params', new_params, param, value);
-                api.view.signal(param, value);
-            }
-            await api.view.runAsync();
-            console.log('change:_params done');
-        });
-
-        // Add signal/data listeners
-        for (const watch of model.get("_js_watch_plan") ?? []) {
-            if (watch.namespace === "data") {
-                const dataHandler = (_, value) => {
-                    model.set("_js_to_py_updates", [{
-                        namespace: "data",
-                        name: watch.name,
-                        scope: watch.scope,
-                        value: cleanJson(value)
-                    }]);
-                    model.save_changes();
-                };
-                addDataListener(api.view, watch.name, watch.scope, lodashDebounce(dataHandler, wait, debounceOpts))
-
-            } else if (watch.namespace === "signal") {
-                const signalHandler = (_, value) => {
-                    model.set("_js_to_py_updates", [{
-                        namespace: "signal",
-                        name: watch.name,
-                        scope: watch.scope,
-                        value: cleanJson(value)
-                    }]);
-                    model.save_changes();
-                };
-
-                addSignalListener(api.view, watch.name, watch.scope, lodashDebounce(signalHandler, wait, debounceOpts))
-            }
-        }
-
-        // Add signal/data updaters
-        model.on('change:_py_to_js_updates', async (updates) => {
-            for (const update of updates.changed._py_to_js_updates ?? []) {
-                if (update.namespace === "signal") {
-                    console.log('change:_py_to_js_updates signal', update.name, update.scope, update.value);
-                    setSignalValue(api.view, update.name, update.scope, update.value);
-                } else if (update.namespace === "data") {
-                    console.log('change:_py_to_js_updates data', update.name, update.scope, update.value);
-                    setDataValue(api.view, update.name, update.scope, update.value);
-                }
-            }
-            await api.view.runAsync();
-        });
-    }
-
-    model.on('change:spec', reembed);
-    model.on('change:embed_options', reembed);
-    model.on('change:debounce_wait', reembed);
-    model.on('change:max_wait', reembed);
-    await reembed();
-}
-
-function cleanJson(data) {
-    return JSON.parse(JSON.stringify(data))
-}
-
-function getNestedRuntime(view, scope) {
-    var runtime = view._runtime;
-    for (const index of scope) {
-        runtime = runtime.subcontext[index];
-    }
-    return runtime
-}
-
-function lookupSignalOp(view, name, scope) {
-    let parent_runtime = getNestedRuntime(view, scope);
-    return parent_runtime.signals[name] ?? null;
-}
-
-function dataRef(view, name, scope) {
-    let parent_runtime = getNestedRuntime(view, scope);
-    return parent_runtime.data[name];
-}
-
-export function setSignalValue(view, name, scope, value) {
-    let signal_op = lookupSignalOp(view, name, scope);
-    view.update(signal_op, value);
-}
-
-export function setDataValue(view, name, scope, value) {
-    let dataset = dataRef(view, name, scope);
-    let changeset = view.changeset().remove(() => true).insert(value)
-    dataset.modified = true;
-    view.pulse(dataset.input, changeset);
-}
-
-export function addSignalListener(view, name, scope, handler) {
-    let signal_op = lookupSignalOp(view, name, scope);
-    return addOperatorListener(
-        view,
-        name,
-        signal_op,
-        handler,
-    );
-}
-
-export function addDataListener(view, name, scope, handler) {
-    let dataset = dataRef(view, name, scope).values;
-    return addOperatorListener(
-        view,
-        name,
-        dataset,
-        handler,
-    );
-}
-
-// Private helpers from Vega for dealing with nested signals/data
-function findOperatorHandler(op, handler) {
-    const h = (op._targets || [])
-        .filter(op => op._update && op._update.handler === handler);
-    return h.length ? h[0] : null;
-}
-
-function addOperatorListener(view, name, op, handler) {
-    let h = findOperatorHandler(op, handler);
-    if (!h) {
-        h = trap(view, () => handler(name, op.value));
-        h.handler = handler;
-        view.on(op, null, h);
-    }
-    return view;
-}
-
-function trap(view, fn) {
-    return !fn ? null : function() {
-        try {
-            fn.apply(this, arguments);
-        } catch (error) {
-            view.error(error);
-        }
-    };
-}
-
-export default { render }
-'''
-
-@ui.page('/')
-def page():
-    ### Example 1: counter widget synchronized with nicegui & anywidget
-    # This is the getting started example from the anywidget documentation:
-    # https://anywidget.dev/en/getting-started/
-    counter = CounterWidget(value=42)
-    anywidget_counter = ui.anywidget(counter)
-
-    def increment_counter():
-        counter.value += 1
-    ui.button(f'NiceGUI count is {counter.value}', on_click=increment_counter).bind_text_from(counter, 'value', backward=lambda c: f'NiceGUI count is {c}')
-
-
-    ### Example 2: altair chart widget synchronized with nicegui & altair
-    # This is the JupyterChart variable params example from the altair documentation:
-    # https://altair-viz.github.io/user_guide/interactions/jupyter_chart.html#accessing-variable-params
     import altair as alt
     import numpy as np
     import pandas as pd
@@ -314,24 +59,54 @@ def page():
 
     slider = alt.binding_range(min=0, max=100, step=1)
     cutoff = alt.param(name='cutoff', bind=slider, value=50)
-    predicate = alt.datum.xval < 50
 
     chart = alt.Chart(df).mark_point().encode(
         x='xval',
         y='yval',
-        color=alt.when(predicate).then(alt.value('red')).otherwise(alt.value('blue')),
+        color=alt.condition(
+            alt.datum.xval < cutoff,
+            alt.value('red'), alt.value('blue')
+        )
     ).add_params(
         cutoff
     )
-    # jchart = alt.JupyterChart(chart)
-    jchart = AltairChart(chart)
-    ui.anywidget(jchart, throttle=0.2)
+    return alt.JupyterChart(chart)
 
-    def update_cutoff(change):
-        jchart.params.cutoff = change.value
-    slider = ui.slider(min=0, max=100, value=cutoff.value, on_change=update_cutoff).bind_value_from(jchart, '_params', backward=lambda p: p['cutoff'])
-    ui.label().bind_text_from(slider, 'value', backward=lambda c: f'Cutoff is {c}')
 
+@ui.page('/')
+def page():
+    # Example 1: counter widget synchronized with nicegui & anywidget
+    # This is the getting started example from the anywidget documentation:
+    # https://anywidget.dev/en/getting-started/
+    with ui.card().classes('min-w-200px max-w-300px'):
+        ui.label('Synchronized anywidget and nicegui buttons').classes('text-xl font-bold')
+        counter = CounterWidget(value=42)
+        ui.anywidget(counter)
+
+        def increment_counter():
+            counter.value += 1
+        ui.button(
+            f'NiceGUI count is {counter.value}', on_click=increment_counter
+        ).bind_text_from(counter, 'value', backward=lambda c: f'NiceGUI count is {c}')
+
+    # Example 2: altair chart widget with slider synchronized between nicegui & altair
+    # This is the JupyterChart variable params example from the altair documentation:
+    # https://altair-viz.github.io/user_guide/interactions/jupyter_chart.html#accessing-variable-params
+    with ui.card().classes('min-w-200px max-w-300px'):
+        ui.label('Synchronized altair and nicegui sliders').classes('text-xl font-bold')
+        # jchart = AltairChart(create_altair_chart())
+        jchart = create_altair_chart()
+        ui.anywidget(jchart, throttle=0.5)
+
+        def update_cutoff(change):
+            # NOTE: as of altair v5.5, there is a JavaScript side bug in altair.JupyterChart
+            # that causes this callback to fail when accessing .changed (only supported in Jupyter):
+            # https://github.com/vega/altair/issues/3868
+            jchart.params.cutoff = change.value
+        slider = ui.slider(
+            min=0, max=100, value=jchart.params.cutoff, on_change=update_cutoff, throttle=0.2
+        ).bind_value_from(jchart, '_params', backward=lambda p: p['cutoff'])
+        ui.label().bind_text_from(slider, 'value', backward=lambda c: f'Cutoff is {c}')
 
 
 ui.run(show=False)

--- a/nicegui/elements/altair.py
+++ b/nicegui/elements/altair.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING, Any
+
+from .. import optional_features
+from ..elements.anywidget import AnyWidget
+
+if importlib.util.find_spec('altair'):
+    optional_features.register('altair')
+    if TYPE_CHECKING:
+        import altair
+
+
+class Altair(AnyWidget):
+    def __init__(self, chart: altair.Chart | altair.JupyterChart, **kwargs: Any) -> None:
+        """Wrap an altair chart in NiceGUI via anywidget
+
+        Refer to `AnyWidget` for more details.
+        """
+        import altair
+        if isinstance(chart, altair.Chart):
+            chart = altair.JupyterChart(chart)
+        super().__init__(chart, **kwargs)

--- a/nicegui/elements/anywidget.js
+++ b/nicegui/elements/anywidget.js
@@ -1,0 +1,149 @@
+import { load_widget, load_css } from "widget";  // lib/anywidget/widget.js
+import { convertDynamicProperties } from "../../static/utils/dynamic_properties.js";
+
+export default {
+  template: "<div></div>",
+  mounted() {
+    this.init_widget();
+  },
+  methods: {
+    init_widget() {
+      (async () => {
+        const this_ = this;
+
+        // Implement AFM: https://anywidget.dev/en/afm/
+        // References:
+        // * Marimo AFM impl:
+        // https://github.com/marimo-team/marimo/blob/7f3023ff0caef22b2bf4c1b5a18ad1899bd40fa3/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx#L161-L267
+        const model = {
+          attributes: { ...this.traits },
+          callbacks: {},
+          get: function (key) {
+            console.log('Getting value for', key, ':', this.attributes[key]);
+            const value = this.attributes[key];
+            try {
+              // TODO: this should not be necessary but was running into some
+              // JavaScript issues that haven't tried to figure out
+              return JSON.parse(JSON.stringify(value));
+            } catch (e) {
+              // If value is not serializable, return null or a fallback
+              console.warn('Value for key', key, 'is not JSON-serializable:', value);
+              return null;
+            }
+          },
+          set: function (key, value) {
+            console.log('Setting value for', key, ':', value);
+            this.attributes[key] = value;
+            this.emit('change:' + key, value);
+          },
+          save_changes: function () {
+            console.log('Saving changes:', this.attributes);
+
+            // Trigger any change callbacks
+            if (this.callbacks['change'] && Array.isArray(this.callbacks['change'])) {
+              this.callbacks['change'].forEach((cb) => cb());
+            }
+
+            // Propagate the change back to python backend
+            this_.$emit('update:traits', { ...this.attributes });
+          },
+          on: function (event, callback) {
+            console.log('Registering callback for event:', event);
+            if (!this.callbacks[event]) {
+              this.callbacks[event] = [];
+            }
+            this.callbacks[event].push(callback);
+
+            // For property-specific change events
+            if (event.startsWith('change:') && callback) {
+              const propName = event.split(':')[1];
+              console.log('Registered property change callback for', propName);
+            }
+          },
+          off: function (event, callback) {
+            if (!event) {
+              this.callbacks = {};
+              return;
+            }
+            if (!callback) {
+              this.callbacks[event] = [];
+              return;
+            }
+            this.callbacks[event]?.delete(callback);
+          },
+          emit: function (event, value) {
+            if (this.callbacks[event]) {
+              this.callbacks[event].forEach(cb => cb(value));
+            }
+          },
+          send: function (content, callbacks, buffers) {
+            if (buffers) {
+              console.warn('anywidget.send() buffers are not supported in NiceGUI currently');
+            }
+            console.warn('anywidget.send() is not yet implemented in NiceGUI;', content);
+            // this_.$emit('custom', content);
+          }
+        };
+
+        // Dynamically load esm_content as an ECMAScript module
+        const mod = await load_widget(this.esm_content, this.traits["_anywidget_id"]);
+        // TODO: cleanup_widget and cleanup_view should be called when the widget is destroyed
+        this.cleanup_widget = await mod.initialize?.({ model: model });
+        this.cleanup_view = await mod.render?.({ model: model, el: this.$el });
+        this.model = model;
+
+        // // Create a Blob from the ESM content
+        // const blob = new Blob([this.esm_content], { type: 'text/javascript' });
+        // const url = URL.createObjectURL(blob);
+        // // TODO: initialize()
+        // try {
+        //   // Dynamically import the module
+        //   const mod = await import(/* @vite-ignore */ url);
+        //   if (mod && typeof mod.render === 'function') {
+        //     // Call the render function with the model and element
+        //     mod.render({ model: model, el: this.$el });
+        //   } else if (mod && mod.default && typeof mod.default.render === 'function') {
+        //     mod.default.render({ model: model, el: this.$el });
+        //   }
+        //   this.model = model;
+        // } finally {
+        //   // Clean up the object URL
+        //   URL.revokeObjectURL(url);
+        // }
+      })();
+
+      load_css(this.css_content, this.traits["_anywidget_id"]);
+      // // Optionally inject CSS if provided
+      // if (this.css_content) {
+      //   const style = document.createElement('style');
+      //   style.textContent = this.css_content;
+      //   document.head.appendChild(style);
+      // }
+
+      // If you have an API to add listeners, do so here (placeholder)
+      // this.api.addGlobalListener(this.handle_event);
+    },
+    update_trait(change) {
+      // Callback from Python traitlet backend change event
+      // change is a dictionary with 'trait', 'new', and 'old' keys
+      convertDynamicProperties(change, true);
+      console.log('Updating trait:', change);
+      if (change) {
+        this.model.attributes[change['trait']] = change['new'];
+        this.model.emit("change:" + change['trait'], change['new']);
+      }
+    },
+    update_traits() {
+      // Currently no-op
+      console.log('Updating traits:', this.traits, this.model.attributes);
+    },
+    handle_event(type, args) {
+      console.log('handle_event', type, args);
+    },
+  },
+  props: {
+    traits: Object,
+    esm_content: String,
+    css_content: String,
+  },
+};

--- a/nicegui/elements/anywidget.py
+++ b/nicegui/elements/anywidget.py
@@ -16,9 +16,9 @@ if importlib.util.find_spec('anywidget'):
 
 
 class AnyWidget(ValueElement,
-             component='anywidget.js',
-             dependencies=['lib/anywidget/widget.js'],
-             default_classes='nicegui-anywidget'):
+                component='anywidget.js',
+                dependencies=['lib/anywidget/widget.js'],
+                default_classes='nicegui-anywidget'):
 
     VALUE_PROP: str = 'traits'
 
@@ -40,14 +40,14 @@ class AnyWidget(ValueElement,
         traits = self.get_traits(widget)
         super().__init__(value=traits, **kwargs)
         self._props['esm_content'], self._props['css_content'] = self.get_esm_css(widget)
+        self._props['_debug'] = False  # set to True for console logging
 
         # Observe all widget traits and fire update_trait() JS method when changed in python
         for trait in traits:
             def update_trait(change, trait=trait):
                 self.run_method('update_trait', {'trait': trait, 'new': change['new'], 'old': change['old']})
-                # print('Updated trait:', trait, change['new'])
             self._widget.observe(update_trait, trait)
-        self._update_method = 'update_trait'
+        self._update_method = 'update_traits'
 
     @classmethod
     def get_esm_css(cls, widget_instance: anywidget.AnyWidget) -> Tuple[str, str]:

--- a/nicegui/elements/anywidget.py
+++ b/nicegui/elements/anywidget.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Tuple
+
+from .. import optional_features
+from .mixins.value_element import ValueElement
+
+if importlib.util.find_spec('anywidget'):
+    optional_features.register('anywidget')
+    if TYPE_CHECKING:
+        import anywidget
+
+
+class AnyWidget(ValueElement,
+             component='anywidget.js',
+             dependencies=['lib/anywidget/widget.js'],
+             default_classes='nicegui-anywidget'):
+
+    VALUE_PROP: str = 'traits'
+
+    def __init__(self,
+                 widget: anywidget.AnyWidget,
+                 **kwargs: Any,
+                 ) -> None:
+        """Embed an `anywidget.AnyWidget` in NiceGUI
+
+        This element will observe all `sync` traits of the widget and trigger JS
+        updates when they change.
+        Conversely, changes on the frontend will be synced back to the widget,
+        using `ValueElement`'s handling to listen to changes on `traits`.
+
+        :param widget: the `anywidget.AnyWidget` to wrap
+        :param throttle: minimum time (in seconds) between widget updates to python (default: 0.0)
+        """
+        self._widget = widget
+        traits = self.get_traits(widget)
+        super().__init__(value=traits, **kwargs)
+        self._props['esm_content'], self._props['css_content'] = self.get_esm_css(widget)
+
+        # Observe all widget traits and fire update_trait() JS method when changed in python
+        for trait in traits:
+            def update_trait(change, trait=trait):
+                self.run_method('update_trait', {'trait': trait, 'new': change['new'], 'old': change['old']})
+                # print('Updated trait:', trait, change['new'])
+            self._widget.observe(update_trait, trait)
+        self._update_method = 'update_trait'
+
+    @classmethod
+    def get_esm_css(cls, widget_instance: anywidget.AnyWidget) -> Tuple[str, str]:
+        """Extract the widget's ESM and CSS content, reading if they are `Path` objects"""
+        # Get the ESM module content
+        esm_content = getattr(widget_instance, '_esm')
+
+        # Check if ESM content is a property function (sometimes the case in anywidget)
+        if callable(esm_content) and not inspect.isclass(esm_content):
+            esm_content = esm_content()
+
+        # Get CSS content if available
+        css_content = None
+        if hasattr(widget_instance, '_css'):
+            css_attr = getattr(widget_instance, '_css')
+            if callable(css_attr) and not inspect.isclass(css_attr):
+                css_content = css_attr()
+            else:
+                css_content = css_attr
+
+        if isinstance(esm_content, str) and os.path.exists(esm_content):
+            esm_content = Path(esm_content)
+        if isinstance(css_content, str) and os.path.exists(css_content):
+            css_content = Path(css_content)
+
+        if isinstance(esm_content, os.PathLike):
+            with open(esm_content, 'r') as f:
+                esm_content = f.read()
+        if isinstance(css_content, os.PathLike):
+            with open(css_content, 'r') as f:
+                css_content = f.read()
+        return esm_content or '', css_content or ''
+
+    @classmethod
+    def get_traits(cls, widget_instance: anywidget.AnyWidget) -> dict[str, Any]:
+        """Extract the widget's current state - only get traits marked with `sync=True`"""
+        sync_traits = list(widget_instance.traits(sync=True))
+        # get_state() will access the trait values and serialize to JSON if needed
+        # https://ipywidgets.readthedocs.io/en/latest/_modules/ipywidgets/widgets/widget.html#Widget.get_state
+        return widget_instance.get_state(key=sync_traits)
+
+    def _handle_value_change(self, value: Any) -> None:
+        """Update the widget's state when the value changes from frontend"""
+        super()._handle_value_change(value)
+        # TODO: currently this is iterating all traits and doing extra JSON serialization.
+        # Ideally we would directly have the frontend tell us which traits have changed?
+        current_traits = self.get_traits(self._widget)
+        for key, value_ in value.items():
+            if current_traits[key] != value_:
+                setattr(self._widget, key, value_)
+        if self._send_update_on_value_change:
+            self.run_method('update_traits')

--- a/nicegui/elements/lib/anywidget/widget.js
+++ b/nicegui/elements/lib/anywidget/widget.js
@@ -1,0 +1,168 @@
+// Core functions from anywidget's Jupyter widget implementation
+// https://github.com/manzt/anywidget/blob/main/packages/anywidget/src/widget.js
+
+/** @import { Initialize, Render, AnyModel } from "@anywidget/types" */
+
+/**
+ * @template T
+ * @typedef {T | PromiseLike<T>} Awaitable
+ */
+
+/**
+ * @typedef AnyWidget
+ * @prop initialize {Initialize}
+ * @prop render {Render}
+ */
+
+/**
+ *  @typedef AnyWidgetModule
+ *  @prop render {Render=}
+ *  @prop default {AnyWidget | (() => AnyWidget | Promise<AnyWidget>)=}
+ */
+
+/**
+ * @param {unknown} condition
+ * @param {string} message
+ * @returns {asserts condition}
+ */
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+/**
+ * @param {string} str
+ * @returns {str is "https://${string}" | "http://${string}"}
+ */
+function is_href(str) {
+  return str.startsWith("http://") || str.startsWith("https://");
+}
+
+/**
+ * @param {string} href
+ * @param {string} anywidget_id
+ * @returns {Promise<void>}
+ */
+async function load_css_href(href, anywidget_id) {
+  /** @type {HTMLLinkElement | null} */
+  let prev = document.querySelector(`link[id='${anywidget_id}']`);
+
+  // Adapted from https://github.com/vitejs/vite/blob/d59e1acc2efc0307488364e9f2fad528ec57f204/packages/vite/src/client/client.ts#L185-L201
+  // Swaps out old styles with new, but avoids flash of unstyled content.
+  // No need to await the load since we already have styles applied.
+  if (prev) {
+    let newLink = /** @type {HTMLLinkElement} */ (prev.cloneNode());
+    newLink.href = href;
+    newLink.addEventListener("load", () => prev?.remove());
+    newLink.addEventListener("error", () => prev?.remove());
+    prev.after(newLink);
+    return;
+  }
+
+  return new Promise((resolve) => {
+    let link = Object.assign(document.createElement("link"), {
+      rel: "stylesheet",
+      href,
+      onload: resolve,
+    });
+    document.head.appendChild(link);
+  });
+}
+
+/**
+ * @param {string} css_text
+ * @param {string} anywidget_id
+ * @returns {void}
+ */
+function load_css_text(css_text, anywidget_id) {
+  /** @type {HTMLStyleElement | null} */
+  let prev = document.querySelector(`style[id='${anywidget_id}']`);
+  if (prev) {
+    // replace instead of creating a new DOM node
+    prev.textContent = css_text;
+    return;
+  }
+  let style = Object.assign(document.createElement("style"), {
+    id: anywidget_id,
+    type: "text/css",
+  });
+  style.appendChild(document.createTextNode(css_text));
+  document.head.appendChild(style);
+}
+
+/**
+ * @param {string | undefined} css
+ * @param {string} anywidget_id
+ * @returns {Promise<void>}
+ */
+async function load_css(css, anywidget_id) {
+  if (!css || !anywidget_id) return;
+  if (is_href(css)) return load_css_href(css, anywidget_id);
+  return load_css_text(css, anywidget_id);
+}
+
+/**
+ * @param {string} esm
+ * @returns {Promise<AnyWidgetModule>}
+ */
+async function load_esm(esm) {
+  if (is_href(esm)) {
+    return await import(/* webpackIgnore: true */ /* @vite-ignore */ esm);
+  }
+  let url = URL.createObjectURL(new Blob([esm], { type: "text/javascript" }));
+  let mod = await import(/* webpackIgnore: true */ /* @vite-ignore */ url);
+  URL.revokeObjectURL(url);
+  return mod;
+}
+
+/** @param {string} anywidget_id */
+function warn_render_deprecation(anywidget_id) {
+  console.warn(`\
+[anywidget] Deprecation Warning for ${anywidget_id}: Direct export of a 'render' will likely be deprecated in the future. To migrate ...
+
+Remove the 'export' keyword from 'render'
+-----------------------------------------
+
+export function render({ model, el }) { ... }
+^^^^^^
+
+Create a default export that returns an object with 'render'
+------------------------------------------------------------
+
+function render({ model, el }) { ... }
+         ^^^^^^
+export default { render }
+                 ^^^^^^
+
+Pin to anywidget>=0.9.0 in your pyproject.toml
+----------------------------------------------
+
+dependencies = ["anywidget>=0.9.0"]
+
+To learn more, please see: https://github.com/manzt/anywidget/pull/395.
+`);
+}
+
+/**
+ * @param {string} esm
+ * @param {string} anywidget_id
+ * @returns {Promise<AnyWidget>}
+ */
+async function load_widget(esm, anywidget_id) {
+  let mod = await load_esm(esm);
+  if (mod.render) {
+    warn_render_deprecation(anywidget_id);
+    return {
+      async initialize() { },
+      render: mod.render,
+    };
+  }
+  assert(
+    mod.default,
+    `[anywidget] module must export a default function or object.`,
+  );
+  let widget =
+    typeof mod.default === "function" ? await mod.default() : mod.default;
+  return widget;
+}
+
+export { load_widget, load_css };

--- a/nicegui/elements/slider.py
+++ b/nicegui/elements/slider.py
@@ -13,6 +13,7 @@ class Slider(ValueElement, DisableableElement):
                  step: float = 1.0,
                  value: Optional[float] = None,
                  on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 throttle: float = 0.05,
                  ) -> None:
         """Slider
 
@@ -24,7 +25,7 @@ class Slider(ValueElement, DisableableElement):
         :param value: initial value to set position of the slider
         :param on_change: callback which is invoked when the user releases the slider
         """
-        super().__init__(tag='q-slider', value=value, on_value_change=on_change, throttle=0.05)
+        super().__init__(tag='q-slider', value=value, on_value_change=on_change, throttle=throttle)
         self._props['min'] = min
         self._props['max'] = max
         self._props['step'] = step

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -5,6 +5,7 @@ __all__ = [
     'add_sass',
     'add_scss',
     'aggrid',
+    'anywidget',
     'audio',
     'avatar',
     'badge',
@@ -134,6 +135,7 @@ __all__ = [
 from .context import context
 from .element import Element as element
 from .elements.aggrid import AgGrid as aggrid
+from .elements.anywidget import AnyWidget as anywidget
 from .elements.audio import Audio as audio
 from .elements.avatar import Avatar as avatar
 from .elements.badge import Badge as badge

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -5,6 +5,7 @@ __all__ = [
     'add_sass',
     'add_scss',
     'aggrid',
+    'altair',
     'anywidget',
     'audio',
     'avatar',
@@ -135,6 +136,7 @@ __all__ = [
 from .context import context
 from .element import Element as element
 from .elements.aggrid import AgGrid as aggrid
+from .elements.altair import Altair as altair
 from .elements.anywidget import AnyWidget as anywidget
 from .elements.audio import Audio as audio
 from .elements.avatar import Avatar as avatar


### PR DESCRIPTION
### Motivation

Refer to #5096 for details: add support for anywidgets to be rendered in NiceGUI, such as the 70+ examples from the anywidgets gallery: https://try.anywidget.dev/. For example, this solves #657 (adding `altair` support); for convenience, this PR exposes a `ui.altair(chart: altair.Chart)` although its a one-line wrapper around `ui.anywidget()`.

Roughly speaking the flow is:
- python->JS: Use `traitlets.HasTraits.observe()` to listen to changes to anywidget's traitlets; on observing changes, call `nicegui.Element.run_method("update_trait", <trait>)` to invoke any callbacks on JS side registered by `model.on("change:<trait>")` in the anywidget's`esm`
- JS->python: `model.save_changes()` `$emit`s the state of `traits` to `ValueElement._handle_value_change`, where any changed traits will be set on the anywidget 

It also might simplify feature requests for other pure-JS libraries, for example it took me a couple of minutes to vibe code a TradingView LightWeight chart widget (#813) that I iterated on in Jupyter and then copy-pasted into NiceGUI, without needing to add any code to NiceGUI.

### Implementation

I borrowed most of the structure behind the [AFM implementation](https://anywidget.dev/en/afm/) from the few examples out there such as [marimo](https://github.com/marimo-team/marimo/blob/7f3023ff0caef22b2bf4c1b5a18ad1899bd40fa3/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx#L161-L267).

Known issues:
- The `model.send()` method in AFM is left unimplemented, haven't checked how its used
- The cleanup methods returned by `initialize() / render()` are not currently used
- `model.save_changes()` currently sends all traits back to python including unchanged traits, which is unnecessarily expensive
- `altair`: JS errors when `altair.params` are updated but this is an issue with `altair`: https://github.com/vega/altair/issues/3868
- Right now linking nicegui --> anywidget via python-side `on_change` callbacks is very jittery -- see the recording below, I'm not sure what throttling / debouncing needs to applied. Is there an easy way to link the two NiceGUI elements on the JS side?

https://github.com/user-attachments/assets/8214591a-caef-4526-8a42-854bc2d2b081

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).
