### PR TITLE
Investigate python 3.8/3.9 test failures

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,25 @@
 pytest-asyncio
 pytest-selenium
+
+# Test runtime dependencies used across the suite
+# Keep versions compatible with Python 3.8 and newer
+
+# Core scientific/plotting libs used in tests
+numpy==1.24.* ; python_version == '3.8'
+numpy>=1.26 ; python_version >= '3.9'
+pandas>=2.0
+polars==1.8.* ; python_version == '3.8'
+polars>=1.12 ; python_version >= '3.9'
+plotly>=5.13,<7.0
+pyecharts>=2.0
+nicegui-highcharts>=2.0.2
+
+# SCSS support used by style tests
+libsass>=0.23.0
+
+# Selenium stack for browser tests
+selenium>=4.11.2
+webdriver-manager>=3.8.6,<5.0.0
+
+# Matplotlib for pyplot tests
+matplotlib>=3.5


### PR DESCRIPTION
### Motivation

This PR addresses the issue of over 100 failing tests on Python 3.8 and 3.9 in CI. The root cause was identified as missing optional test dependencies that were not implicitly installed in these environments, rather than "warnings as errors" as initially suspected.

### Implementation

The `tests/requirements.txt` file has been updated to explicitly include essential optional test dependencies, such as `numpy`, `pandas`, `polars`, `plotly`, `pyecharts`, `nicegui-highcharts`, `libsass`, `matplotlib`, `selenium`, and `webdriver-manager`. Specific version pins, including conditional pins for Python 3.8 compatibility (e.g., for `numpy` and `polars`), ensure that these packages are correctly installed, allowing tests to run successfully across Python 3.8 and 3.9.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
<a href="https://cursor.com/background-agent?bcId=bc-442151a0-90d2-4594-9400-e02e4ba06ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-442151a0-90d2-4594-9400-e02e4ba06ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

