### PR TITLE
Add documentation for upload event arguments

### DIFF
--- a/website/documentation/content/upload_documentation.py
+++ b/website/documentation/content/upload_documentation.py
@@ -73,4 +73,5 @@ def uploading_large_files() -> None:
     ui.upload(on_upload=lambda e: ui.notify(f'Uploaded {e.file.name}')).classes('max-w-full')
 
 
-doc.reference(ui.upload)
+doc.reference(ui.upload, title='Reference for ui.upload')
+doc.reference(ui.upload.FileUpload, title='Reference for ui.upload.FileUpload')


### PR DESCRIPTION
### Motivation

The Discord user MasterOfNone asked about documentation for the event arguments of `ui.upload`. So far we only described them in the [release notes](https://github.com/zauberzeug/nicegui/releases/tag/v3.0.0) for version 3.0.

### Implementation

This PR doesn't try to demonstrate all properties and methods, but simply lists them with a short description. In combination with other demos this should be sufficient.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation has been added.
