### PR TITLE
Deprecate `ClientConnectionTimeout` and `timeout` for `await client.connected()`

### DIFF
--- a/nicegui/elements/timer.py
+++ b/nicegui/elements/timer.py
@@ -1,8 +1,7 @@
 from contextlib import AbstractContextManager, nullcontext
 
-from ..client import Client, ClientConnectionTimeout
+from ..client import Client
 from ..element import Element
-from ..logging import log
 from ..timer import Timer as BaseTimer
 
 
@@ -11,19 +10,12 @@ class Timer(BaseTimer, Element, component='timer.js'):
     def _get_context(self) -> AbstractContextManager:
         return self.parent_slot or nullcontext()
 
-    async def _can_start(self) -> bool:
+    async def _can_start(self) -> None:
         """Wait for the client connection before the timer callback can be allowed to manipulate the state.
 
         See https://github.com/zauberzeug/nicegui/issues/206 for details.
-        Returns True if the client is connected, False if the client is not connected and the timer should be cancelled.
         """
-        try:
-            await self.client.connected()
-            return True
-        except ClientConnectionTimeout:
-            self.cancel()
-            log.debug('Timer cancelled because client connection timed out')
-            return False
+        await self.client.connected()
 
     def _should_stop(self) -> bool:
         return (

--- a/nicegui/event.py
+++ b/nicegui/event.py
@@ -12,7 +12,7 @@ from typing_extensions import ParamSpec
 
 from . import background_tasks, core, helpers
 from .awaitable_response import AwaitableResponse
-from .client import Client, ClientConnectionTimeout
+from .client import Client
 from .context import context
 from .dataclasses import KWONLY_SLOTS
 from .logging import log
@@ -85,12 +85,8 @@ class Event(Generic[P]):
                                'is not supported.')
         if client is not None and unsubscribe_on_disconnect is not False:
             async def register_disconnect() -> None:
-                try:
-                    await client.connected()
-                    client.on_disconnect(lambda: self.unsubscribe(callback))
-                except ClientConnectionTimeout:
-                    log.debug('Could not register a disconnect handler for callback %s', callback)
-                    self.unsubscribe(callback)
+                await client.connected()
+                client.on_disconnect(lambda: self.unsubscribe(callback))
             if core.loop and core.loop.is_running():
                 background_tasks.create(register_disconnect())
             else:

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from fastapi import HTTPException, Request, Response
 
 from . import background_tasks, binding, core, helpers
-from .client import Client, ClientConnectionTimeout
+from .client import Client
 from .favicon import create_favicon_route
 from .language import Language
 from .logging import log
@@ -116,9 +116,6 @@ class page:
                               'it was returned after the HTML had been delivered to the client')
             except asyncio.CancelledError:
                 pass
-            except ClientConnectionTimeout as e:
-                log.debug('client connection timed out')
-                e.client.delete()
             except Exception as e:
                 core.app.handle_exception(e)
 

--- a/nicegui/timer.py
+++ b/nicegui/timer.py
@@ -71,8 +71,7 @@ class Timer:
 
     async def _run_once(self) -> None:
         try:
-            if not await self._can_start():
-                return
+            await self._can_start()
             with self._get_context():
                 await asyncio.sleep(self.interval)
                 if self.active and not self._should_stop():
@@ -85,8 +84,7 @@ class Timer:
         try:
             if not self._immediate:
                 await asyncio.sleep(self.interval)
-            if not await self._can_start():
-                return
+            await self._can_start()
             with self._get_context():
                 while not self._should_stop():
                     try:
@@ -114,8 +112,8 @@ class Timer:
         except Exception as e:
             core.app.handle_exception(e)
 
-    async def _can_start(self) -> bool:
-        return True
+    async def _can_start(self) -> None:
+        return
 
     def _should_stop(self) -> bool:
         return (


### PR DESCRIPTION
### Motivation

In #5116 `ClientConnectionTimeout` was an exception raised (and NiceGUI internally handled) that would occur when `await client.connected()` timed out. 

But as #5116 progressed we made `await client.connected()` never timeout unless you pass in a timeout parameter, and so if we just got rid of that parameter we can get rid of `ClientConnectionTimeout` entirely. 

I was trying to slip this into #5116 but (1) we need to feature-freeze 3.0 and (2) indeed there may be uses for `ClientConnectionTimeout` and so we can deprecate the timeout parameter in 3.x and remove it in 4.0? 

### Implementation

- See `ClientConnectionTimeout`? Remove it
- Timer can always start when the client is eventually connected; Assuming entire client will be destroyed alongside its timer. 
- Do not unsubscribe the callback on client disconnect; Assuming the entire client will be destroyed alongside its callback. 
- Page late return value will not delete client; Client is destroyed by the purge anyways. 

I made 2 assumptions there, so this code may or may not work!

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).

@falkoschindler Milestone 4.0? 