### PR TITLE
Drop "install test startup dependencies" (indeed useless)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,11 +56,6 @@ jobs:
           name: screenshots-${{ matrix.python }}
           path: screenshots/*.failed.png
           retention-days: 14
-      - name: install test startup dependencies
-        run: |
-          set -x
-          # install packages to run the examples
-          poetry run pip install opencv-python opencv-contrib-python-headless httpx isort replicate openai simpy tortoise-orm
       - name: test startup
         run: poetry run ./test_startup.sh
       - name: restore dependencies for effective caching


### PR DESCRIPTION
### Motivation

It has been a mystery why we even need the test startup dependencies. 

So I removed it and to my surprise the pipeline passes. 

So that stage proved to be useless as `test_startup.sh` incorporates installation from `requirements.txt` already. 

https://github.com/evnchn/nicegui/actions/runs/18660615231

### Implementation

Remove stage "install test startup dependencies" entirely, rely on `test_startup.sh` installations

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
