### PR TITLE
Implement ui.sub_pages navigation for user simulated tests

### DIFF
--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -69,7 +69,7 @@ class Navigate:
         if not new_tab and isinstance(target, str):
             parsed = urlparse(path)
             if not parsed.scheme and not parsed.netloc and \
-                    any(isinstance(el, SubPages) for el in context.client.elements.values()):
+                    any(isinstance(el, SubPages) for el in context.client.layout.descendants()):
                 client = context.client
                 navigate_coro = client.sub_pages_router._handle_navigate(path)  # pylint: disable=protected-access
                 background_tasks.create(helpers.await_with_context(navigate_coro, client), name='navigate_sub_pages')

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from typing_extensions import Self
 
-from nicegui import background_tasks, events, ui
+from nicegui import events, ui
 from nicegui.elements.mixins.disableable_element import DisableableElement
 from nicegui.elements.mixins.value_element import ValueElement
 
@@ -82,8 +82,7 @@ class UserInteraction(Generic[T]):
                 if isinstance(element, DisableableElement) and not element.enabled:
                     continue
                 if isinstance(element, ui.link):
-                    href = element.props.get('href', '#')
-                    background_tasks.create(self.user.open(href), name=f'open {href}')
+                    self.user.navigate.to(element.props.get('href', '#'))
                     return self
 
                 if isinstance(element, ui.select):

--- a/nicegui/testing/user_navigate.py
+++ b/nicegui/testing/user_navigate.py
@@ -24,7 +24,7 @@ class UserNavigate(Navigate):
             # NOTE navigation to an element does not do anything in the user simulation (the whole content is always visible)
             return
         path = Client.page_routes[target] if callable(target) else target
-        background_tasks.create(self._open(path), name=f'navigate to {path}')
+        background_tasks.create(self._open(path, clear_forward_history=True), name=f'navigate to {path}')
 
     def back(self) -> None:
         current = self.user.back_history.pop()
@@ -43,21 +43,24 @@ class UserNavigate(Navigate):
         target = self.user.back_history.pop()
         background_tasks.create(self._open(target, clear_forward_history=False), name=f'navigate reload to {target}')
 
-    async def _open(self, path: str, *, clear_forward_history: bool = True) -> None:
+    async def _open(self, path: str, *, clear_forward_history: bool) -> None:
         client = self.user.client
-        if client is not None:
-            parsed = urlparse(path)
-            if not parsed.scheme and not parsed.netloc and \
-                    any(isinstance(el, SubPages) for el in client.layout.descendants()):
-                router = client.sub_pages_router
-                with client:
-                    await router._handle_open(path)  # pylint: disable=protected-access
-                if (
-                    not has_any_unresolved_path(client) or
-                    not router._other_page_builder_matches_path(path, client)  # pylint: disable=protected-access
-                ):
-                    self.user.back_history.append(path)
-                    if clear_forward_history:
-                        self.user.forward_history.clear()
-                    return
-        await self.user.open(path, clear_forward_history=clear_forward_history)
+        parsed_url = urlparse(path)
+        if (
+            client is None or  # user is not yet on any page
+            parsed_url.scheme or parsed_url.netloc or  # path is absolute URL
+            not any(isinstance(el, SubPages) for el in client.layout.descendants())  # no SubPages in the layout
+        ):
+            await self.user.open(path, clear_forward_history=clear_forward_history)  # full page reload
+            return
+
+        router = client.sub_pages_router
+        with client:
+            await router._handle_open(path)  # pylint: disable=protected-access
+        if has_any_unresolved_path(client) and router._other_page_builder_matches_path(path, client):  # pylint: disable=protected-access
+            await self.user.open(path, clear_forward_history=clear_forward_history)  # fallback to full page reload
+            return
+
+        self.user.back_history.append(path)
+        if clear_forward_history:
+            self.user.forward_history.clear()

--- a/nicegui/testing/user_navigate.py
+++ b/nicegui/testing/user_navigate.py
@@ -29,21 +29,18 @@ class UserNavigate(Navigate):
         current = self.user.back_history.pop()
         self.user.forward_history.append(current)
         target = self.user.back_history.pop()
-        background_tasks.create(self._open(target, clear_forward_history=False),
-                                name=f'navigate back to {target}')
+        background_tasks.create(self._open(target, clear_forward_history=False), name=f'navigate back to {target}')
 
     def forward(self) -> None:
         if not self.user.forward_history:
             return
         target = self.user.forward_history[0]
         del self.user.forward_history[0]
-        background_tasks.create(self._open(target, clear_forward_history=False),
-                                name=f'navigate forward to {target}')
+        background_tasks.create(self._open(target, clear_forward_history=False), name=f'navigate forward to {target}')
 
     def reload(self) -> None:
         target = self.user.back_history.pop()
-        background_tasks.create(self._open(target, clear_forward_history=False),
-                                name=f'navigate reload to {target}')
+        background_tasks.create(self._open(target, clear_forward_history=False), name=f'navigate reload to {target}')
 
     async def _open(self, path: str, *, clear_forward_history: bool = True) -> None:
         if self.user.client is not None:

--- a/nicegui/testing/user_navigate.py
+++ b/nicegui/testing/user_navigate.py
@@ -41,7 +41,8 @@ class UserNavigate(Navigate):
 
     def reload(self) -> None:
         target = self.user.back_history.pop()
-        background_tasks.create(self._open(target, clear_forward_history=False), name=f'navigate reload to {target}')
+        background_tasks.create(self.user.open(target, clear_forward_history=False),
+                                name=f'navigate reload to {target}')
 
     async def _open(self, path: str, *, clear_forward_history: bool) -> None:
         client = self.user.client

--- a/nicegui/testing/user_navigate.py
+++ b/nicegui/testing/user_navigate.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from nicegui import Client, background_tasks, ui
 from nicegui.elements.sub_pages import SubPages
 from nicegui.functions.navigate import Navigate
+from nicegui.sub_pages_router import has_any_unresolved_path
 
 if TYPE_CHECKING:
     from .user import User
@@ -43,14 +44,20 @@ class UserNavigate(Navigate):
         background_tasks.create(self._open(target, clear_forward_history=False), name=f'navigate reload to {target}')
 
     async def _open(self, path: str, *, clear_forward_history: bool = True) -> None:
-        if self.user.client is not None:
+        client = self.user.client
+        if client is not None:
             parsed = urlparse(path)
             if not parsed.scheme and not parsed.netloc and \
-                    any(isinstance(el, SubPages) for el in self.user.client.layout.descendants()):
-                with self.user.client:
-                    await self.user.client.sub_pages_router._handle_open(path)  # pylint: disable=protected-access
-                self.user.back_history.append(path)
-                if clear_forward_history:
-                    self.user.forward_history.clear()
-                return
+                    any(isinstance(el, SubPages) for el in client.layout.descendants()):
+                router = client.sub_pages_router
+                with client:
+                    await router._handle_open(path)  # pylint: disable=protected-access
+                if (
+                    not has_any_unresolved_path(client) or
+                    not router._other_page_builder_matches_path(path, client)  # pylint: disable=protected-access
+                ):
+                    self.user.back_history.append(path)
+                    if clear_forward_history:
+                        self.user.forward_history.clear()
+                    return
         await self.user.open(path, clear_forward_history=clear_forward_history)

--- a/nicegui/testing/user_navigate.py
+++ b/nicegui/testing/user_navigate.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 from nicegui import Client, background_tasks, ui
+from nicegui.elements.sub_pages import SubPages
 from nicegui.functions.navigate import Navigate
 
 if TYPE_CHECKING:
@@ -21,23 +23,37 @@ class UserNavigate(Navigate):
             # NOTE navigation to an element does not do anything in the user simulation (the whole content is always visible)
             return
         path = Client.page_routes[target] if callable(target) else target
-        background_tasks.create(self.user.open(path), name=f'navigate to {path}')
+        background_tasks.create(self._open(path), name=f'navigate to {path}')
 
     def back(self) -> None:
         current = self.user.back_history.pop()
         self.user.forward_history.append(current)
         target = self.user.back_history.pop()
-        background_tasks.create(self.user.open(target, clear_forward_history=False), name=f'navigate back to {target}')
+        background_tasks.create(self._open(target, clear_forward_history=False),
+                                name=f'navigate back to {target}')
 
     def forward(self) -> None:
         if not self.user.forward_history:
             return
         target = self.user.forward_history[0]
         del self.user.forward_history[0]
-        background_tasks.create(self.user.open(target, clear_forward_history=False),
+        background_tasks.create(self._open(target, clear_forward_history=False),
                                 name=f'navigate forward to {target}')
 
     def reload(self) -> None:
         target = self.user.back_history.pop()
-        background_tasks.create(self.user.open(target, clear_forward_history=False),
+        background_tasks.create(self._open(target, clear_forward_history=False),
                                 name=f'navigate reload to {target}')
+
+    async def _open(self, path: str, *, clear_forward_history: bool = True) -> None:
+        if self.user.client is not None:
+            parsed = urlparse(path)
+            if not parsed.scheme and not parsed.netloc and \
+                    any(isinstance(el, SubPages) for el in self.user.client.layout.descendants()):
+                with self.user.client:
+                    await self.user.client.sub_pages_router._handle_open(path)  # pylint: disable=protected-access
+                self.user.back_history.append(path)
+                if clear_forward_history:
+                    self.user.forward_history.clear()
+                return
+        await self.user.open(path, clear_forward_history=clear_forward_history)

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -960,36 +960,3 @@ async def test_switching_between_sub_pages(user: User) -> None:
     user.find('Go to B with slash').click()
     await user.should_see('Page B')
     assert calls == {'index': 1, 'a': 3, 'b': 3}, 'no rebuilding if path stays the same'
-
-
-async def test_sub_pages_with_fragments(user: User) -> None:
-    calls = {'index': 0, 'page': 0}
-
-    @ui.page('/')
-    @ui.page('/{_:path}')
-    def index():
-        calls['index'] += 1
-        ui.sub_pages({
-            '/': main_page,
-            '/page': content_page,
-        })
-
-    def main_page():
-        ui.label('Main')
-
-    def content_page():
-        calls['page'] += 1
-        ui.link_target('top')
-        ui.label('Top content')
-        ui.link('Go to bottom', '/page#bottom')
-        ui.link_target('bottom')
-        ui.label('Bottom content')
-        ui.link('Go to top', '/page#top')
-
-    await user.open('/page#bottom')
-    await user.should_see('Bottom content')
-    assert calls == {'index': 1, 'page': 1}
-
-    user.find('Go to top').click()
-    await user.should_see('Top content')
-    assert calls == {'index': 1, 'page': 1}, 'same-page fragment navigation should not rebuild'

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -914,7 +914,6 @@ async def test_switching_between_sub_pages(user: User) -> None:
     @ui.page('/b')
     def index():
         calls['index'] += 1
-        ui.label('Index')
         ui.button('back', on_click=ui.navigate.back)
         ui.button('forward', on_click=ui.navigate.forward)
         ui.sub_pages({
@@ -935,32 +934,25 @@ async def test_switching_between_sub_pages(user: User) -> None:
         ui.link('Go to B with slash', '/b/')
 
     await user.open('/')
-    await user.should_see('Index')
     await user.should_see('Page A')
-    await user.should_not_see('Page B')
     assert calls == {'index': 1, 'a': 1, 'b': 0}
 
     user.find('Go to B').click()
-    await user.should_see('Index')
     await user.should_see('Page B')
-    await user.should_not_see('Page A')
     assert calls == {'index': 1, 'a': 1, 'b': 1}
 
     user.find('back').click()
-    await user.should_see('Index')
     await user.should_see('Page A')
-    await user.should_not_see('Page B')
     assert calls == {'index': 1, 'a': 2, 'b': 1}
 
     user.find('forward').click()
-    await user.should_see('Index')
     await user.should_see('Page B')
-    await user.should_not_see('Page A')
     assert calls == {'index': 1, 'a': 2, 'b': 2}
 
     user.find('Go to A').click()
     await user.should_see('Page A')
     assert calls == {'index': 1, 'a': 3, 'b': 2}
+
     user.find('Go to B with slash').click()
     await user.should_see('Page B')
     assert calls == {'index': 1, 'a': 3, 'b': 3}

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -918,10 +918,10 @@ async def test_switching_between_sub_pages(user: User) -> None:
         ui.button('back', on_click=ui.navigate.back)
         ui.button('forward', on_click=ui.navigate.forward)
         ui.button('reload', on_click=ui.navigate.reload)
-        ui.link('Go to /', '/')
-        ui.link('Go to /b', '/b')
-        ui.link('Go to /b/', '/b/')
-        ui.link('Go to /other', '/other')
+        ui.link('Go to "/"', '/')
+        ui.link('Go to "/b"', '/b')
+        ui.link('Go to "/b/"', '/b/')
+        ui.link('Go to "/other"', '/other')
         ui.sub_pages({
             '/': lambda: (ui.label('Page A'), calls.update(a=calls['a'] + 1)),
             '/b': lambda: (ui.label('Page B'), calls.update(b=calls['b'] + 1)),
@@ -936,7 +936,7 @@ async def test_switching_between_sub_pages(user: User) -> None:
     await user.should_see('Page A')
     assert calls == {'index': 1, 'a': 1, 'b': 0, 'other': 0}
 
-    user.find('Go to /b').click()
+    user.find('Go to "/b"').click()
     await user.should_see('Page B')
     assert calls == {'index': 1, 'a': 1, 'b': 1, 'other': 0}
 
@@ -948,19 +948,19 @@ async def test_switching_between_sub_pages(user: User) -> None:
     await user.should_see('Page B')
     assert calls == {'index': 1, 'a': 2, 'b': 2, 'other': 0}
 
-    user.find('Go to /').click()
+    user.find('Go to "/"').click()
     await user.should_see('Page A')
     assert calls == {'index': 1, 'a': 3, 'b': 2, 'other': 0}
 
-    user.find('Go to /b/').click()
+    user.find('Go to "/b/"').click()
     await user.should_see('Page B')
     assert calls == {'index': 1, 'a': 3, 'b': 3, 'other': 0}
 
-    user.find('Go to /b/').click()
+    user.find('Go to "/b/"').click()
     await user.should_see('Page B')
     assert calls == {'index': 1, 'a': 3, 'b': 3, 'other': 0}, 'no rebuilding if path stays the same'
 
-    user.find('Go to /').click()
+    user.find('Go to "/"').click()
     await user.should_see('Page A')
     assert calls == {'index': 1, 'a': 4, 'b': 3, 'other': 0}
 
@@ -968,6 +968,6 @@ async def test_switching_between_sub_pages(user: User) -> None:
     await user.should_see('Index render 2')
     assert calls == {'index': 2, 'a': 5, 'b': 3, 'other': 0}, 'reload triggers a full page reload'
 
-    user.find('Go to /other').click()
+    user.find('Go to "/other"').click()
     await user.should_see('Other page')
     assert calls == {'index': 2, 'a': 5, 'b': 3, 'other': 1}, 'navigating to sibling page falls back to full page open'

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -905,3 +905,99 @@ async def test_clearing_container_with_button_inside(user: User) -> None:
     await user.should_see('First handler')
     await user.should_see('click me')
     await user.should_not_see('Last handler')
+
+
+async def test_switching_between_sub_pages(user: User) -> None:
+    calls = {'index': 0, 'a': 0, 'b': 0}
+
+    @ui.page('/')
+    @ui.page('/b')
+    def index():
+        calls['index'] += 1
+        ui.label('Index')
+        ui.button('back', on_click=ui.navigate.back)
+        ui.button('forward', on_click=ui.navigate.forward)
+        ui.sub_pages({
+            '/': sub_page_a,
+            '/b': sub_page_b,
+        })
+
+    def sub_page_a():
+        calls['a'] += 1
+        ui.label('Page A')
+        ui.link('Go to B', '/b')
+        ui.link('Go to B with slash', '/b/')
+
+    def sub_page_b():
+        calls['b'] += 1
+        ui.label('Page B')
+        ui.link('Go to A', '/')
+        ui.link('Go to B with slash', '/b/')
+
+    await user.open('/')
+    await user.should_see('Index')
+    await user.should_see('Page A')
+    await user.should_not_see('Page B')
+    assert calls == {'index': 1, 'a': 1, 'b': 0}
+
+    user.find('Go to B').click()
+    await user.should_see('Index')
+    await user.should_see('Page B')
+    await user.should_not_see('Page A')
+    assert calls == {'index': 1, 'a': 1, 'b': 1}
+
+    user.find('back').click()
+    await user.should_see('Index')
+    await user.should_see('Page A')
+    await user.should_not_see('Page B')
+    assert calls == {'index': 1, 'a': 2, 'b': 1}
+
+    user.find('forward').click()
+    await user.should_see('Index')
+    await user.should_see('Page B')
+    await user.should_not_see('Page A')
+    assert calls == {'index': 1, 'a': 2, 'b': 2}
+
+    user.find('Go to A').click()
+    await user.should_see('Page A')
+    assert calls == {'index': 1, 'a': 3, 'b': 2}
+    user.find('Go to B with slash').click()
+    await user.should_see('Page B')
+    assert calls == {'index': 1, 'a': 3, 'b': 3}
+
+    user.find('Go to B with slash').click()
+    await user.should_see('Page B')
+    assert calls == {'index': 1, 'a': 3, 'b': 3}, 'no rebuilding if path stays the same'
+
+
+async def test_sub_pages_with_fragments(user: User) -> None:
+    calls = {'index': 0, 'page': 0}
+
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index():
+        calls['index'] += 1
+        ui.sub_pages({
+            '/': main_page,
+            '/page': content_page,
+        })
+
+    def main_page():
+        ui.label('Main')
+
+    def content_page():
+        calls['page'] += 1
+        ui.link_target('top')
+        ui.label('Top content')
+        ui.link('Go to bottom', '/page#bottom')
+        ui.link_target('bottom')
+        ui.label('Bottom content')
+        ui.link('Go to top', '/page#top')
+
+    await user.open('/page#bottom')
+    await user.should_see('Bottom content')
+    assert calls == {'index': 1, 'page': 1}
+
+    user.find('Go to top').click()
+    await user.should_see('Top content')
+    assert calls == {'index': 1, 'page': 1}, 'same-page fragment navigation should not rebuild'

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -908,55 +908,66 @@ async def test_clearing_container_with_button_inside(user: User) -> None:
 
 
 async def test_switching_between_sub_pages(user: User) -> None:
-    calls = {'index': 0, 'a': 0, 'b': 0}
+    calls = {'index': 0, 'a': 0, 'b': 0, 'other': 0}
 
     @ui.page('/')
     @ui.page('/b')
     def index():
         calls['index'] += 1
+        ui.label(f'Index render {calls["index"]}')
         ui.button('back', on_click=ui.navigate.back)
         ui.button('forward', on_click=ui.navigate.forward)
+        ui.button('reload', on_click=ui.navigate.reload)
+        ui.link('Go to /', '/')
+        ui.link('Go to /b', '/b')
+        ui.link('Go to /b/', '/b/')
+        ui.link('Go to /other', '/other')
         ui.sub_pages({
-            '/': sub_page_a,
-            '/b': sub_page_b,
+            '/': lambda: (ui.label('Page A'), calls.update(a=calls['a'] + 1)),
+            '/b': lambda: (ui.label('Page B'), calls.update(b=calls['b'] + 1)),
         })
 
-    def sub_page_a():
-        calls['a'] += 1
-        ui.label('Page A')
-        ui.link('Go to B', '/b')
-        ui.link('Go to B with slash', '/b/')
-
-    def sub_page_b():
-        calls['b'] += 1
-        ui.label('Page B')
-        ui.link('Go to A', '/')
-        ui.link('Go to B with slash', '/b/')
+    @ui.page('/other')
+    def other_page():
+        calls['other'] += 1
+        ui.label('Other page')
 
     await user.open('/')
     await user.should_see('Page A')
-    assert calls == {'index': 1, 'a': 1, 'b': 0}
+    assert calls == {'index': 1, 'a': 1, 'b': 0, 'other': 0}
 
-    user.find('Go to B').click()
+    user.find('Go to /b').click()
     await user.should_see('Page B')
-    assert calls == {'index': 1, 'a': 1, 'b': 1}
+    assert calls == {'index': 1, 'a': 1, 'b': 1, 'other': 0}
 
     user.find('back').click()
     await user.should_see('Page A')
-    assert calls == {'index': 1, 'a': 2, 'b': 1}
+    assert calls == {'index': 1, 'a': 2, 'b': 1, 'other': 0}
 
     user.find('forward').click()
     await user.should_see('Page B')
-    assert calls == {'index': 1, 'a': 2, 'b': 2}
+    assert calls == {'index': 1, 'a': 2, 'b': 2, 'other': 0}
 
-    user.find('Go to A').click()
+    user.find('Go to /').click()
     await user.should_see('Page A')
-    assert calls == {'index': 1, 'a': 3, 'b': 2}
+    assert calls == {'index': 1, 'a': 3, 'b': 2, 'other': 0}
 
-    user.find('Go to B with slash').click()
+    user.find('Go to /b/').click()
     await user.should_see('Page B')
-    assert calls == {'index': 1, 'a': 3, 'b': 3}
+    assert calls == {'index': 1, 'a': 3, 'b': 3, 'other': 0}
 
-    user.find('Go to B with slash').click()
+    user.find('Go to /b/').click()
     await user.should_see('Page B')
-    assert calls == {'index': 1, 'a': 3, 'b': 3}, 'no rebuilding if path stays the same'
+    assert calls == {'index': 1, 'a': 3, 'b': 3, 'other': 0}, 'no rebuilding if path stays the same'
+
+    user.find('Go to /').click()
+    await user.should_see('Page A')
+    assert calls == {'index': 1, 'a': 4, 'b': 3, 'other': 0}
+
+    user.find('reload').click()
+    await user.should_see('Index render 2')
+    assert calls == {'index': 2, 'a': 5, 'b': 3, 'other': 0}, 'reload triggers a full page reload'
+
+    user.find('Go to /other').click()
+    await user.should_see('Other page')
+    assert calls == {'index': 2, 'a': 5, 'b': 3, 'other': 1}, 'navigating to sibling page falls back to full page open'


### PR DESCRIPTION
### Motivation

Currently the user fixture always triggers a full page reload — even if the navigation should be done with `ui.sub_pages`. The core problem: the user fixture injects its own `ui.navigate.to` implementation to skip over any browser and JavaScript behaviour, and this custom implementation was not aware of sub pages navigation.

### Implementation

`UserNavigate.to/back/forward` and `ui.link` clicks in the user simulation now funnel through a single sub-pages-aware helper `UserNavigate._open()`. The helper mirrors the production logic in `nicegui/functions/navigate.py`: when the path is relative and the current layout contains a `ui.sub_pages`, it routes through `sub_pages_router._handle_open()`. If the resulting state is unresolved and another `@ui.page` builder claims the path, it falls back to a full `user.open()`, matching the `_handle_navigate` fallback used in production.

`UserNavigate.reload()` deliberately bypasses `_open()` and always calls `user.open()` directly, mirroring production's `history.go(0)` semantics (full page reload, not partial sub_pages routing).

Drive-by: `Navigate.to` now detects `SubPages` via `client.layout.descendants()` instead of the flat `client.elements` registry, aligning with `_handle_open`, `has_any_unresolved_path`, and the new user-simulation helper.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
