### PR TITLE
Fix usage of cursor rules by adhering to the proper format

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -6,9 +6,9 @@ alwaysApply: true
 
 **Read these files before working:**
 
-1. [README.md](../README.md) - Project overview and setup
-2. [AGENTS.md](../AGENTS.md) - AI agent guidelines and code review instructions
-3. [CONTRIBUTING.md](../CONTRIBUTING.md) - Coding standards and workflow
+1. [README.md](../../README.md) - Project overview and setup
+2. [AGENTS.md](../../AGENTS.md) - AI agent guidelines and code review instructions
+3. [CONTRIBUTING.md](../../CONTRIBUTING.md) - Coding standards and workflow
 
 ## Quick Reference
 


### PR DESCRIPTION
### Motivation

`.cursor/rules` must be a directory with `*.mdc` files. See https://cursor.com/docs/context/rules#project-rules.

### Implementation

Simply moved the file to the right location and added the "always" header.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not needed.
- [x] Documentation is not necessary.
