### PR TITLE
Init the attribute `data-ag-theme-mode` of `ui.aggrid` before themeObserver created

### DIFF
--- a/nicegui/elements/aggrid/aggrid.js
+++ b/nicegui/elements/aggrid/aggrid.js
@@ -5,11 +5,12 @@ export default {
   template: "<div></div>",
   mounted() {
     this.update_grid();
-    this.$el.setAttribute("data-ag-theme-mode", document.body.classList.contains("body--dark") ? "dark" : "light")
-    this.themeObserver = new MutationObserver(() =>
-      this.$el.setAttribute("data-ag-theme-mode", document.body.classList.contains("body--dark") ? "dark" : "light")
-    );
+
+    const updateTheme = () =>
+      this.$el.setAttribute("data-ag-theme-mode", document.body.classList.contains("body--dark") ? "dark" : "light");
+    this.themeObserver = new MutationObserver(updateTheme);
     this.themeObserver.observe(document.body, { attributes: true, attributeFilter: ["class"] });
+    updateTheme();
   },
   unmounted() {
     this.themeObserver.disconnect();


### PR DESCRIPTION
### Motivation
If  `ui.aggrid` was created in a page with dark mode,  `ui.aggrid`'s theme won't be dark mode unless resizing page.
<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation

Add `this.$el.setAttribute("data-ag-theme-mode", document.body.classList.contains("body--dark") ? "dark" : "light")` to aggrid.js line 8.
Before themeObserver created, init the attribute `data-ag-theme-mode` of `ui.aggrid`.
<!-- What is the concept behind the implementation? How does it work? -->
<!-- Include any important technical decisions or trade-offs made -->

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
