### PR TITLE
Move `window.L = L` earlier for loading `additional_resources` successfully

### DIFF
--- a/nicegui/elements/leaflet/leaflet.js
+++ b/nicegui/elements/leaflet/leaflet.js
@@ -16,8 +16,8 @@ export default {
   async mounted() {
     await this.$nextTick(); // NOTE: wait for window.path_prefix to be set
     await loadResource(window.path_prefix + `${this.resource_path}/leaflet/leaflet.css`);
-    await Promise.all(this.additional_resources.map((resource) => loadResource(resource)));
     window.L = L;
+    await Promise.all(this.additional_resources.map((resource) => loadResource(resource)));
     if (this.draw_control) {
       await Promise.all([
         loadResource(window.path_prefix + `${this.resource_path}/leaflet-draw/leaflet.draw.css`),


### PR DESCRIPTION
### Motivation

Fix #5317, where `additional_resources` which hinges on `window.L` availability breaks. 

### Implementation

Looking back at #5281, I've set `window.L = L` too late 🤡 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

P.S.: @jacksonhshields I apologize for the jumping-to-conclusion but I was on a bus back then. This should fix your issue. 