### PR TITLE
`props._set_and_warn`: NiceGUI take precedence, nicely

### DIFF
--- a/nicegui/elements/mixins/color_elements.py
+++ b/nicegui/elements/mixins/color_elements.py
@@ -23,7 +23,7 @@ class BackgroundColorElement(Element):
     def __init__(self, *, background_color: Optional[str], **kwargs: Any) -> None:
         super().__init__(**kwargs)
         if background_color in QUASAR_COLORS:
-            self._props[self.BACKGROUND_COLOR_PROP] = background_color
+            self._props._set_and_warn(self.BACKGROUND_COLOR_PROP, background_color)
         elif background_color in TAILWIND_COLORS:
             self._classes.append(f'bg-{background_color}')
         elif background_color is not None:

--- a/nicegui/elements/tabs.py
+++ b/nicegui/elements/tabs.py
@@ -76,8 +76,8 @@ class TabPanels(ValueElement):
         super().__init__(tag='q-tab-panels', value=value, on_value_change=on_change)
         if tabs is not None:
             tabs.bind_value(self, 'value')
-        self._props['animated'] = animated
-        self._props['keep-alive'] = keep_alive
+        self._props._set_and_warn('animated', animated)
+        self._props._set_and_warn('keep-alive', keep_alive)
 
     def _value_to_model_value(self, value: Any) -> Any:
         return value.props['name'] if isinstance(value, (Tab, TabPanel)) else value

--- a/nicegui/props.py
+++ b/nicegui/props.py
@@ -138,3 +138,9 @@ class Props(ObservableDict, Generic[T]):
                     props[key] = True
 
         return props
+
+    def _set_and_warn(self, key: str, value: Any) -> None:
+        if key in self:
+            helpers.warn_once(
+                f"Conflict in {str(self.element).partition(' ')[0]}.props['{key}']: User set '{self[key]}', but NiceGUI set '{value}' instead. Please use the Python API.")
+        self[key] = value


### PR DESCRIPTION
### Motivation

**TL-DR: Stand weak and we're no longer nice. Stand strong but warn.** 

After reviewing #5423 and #4857 with a new perspective, I have come to realize:

1. 👍 What makes NiceGUI nice is its Python API, that's _beautiful_, _pythonic_ and _well-documented_. 
2. 👎 What makes NiceGUI nice is NOT `.props` and `.default_props`, that's _ugly_ (to be clear: not Quasar's fault). 
3. 👍 What makes NiceGUI un-nice is NOT that we override user's props. We should do it otherwise we endorse (2).
4. 👎 What makes NiceGUI un-nice is that we override user's props _without telling them_, leading to head-scratchers like #5423.  

(read the above **carefully**, it's a brain-teaser)

So, instead of thinking hard in #4857's mentality to honor user's props (let's be honest: `PRIMARY_UNLESS_OVERRIDDEN` is horrendous, so is `color: Union[None, str, EllipsisType] = ...` 🤢) **and** break existing code by changing our behaviour (so that's at least 4.0 if not later since this is one big change and need time to deprecate), we should double-down on our (arguably correct) existing behaviour and inform the user as to what is going on. Hence this PR. 

### Implementation

This PR introduces `_set_and_warn`. As seen from the private method, it is intended for library use only. 

When the library use it, should there be user-set prop (not even a conflict), messages will show, informing the user to use the Python API. 

Reason why we show despite no conflict is, since NiceGUI will override user, we want to inform user early, instead of user wonder "why primary is OK but everything else not". 

### Results

Obviously I have not applied it to every element, but it works for `ui.button` (#4857) and `ui.tab_panels` (#5203)

```py
from nicegui import ui

ui.button.default_props('color="secondary"')
ui.tab_panels.default_props('animated=false')

ui.button()
ui.tab_panels()

ui.run()
```

Console will have: 

```
Conflict in Button.props['color']: User set 'secondary', but NiceGUI set 'primary' instead. Please use the Python API.
Conflict in TabPanels.props['animated']: User set 'false', but NiceGUI set 'True' instead. Please use the Python API.
```

Which _should_ prompt the user to do the following instead:

```py
ui.button(color='secondary')
ui.tab_panels(animated=False)
```

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] The implementation is complete.
  - [ ] Have we covered ALL NiceGUI library code? Require @falkoschindler or @rodja's review
- [ ] Pytests have been added (or are not necessary).
- [x] Documentation is not necessary (error message self-explanatory...)

### PS

We do lack a Python API for setting defaults which persist across Python-land, but that is a non-blocking item and should go to the NiceGUI wishlist. 

And you can always do: 

```py
def my_secondary_button():
    return ui.button(color='secondary')
```
