### PR TITLE
Fix emitting and calling chained events

### DIFF
--- a/nicegui/event.py
+++ b/nicegui/event.py
@@ -33,6 +33,10 @@ class Callback(Generic[P]):
         """Run the callback."""
         with (self.slot and self.slot()) or nullcontext():
             expect_args = helpers.expects_arguments(self.func)
+            expect_args |= (
+                isinstance(getattr(self.func, '__self__', None), Event) and
+                getattr(self.func, '__name__', None) in {'emit', 'call'}
+            )
             return self.func(*args, **kwargs) if expect_args else self.func()  # type: ignore[call-arg]
 
     async def await_result(self, result: Awaitable | AwaitableResponse | asyncio.Task) -> Any:

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -63,3 +63,18 @@ async def test_event_handler_in_correct_slot(user: User):
     await user.open('/')
     user.find('Click me').click()
     assert len(card.default_slot.children) == 1
+
+
+async def test_chaining_events(user: User):
+    event1 = Event[str]()
+    event2 = Event[str]()
+
+    @ui.page('/')
+    def page():
+        ui.button('Click me', on_click=lambda: event1.emit('Hello'))
+        event1.subscribe(event2.emit)
+        event2.subscribe(ui.notify)
+
+    await user.open('/')
+    user.find('Click me').click()
+    await user.should_see('Hello')


### PR DESCRIPTION
### Motivation

While migrating [RoSys](https://github.com/zauberzeug/rosys/) to NiceGUI 3.0, we noticed that event chaining doesn't work if the handler expects arguments:

```py
event1 = Event[str]()
event2 = Event[str]()
ui.button('Click me', on_click=lambda: event1.emit('Hello'))
event1.subscribe(event2.emit)
event2.subscribe(ui.notify)
```

### Implementation

When emitting an event, the function `helpers.expects_arguments` is used to check if the handler needs to be called with an argument. But the `emit` function itself expects arbitrarily many arguments, so it is unclear how to call it. The caller of `emit` can't know when the internally called subscribers expect.

Therefore we added an extra check if the callback is an `emit` or `call` method. In this case, arguments are provided.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
