### PR TITLE
Fix spurious ui.table "found list in column" warnings

### DIFF
--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -113,7 +113,7 @@ class Table(FilterElement, component='table.js'):
                 value = row.get(field)
                 if isinstance(value, (list, set, tuple)):
                     log.warning(
-                        f'Found list in column "{field}": {value}.\n'
+                        f'Found list in column "{name}": {value}.\n'
                         'Unless there is slot template, table rows must not contain lists or the browser will crash.\n'
                         'NiceGUI is intervening by adding a slot template to display the list as comma-separated values.'
                     )


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->

Follow-up to #5290. Unfortunately, QTable's slots `body-cell-[name]` actually refers to column names, not column fields. This discrepancy caused a spurious "found list in column" warning (and unnecessary slot addition) for columns that have custom slots defined already.

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->
<!-- Include any important technical decisions or trade-offs made -->

Just a simple one-line fix.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
