### PR TITLE
Add "convertEol" parameter to `ui.xterm` subprocess demo

### DIFF
--- a/website/documentation/content/xterm_documentation.py
+++ b/website/documentation/content/xterm_documentation.py
@@ -66,10 +66,13 @@ def connecting_to_subprocess():
     async def run_subprocess():
         button.disable()
         process = await asyncio.create_subprocess_exec(
-            'python3', '-c',
+            'python3', '-u', '-c',
             (
-                'import time; [print(f"\\r[{\'#\' * i}{\' \' * (10 - i)}] {i * 10}%", end="", flush=True) or '
-                'time.sleep(0.5) for i in range(11)]; print("\x1b[32m  Done!\x1b[0m")'
+                'import time\n'
+                'for i in range(5):\n'
+                '    print(f"Step {i+1}/5: Processing...")\n'
+                '    time.sleep(0.5)\n'
+                'print("\\x1b[32m✓ All steps completed!\\x1b[0m")'
             ),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,


### PR DESCRIPTION
### Motivation

In #5353 we noticed that the demo about `ui.xterm` with subprocesses should enable `convertEol` to avoid missing carriage returns.

### Implementation

This PR adds the parameter (even though it doesn't make a difference for the single-line output in this demo) and describes it briefly.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation has been added.
