### PR TITLE
Rearrange the dependencies installation steps for the pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           set -x
           # install packages to run the examples
-          poetry run pip install $(printf -- '-r %s ' examples/*/requirements.txt)
+          poetry run pip install opencv-python opencv-contrib-python-headless httpx isort replicate langchain openai simpy tortoise-orm
       - name: test startup
         run: poetry run ./test_startup.sh
       - name: restore dependencies for effective caching


### PR DESCRIPTION
### Motivation

There are 2 issues which lead to this: 

1. I want fast pipelines. Before there were 3.14 builds, Py3.14 pipeline always take a solid 5 minutes more than the rest in the "install dependencies" stage building numpy (check https://github.com/zauberzeug/nicegui/actions/runs/18411862410/job/52466073580)
2. I want consistent environment to run the tests. We already did #5254, but turns out I did not move the dependencies install for "test startup" accordingly back then. 
3. ~~#5258, and previous attempts, consistently fails.~~

### Implementation

#### We will always use `poetry install --all-extras --with dev` to install the dependencies
  - **Advantage**: The cache for the "code-check" and the "test matrix 3.9" will be the same. 
  - **Advantage**: No need to use `pip` to install the `pytest-*` libraries, which avoid mix of package managers in the pytest stage (according to #4872)
  - **Disadvantage**: Slightly more bulky cache for 3.10-3.14. 

#### For the packages needed to run the examples, we move them to the bottom, just before test startup
  - **Advantage**: Fully lock the dependency installed for the pytest stage. 
  - ~~**Advantage**: After merge, this should fully resolve pipeline issues in #5258~~

<details>
<summary>
Case study
</summary>

With this PR (https://github.com/evnchn/nicegui/actions/runs/18428088518/job/52512692363)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/39f10a8b-b5d5-488f-9103-918472ea836d" />

Without this PR (https://github.com/evnchn/nicegui/actions/runs/18412996019)

<img width="2233" height="312" alt="image" src="https://github.com/user-attachments/assets/8728e13e-cc74-4c51-80d8-d2a7640a7d66" />

If not for this PR, we would run tests with `async-timeout` 4.0.3, and who knows what kind of incompatibilities lies there. 
</details>

#### Restore dependencies for effective caching
  - **Advantage**: The cache will be the pytest dependencies, and minimize time taken in "install dependencies" stage
  - Note: Since there are already Py3.14 builds for the dependencies, the time savings are less. But it's still good practice. 


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
