### PR TITLE
introduce code transformation to simplify writing ui.sub_pages demos

### DIFF
--- a/tests/test_demo_transformation.py
+++ b/tests/test_demo_transformation.py
@@ -1,0 +1,320 @@
+from textwrap import dedent
+
+from website.documentation.code_extraction import get_full_code, transform_for_demo_execution
+
+
+def prepare(text: str) -> str:
+    return dedent(text).strip() + '\n'
+
+
+def test_simple_sub_pages():
+    assert transform_for_demo_execution(prepare('''
+        from nicegui import ui
+
+        def root():
+            ui.sub_pages({'/': main, '/other': other})
+
+        ui.run(root)
+    ''')) == prepare('''
+        from nicegui import ui
+        from website.documentation.content.sub_pages_documentation import FakeSubPages
+
+        pages = FakeSubPages()
+
+        def root():
+            pages.routes = {'/': main, '/other': other}
+            pages.init()
+
+        ui.run(root)
+    ''')
+
+
+def test_sub_pages_with_data():
+    assert transform_for_demo_execution(prepare('''
+        from nicegui import ui
+
+        def root():
+            ui.sub_pages({
+                '/': main,
+                '/other': other,
+            }, data={'title': title})
+    ''')) == prepare('''
+        from nicegui import ui
+        from website.documentation.content.sub_pages_documentation import FakeSubPages
+
+        pages = FakeSubPages()
+
+        def root():
+            pages.routes = {
+                '/': main,
+                '/other': other,
+            }
+            pages.data = {'title': title}
+            pages.init()
+    ''')
+
+
+def test_empty_sub_pages():
+    assert transform_for_demo_execution(prepare('''
+        from nicegui import ui
+
+        def root():
+            pages = ui.sub_pages()
+            pages.add('/', main)
+    ''')) == prepare('''
+        from nicegui import ui
+        from website.documentation.content.sub_pages_documentation import FakeSubPages
+
+        pages = FakeSubPages()
+
+        def root():
+            pages.init()
+            pages.add('/', main)
+    ''')
+
+
+def test_chained_methods():
+    assert transform_for_demo_execution(prepare('''
+        from nicegui import ui
+
+        def root():
+            ui.sub_pages({
+                '/': main,
+                '/other': other,
+            }).classes('border p-2')
+    ''')) == prepare('''
+        from nicegui import ui
+        from website.documentation.content.sub_pages_documentation import FakeSubPages
+
+        pages = FakeSubPages()
+
+        def root():
+            pages.routes = {
+                '/': main,
+                '/other': other,
+            }
+            pages.classes('border p-2')
+            pages.init()
+    ''')
+
+
+def test_ui_link_transformation():
+    assert transform_for_demo_execution(prepare('''
+        from nicegui import ui
+
+        def root():
+            ui.link('Home', '/')
+            ui.sub_pages({'/': main})
+    ''')) == prepare('''
+        from nicegui import ui
+        from website.documentation.content.sub_pages_documentation import FakeSubPages
+
+        pages = FakeSubPages()
+
+        def root():
+            pages.link('Home', '/')
+            pages.routes = {'/': main}
+            pages.init()
+    ''')
+
+
+def test_ui_link_before_sub_pages():
+    assert transform_for_demo_execution(prepare('''
+        from nicegui import ui
+
+        def root():
+            ui.link('msg=hello', '/?msg=hello')
+            ui.link('msg=world', '/?msg=world')
+            ui.sub_pages({'/': main})
+    ''')) == prepare('''
+        from nicegui import ui
+        from website.documentation.content.sub_pages_documentation import FakeSubPages
+
+        pages = FakeSubPages()
+
+        def root():
+            pages.link('msg=hello', '/?msg=hello')
+            pages.link('msg=world', '/?msg=world')
+            pages.routes = {'/': main}
+            pages.init()
+    ''')
+
+
+def test_multiple_imports():
+    assert transform_for_demo_execution(prepare('''
+        from nicegui import PageArguments, ui
+
+        def root():
+            ui.link('test', '/')
+            ui.sub_pages({'/': main})
+    ''')) == prepare('''
+        from nicegui import PageArguments, ui
+        from website.documentation.content.sub_pages_documentation import FakeSubPages
+
+        pages = FakeSubPages()
+
+        def root():
+            pages.link('test', '/')
+            pages.routes = {'/': main}
+            pages.init()
+    ''')
+
+
+def test_nested_sub_pages():
+    assert transform_for_demo_execution(prepare('''
+        from nicegui import ui
+
+        def root():
+            ui.sub_pages({'/': main, '/other': other})
+
+        def other():
+            ui.link('Go to A', '/other/a') # TRANSFORM: nested '/a'
+            ui.sub_pages({'/': sub_main}) # TRANSFORM: nested
+    ''')) == prepare('''
+        from nicegui import ui
+        from website.documentation.content.sub_pages_documentation import FakeSubPages
+
+        pages = FakeSubPages()
+
+        def root():
+            pages.routes = {'/': main, '/other': other}
+            pages.init()
+
+        def other():
+            nested = FakeSubPages()
+            nested.link('Go to A', '/a')
+            nested.routes = {'/': sub_main}
+            nested.init()
+    ''')
+
+
+def test_no_transformation_without_sub_pages():
+    code = prepare('''
+        from nicegui import ui
+
+        def root():
+            ui.label('Hello')
+            ui.button('Click me')
+    ''')
+    assert transform_for_demo_execution(code) == code
+
+
+def test_single_line_sub_pages():
+    assert transform_for_demo_execution(prepare('''
+        from nicegui import ui
+
+        def root():
+            ui.sub_pages({'/': main})
+    ''')) == prepare('''
+        from nicegui import ui
+        from website.documentation.content.sub_pages_documentation import FakeSubPages
+
+        pages = FakeSubPages()
+
+        def root():
+            pages.routes = {'/': main}
+            pages.init()
+    ''')
+
+
+def test_multiline_sub_pages():
+    assert transform_for_demo_execution(prepare('''
+        from nicegui import ui
+
+        def root():
+            ui.sub_pages({
+                '/': main,
+                '/about': lambda: other('About'),
+                '/contact': contact,
+            }, data={'foo': 'bar'})
+    ''')) == prepare('''
+        from nicegui import ui
+        from website.documentation.content.sub_pages_documentation import FakeSubPages
+
+        pages = FakeSubPages()
+
+        def root():
+            pages.routes = {
+                '/': main,
+                '/about': lambda: other('About'),
+                '/contact': contact,
+            }
+            pages.data = {'foo': 'bar'}
+            pages.init()
+    ''')
+
+
+def test_transform_hint():
+    assert transform_for_demo_execution(prepare('''
+        from nicegui import ui
+
+        def root():
+            ui.link('item 1', '/item/1')  # TRANSFORM: pages '/item/{item_id}', item_id=1
+            ui.link('item 2', '/item/2')  # TRANSFORM: pages '/item/{item_id}', item_id=2
+            ui.sub_pages({'/': main, '/item/{item_id}': item})
+
+        ui.run(root)
+    ''')) == prepare('''
+        from nicegui import ui
+        from website.documentation.content.sub_pages_documentation import FakeSubPages
+
+        pages = FakeSubPages()
+
+        def root():
+            pages.link('item 1', '/item/{item_id}', item_id=1)
+            pages.link('item 2', '/item/{item_id}', item_id=2)
+            pages.routes = {'/': main, '/item/{item_id}': item}
+            pages.init()
+
+        ui.run(root)
+    ''')
+
+
+def test_hide_directive_with_comment():
+    """Test that # HIDE can be used to show one version in display and execute another."""
+    assert transform_for_demo_execution(prepare('''
+        from nicegui import ui
+
+        def root():
+            ui.link('test', '/')
+            ui.sub_pages({'/': main})
+
+        # def main(args: PageArguments):
+        def main(args: PageArguments = FakeArguments(msg='no message')):  # HIDE
+            ui.label(args.query_parameters.get('msg', 'no message'))
+    ''')) == prepare('''
+        from nicegui import ui
+        from website.documentation.content.sub_pages_documentation import FakeArguments, FakeSubPages
+
+        pages = FakeSubPages()
+
+        def root():
+            pages.link('test', '/')
+            pages.routes = {'/': main}
+            pages.init()
+
+        def main(args: PageArguments = FakeArguments(msg='no message')):
+            ui.label(args.query_parameters.get('msg', 'no message'))
+    ''')
+
+
+def test_get_full_code_with_hide_and_comment():
+    """Test that get_full_code shows commented line and hides the HIDE line for display."""
+    def demo_func():
+        from nicegui import ui
+
+        def _root():
+            ui.sub_pages({'/': main})
+
+        # def main():
+        def main():  # HIDE
+            ui.label('test')
+
+    display_code = get_full_code(demo_func, keep_transform=False)
+    assert 'def main():' in display_code
+    assert '# HIDE' not in display_code
+    assert display_code.count('def main():') == 1
+
+    execution_code = get_full_code(demo_func, keep_transform=True)
+    assert '# def main():' in execution_code
+    assert 'def main():  # HIDE' in execution_code

--- a/website/documentation/code_extraction.py
+++ b/website/documentation/code_extraction.py
@@ -5,16 +5,27 @@ from typing import Callable
 import isort
 
 UNCOMMENT_PATTERN = re.compile(r'^(\s*)# ?')
+TRANSFORM_COMMENT_PATTERN = re.compile(r'#\s*TRANSFORM:\s*.+')
+SUBPAGES_PATTERN = re.compile(r'(\w+\s*=\s*)?ui\.sub_pages\(')
+LINK_PATTERN = re.compile(r'\bui\.link\(')
+TRANSFORM_VARNAME_PATTERN = re.compile(r'#\s*TRANSFORM:\s*(\w+)(?:\s+(.+))?$')
 
 
 def _uncomment(text: str) -> str:
     return UNCOMMENT_PATTERN.sub(r'\1', text)  # NOTE: non-executed lines should be shown in the code examples
 
 
-def get_full_code(f: Callable) -> str:
-    """Get the full code of a function as a string."""
+def get_full_code(f: Callable, *, keep_transform: bool = False) -> str:
+    """Get the full code of a function as a string.
+
+    Args:
+        f: The function to extract code from
+        keep_transform: If True, keep TRANSFORM comments (for transformation), else strip them (for display)
+    """
     code = inspect.getsource(f).split('# END OF DEMO', 1)[0].strip().splitlines()
-    code = [line for line in code if not line.endswith('# HIDE')]
+    if not keep_transform:
+        code = [TRANSFORM_COMMENT_PATTERN.sub('', line).rstrip() for line in code]
+        code = [line for line in code if not line.endswith('# HIDE')]
     while not code[0].strip().startswith(('def', 'async def')):
         del code[0]
     del code[0]
@@ -24,10 +35,177 @@ def get_full_code(f: Callable) -> str:
         del code[0]
     indentation = len(code[0]) - len(code[0].lstrip())
     code = [line[indentation:] for line in code]
-    code = ['from nicegui import ui'] + [_uncomment(line) for line in code]
+    if not keep_transform:
+        code = [_uncomment(line) for line in code]
+    code = ['from nicegui import ui', *code]
     code = ['' if line == '#' else line for line in code]
-    if not code[-1].startswith('ui.run('):
+
+    if any(line.strip().startswith('def root(') for line in code):
+        code.append('')
+        code.append('ui.run(root)')
+    elif not code[-1].startswith('ui.run('):
         code.append('')
         code.append('ui.run()')
     full_code = isort.code('\n'.join(code), no_sections=True, lines_after_imports=1)
     return full_code
+
+
+def _process_subpages_call(subpages_call_lines: list[str], sub_pages_var: str, indent: int) -> list[str]:
+    """Process a complete ui.sub_pages() call and return transformed lines."""
+    result_lines = []
+    full_call = '\n'.join(subpages_call_lines)
+    call_content = SUBPAGES_PATTERN.sub('', full_call, count=1)
+
+    chained_methods = ''
+    paren_depth = 0
+    close_paren_idx = -1
+
+    for i, char in enumerate(call_content):
+        if char == '(':
+            paren_depth += 1
+        elif char == ')':
+            if paren_depth == 0:
+                close_paren_idx = i
+                break
+            paren_depth -= 1
+
+    if close_paren_idx != -1:
+        chained_methods = call_content[close_paren_idx + 1:].strip()
+        call_content = call_content[:close_paren_idx].strip()
+    else:
+        call_content = call_content.rstrip().rstrip(')').rstrip()
+
+    if not call_content or call_content.strip() == '':
+        pass
+    elif ', data=' in call_content or ',data=' in call_content:
+        parts = call_content.rsplit(
+            ', data=', 1) if ', data=' in call_content else call_content.rsplit(',data=', 1)
+        routes_part = parts[0].strip()
+        data_part = parts[1].strip()
+        result_lines.append(' ' * indent + f'{sub_pages_var}.routes = {routes_part}')
+        result_lines.append(' ' * indent + f'{sub_pages_var}.data = {data_part}')
+    else:
+        result_lines.append(' ' * indent + f'{sub_pages_var}.routes = {call_content.strip()}')
+
+    if chained_methods:
+        result_lines.append(' ' * indent + f'{sub_pages_var}{chained_methods}')
+
+    result_lines.append(' ' * indent + f'{sub_pages_var}.init()')
+    return result_lines
+
+
+def transform_for_demo_execution(code: str) -> str:
+    """Transform code for demo execution by replacing ui.sub_pages and ui.link with FakeSubPages equivalents."""
+    lines = code.split('\n')
+    lines = [line for line in lines if not line.strip().startswith('#')]
+    lines = [line.removesuffix('  # HIDE').removesuffix(' # HIDE').removesuffix('# HIDE').rstrip() for line in lines]
+    if not any('ui.sub_pages' in line for line in lines):
+        return '\n'.join(lines)
+
+    transformed_lines = []
+    sub_pages_var_stack = []
+    in_subpages_call = False
+    paren_depth = 0
+    current_sub_pages_var = None
+    subpages_indent = 0
+    subpages_call_lines = []
+    instantiated_vars = set()
+
+    for line in lines:
+        varname_match = TRANSFORM_VARNAME_PATTERN.search(line)
+        hint_var_name = None
+        if varname_match:
+            hint_var_name = varname_match.group(1)
+            line = TRANSFORM_VARNAME_PATTERN.sub('', line).rstrip()  # noqa: PLW2901
+
+        match = SUBPAGES_PATTERN.search(line)
+        if match and not in_subpages_call:
+            sub_pages_var = match.group(1).split('=')[0].strip() if match.group(1) else (hint_var_name or 'pages')
+
+            if sub_pages_var not in sub_pages_var_stack:
+                sub_pages_var_stack.append(sub_pages_var)
+
+            if hint_var_name and sub_pages_var not in instantiated_vars and sub_pages_var != 'pages':
+                subpages_indent = len(line) - len(line.lstrip())
+                transformed_lines.append(' ' * subpages_indent + f'{sub_pages_var} = FakeSubPages()')
+                instantiated_vars.add(sub_pages_var)
+
+            subpages_indent = len(line) - len(line.lstrip())
+            current_sub_pages_var = sub_pages_var
+            in_subpages_call = True
+            subpages_call_lines = [line]
+            paren_depth = line.count('(') - line.count(')')
+
+            if paren_depth == 0:
+                transformed_lines.extend(_process_subpages_call(
+                    subpages_call_lines, current_sub_pages_var, subpages_indent))
+                in_subpages_call = False
+                subpages_call_lines = []
+        elif in_subpages_call:
+            subpages_call_lines.append(line)
+            paren_depth += line.count('(') - line.count(')')
+            if paren_depth == 0:
+                transformed_lines.extend(_process_subpages_call(
+                    subpages_call_lines, current_sub_pages_var, subpages_indent))
+                in_subpages_call = False
+                subpages_call_lines = []
+        elif 'ui.link(' in line:
+            if varname_match:
+                var_name = varname_match.group(1)
+                if var_name not in instantiated_vars and var_name != 'pages':
+                    indent = len(line) - len(line.lstrip())
+                    transformed_lines.append(' ' * indent + f'{var_name} = FakeSubPages()')
+                    instantiated_vars.add(var_name)
+                if var_name not in sub_pages_var_stack:
+                    sub_pages_var_stack.append(var_name)
+
+                extra_args = varname_match.group(2)
+                if extra_args:
+                    link_match = re.match(r'(\s*)ui\.link\(([^,]+),', line)
+                    if link_match:
+                        indent = link_match.group(1)
+                        text_arg = link_match.group(2)
+                        transformed_lines.append(f'{indent}{var_name}.link({text_arg}, {extra_args})')
+                    else:
+                        transformed_lines.append(LINK_PATTERN.sub(f'{var_name}.link(', line))
+                else:
+                    transformed_lines.append(LINK_PATTERN.sub(f'{var_name}.link(', line))
+            else:
+                current_var = sub_pages_var_stack[0] if sub_pages_var_stack else 'pages'
+                if not sub_pages_var_stack:
+                    sub_pages_var_stack.append('pages')
+                transformed_lines.append(LINK_PATTERN.sub(f'{current_var}.link(', line))
+        else:
+            transformed_lines.append(line)
+
+    result = '\n'.join(transformed_lines)
+
+    if sub_pages_var_stack:
+        non_instantiated_vars = sorted(set(sub_pages_var_stack) - instantiated_vars)
+
+        if non_instantiated_vars:
+            sub_pages_init = '\n'.join(f'{var} = FakeSubPages()' for var in non_instantiated_vars)
+
+            lines = result.split('\n')
+            needs_fake_arguments = 'FakeArguments' in result
+            imports = 'FakeArguments, FakeSubPages' if needs_fake_arguments else 'FakeSubPages'
+            for i, line in enumerate(lines):
+                if line.startswith('from nicegui import'):
+                    lines.insert(
+                        i + 1, f'from website.documentation.content.sub_pages_documentation import {imports}')
+                    lines.insert(i + 2, '')
+                    lines.insert(i + 3, sub_pages_init)
+                    break
+            result = '\n'.join(lines)
+        else:
+            lines = result.split('\n')
+            needs_fake_arguments = 'FakeArguments' in result
+            imports = 'FakeArguments, FakeSubPages' if needs_fake_arguments else 'FakeSubPages'
+            for i, line in enumerate(lines):
+                if line.startswith('from nicegui import'):
+                    lines.insert(
+                        i + 1, f'from website.documentation.content.sub_pages_documentation import {imports}')
+                    break
+            result = '\n'.join(lines)
+
+    return result

--- a/website/documentation/demo.py
+++ b/website/documentation/demo.py
@@ -1,10 +1,37 @@
+import logging
 from typing import Callable, Optional, Union
 
 from nicegui import helpers, json, ui
 
-from .code_extraction import get_full_code
+from .code_extraction import get_full_code, transform_for_demo_execution
 from .intersection_observer import IntersectionObserver as intersection_observer
 from .windows import browser_window, python_window
+
+
+def _execute_demo_code(f: Callable) -> Callable:
+    """Execute demo function with automatic transformation and root() handling.
+
+    Returns:
+        A callable (sync or async) that can be executed.
+    """
+    full_code_with_hints = get_full_code(f, keep_transform=True)
+    transformed_code = transform_for_demo_execution(full_code_with_hints)
+
+    lines = transformed_code.split('\n')
+    lines = [line for line in lines if not line.strip().startswith('ui.run(')]
+
+    if 'nested' in full_code_with_hints:
+        print(transformed_code)
+    namespace = {}
+    try:
+        exec('\n'.join(lines), namespace)
+
+        if 'root' in namespace and callable(namespace['root']):
+            return namespace['root']
+        return f
+    except Exception:
+        logging.exception(f'Error executing demo code:\n\n{transformed_code}')
+        return f
 
 
 def demo(f: Callable, *, lazy: bool = True, tab: Optional[Union[str, Callable]] = None) -> Callable:
@@ -24,13 +51,21 @@ def demo(f: Callable, *, lazy: bool = True, tab: Optional[Union[str, Callable]] 
 
                 async def handle_intersection():
                     window.remove(spinner)
-                    if helpers.is_coroutine_function(f):
-                        await f()
-                    else:
-                        f()
+                    func = _execute_demo_code(f)
+                    result = func()
+                    if helpers.is_coroutine_function(func):
+                        await result
+                    elif callable(result):
+                        if helpers.is_coroutine_function(result):
+                            await result()
+                        else:
+                            result()
                 intersection_observer(on_intersection=handle_intersection)
             else:
                 assert not helpers.is_coroutine_function(f), 'async functions are not supported in non-lazy demos'
-                f()
+                func = _execute_demo_code(f)
+                result = func()
+                if callable(result):
+                    result()
 
     return f


### PR DESCRIPTION
### Motivation

Writing demos for Single Page Applications (SPAs) with `ui.sub_pages` has been cumbersome and unnatural. Demo code doesn't match what users should actually write in their own applications:

1. Unnatural code patterns: Demo code used `FakeSubPages` and manual workarounds (sub_pages.link(), FakeArguments, etc.) instead of the clean, straightforward API (ui.link(), ui.sub_pages())
2. Quite some code duplications which makes it hard to find areas where the rendered demo didn't match what users should write

### Implementation

This PR introduces an automatic code transformation system that allows demo authors to write natural, idiomatic NiceGUI code while still supporting browser-based demo execution:

1. New transformation infrastructure (`website/documentation/code_extraction.py`):  
   * Transform `ui.sub_pages()` → `FakeSubPages.init()`, `ui.link()` → `pages.link()`
   * Handles nested sub-pages, URL parameters, query strings, and chained methods  
   * Uses special `# TRANSFORM` comments for complex cases (e.g., parameterized routes)  
   * test cases covering transformation of sub-pages, nested routes, URL parameters, TRANSFORM hints  
1. Demo execution engine (`website/documentation/demo.py`):  
   * Displays non-transformed code block
   * Executes transformed code with automatic root() function detection  
1. Updated sub-pages documentation (`website/documentation/content/sub_pages_documentation.py`):  
   * All demos now use natural ui.link() and ui.sub\_pages() API  
   * Removed \~140 lines of workaround code  

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] The implementation is complete.
  - [ ] The transformation itself is AI generated hand I have not yet found the time to clean it up
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been updated.
