### PR TITLE
Add table demo: Delete button in Actions column using Quasar template

### DIFF
--- a/website/documentation/content/table_documentation.py
+++ b/website/documentation/content/table_documentation.py
@@ -111,6 +111,40 @@ def table_with_expandable_rows():
         </q-tr>
     ''')
 
+@doc.demo('Table with Delete button', '''
+    Each row has a Delete button in the Actions column.
+    Clicking the button shows a notification with the row name.
+''')
+def table_with_delete_button():
+    columns = [
+        {'name': 'id', 'label': 'ID', 'field': 'id'},
+        {'name': 'name', 'label': 'Name', 'field': 'name'},
+        {'name': 'age', 'label': 'Age', 'field': 'age'},
+        {'name': 'actions', 'label': 'Actions'},
+    ]
+
+    rows = [{'id': 0, 'name': 'Paul', 'age': 38}]
+
+    table = ui.table(columns=columns, rows=rows, row_key='id').classes('w-full')
+
+    # Quasar template for Actions column
+    table.add_slot(
+        'body-cell-actions',
+        '''
+        <q-td auto-width :props="props">
+            <q-btn 
+                size="sm" 
+                color="red" 
+                label="Delete" 
+                flat 
+                dense 
+                round
+                @click="() => $q.notify({message: 'Deleted ' + props.row.name + '!'})"
+            />
+        </q-td>
+        '''
+    )
+
 
 @doc.demo('Show and hide columns', '''
     Here is an example of how to show and hide columns in a table.


### PR DESCRIPTION
### Motivation

Add an example to the NiceGUI table documentation showing how to include a Delete button in a custom “Actions” column using Quasar template slots. This addresses a common question in the discussions about rendering per-row buttons in tables, which wasn’t clearly covered in the existing docs.

### Implementation

Added a new demo in website/documentation/content/table_documentation.py using table.add_slot() with a Quasar template.

The demo shows a red Delete button in each row’s Actions column that triggers a notification when clicked.

Could you ensure the button displays correctly and is aligned with the row content?

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary). [x] (not required for UI demo)
- [x] Documentation has been added (or is not necessary). [x] (demo added directly to table documentation)


<img width="346" height="232" alt="Table_delete_button" src="https://github.com/user-attachments/assets/c3c99718-79f4-4c74-b186-12f5dc511fd4" />
