### PR TITLE
Make the style of `ui.separator` be different in different orientation

### DIFF
--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -215,10 +215,7 @@
 .nicegui-link:active {
   opacity: 0.8;
 }
-.q-separator--vertical.nicegui-separator {
-  width: 1px;
-}
-.q-separator--horizontal.nicegui-separator {
+.nicegui-separator.q-separator--horizontal {
   width: 100%;
 }
 .nicegui-aggrid,


### PR DESCRIPTION
### Motivation
Fix #5270, where the style of `ui.separator().props('vertical')` doesn't work as expected in NiceGUI 3.0.0. above.
<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation
change
```css
.nicegui-separator {
  width: 100%;
}
```
into
```css
.q-separator--vertical.nicegui-separator {
  width: 1px;
}
.q-separator--horizontal.nicegui-separator {
  width: 100%;
}
```
<!-- What is the concept behind the implementation? How does it work? -->
<!-- Include any important technical decisions or trade-offs made -->

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Test

Testing it by:
```python3
from nicegui import ui

def index():
    with ui.column():
        ui.button('1')
        ui.separator()
        ui.button('2')
    with ui.row():
        ui.button('1')
        ui.separator().props('vertical')
        ui.button('2')

ui.run(
    root=index
)
```
It should work as following:
<img width="174" height="220" alt="image" src="https://github.com/user-attachments/assets/0bf3cfb7-3630-4677-ac9c-5d05606036eb" />
