### PR TITLE
Allow toggling line wrap in `ui.codemirror`

### DIFF
--- a/nicegui/elements/codemirror/codemirror.js
+++ b/nicegui/elements/codemirror/codemirror.js
@@ -23,6 +23,9 @@ export default {
     disable(newDisable) {
       this.setDisabled(newDisable);
     },
+    lineWrapping(newLineWrapping) {
+      this.setLineWrapping(newLineWrapping);
+    },
   },
   data() {
     return {
@@ -104,6 +107,11 @@ export default {
         effects: this.editableConfig.reconfigure(this.editableStates[!disabled]),
       });
     },
+    setLineWrapping(wrap) {
+      this.editor.dispatch({
+        effects: this.lineWrappingConfig.reconfigure(wrap ? [CM.EditorView.lineWrapping] : []),
+      });
+    },
     setupExtensions() {
       const self = this;
 
@@ -133,13 +141,13 @@ export default {
         this.themeConfig.of([]),
         this.languageConfig.of([]),
         this.editableConfig.of([]),
+        this.lineWrappingConfig.of([]),
         CM.EditorView.theme({
           "&": { height: "100%" },
           ".cm-scroller": { overflow: "auto" },
         }),
       ];
 
-      if (this.lineWrapping) extensions.push(CM.EditorView.lineWrapping);
       if (this.highlightWhitespace) extensions.push([CM.highlightWhitespace()]);
 
       return extensions;
@@ -156,6 +164,7 @@ export default {
     this.languageConfig = new CM.Compartment();
     this.editableConfig = new CM.Compartment();
     this.editableStates = { true: CM.EditorView.editable.of(true), false: CM.EditorView.editable.of(false) };
+    this.lineWrappingConfig = new CM.Compartment();
 
     const extensions = this.setupExtensions();
 
@@ -170,5 +179,6 @@ export default {
     this.setLanguage(this.language);
     this.setTheme(this.theme);
     this.setDisabled(this.disable);
+    this.setLineWrapping(this.lineWrapping);
   },
 };

--- a/nicegui/elements/codemirror/codemirror.py
+++ b/nicegui/elements/codemirror/codemirror.py
@@ -332,6 +332,25 @@ class CodeMirror(ValueElement, DisableableElement,
         """List of supported languages."""
         return list(get_args(SUPPORTED_LANGUAGES))
 
+    @property
+    def line_wrapping(self) -> bool:
+        """Whether line wrapping is enabled
+
+        *Added in version 3.2.0*
+        """
+        return self._props['lineWrapping']
+
+    @line_wrapping.setter
+    def line_wrapping(self, value: bool) -> None:
+        self._props['lineWrapping'] = value
+
+    def set_line_wrapping(self, value: bool) -> None:
+        """Sets whether line wrapping is enabled.
+
+        *Added in version 3.2.0*
+        """
+        self._props['lineWrapping'] = value
+
     def _event_args_to_value(self, e: GenericEventArguments) -> str:
         """The event contains a change set which is applied to the current value."""
         return self._apply_change_set(e.args['sections'], e.args['inserted'])

--- a/website/documentation/content/codemirror_documentation.py
+++ b/website/documentation/content/codemirror_documentation.py
@@ -10,6 +10,8 @@ def main_demo() -> None:
         .classes('w-32').bind_value(editor, 'language')
     ui.select(editor.supported_themes, label='Theme') \
         .classes('w-32').bind_value(editor, 'theme')
+    ui.checkbox('Wrap Lines', value=editor.line_wrapping,
+                on_change=lambda e: editor.set_line_wrapping(e.value))
 
 
 doc.reference(ui.codemirror)


### PR DESCRIPTION
### Motivation

In #5341 we noticed that you can't change the line wrap setting after creating a `ui.codemirror` element.

### Implementation

This PR introduces a new property very similar to `language` and `theme`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation has been added.
