### PR TITLE
Check disabled state before clicking or clearing via user simulated interaction in pytests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Bugfixes
+
+- Check disabled state before clicking or clearing via user simulated interaction in pytests (#5209 by @igro-marczak, @rodja)
+
 ### Infrastructure
 
 - Re-run poetry lock to fix nicegui-highcharts incompatibility (#5204 by @evnchn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [Unreleased]
 
-### Bugfixes
+### Testing
 
-- Check disabled state before clicking or clearing via user simulated interaction in pytests (#5209 by @igro-marczak, @rodja)
+- Check disabled state before clicking or clearing via user simulated interaction (#5191, #5209 by @igro-marczak, @rodja)
 
 ### Infrastructure
 

--- a/deploy.py
+++ b/deploy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json
 import subprocess
+import time
 
 
 def run(cmd: list[str], *, capture: bool = False) -> str:
@@ -17,16 +18,16 @@ try:
 except Exception:
     version = '0.0.0'
 
-run(['fly', 'deploy', '--wait-timeout', '360', '--build-arg', f'VERSION={version}'])
+run(['fly', 'deploy', '--wait-timeout', '600', '--lease-timeout', '30s', '--build-arg', f'VERSION={version}'])
 
 instances = {
     'yul': 2,  # Montreal, Quebec (Canada)
-    'iad': 4,  # Washington DC, Virginia (US)
+    'iad': 3,  # Washington DC, Virginia (US)
     'sjc': 2,  # San Jose, California (US)
     'lax': 2,  # Los Angeles, California (US)
-    'mia': 3,  # Miami, Florida (US)
+    'mia': 2,  # Miami, Florida (US)
     'sea': 2,  # Seattle, Washington (US)
-    'fra': 5,  # Frankfurt, Germany
+    'fra': 3,  # Frankfurt, Germany
     'ams': 2,  # Amsterdam, Netherlands
     'mad': 1,  # Madrid, Spain
     'cdg': 2,  # Paris, France
@@ -34,16 +35,20 @@ instances = {
     'otp': 1,  # Bucharest, Romania
     'jnb': 1,  # Johannesburg, South Africa
     'bom': 1,  # Mumbai, India
-    'nrt': 4,  # Tokyo, Japan
+    'nrt': 3,  # Tokyo, Japan
     'sin': 2,  # Singapore
-    'hkg': 4,  # Hong Kong
+    'hkg': 3,  # Hong Kong
     'syd': 1,  # Sydney, Australia
     'gru': 1,  # Sao Paulo, Brazil
 }
+
+print('scaling regions...')
 for region, count in instances.items():
     run(['fly', 'scale', 'count', f'app={count}', '--region', region, '-y'])
+    time.sleep(2)
 
 # NOTE: pin first machine per region to avoid cold-start latency
+print('pinning machines...')
 machines_json = run(['fly', 'machines', 'list', '--json'], capture=True)
 machines = json.loads(machines_json)
 pinned_regions = set()
@@ -56,3 +61,4 @@ for m in machines:
         run(['fly', 'machine', 'update', machine_id, '--autostop=false', '-y'])
         print(f'pinned {machine_id} in {region}')
         pinned_regions.add(region)
+        time.sleep(2)

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -70,6 +70,8 @@ class UserInteraction(Generic[T]):
         assert self.user.client
         with self.user.client:
             for element in self.elements:
+                if isinstance(element, DisableableElement) and not element.enabled:
+                    continue
                 if isinstance(element, ui.link):
                     href = element.props.get('href', '#')
                     background_tasks.create(self.user.open(href), name=f'open {href}')

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -139,6 +139,8 @@ class UserInteraction(Generic[T]):
         assert self.user.client
         with self.user.client:
             for element in self.elements:
+                if isinstance(element, DisableableElement) and not element.enabled:
+                    continue
                 assert isinstance(element, ValueElement)
                 element.value = None
         return self

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -60,6 +60,17 @@ async def test_button_click(user: User) -> None:
     await user.should_see('clicked')
 
 
+async def test_clicking_disabled_button(user: User) -> None:
+    @ui.page('/')
+    def page():
+        button = ui.button('My Button', on_click=lambda: ui.notify('Button clicked'))
+        button.disable()
+
+    await user.open('/')
+    user.find('My Button').click()
+    await user.should_not_see('Button clicked')
+
+
 async def test_assertion_raised_when_no_nicegui_page_is_returned(user: User) -> None:
     @app.get('/plain')
     def index() -> PlainTextResponse:

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -594,6 +594,23 @@ async def test_typing_to_disabled_element(user: User) -> None:
     await user.should_not_see(given_new_input)
 
 
+async def test_clearing_disabled_element(user: User) -> None:
+    initial_value = 'Cannot clear this'
+    target = None
+
+    @ui.page('/')
+    def page():
+        nonlocal target
+        target = ui.input(value=initial_value)
+        target.disable()
+
+    await user.open('/')
+    user.find(ui.input).clear()
+
+    assert target.value == initial_value
+    await user.should_see(initial_value)
+
+
 async def test_drawer(user: User):
     @ui.page('/')
     def test_page():


### PR DESCRIPTION
### Motivation

This PR fixes #5191, where @igro-marczak reported that the disabled state is currently ignored when clicking with the user fixture.

### Implementation

The fix ensures that disabled elements (buttons, checkboxes, switches, etc.) behave correctly when clicked or cleared, matching real browser behavior -- same way as it was already implemented for `type(...)`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
