### PR TITLE
`ui.aggrid` do not error out if no onGridReady

### DIFF
--- a/nicegui/elements/aggrid.js
+++ b/nicegui/elements/aggrid.js
@@ -44,8 +44,11 @@ export default {
 
       const originalOnGridReady = this.gridOptions.onGridReady;
       this.gridOptions.onGridReady = (params) => {
-        originalOnGridReady(params);
-        this.handle_event("gridReady", params);
+        try {
+          originalOnGridReady(params);
+        } finally {
+          this.handle_event("gridReady", params);
+        }
       };
       this.api = agGrid.createGrid(this.$el, this.gridOptions);
       this.api.addGlobalListener(this.handle_event);


### PR DESCRIPTION
### Motivation

Fixes #5141. I found that while fixing #5087, that https://github.com/zauberzeug/nicegui/commit/5f57a41814576e1693dde12769b2826155a94e54 does not account for the case where the user did not provide `onGridReady`, will lead to `originalOnGridReady is not a function` error. 

### Implementation

This PR makes it not error out. Compared to `if (typeof originalOnGridReady === "function")`, the advantage is: 
- An erroring-out AG grid `onGridReady` will not supress the emission of `gridReady`
- If someone manage to pass a `onGridReady` which is callable but not a function, we also call it

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary?
  - More than anything we may need to "make the tests fail if browser console has error" across all tests?  
- [x] Documentation is not necessary.
