### PR TITLE
Call lifecycle event handlers more consistently

### DIFF
--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -44,8 +44,10 @@ class App(FastAPI):
 
         self._startup_handlers: list[Union[Callable[..., Any], Awaitable]] = []
         self._shutdown_handlers: list[Union[Callable[..., Any], Awaitable]] = []
+        self._handshake_handlers: list[Union[Callable[..., Any], Awaitable]] = []
         self._connect_handlers: list[Union[Callable[..., Any], Awaitable]] = []
         self._disconnect_handlers: list[Union[Callable[..., Any], Awaitable]] = []
+        self._deletion_handlers: list[Union[Callable[..., Any], Awaitable]] = []
         self._exception_handlers: list[Callable[..., Any]] = [log.exception]
         self._page_exception_handler: Optional[Callable[..., Any]] = None
 
@@ -107,6 +109,13 @@ class App(FastAPI):
         except Exception as e:
             self.handle_exception(e)
 
+    def on_handshake(self, handler: Union[Callable, Awaitable]) -> None:
+        """Called when a client completes the handshake with NiceGUI.
+
+        The callback has an optional parameter of `nicegui.Client`.
+        """
+        self._handshake_handlers.append(handler)
+
     def on_connect(self, handler: Union[Callable, Awaitable]) -> None:
         """Called every time a new client connects to NiceGUI.
 
@@ -120,6 +129,13 @@ class App(FastAPI):
         The callback has an optional parameter of `nicegui.Client`.
         """
         self._disconnect_handlers.append(handler)
+
+    def on_deletion(self, handler: Union[Callable, Awaitable]) -> None:
+        """Called when a client is deleted.
+
+        The callback has an optional parameter of `nicegui.Client`.
+        """
+        self._deletion_handlers.append(handler)
 
     def on_startup(self, handler: Union[Callable, Awaitable]) -> None:
         """Called when NiceGUI is started or restarted.
@@ -306,8 +322,10 @@ class App(FastAPI):
         self.storage.clear()
         self._startup_handlers.clear()
         self._shutdown_handlers.clear()
+        self._handshake_handlers.clear()
         self._connect_handlers.clear()
         self._disconnect_handlers.clear()
+        self._deletion_handlers.clear()
         self._exception_handlers[:] = [log.exception]
         self.config = AppConfig()
 

--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -44,10 +44,9 @@ class App(FastAPI):
 
         self._startup_handlers: list[Union[Callable[..., Any], Awaitable]] = []
         self._shutdown_handlers: list[Union[Callable[..., Any], Awaitable]] = []
-        self._handshake_handlers: list[Union[Callable[..., Any], Awaitable]] = []
         self._connect_handlers: list[Union[Callable[..., Any], Awaitable]] = []
         self._disconnect_handlers: list[Union[Callable[..., Any], Awaitable]] = []
-        self._deletion_handlers: list[Union[Callable[..., Any], Awaitable]] = []
+        self._delete_handlers: list[Union[Callable[..., Any], Awaitable]] = []
         self._exception_handlers: list[Callable[..., Any]] = [log.exception]
         self._page_exception_handler: Optional[Callable[..., Any]] = None
 
@@ -109,13 +108,6 @@ class App(FastAPI):
         except Exception as e:
             self.handle_exception(e)
 
-    def on_handshake(self, handler: Union[Callable, Awaitable]) -> None:
-        """Called when a client completes the handshake with NiceGUI.
-
-        The callback has an optional parameter of `nicegui.Client`.
-        """
-        self._handshake_handlers.append(handler)
-
     def on_connect(self, handler: Union[Callable, Awaitable]) -> None:
         """Called every time a new client connects to NiceGUI.
 
@@ -127,15 +119,19 @@ class App(FastAPI):
         """Called every time a new client disconnects from NiceGUI.
 
         The callback has an optional parameter of `nicegui.Client`.
+
+        *Updated in version 3.0.0: The handler is also called when a client reconnects.*
         """
         self._disconnect_handlers.append(handler)
 
-    def on_deletion(self, handler: Union[Callable, Awaitable]) -> None:
+    def on_delete(self, handler: Union[Callable, Awaitable]) -> None:
         """Called when a client is deleted.
 
         The callback has an optional parameter of `nicegui.Client`.
+
+        *Added in version 3.0.0*
         """
-        self._deletion_handlers.append(handler)
+        self._delete_handlers.append(handler)
 
     def on_startup(self, handler: Union[Callable, Awaitable]) -> None:
         """Called when NiceGUI is started or restarted.
@@ -322,10 +318,9 @@ class App(FastAPI):
         self.storage.clear()
         self._startup_handlers.clear()
         self._shutdown_handlers.clear()
-        self._handshake_handlers.clear()
         self._connect_handlers.clear()
         self._disconnect_handlers.clear()
-        self._deletion_handlers.clear()
+        self._delete_handlers.clear()
         self._exception_handlers[:] = [log.exception]
         self.config = AppConfig()
 

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -274,13 +274,14 @@ class Client:
         self._num_connections[document_id] -= 1
         self.tab_id = None
 
+        for t in self.disconnect_handlers:
+            self.safe_invoke(t)
+        for t in core.app._disconnect_handlers:  # pylint: disable=protected-access
+            self.safe_invoke(t)
+
         async def delete_content() -> None:
             await asyncio.sleep(self.page.resolve_reconnect_timeout())
             if self._num_connections[document_id] == 0:
-                for t in self.disconnect_handlers:
-                    self.safe_invoke(t)
-                for t in core.app._disconnect_handlers:  # pylint: disable=protected-access
-                    self.safe_invoke(t)
                 self._num_connections.pop(document_id)
                 self._delete_tasks.pop(document_id)
                 self.delete()

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -278,12 +278,7 @@ class Client:
             self.safe_invoke(t)
 
     def handle_disconnect(self, socket_id: str) -> None:
-        """Wait for the browser to reconnect; invoke disconnect handlers if it doesn't.
-
-        NOTE:
-        In contrast to connect handlers, disconnect handlers are not called during a reconnect.
-        This behavior should be fixed in version 3.0.
-        """
+        """Wait for the browser to reconnect; invoke deletion handlers if it doesn't."""
         if socket_id not in self._socket_to_document_id:
             return
         document_id = self._socket_to_document_id.pop(socket_id)

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -109,28 +109,36 @@ def test_startup_and_shutdown_handlers(screen: Screen):
 def test_all_lifecycle_handlers_are_called(screen: Screen):
     events: list[str] = []
 
-    app.on_handshake(lambda: events.append('app handshake'))
     app.on_connect(lambda: events.append('app connect'))
     app.on_disconnect(lambda: events.append('app disconnect'))
-    app.on_deletion(lambda: events.append('app deletion'))
+    app.on_delete(lambda: events.append('app delete'))
 
     @ui.page('/')
     def page():
-        ui.context.client.on_handshake(lambda: events.append('page handshake'))
         ui.context.client.on_connect(lambda: events.append('page connect'))
         ui.context.client.on_disconnect(lambda: events.append('page disconnect'))
-        ui.context.client.on_deletion(lambda: events.append('page deletion'))
+        ui.context.client.on_delete(lambda: events.append('page delete'))
+
+        ui.button('Delete', on_click=ui.context.client.delete)
 
     screen.open('/')
     screen.wait(0.5)
-    assert events == ['page handshake', 'app handshake', 'page connect', 'app connect']
+    assert events == ['page connect', 'app connect']
 
     screen.selenium.execute_script('window.socket.disconnect();')
     screen.wait(0.5)
-    assert events == ['page handshake', 'app handshake', 'page connect', 'app connect',
+    assert events == ['page connect', 'app connect',
                       'page disconnect', 'app disconnect']
 
     screen.selenium.execute_script('window.socket.connect();')
     screen.wait(0.5)
-    assert events == ['page handshake', 'app handshake', 'page connect', 'app connect',
-                      'page disconnect', 'app disconnect', 'page connect', 'app connect']
+    assert events == ['page connect', 'app connect',
+                      'page disconnect', 'app disconnect',
+                      'page connect', 'app connect']
+
+    screen.click('Delete')
+    screen.wait(0.5)
+    assert events == ['page connect', 'app connect',
+                      'page disconnect', 'app disconnect',
+                      'page connect', 'app connect',
+                      'page delete', 'app delete']

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -125,7 +125,12 @@ def test_all_lifecycle_handlers_are_called(screen: Screen):
     screen.wait(0.5)
     assert events == ['page handshake', 'app handshake', 'page connect', 'app connect']
 
-    screen.close()
+    screen.selenium.execute_script('window.socket.disconnect();')
     screen.wait(0.5)
     assert events == ['page handshake', 'app handshake', 'page connect', 'app connect',
                       'page disconnect', 'app disconnect']
+
+    screen.selenium.execute_script('window.socket.connect();')
+    screen.wait(0.5)
+    assert events == ['page handshake', 'app handshake', 'page connect', 'app connect',
+                      'page disconnect', 'app disconnect', 'page connect', 'app connect']

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -323,10 +323,9 @@ def map_of_nicegui():
             - `app.storage.general`: stored in a file on the server, shared across the entire app
             - `app.storage.browser`: stored in the browser's local storage, unique per browser
         - [lifecycle hooks](/documentation/section_action_events#events):
-            - `app.on_handshake()`: called when a client completes the initial handshake
             - `app.on_connect()`: called when a client connects (even when reconnecting)
             - `app.on_disconnect()`: called when a client disconnects (even when reconnecting)
-            - `app.on_deletion()`: called when a client is deleted (if it does not reconnect)
+            - `app.on_delete()`: called when a client is deleted (if it does not reconnect)
             - `app.on_startup()`: called when the app starts
             - `app.on_shutdown()`: called when the app shuts down
             - `app.on_exception()`: called when an exception occurs

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -323,8 +323,10 @@ def map_of_nicegui():
             - `app.storage.general`: stored in a file on the server, shared across the entire app
             - `app.storage.browser`: stored in the browser's local storage, unique per browser
         - [lifecycle hooks](/documentation/section_action_events#events):
-            - `app.on_connect()`: called when a client connects
-            - `app.on_disconnect()`: called when a client disconnects
+            - `app.on_handshake()`: called when a client completes the initial handshake
+            - `app.on_connect()`: called when a client connects (even when reconnecting)
+            - `app.on_disconnect()`: called when a client disconnects (even when reconnecting)
+            - `app.on_deletion()`: called when a client is deleted (if it does not reconnect)
             - `app.on_startup()`: called when the app starts
             - `app.on_shutdown()`: called when the app shuts down
             - `app.on_exception()`: called when an exception occurs

--- a/website/documentation/content/section_action_events.py
+++ b/website/documentation/content/section_action_events.py
@@ -113,8 +113,10 @@ doc.intro(event_documentation)
 
     - `app.on_startup`: called when NiceGUI is started or restarted
     - `app.on_shutdown`: called when NiceGUI is shut down or restarted
-    - `app.on_connect`: called for each client which connects (optional argument: nicegui.Client)
-    - `app.on_disconnect`: called for each client which disconnects (optional argument: nicegui.Client)
+    - `app.on_handshake`: called when a client completes the initial handshake (optional argument: `nicegui.Client`, *added in version 3.0.0*)
+    - `app.on_connect`: called for each client which connects (even when reconnecting, optional argument: `nicegui.Client`, *changed in version 3.0.0*)
+    - `app.on_disconnect`: called for each client which disconnects (even when reconnecting, optional argument: `nicegui.Client`, *changed in version 3.0.0*)
+    - `app.on_deletion`: called when a client is deleted (if it does not reconnect, optional argument: `nicegui.Client`, *added in version 3.0.0*)
     - `app.on_exception`: called when an exception occurs (optional argument: exception)
 
     When NiceGUI is shut down or restarted, all tasks still in execution will be automatically canceled.

--- a/website/documentation/content/section_action_events.py
+++ b/website/documentation/content/section_action_events.py
@@ -113,10 +113,9 @@ doc.intro(event_documentation)
 
     - `app.on_startup`: called when NiceGUI is started or restarted
     - `app.on_shutdown`: called when NiceGUI is shut down or restarted
-    - `app.on_handshake`: called when a client completes the initial handshake (optional argument: `nicegui.Client`, *added in version 3.0.0*)
-    - `app.on_connect`: called for each client which connects (even when reconnecting, optional argument: `nicegui.Client`, *changed in version 3.0.0*)
+    - `app.on_connect`: called for each client which connects (even when reconnecting, optional argument: `nicegui.Client`)
     - `app.on_disconnect`: called for each client which disconnects (even when reconnecting, optional argument: `nicegui.Client`, *changed in version 3.0.0*)
-    - `app.on_deletion`: called when a client is deleted (if it does not reconnect, optional argument: `nicegui.Client`, *added in version 3.0.0*)
+    - `app.on_delete`: called when a client is deleted (if it does not reconnect, optional argument: `nicegui.Client`, *added in version 3.0.0*)
     - `app.on_exception`: called when an exception occurs (optional argument: exception)
 
     When NiceGUI is shut down or restarted, all tasks still in execution will be automatically canceled.


### PR DESCRIPTION
### Motivation

In #4285 we noticed that connect and disconnect handlers are not both called when reconnecting. To avoid breaking changes, we left it unchanged until now. With version 3.0 we now have the chance to unify how lifecycle event handlers are called.

### Implementation

This PR introduces new event handlers to complete the following list:

- `on_handshake`: when the first socket connection is established
- `on_connect`: when the socket connection is established (even during reconnect)
- `on_disconnect`: when the socket connection is interrupted (even during reconnect)
- `on_deleted`: when a client is deleted after it didn't reconnect for a while

Note that the (internal) `client.handle_handshake` method is called on every reconnect, but the handshake even handler is only called at the first connection.

I also added a new pytest, but didn't manage to simulate connection losses.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (although without maximum test coverage).
- [x] Documentation has been added.
- [ ] decision about event names, especially "on_handshake"