### PR TITLE
Don't auto-resize `ui.plotly` if `responsive === false`

### DIFF
--- a/nicegui/elements/plotly/plotly.vue
+++ b/nicegui/elements/plotly/plotly.vue
@@ -9,7 +9,10 @@ export default {
     this.Plotly = Plotly;
     this.update();
     this.$nextTick(() => {
-      this.resizeObserver = new ResizeObserver(() => this.Plotly.Plots.resize(this.$el));
+      this.resizeObserver = new ResizeObserver(() => {
+        if (this.options.config?.responsive === false) return;
+        this.Plotly.Plots.resize(this.$el);
+      });
       this.resizeObserver.observe(this.$el);
     });
   },


### PR DESCRIPTION
### Motivation

With PR #5369 `ui.plotly will auto-resize even if the "responsive" option is set to `False`:
```py
ui.plotly({'config': {'responsive': False}}).classes('w-full')
```

### Implementation

This PR conditionally early-exits the auto-resize callback if the user opted-out the "responsive" configuration.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
