### PR TITLE
Add a note about packaging NiceGUI scripts

### DIFF
--- a/website/documentation/content/section_configuration_deployment.py
+++ b/website/documentation/content/section_configuration_deployment.py
@@ -257,7 +257,7 @@ doc.text('Package for Installation', '''
     Just make sure
 
     - to call `ui.run` with `reload=False` in your main script to disable the auto-reload feature, and
-    - to use either a `root` page function in `ui.run` or decorated `@page` functions. The script mode is not supported.
+    - to pass a `root` page function to `ui.run` or define at least one decorated `@page` function.
 
     Running the `nicegui-pack` command below will create an executable `myapp` in the `dist` folder:
 ''')


### PR DESCRIPTION
### Motivation

In #5247 we noticed that packaging NiceGUI scripts (apps without `@page` or `root` functions) does not work - especially using the `--onefile` argument.

### Implementation

This PR adds a note about this limitation and adjusts the demo accordingly.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation has been added.
