### PR TITLE
`renderMermaid` don't error, before Mermaid loads (anti-race-condition)

### DIFF
--- a/nicegui/elements/markdown.js
+++ b/nicegui/elements/markdown.js
@@ -22,6 +22,7 @@ export default {
   },
   methods: {
     renderMermaid() {
+      if (!this.use_mermaid || !this.mermaid) return;
       // render new diagrams
       const usedKeys = new Set();
       this.$el.querySelectorAll(".mermaid-pre").forEach(async (pre, i) => {


### PR DESCRIPTION
### Motivation

Falko spotted the following error in the console which would indicate the flaky Mermaid test is actually the result of a race condition. 

```
ERROR tests/test_markdown.py::test_markdown_with_mermaid - Failed: JavaScript console error:
{'level': 'SEVERE', 'message': "http://localhost:3392/_nicegui/3.0.0/components/bdd7c6216b0d44b23fee7cbbdd8aa186/markdown.js 33:52 Uncaught TypeError: Cannot read properties of null (reading 'render')", 'source': 'javascript', 'timestamp': 1761642484613}
```

### Implementation

See, `.render` is called inside `renderMermaid`. If that is called before the Mermaid loads in, which could happen, then the error in the screen occurs. 

In my implementation, I just made `this.renderMermaid` fall through if Mermaid isn't loaded or isn't enabled (so is markdown right now generating JS errors when mermaid is disabled and content is update? hmm 🤔)

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Extra notes

Simulate a race condition with the below:

<img width="715" height="228" alt="image" src="https://github.com/user-attachments/assets/9d899db8-dcd8-4efd-b61f-2f5072c21b10" />
