### PR TITLE
Inject request object if root page wants it

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -160,13 +160,12 @@ async def _shutdown() -> None:
 async def _exception_handler_404(request: Request, exception: Exception) -> Response:
     root = core.root
     if root is not None:
-        signature = inspect.signature(root)
         kwargs = {
             name: PageArguments._convert_parameter(  # pylint: disable=protected-access
                 request.query_params[name],
                 param.annotation,
             )
-            for name, param in signature.parameters.items()
+            for name, param in inspect.signature(root).parameters.items()
             if name in request.query_params and name != 'request'
         }
         return await page('')._wrap(root)(request=request, **kwargs)  # pylint: disable=protected-access

--- a/tests/test_root_page.py
+++ b/tests/test_root_page.py
@@ -40,13 +40,13 @@ def test_root_page_with_request_injection(screen: Screen):
 
     def root(request: Request):
         ui.label(f'path: {request.url.path}')
-        ui.label(f'query: {request.query_params.get("name", "unknown")}')
+        ui.label(f'name: {request.query_params.get("name", "unknown")}')
 
     screen.ui_run_kwargs['root'] = root
     screen.open('/')
     screen.should_contain('path: /')
-    screen.should_contain('query: unknown')
+    screen.should_contain('name: unknown')
 
     screen.open('/?name=test')
     screen.should_contain('path: /')
-    screen.should_contain('query: test')
+    screen.should_contain('name: test')


### PR DESCRIPTION
### Motivation

Root page functions should support the same parameter injection patterns as regular `@ui.page()` decorated functions for consistency and to provide access to request details (headers, cookies, URL components, etc.).

### Implementation

Reuse existing page._wrap() infrastructure rather than duplicating logic. The wrapped page function already inspects signatures and injects request when present, so we simply avoid conflicting with it.

There currently is no proper documentation location for root page specifics. Therefor I decided to not do this in this PR (simplifies review) and ideally add another PR later to do comprehensive documentation for root page.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added.
- [x] Documentation will be added in a separate PR.
