### PR TITLE
Fix docker builds where element dist/ dirs had been excluded from the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 **/*.egg-info
 **/.*.swp
 **/dist
+!nicegui/elements/*/dist
 test.py
 demo.py
 **/*.pickle


### PR DESCRIPTION
### Motivation

This PR fixes #5200 where @Yuerchu reported that the public documentation has issues displaying certain content. After some investigation me and claude-4.5-sonnet found the core issue: our `.dockerignore` file excluded all `dist/` dirs from the docker build. But in #5021 we changed the dependency management so an element can provide their js code in `dist/` folders.

### Implementation

This PR just ensures elements `dist/` directories are not excluded from docker context.

NOTE: the fix is already deployed on https://nicegui.io

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
