### PR TITLE
Use `run_name='__main__'` for backwards-compatibility to a typical mainguard in 2.x setup

### DIFF
--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -128,7 +128,7 @@ def run(root: Optional[Callable] = None, *,
             return
 
         def run_script() -> None:
-            runpy.run_path(sys.argv[0])
+            runpy.run_path(sys.argv[0], run_name='__main__')
         root = run_script
         assert core.script_client is not None
         core.script_client.delete()


### PR DESCRIPTION
### Motivation

Fix #5280, where people who use our suggested main guard in 2.x, when moving to 3.0.4, find their page blank. 

**Real motivation: 3.1 is round the corner!**

### Implementation

We can configure the`__name__` which runpy runs the file with `run_name` parameter. Passing `__main__` to that, and our call fits the main guard. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.

P.S.: Intend to push to my branch, but misclicked. It's brain-melting to choose between "origin" and "zauberzeug"...
P.S 2: Intend to merge, as seen in https://github.com/zauberzeug/nicegui/issues/5280#issuecomment-3415120564
