### PR TITLE
Disabling the deselection of tree elements in docs

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ def _main_page() -> None:
             .style('height: calc(100% + 20px) !important') as menu:
         tree = ui.tree(documentation.tree.nodes, label_key='title',
                        on_select=lambda e: ui.navigate.to(f'/documentation/{e.value}')) \
-            .classes('w-full').props('accordion no-connectors')
+            .classes('w-full').props('accordion no-connectors no-selection-unset')
     menu_button = header.add_header(menu)
 
     window_state = {'is_desktop': None}


### PR DESCRIPTION
### Motivation

This fixes #5207 reported by @python-and-novella where clicking on a tree node if it is already active results in blank content (because path changes to /documentation/None).

### Implementation

This PR simply deactivates the ability to deselect tree elements.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
