### PR TITLE
Remove `beforeDestroy` in place of `beforeUnmount` (complete the Vue 3 migration)

### DIFF
--- a/nicegui/elements/echart/echart.js
+++ b/nicegui/elements/echart/echart.js
@@ -81,9 +81,6 @@ export default {
 
     this.update_chart();
   },
-  beforeDestroy() {
-    this.chart.dispose();
-  },
   beforeUnmount() {
     this.chart.dispose();
   },

--- a/nicegui/elements/json_editor/json_editor.js
+++ b/nicegui/elements/json_editor/json_editor.js
@@ -16,9 +16,6 @@ export default {
       props: this.properties,
     });
   },
-  beforeDestroy() {
-    this.destroyEditor();
-  },
   beforeUnmount() {
     this.destroyEditor();
   },

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -235,7 +235,7 @@ export default {
     }, 100);
   },
 
-  beforeDestroy() {
+  beforeUnmount() {
     window.removeEventListener("resize", this.resize);
     window.removeEventListener("DOMContentLoaded", this.resize);
   },

--- a/nicegui/elements/scene/scene_view.js
+++ b/nicegui/elements/scene/scene_view.js
@@ -101,7 +101,7 @@ export default {
     }, 100);
   },
 
-  beforeDestroy() {
+  beforeUnmount() {
     window.removeEventListener("resize", this.resize);
     window.removeEventListener("DOMContentLoaded", this.resize);
   },


### PR DESCRIPTION
### Motivation

@falkoschindler initially spotted beforeDestroy in the codebase which should not exist since we're using Vue 3. 

https://github.com/zauberzeug/nicegui/pull/5369#issuecomment-3460665023

NiceGUI v1.0.0 may not be that complete in the migration to Vue 3... https://github.com/zauberzeug/nicegui/releases/tag/v1.0.0

### Implementation

Follow https://v3-migration.vuejs.org/breaking-changes/vnode-lifecycle-events.html#migration-strategy

`beforeDestroy` -> `beforeUnmount` everywhere. 

For `ui.echart` and `ui.json_editor` since the functions are duplicate, just delete. For `ui.scene` and `ui.scene_view` apply rename. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Additional notes

**Not sure if Vue 3 still executes `beforeDestroy`, so potentially we may have a client-side memory leak for `ui.scene` and `ui.scene_view`** so I think this is a **medium** or above. 
