### PR TITLE
Move Tailwind layer less important than Quasar so that Tailwind wins when with !important

### DIFF
--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="{{ viewport }}" />
     <link href="{{ favicon_url }}" rel="shortcut icon" />
     <style>
-      @layer theme, base, quasar, nicegui, components, utilities, overrides;
+      @layer theme, base, utilities, quasar, nicegui, components, overrides;
       @import url("{{ prefix | safe }}/_nicegui/{{version}}/static/fonts.css") layer(base);
       {% if prod_js %}
         @import url("{{ prefix | safe }}/_nicegui/{{version}}/static/quasar.prod.css") layer(quasar);


### PR DESCRIPTION
### Motivation

Fix #5156, in which we see that Tailwind always loses in the CSS importance battle if Tailwind's layer is higher than Quasar. 

- Tailwind loses to Quasar's `!important` if Tailwind isn't begin with `!`
- Tailwind still loses to Quasar since layer order is reversed if both rules are `!important`

That's no good. In addition, testing at https://github.com/zauberzeug/nicegui/issues/5156#issuecomment-3324250564 reveals the new behaviour diverges from the old, which is not what we want either. 

**Real motivation: Want 3.0 ASAP**

**Real motivation 2: Check the pipeline results to see if this broke anything**

### Implementation

Now we move Tailwind layer to be lower than Quasar. 

- Tailwind still loses to Quasar's `!important` if Tailwind isn't begin with `!`. It didn't have a chance without `!` anyways
- Tailwind now wins Quasar precisely because layer order is reversed if both rules are `!important`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
  - I'm contemplating whether to Pytest this. 
- [ ] Documentation has been added (or is not necessary).
  - We **need** to document this.  
