### PR TITLE
Don't catch exceptions during `call`, forward to exception handlers during `emit`

### DIFF
--- a/nicegui/event.py
+++ b/nicegui/event.py
@@ -144,18 +144,15 @@ def _invoke_and_forget(callback: Callback[P], *args: P.args, **kwargs: P.kwargs)
                 background_tasks.create(callback.await_result(result), name=f'{callback.filepath}:{callback.line}')
             else:
                 core.app.on_startup(callback.await_result(result))
-    except Exception:
-        log.exception('Could not emit callback %s', callback)
+    except Exception as e:
+        core.app.handle_exception(e)
 
 
 async def _invoke_and_await(callback: Callback[P], *args: P.args, **kwargs: P.kwargs) -> Any:
-    try:
-        result = callback.run(*args, **kwargs)
-        if _should_await(result):
-            result = await callback.await_result(result)
-        return result
-    except Exception as e:
-        core.app.handle_exception(e)
+    result = callback.run(*args, **kwargs)
+    if _should_await(result):
+        result = await callback.await_result(result)
+    return result
 
 
 def _should_await(result: Any) -> bool:

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,6 +1,8 @@
 import asyncio
 
-from nicegui import Event, ui
+import pytest
+
+from nicegui import Event, app, ui
 from nicegui.testing import User
 
 
@@ -63,3 +65,39 @@ async def test_event_handler_in_correct_slot(user: User):
     await user.open('/')
     user.find('Click me').click()
     assert len(card.default_slot.children) == 1
+
+
+async def test_exception_during_emit(user: User, caplog: pytest.LogCaptureFixture):
+    event = Event()
+    event.subscribe(lambda: print(1 / 0))
+
+    exceptions = []
+    app.on_exception(exceptions.append)
+
+    @ui.page('/')
+    def page():
+        ui.button('Click me', on_click=event.emit)
+
+    await user.open('/')
+    user.find('Click me').click()
+    assert len(exceptions) == 1 and isinstance(exceptions[0], ZeroDivisionError)
+    assert len(caplog.records) == 1 and 'division by zero' in caplog.records[0].message
+    caplog.records.pop(0)
+
+
+async def test_exception_during_call(user: User):
+    event = Event()
+    event.subscribe(lambda: print(1 / 0))
+
+    @ui.page('/')
+    def page():
+        @ui.button('Click me').on_click
+        async def click():
+            try:
+                await event.call()
+            except Exception:
+                ui.notify('There was an exception')
+
+    await user.open('/')
+    user.find('Click me').click()
+    await user.should_see('There was an exception')


### PR DESCRIPTION
### Motivation

While exceptions can't be caught when emitting events (fire and forget, they will only be logged to the console), it should be possible to catch them when calling events:

```py
event = Event()
event.subscribe(lambda: print(1 / 0))

@ui.button('Click me').on_click
async def click():
    try:
        await event.call()
    except Exception:
        print('💣')
```

While investigating the corresponding code, I noticed that we didn't use `core.app.handle_exception(e)` during `emit`, so we bypassed the registered exception handlers.

### Implementation

This PR replaces `log.exception(...)` with `core.app.handle_exception(e)` in `emit`,
removes the try-except wrapper in `call`,
and adds pytests to verify the promised behavior.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added.
- [x] Documentation is not necessary (the "Emitting vs. calling events" demo already assumed exceptions during `call` would bubble).
