### PR TITLE
Fix auto-sizing of `ui.aggrid`

### DIFF
--- a/nicegui/elements/aggrid/aggrid.js
+++ b/nicegui/elements/aggrid/aggrid.js
@@ -74,13 +74,6 @@ export default {
       return runMethod(this.api.getRowNode(row_id), name, args);
     },
     handle_event(type, args) {
-      if (
-        type === "gridSizeChanged" &&
-        this.auto_size_columns &&
-        !this.gridOptions.columnDefs?.some((col) => col.flex !== undefined)
-      ) {
-        this.api.sizeColumnsToFit();
-      }
       this.$emit(type, {
         value: args.value,
         oldValue: args.oldValue,
@@ -118,6 +111,5 @@ export default {
   props: {
     options: Object,
     html_columns: Array,
-    auto_size_columns: Boolean,
   },
 };


### PR DESCRIPTION
### Motivation

In #5276 we noticed that `ui.aggrid`'s column auto-sizing break in the presence of flex columns.

### Implementation

~~This PR conditionally ignores the `auto_size_columns` parameter if any column has a `flex` attribute.~~
This PR uses the "autoSizeStrategy" to implement the `auto_size_columns` parameter instead of calling a JavaScript function on size change.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation has been added.
