### PR TITLE
Mount `ui.xterm` in sync to avoid `this.terminal` undefined error

### DIFF
--- a/nicegui/elements/xterm/xterm.js
+++ b/nicegui/elements/xterm/xterm.js
@@ -17,10 +17,8 @@ export default {
         this.terminal[key]((e) => this.$emit(key.slice(2).toLowerCase(), e));
       });
 
-    this.$nextTick().then(() => {
-      // NOTE: wait for window.path_prefix to be set
-      loadResource(window.path_prefix + `${this.resource_path}/xterm.css`);
-    });
+    // NOTE: wait for window.path_prefix to be set
+    this.$nextTick().then(() => loadResource(window.path_prefix + `${this.resource_path}/xterm.css`));
   },
   methods: {
     getRows() {

--- a/website/documentation/content/xterm_documentation.py
+++ b/website/documentation/content/xterm_documentation.py
@@ -8,7 +8,7 @@ from . import doc
 @doc.demo(ui.xterm)
 def main_demo() -> None:
     terminal = ui.xterm({'cols': 30, 'rows': 9})
-    ui.timer(0.1, lambda: terminal.write('Hello NiceGUI!'), once=True)
+    ui.timer(0, lambda: terminal.write('Hello NiceGUI!'), once=True)
 
 
 @doc.demo('Using ANSI escape codes', '''


### PR DESCRIPTION
### Motivation

Fix #5343, where since the methods are sync but mount is async, we "mount too late" and methods cannot write to the terminal. 

### Implementation

Move from async mounted, into mounted. Since we're loading CSS we can load it whenever(TM), no need to block the rest of the mount logic. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

@falkoschindler The problem is indeed solved, but is going from async component back to sync component a breaking change? 
