### PR TITLE
Allow non-AMD64 devcontainer, such as ARM (reverts #3328)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.9
+FROM python:3.9
 
 ENV POETRY_VERSION=1.6.1 \
     POETRY_NO_INTERACTION=1 \


### PR DESCRIPTION
### Motivation

I just checked and we can install `chromium` and `chromium-driver` on ARM64, covering a major use case of developing on Apple Silicon Macs

<img width="599" height="99" alt="image" src="https://github.com/user-attachments/assets/b6fb8be5-5778-4225-a143-a6fe9fbc7350" />

I can't trace back which release it was supported, though. 

So we can revert #3328 and improve devcontainer performance. 

For those who need AMD64 they can specify it themselves? 

### Implementation

Revert #3328, drop `--platform=linux/amd64`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
