### PR TITLE
Run publisher in background and use pkill to end example

### DIFF
--- a/examples/zeromq/README.md
+++ b/examples/zeromq/README.md
@@ -32,12 +32,12 @@ python main.py
 
 ### Results
 
-Once both the publisher and GUI server are running, you will see an updating plot on the UI. 
+Once both the publisher and GUI server are running, you will see an updating plot on the UI.
 
 ![plot](images/plot.png)
 
 To kill zmq-server.py running in the background, execute the following command after main.py ends.
 
 ```bash
-kill -9 %% 
+kill -9 %%
 ```


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
Make running the ZeroMQ example easier for beginners that don't understand they will need two terminals open to run this example. For experts this  speeds up example boot-up with a friendly reminder to use "&" at the end of command to run code in the background and give terminal control back to the user. 

<!-- Please provide relevant links to corresponding issues and feature requests. -->
https://www.linux.com/training-tutorials/and-ampersand-and-linux/

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->
Uses "&" and "pkill" to simplify running example 

<!-- Include any important technical decisions or trade-offs made -->
I used "pkill -9" instead on "kill -9"  to send SIGKILL to all processes whose name matches “python”.

✅ Pros:
	• Convenient: No need to find PIDs manually.
	• Powerful for bulk termination (e.g., stop all instances of Python).

⚠️ Cons:
	• Riskier — might kill more than you intend.
        • No confirmation prompt by default.

### Progress

- [X] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [X] The implementation is complete.
- [X] Pytests are not necessary
- [X] Documentation has been added (or is not necessary).
