### PR TITLE
Provide pytest fixture for user test startup

### DIFF
--- a/nicegui/testing/plugin.py
+++ b/nicegui/testing/plugin.py
@@ -7,4 +7,4 @@ from .screen_plugin import (  # noqa: F401
     pytest_runtest_makereport,
     screen,
 )
-from .user_plugin import create_user, user  # noqa: F401
+from .user_plugin import create_user, user_startup_func, user  # noqa: F401

--- a/tests/test_user_simulation_startup_fixture.py
+++ b/tests/test_user_simulation_startup_fixture.py
@@ -1,0 +1,26 @@
+from typing import Callable
+
+import pytest
+
+from nicegui import app, ui
+from nicegui.testing import User
+
+
+@pytest.fixture
+def user_startup_func() -> Callable[[], None]:
+    def custom_startup():
+        @ui.page('/')
+        def page():
+            ui.label('Hello from my custom startup :-)')
+
+        ui.run()
+
+    return custom_startup
+
+
+# NOTE: this test is in a separate file to ensure the user_startup fixture override is only applied to this test
+async def test_user_startup_fixture(user: User):
+    await user.open('/')
+
+    await user.should_see('Hello from my custom startup :-)')
+    assert app.storage.secret is None, 'normally the startup sets a storage secret, but our custom startup does not'

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -10,7 +10,7 @@ def user_fixture():
     ui.markdown('''
         We recommend utilizing the `user` fixture instead of the [`screen` fixture](/documentation/screen) wherever possible
         because execution is as fast as unit tests and it does not need Selenium as a dependency.
-        The `user` fixture cuts away the browser and replaces it by a lightweight simulation.
+        The `user` fixture cuts away the browser and replaces it with a lightweight simulation.
 
         You can assert to "see" specific elements or content, click buttons, type into inputs and trigger events.
         We aimed for a nice API to write acceptance tests which read like a story and are easy to understand.
@@ -356,6 +356,56 @@ def simulate_javascript():
             ''')
 
 
+doc.text('Using pytest fixtures to startup your app', '''
+    Sometimes it is not enough using a file (specified by the `main_file` config) for starting up your app for testing. 
+    In that case you can replace the `pytest` fixture `user_startup_func` and return your own startup function. 
+    That enables you to provide test objects via your own `pytest` fixtures that can be used in the startup function 
+    and in your test function.
+    
+    *Added in version 3.3.0*
+    
+    The following snippet should give you an idea of how to use fixtures to startup your app.
+''')
+
+
+@doc.ui
+def user_startup_function_pytest_fixture():
+    with ui.row().classes('gap-4 items-stretch'):
+        with python_window(classes='w-[500px]', title='conftest.py'):
+            ui.markdown('''
+                ```python
+                @pytest.fixture
+                def test_database() -> MyTestDatabase:
+                    # simulate some test database creation
+                    return MyTestDatabase()
+            
+                
+                @pytest.fixture
+                def user_startup_func(test_database: MyTestDatabase) -> Callable[[], None]:
+                    def my_startup():
+                        # consider you have a function to create a root that receives a database
+                        root = create_root(test_database)
+                        
+                        ui.run(root)
+                        
+                    return my_startup
+                ```
+            ''')
+
+        with python_window(classes='w-[500px]', title='my_test.py'):
+            ui.markdown('''
+                ```python
+                def my_test(user: User, test_database: MyTestDatabase):
+                    test_database.prepare_test_scenario("some-test-scenario")
+                
+                    await user.open('/my-app')
+                    user.find("Do some action").click()
+                    
+                    assert 1 == test_database.query("SELECT COUNT(*) FROM table"
+                ```
+            ''')
+
+
 doc.text('Comparison with the screen fixture', '''
     By cutting out the browser, test execution becomes much faster than the [`screen` fixture](/documentation/screen).
     See our [pytests example](https://github.com/zauberzeug/nicegui/tree/main/examples/pytests)
@@ -363,6 +413,7 @@ doc.text('Comparison with the screen fixture', '''
     Of course, some features like screenshots or browser-specific behavior are not available,
     but in most cases the speed of the `user` fixture makes it the first choice.
 ''')
+
 
 doc.reference(User, title='User Reference')
 doc.reference(UserInteraction, title='UserInteraction Reference')


### PR DESCRIPTION
### Motivation

In some circumstances, it is not feasible to use a file (e.g. `main.py`) in your project to startup the ui for testing (via the `main_file` pytest ini config). 

E.g. Imagine your production code uses a database that is created before calling `ui.run` and passed to the pages via some injection mechanism. In your test you want to:

1. provide a mock database (e.g. in-memory) and pass this through your production code (this would already be possible by using the existing `main_file`approach)
2. you also want to access the mocked database in you test to arrange the test data and to assert that the data was manipulated correctly be the pages. This is not possible (at least not without wild hacks).

By providing a `pytest.fixture` that is starting up the ui, the test database could be injected there and in your actual test by another ´pytest.fixture´. 

This is of course not limited to a database.

### Implementation

Using `pytest` fixtures to provide custom startup functions is a natural and backward-compatible way of setting up your test startups.
By default, the fixture `user_startup` returns the function that implements the 'old' behaviour. By overriding this fixture, you can provide your own startup function.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
