### PR TITLE
Avoid conflict between `responsive` and `resizeObserver`

### DIFF
--- a/nicegui/elements/plotly/plotly.vue
+++ b/nicegui/elements/plotly/plotly.vue
@@ -29,8 +29,7 @@ export default {
 
       // default responsive to true
       const options = this.options;
-      if (options.config === undefined) options.config = { responsive: true };
-      if (options.config.responsive === undefined) options.config.responsive = true;
+      if (options.config?.responsive === true) options.config.responsive = undefined;
 
       // re-use plotly instance if config is the same
       if (JSON.stringify(options.config) == JSON.stringify(this.last_options.config)) {


### PR DESCRIPTION
### Motivation

In #4870 we observed a jumping button in combination with a Plotly element:
```py
ui.plotly(go.Figure())
ui.button('Change colormap', on_click=plot.update)
```
As it turns out, it is caused by Plotly's "responsive" setting which causes the plot to shrink to size 0x0.

### Implementation

This PR removes the "responsive" setting if it is `true`. In this case our `resizeObserver` from PR #5369 handles the change of the container size anyway and would conflict with this setting.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
