### PR TITLE
Plotly `this.last_options_set`: fix wrongful re-use plotly instance on first-spawn

### DIFF
--- a/nicegui/elements/plotly/plotly.vue
+++ b/nicegui/elements/plotly/plotly.vue
@@ -32,7 +32,7 @@ export default {
       if (options.config?.responsive === true) options.config.responsive = undefined;
 
       // re-use plotly instance if config is the same
-      if (this.last_options_set && JSON.stringify(options.config) == JSON.stringify(this.last_options.config)) {
+      if (this.last_options && JSON.stringify(options.config) === JSON.stringify(this.last_options.config)) {
         this.Plotly.react(this.$el, this.options, options.config);
       } else {
         this.Plotly.newPlot(this.$el, this.options, options.config);
@@ -41,7 +41,6 @@ export default {
 
       // store last options
       this.last_options = options;
-      this.last_options_set = true;
     },
     set_handlers() {
       // forward events
@@ -83,8 +82,7 @@ export default {
   },
   data() {
     return {
-      last_options: {},
-      last_options_set: false,
+      last_options: null,
     };
   },
   props: {


### PR DESCRIPTION
### Motivation

A logic error in value change check in `ui.plotly` revealed itself with #5404, which instead of force-set `options.config = { responsive: true }` on behalf of user, force-unsets it instead. 

### Implementation

Since `this.last_options.config` is undefined at first, `if (JSON.stringify(options.config) == JSON.stringify(this.last_options.config))` is not a sufficient check in the case that `this.options.config` is also undefined, which with #5404 is the likely possibility. 

I added `this.last_options_set` to force the first time render to always false the if-condition and so `this.set_handlers();` is ran. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary
  - I am considering to add regression tests, but #5459 is a critical. 
- [x] Documentation is not necessary.
