### PR TITLE
Let pywebview create a storage path if needed

### DIFF
--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -5,7 +5,6 @@ import multiprocessing as mp
 import queue
 import socket
 import sys
-import tempfile
 import time
 import warnings
 from threading import Event, Thread
@@ -48,9 +47,7 @@ def _open_window(
     closed = Event()
     window.events.closed += closed.set
     _start_window_method_executor(window, method_queue, response_queue, closed)
-    if not core.app.native.start_args.get('private_mode', True) and 'storage_path' not in core.app.native.start_args:
-        log.warning('Pass in a `storage_path` to properly disable `private_mode` for the native app.')
-    webview.start(**{'storage_path': tempfile.mkdtemp(), **core.app.native.start_args})
+    webview.start(**core.app.native.start_args)
 
 
 def _start_window_method_executor(window: webview.Window,


### PR DESCRIPTION
### Motivation

In #4882 we noticed problems with NiceGUI's random storage path for native apps based on `tempfile.mkdtemp()`. A bad path can cause `0x8000FFFF` WebView2 errors when calling `webview.start()`.

### Implementation

This PR removes our custom storage path and relies on webview's default. This kind of contradicts our discussion in #4805 where we hesitated to leave it up to pywebview. But experiments show that storage works as expected with privacy mode (the default) and without, even with multiple app instances.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
