### PR TITLE
Fix ui.notify documentation link

### DIFF
--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -298,7 +298,7 @@ def map_of_nicegui():
             - [`ui.fullscreen`](/documentation/fullscreen): enter, exit and toggle fullscreen mode
             - [`ui.keyboard`](/documentation/keyboard): define keyboard event handlers
             - [`ui.navigate`](/documentation/navigate): let the browser navigate to another location
-            - [`ui.notify`](/documentation/notification): show a notification
+            - [`ui.notify`](/documentation/notify): show a notification
             - [`ui.on`](/documentation/generic_events#custom_events): register an event handler
             - [`ui.page_title`](/documentation/page_title): change the current page title
             - [`ui.query`](/documentation/query): query HTML elements on the client side to modify props, classes and style definitions


### PR DESCRIPTION
### Motivation

The `ui.notify` link on https://nicegui.io/documentation points to the wrong page ("notification" vs "notify").

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation

Fix URL in markdown.

<!-- What is the concept behind the implementation? How does it work? -->
<!-- Include any important technical decisions or trade-offs made -->

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
