### PR TITLE
Fix typo in documentation leading to broken link

### DIFF
--- a/website/examples.py
+++ b/website/examples.py
@@ -74,5 +74,5 @@ examples: list[Example] = [
     Example('Google OAuth2', 'Authenticate with Google OAuth2'),
     Example('Stripe', 'Use Stripe to process payments'),
     Example('Xterm', 'Connect a terminal emulator [xterm.js](https://github.com/xtermjs/xterm.js) to a Bash process'),
-    Example('API Request', 'Fetch and display random quotes from [Zen Quotes API](https://zenquotes.io/)'),
+    Example('API Requests', 'Fetch and display random quotes from [Zen Quotes API](https://zenquotes.io/)'),
 ]


### PR DESCRIPTION
### Motivation

Fix #5347. 

Due to the fact that the example title is tied to the URL, we do not have freedom to change it to be whatever. 

So although "Example: API Requests" may sound worse, we might just have to do that for the link to work

### Implementation

It's a one-character change: Add a single `s`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

@falkoschindler Simple-win, consider merge ASAP to let docs work. 
