### PR TITLE
Fix clipboard button in `ui.code` after content has been changed

### DIFF
--- a/nicegui/elements/code.js
+++ b/nicegui/elements/code.js
@@ -3,4 +3,7 @@ export default {
   mounted() {
     if (!navigator.clipboard) this.$el.querySelector(".q-btn").style.display = "none";
   },
+  props: {
+    content: String,
+  },
 };

--- a/nicegui/elements/code.py
+++ b/nicegui/elements/code.py
@@ -2,7 +2,6 @@ import asyncio
 import time
 from typing import Optional
 
-from .. import json
 from .button import Button as button
 from .markdown import Markdown as markdown
 from .markdown import remove_indentation
@@ -29,8 +28,9 @@ class Code(ContentElement, component='code.js', default_classes='nicegui-code'):
                 .bind_content_from(self, 'content', lambda content: f'```{language}\n{content}\n```')
             self.copy_button = button(icon='content_copy', on_click=self.show_checkmark) \
                 .props('round flat size=sm').classes('absolute right-2 top-2 opacity-20 hover:opacity-80') \
-                .on('click', js_handler=f'() => navigator.clipboard.writeText({json.dumps(self.content)})')
+                .on('click', js_handler=f'() => navigator.clipboard.writeText(getElement("{self.id}").content)')
 
+        self._props['content'] = self.content
         self._last_scroll: float = 0.0
         self.markdown.on('scroll', self._handle_scroll)
         with self:
@@ -49,4 +49,4 @@ class Code(ContentElement, component='code.js', default_classes='nicegui-code'):
         self.copy_button.set_visibility(time.time() > self._last_scroll + 1.0)
 
     def _handle_content_change(self, content: str) -> None:
-        pass  # handled by markdown element
+        self._props['content'] = content


### PR DESCRIPTION
### Motivation

In #5177 we noticed that the copy button writes old content to the clipboard when the content of `ui.code` has been updated:
```py
c = ui.code('old content')
c.content = 'new content'
```
Clicking the button will write "old content" to the clipboard.

### Implementation

This PR introduces a new "content" prop to hold the raw (non-HTML) version of the content. When clicking the copy button, a JavaScript call will write the value of this prop to the clipboard.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are probably not necessary (and probably pretty hard to write).
- [x] Documentation is not necessary.
