### PR TITLE
Add `fps` to `ui.scene` (3.0)

### DIFF
--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -552,6 +552,6 @@ export default {
     click_events: Array,
     drag_constraints: String,
     background_color: String,
-    fps: { type: Number, default: 20 },
+    fps: Number,
   },
 };

--- a/nicegui/elements/scene/scene.py
+++ b/nicegui/elements/scene/scene.py
@@ -61,6 +61,7 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
     def __init__(self,
                  width: int = 400,
                  height: int = 300,
+                 # DEPRECATED: enforce keyword-only arguments in NiceGUI 4.0
                  grid: Union[bool, tuple[int, int]] = True,
                  camera: Optional[SceneCamera] = None,
                  on_click: Optional[Handler[SceneClickEventArguments]] = None,
@@ -88,7 +89,7 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
         :param on_drag_end: callback to execute when a 3D object is dropped
         :param drag_constraints: comma-separated JavaScript expression for constraining positions of dragged objects (e.g. ``'x = 0, z = y / 2'``)
         :param background_color: background color of the scene (default: "#eee")
-        :param fps: target frame rate for the scene in frames per second (default: 20)
+        :param fps: target frame rate for the scene in frames per second (default: 20, *added in version 3.2.0*)
         """
         super().__init__()
         self._props['width'] = width

--- a/nicegui/elements/scene/scene_view.js
+++ b/nicegui/elements/scene/scene_view.js
@@ -157,6 +157,6 @@ export default {
     camera_type: String,
     camera_params: Object,
     scene_id: String,
-    fps: { type: Number, default: 20 },
+    fps: Number,
   },
 };

--- a/nicegui/elements/scene/scene_view.py
+++ b/nicegui/elements/scene/scene_view.py
@@ -20,6 +20,7 @@ class SceneView(Element, component='scene_view.js', default_classes='nicegui-sce
 
     def __init__(self,
                  scene: Scene,
+                 # DEPRECATED: enforce keyword-only arguments in NiceGUI 4.0
                  width: int = 400,
                  height: int = 300,
                  camera: Optional[SceneCamera] = None,
@@ -39,7 +40,7 @@ class SceneView(Element, component='scene_view.js', default_classes='nicegui-sce
         :param height: height of the canvas
         :param camera: camera definition, either instance of ``ui.scene.perspective_camera`` (default) or ``ui.scene.orthographic_camera``
         :param on_click: callback to execute when a 3D object is clicked
-        :param fps: target frame rate for the scene view in frames per second (default: 20)
+        :param fps: target frame rate for the scene view in frames per second (default: 20, *added in version 3.2.0*)
         """
         super().__init__()
         self._props['width'] = width

--- a/website/documentation/content/scene_documentation.py
+++ b/website/documentation/content/scene_documentation.py
@@ -5,7 +5,7 @@ from . import doc
 
 @doc.demo(ui.scene)
 def main_demo() -> None:
-    with ui.scene(fps=60).classes('w-full h-64') as scene:
+    with ui.scene().classes('w-full h-64') as scene:
         scene.axes_helper()
         scene.sphere().material('#4488ff').move(2, 2)
         scene.cylinder(1, 0.5, 2, 20).material('#ff8800', opacity=0.5).move(-2, 1)
@@ -59,21 +59,6 @@ def click_events() -> None:
     with ui.scene(width=285, height=220, on_click=handle_click) as scene:
         scene.sphere().move(x=-1, z=1).with_name('sphere')
         scene.box().move(x=1, z=1).with_name('box')
-
-
-@doc.demo('FPS configuration', '''
-    You can configure the target frames per second (FPS) of the scene using the `fps` argument.
-    The default value is 20. In the main demo you can see it has been set to 60 FPS.
-    The FPS is generally lower than the target frame rate, because the browser also takes some time to render the scene.
-    This also applies to `ui.scene_view`.
-''')
-def fps_configuration() -> None:
-    ui.label('Higher frame rate for the movable view')
-    with ui.scene(fps=40).classes('w-full h-32') as scene:
-        scene.sphere()
-    ui.label('Lower frame rate for the static view')
-    with ui.scene_view(scene, fps=5).classes('w-full h-32') as scene_view:
-        scene_view.move_camera(x=1, y=-3, z=5)
 
 
 @doc.demo('Context menu for 3D objects', '''
@@ -204,6 +189,25 @@ def scene_views():
 
         with ui.scene_view(scene).classes('h-32') as scene_view2:
             scene_view2.move_camera(x=0, y=4, z=3)
+
+
+@doc.demo('Frame Rate', '''
+    You can configure the target frames per second (FPS) of the scene using the `fps` argument.
+    The default value is 20.
+    This demo shows how to set the frame rate to 40 FPS for the main scene and 5 FPS for the static view.
+    The FPS is generally lower than the target frame rate, because the browser also takes some time to render the scene.
+    This also applies to `ui.scene_view`.
+
+    *Added in version 3.2.0*
+''')
+def fps_configuration() -> None:
+    ui.label('Higher frame rate for the movable view')
+    with ui.scene(fps=40).classes('w-full h-32') as scene:
+        scene.sphere()
+
+    ui.label('Lower frame rate for the static view')
+    with ui.scene_view(scene, fps=5).classes('w-full h-32') as scene_view:
+        scene_view.move_camera(x=1, y=-3, z=5)
 
 
 @doc.demo('Camera Parameters', '''


### PR DESCRIPTION
### Motivation

Who doesn't want more FPS than 20, but #4825 is too far gone as it is based off 2.x branch code...

### Implementation

- Replace `20` with `this.fps`
- Add `fps` option
- Add documentation

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation has been added.

-> Established in #4825 pytest is not necessary. 
