### PR TITLE
Let pytest run first in the pipeline, startups later.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,6 @@ jobs:
           poetry run pip install -r tests/requirements.txt
           # try fix issue with importlib_resources
           poetry run pip install importlib-resources
-      - name: test startup
-        run: poetry run ./test_startup.sh
       - name: setup chromedriver
         uses: nanasess/setup-chromedriver@v2.3.0
       - name: pytest
@@ -63,6 +61,8 @@ jobs:
           name: screenshots-${{ matrix.python }}
           path: screenshots/*.failed.png
           retention-days: 14
+      - name: test startup
+        run: poetry run ./test_startup.sh
 
   slack:
     needs:


### PR DESCRIPTION
### Motivation

There are various issues with running the `test_startup.sh` before the `pytest`, in ascending order of seriousness:

1. Delayed to see the results of the pytest
2. Installation of the example's requirements.txt, **defeats the purpose of having pinned dependencies in `poetry.lock`**, as we can see in https://github.com/zauberzeug/nicegui/actions/runs/18400412564/job/52428146319 that packages indicated in `poetry.lock` are then uninstalled in place of other ones. 

We can tolerate with point 1 but point 2 definitely needs improvement. 

This could be the cause of the many errors in #5242. Hence this PR. 

**Real motivation: I squeezed pytest into 5 minutes in #5249, but I need to wait 10 minutes for `test_startup.sh`?**

### Implementation

Move stage `test startup` to the back. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
