### PR TITLE
Fix fly docker build

### DIFF
--- a/fly.dockerfile
+++ b/fly.dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 LABEL maintainer="Zauberzeug GmbH <nicegui@zauberzeug.com>"
 
-RUN apt update && apt install -y curl procps
+RUN apt update && apt install -y curl procps build-essential
 
 RUN pip install \
     dnspython \


### PR DESCRIPTION
### Motivation

`docker build . -f fly.dockerfile` does not work, because `libsass` needs `gcc` when installing via poetry.

### Implementation

Updateed `fly.dockerfile` to from python 3.11 to python 3.12 and added `build-essential` apt package so gcc is available. `release.dockerfile` and `develompent.dockerfile` and Devcontainer already had this dependency.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are are not necessary.
- [x] Documentation is not necessary.
