### PR TITLE
Use `pytest-rerunfailures` to re-run flaky Mermaid tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3527,6 +3527,22 @@ pytest = ">=7.0.0"
 test = ["black (>=22.1.0)", "flake8 (>=4.0.1)", "pre-commit (>=2.17.0)", "tox (>=3.24.5)"]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "16.0.1"
+description = "pytest plugin to re-run tests to eliminate flaky failures"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_rerunfailures-16.0.1-py3-none-any.whl", hash = "sha256:0bccc0e3b0e3388275c25a100f7077081318196569a121217688ed05e58984b9"},
+    {file = "pytest_rerunfailures-16.0.1.tar.gz", hash = "sha256:ed4b3a6e7badb0a720ddd93f9de1e124ba99a0cb13bc88561b3c168c16062559"},
+]
+
+[package.dependencies]
+packaging = ">=17.1"
+pytest = ">=7.4,<8.2.2 || >8.2.2"
+
+[[package]]
 name = "pytest-selenium"
 version = "4.1.0"
 description = "pytest plugin for Selenium"
@@ -5009,4 +5025,4 @@ sass = ["libsass"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "c99cd95b80b7fb7daaba96d60beddc490f32fcde14118fa23840c90eba90a28c"
+content-hash = "dff88f88ad29278e666131bb9f1ddb5c49951fb0f22c48202cfde58522689a4d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ cssbeautifier = "^1.15.4"
 rcssmin = "^1.2.1"
 tinycss2 = "^1.4.0"
 html-sanitizer = "^2.6.0"
+pytest-rerunfailures = "^16.0.1"
 
 [tool.poetry.scripts]
 nicegui-pack = "nicegui.scripts.pack:main"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest-asyncio
 pytest-selenium
+pytest-rerunfailures

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,3 +1,4 @@
+import pytest
 from selenium.webdriver.common.by import By
 
 from nicegui import ui
@@ -24,6 +25,7 @@ def test_markdown(screen: Screen):
 def test_markdown_with_mermaid(screen: Screen):
     m = None
 
+    @pytest.mark.flaky(reruns=2)
     @ui.page('/')
     def page():
         nonlocal m
@@ -57,6 +59,7 @@ def test_markdown_with_mermaid(screen: Screen):
 
 
 def test_markdown_with_mermaid_on_demand(screen: Screen):
+    @pytest.mark.flaky(reruns=2)
     @ui.page('/')
     def page():
         ui.button('Create Mermaid', on_click=lambda: ui.markdown('''

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -4,6 +4,9 @@ from selenium.webdriver.common.by import By
 from nicegui import ui
 from nicegui.testing import Screen
 
+# Retry flaky mermaid tests up to 2 times on failure
+pytestmark = [pytest.mark.flaky(reruns=2)]
+
 
 def test_mermaid(screen: Screen):
     @ui.page('/')


### PR DESCRIPTION
### Motivation

#5232 (make Mermaid tests not flaky) harder than it looks. We may have to live with flakiness. This PR does exactly that. 

### Implementation

This pull request introduces improvements to the test suite's reliability by addressing flaky tests related to Mermaid rendering. The main changes involve adding the `pytest-rerunfailures` plugin and marking relevant tests to automatically rerun on failure, reducing false negatives in CI.

**Test reliability improvements:**

* Added `pytest-rerunfailures` as a dependency in both `pyproject.toml` and `tests/requirements.txt` to enable automatic rerunning of flaky tests. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R78) [[2]](diffhunk://#diff-27c5febcc9ce93e8e5341f263b7d68962733b8a2a86c583723d025a1db39d7a3R3)
* Marked Mermaid-related tests in `tests/test_markdown.py` with `@pytest.mark.flaky(reruns=2)` to allow up to two reruns on failure. [[1]](diffhunk://#diff-f0f45280def5f73305be099b06f97da1b2a3da1f964471c94dd1c58cac6fe799R28) [[2]](diffhunk://#diff-f0f45280def5f73305be099b06f97da1b2a3da1f964471c94dd1c58cac6fe799R62)
* Applied a module-level `pytest.mark.flaky(reruns=2)` marker to all tests in `tests/test_mermaid.py` for consistent rerun behavior.
* Imported `pytest` in relevant test files to support the new flaky test markers.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
