### PR TITLE
Introduce `Screen.CATCH_JS_ERRORS`

### DIFF
--- a/nicegui/testing/screen.py
+++ b/nicegui/testing/screen.py
@@ -29,6 +29,7 @@ class Screen:
     PORT = 3392
     IMPLICIT_WAIT = 4
     SCREENSHOT_DIR = Path('screenshots')
+    CATCH_JS_ERRORS = True
 
     def __init__(self, selenium: webdriver.Chrome, caplog: pytest.LogCaptureFixture, request: Optional[pytest.FixtureRequest] = None) -> None:
         self.selenium = selenium

--- a/nicegui/testing/screen_plugin.py
+++ b/nicegui/testing/screen_plugin.py
@@ -98,7 +98,7 @@ def screen(nicegui_reset_globals,  # noqa: F811, pylint: disable=unused-argument
             screen_.shot(request.node.name, failed=test_failed or bool(logs))
         if logs:
             pytest.fail('There were unexpected ERROR logs.', pytrace=False)
-        if screen_.is_open:
+        if screen_.is_open and Screen.CATCH_JS_ERRORS:
             for js_error in screen_.selenium.get_log('browser'):
                 if str(js_error.get('level', '')).upper() in ('SEVERE', 'ERROR') and \
                         not any(allowed_error in js_error['message'] for allowed_error in screen_.allowed_js_errors):

--- a/website/documentation/content/screen_documentation.py
+++ b/website/documentation/content/screen_documentation.py
@@ -32,6 +32,16 @@ def screen_fixture():
         ''')
 
 
+doc.text('Configuration', '''
+    The `screen` fixture can be configured by setting the following static attributes:
+
+    - `PORT`: The port to use for the server (default: 3392).
+    - `IMPLICIT_WAIT`: The implicit wait time in seconds (default: 4).
+    - `SCREENSHOT_DIR`: The directory to store the screenshots (default: "screenshots").
+    - `CATCH_JS_ERRORS`: Whether to catch JavaScript errors (default: `True`, *added in version 3.2.0*).
+''')
+
+
 @doc.part('Web driver')
 def web_driver():
     ui.markdown('''


### PR DESCRIPTION
### Motivation

With PR #5225 being merged, users don't have an easy way to ignore JavaScript errors like before.

### Implementation

This PR adds a static `Screen.CATCH_JS_ERRORS` flag which can be set to `False` if needed.
Apart from that a new "Configuration" section also describes the three other static attributes.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation has been added.
