### PR TITLE
Apply margin to all `pre` in `.nicegui-markdown`

### DIFF
--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -196,7 +196,7 @@
   border: 1px solid #8884;
 }
 .nicegui-markdown pre {
-  margin: 0.5rem 0.5rem;
+  margin: 0.5rem 0;
 }
 .nicegui-markdown .mermaid-pre > .mermaid {
   display: none;
@@ -256,6 +256,9 @@ h6.q-timeline__title {
   border: 1pt solid rgba(127, 159, 191, 0.15);
   box-shadow: 0 0 0.5em rgba(127, 159, 191, 0.05);
   border-radius: 0.25rem;
+}
+.nicegui-code pre {
+  padding: 0 0.5rem;
 }
 .nicegui-matplotlib > svg,
 .nicegui-pyplot > svg {


### PR DESCRIPTION
### Motivation

Fix #5264, where the margin is inconsistent when `language=''`

### Implementation

* Changed the selector from `.nicegui-markdown .codehilite pre` to `.nicegui-markdown pre` and updated the margin to `0.5rem 0.5rem` to provide both horizontal and vertical margin to both codehilite and non-codehilite code blocks. 
* Removed unnecessary padding from `.nicegui-code .codehilite`. 

### Visual difference

Before:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/48ce0232-bb6d-4d03-be48-a2a15e6d84c0" />

After: 

<img width="600" alt="image" src="https://github.com/user-attachments/assets/2e306fdb-12c5-49a0-8978-019f9e7fc059" />


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
