### PR TITLE
Move Tailwind's important rules to a layer before Quasar to make sure they win

### DIFF
--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="{{ viewport }}" />
     <link href="{{ favicon_url }}" rel="shortcut icon" />
     <style>
-      @layer tailwind_importants, theme, base, quasar, nicegui, components, utilities, overrides;
+      @layer theme, base, quasar, nicegui, components, utilities, overrides, quasar_importants;
       @import url("{{ prefix | safe }}/_nicegui/{{version}}/static/fonts.css") layer(base);
       {% if prod_js %}
         @import url("{{ prefix | safe }}/_nicegui/{{version}}/static/quasar.prod.css") layer(quasar);
@@ -27,8 +27,8 @@
           scroll-behavior: auto !important; /* HACK: avoid smooth-scrolling when dialogs or select popups close */
         }
       }
-      @layer tailwind_importants {
-        /* Do not remove this layer, it is used in the JS to move !important rules from the "utilities" layer here */
+      @layer quasar_importants {
+        /* Do not remove this layer, it is used in nicegui.js to move !important rules from the "quasar" layer here */
       }
     </style>
     <!-- prevent Prettier from removing this line -->


### PR DESCRIPTION
### Motivation

Fix #5156, in which we see that Tailwind always loses in the CSS importance battle if Tailwind's layer is higher than Quasar. 

- Tailwind loses to Quasar's `!important` if Tailwind isn't begin with `!`
- Tailwind still loses to Quasar since layer order is reversed if both rules are `!important`

That's no good. In addition, testing at https://github.com/zauberzeug/nicegui/issues/5156#issuecomment-3324250564 reveals the new behaviour diverges from the old, which is not what we want either. 

We did try #5166, that didn't work (NiceGUI-native documentation site is broken), while #5167 also didn't work (Quasar-native documentation site shall be broken)

**Real motivation: Want 3.0 ASAP**

**Real motivation 2: Check the pipeline results to see if this broke anything**

**Real motivation 3: I look like a 🤡 in #5166**

### Implementation

- `tailwind_importants` layer before all layers, normally empty and does not affect page operation
- `moveRules` to be ran, if we detect any changes in `<head>`
- `moveRules` to move all `!important` rules from Tailwind away from `utilities` into `tailwind_importants` so that accounting for the inverse of layer priority, Tailwind wins. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
  - I'm considering it. 
- [ ] Documentation has been added (or is not necessary).
  - May need document this to keep users in-the-loop of what is happening

### Comprehensive test script

Combines https://github.com/zauberzeug/nicegui/issues/5156#issuecomment-3324250564 and https://github.com/zauberzeug/nicegui/pull/5167#issue-3445876247

```py
@ui.page('/')
def index():
    ui.label('Tailwind & Quasar CSS Comprehensive Test Script').classes('text-2xl')

    ui.label('I want a red button').classes('text-lg')

    ui.button('button').classes('bg-red-700')  # doesn't work in 2.x and 3.0.0rc1 and this PR
    ui.button('button').classes('!bg-red-700')  # doesn't work in 3.0.0rc1, but work in 2.x and this PR

    ui.label('I want "Hi!" to be visible only in dark mode').classes('text-lg')

    dark = ui.dark_mode()
    ui.switch().bind_value(dark, 'value')
    ui.label('Using invisible dark:visible')
    ui.label('Hi!').classes('invisible dark:visible')  # doesn't work in 2.x and 3.0.0rc1 and this PR
    ui.label('Using invisible dark:!visible')
    ui.label('Hi!').classes('invisible dark:!visible')  # doesn't work in 3.0.0rc1, but work in 2.x and this PR

    ui.label('If it is green, Tailwind is winning over Quasar').classes('text-lg')

    ui.label('Quasar Red, Tailwind (no important) Green')
    ui.button('button').props('color="red-10"').classes('bg-green-700')  # never wins

    ui.label('Quasar Red, Tailwind (with important) Green')
    ui.button('button').props('color="red-10"').classes('!bg-green-700')  # wins in 2.x and this PR, but not in 3.0.0rc1
```

### Results

<img width="600" alt="image" src="https://github.com/user-attachments/assets/f624d66f-64a4-4e71-ba0e-16d18902c9f8" />

### Documentation page screenshot

<img width="600" alt="image" src="https://github.com/user-attachments/assets/02003df0-4f6b-40e1-9146-50add652bb47" />


### Additional notes

The value of UnoCSS (#4832) is that we can potentially do the same without the MutationObserver. 