### PR TITLE
Fix async demos

### DIFF
--- a/website/documentation/demo.py
+++ b/website/documentation/demo.py
@@ -24,7 +24,10 @@ def demo(f: Callable, *, lazy: bool = True, tab: Optional[Union[str, Callable]] 
 
                 async def handle_intersection():
                     window.remove(spinner)
-                    result = f()
+                    if helpers.is_coroutine_function(f):
+                        result = await f()
+                    else:
+                        result = f()
                     if callable(result):
                         if helpers.is_coroutine_function(result):
                             await result()


### PR DESCRIPTION
### Motivation

I noticed that some demos like https://nicegui.io/documentation/button#await_button_click are currently broken.
This is because PR #5275 started evaluating the return value of demo functions, but removed the handling of async demo functions.

### Implementation

This PR restores the check `helpers.is_coroutine_function(f)` while processing the result of `f()` as in PR #5275.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
