### PR TITLE
Write all union types as X | Y (PEP 604)

### DIFF
--- a/examples/audio_recorder/audio_recorder.py
+++ b/examples/audio_recorder/audio_recorder.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 import base64
-from typing import Callable, Optional
+from typing import Callable
 
 from nicegui import events, ui
 
 
 class AudioRecorder(ui.element, component='audio_recorder.vue'):
 
-    def __init__(self, *, on_audio_ready: Optional[Callable] = None) -> None:
+    def __init__(self, *, on_audio_ready: Callable | None = None) -> None:
         super().__init__()
         self.recording = b''
 

--- a/examples/authentication/main.py
+++ b/examples/authentication/main.py
@@ -5,7 +5,7 @@ Please see the `OAuth2 example at FastAPI <https://fastapi.tiangolo.com/tutorial
 use the great `Authlib package <https://docs.authlib.org/en/v0.13/client/starlette.html#using-fastapi>`_ to implement a classing real authentication system.
 Here we just demonstrate the NiceGUI integration.
 """
-from typing import Optional
+from __future__ import annotations
 
 from fastapi import Request
 from fastapi.responses import RedirectResponse
@@ -52,7 +52,7 @@ def test_page() -> None:
 
 
 @ui.page('/login')
-def login(redirect_to: str = '/') -> Optional[RedirectResponse]:
+def login(redirect_to: str = '/') -> RedirectResponse | None:
     def try_login() -> None:  # local function to avoid passing username and password as arguments
         if passwords.get(username.value) == password.value:
             app.storage.user.update({'username': username.value, 'authenticated': True})

--- a/examples/custom_binding/main.py
+++ b/examples/custom_binding/main.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import random
-from typing import Optional, cast
+from typing import cast
 
 from typing_extensions import Self
 
@@ -17,7 +19,7 @@ class colorful_label(ui.label):
 
     def __init__(self, text: str = '') -> None:
         super().__init__(text)
-        self.background: Optional[str] = None  # initialize the background property
+        self.background: str | None = None  # initialize the background property
 
     def _handle_background_change(self, bg_class: str) -> None:
         """Update the classes of the label when the background property changes."""

--- a/examples/custom_vue_component/counter.py
+++ b/examples/custom_vue_component/counter.py
@@ -1,11 +1,13 @@
-from typing import Callable, Optional
+from __future__ import annotations
+
+from typing import Callable
 
 from nicegui.element import Element
 
 
 class Counter(Element, component='counter.js'):
 
-    def __init__(self, title: str, *, on_change: Optional[Callable] = None) -> None:
+    def __init__(self, title: str, *, on_change: Callable | None = None) -> None:
         super().__init__()
         self._props['title'] = title
         self.on('change', on_change)

--- a/examples/custom_vue_component/on_off.py
+++ b/examples/custom_vue_component/on_off.py
@@ -1,11 +1,13 @@
-from typing import Callable, Optional
+from __future__ import annotations
+
+from typing import Callable
 
 from nicegui.element import Element
 
 
 class OnOff(Element, component='on_off.vue'):
 
-    def __init__(self, title: str, *, on_change: Optional[Callable] = None) -> None:
+    def __init__(self, title: str, *, on_change: Callable | None = None) -> None:
         super().__init__()
         self._props['title'] = title
         self.on('change', on_change)

--- a/examples/fullcalendar/fullcalendar.py
+++ b/examples/fullcalendar/fullcalendar.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from nicegui.element import Element
 from nicegui.events import handle_event
@@ -7,7 +9,7 @@ from nicegui.events import handle_event
 
 class FullCalendar(Element, component='fullcalendar.js'):
 
-    def __init__(self, options: dict[str, Any], on_click: Optional[Callable] = None) -> None:
+    def __init__(self, options: dict[str, Any], on_click: Callable | None = None) -> None:
         """FullCalendar
 
         An element that integrates the FullCalendar library (https://fullcalendar.io/) to create an interactive calendar display.

--- a/examples/google_oauth2/main.py
+++ b/examples/google_oauth2/main.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import logging
 import time
-from typing import Optional
 
 from authlib.integrations.starlette_client import OAuth, OAuthError
 from fastapi import Request
@@ -28,7 +29,7 @@ oauth.register(
 
 
 @ui.page('/')
-async def main(request: Request) -> Optional[RedirectResponse]:
+async def main(request: Request) -> RedirectResponse | None:
     user_info = app.storage.user.get('user_info', {})
     if not _is_valid(user_info):
         app.storage.user.pop('user_info', None)

--- a/examples/local_file_picker/local_file_picker.py
+++ b/examples/local_file_picker/local_file_picker.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import platform
 from pathlib import Path
-from typing import Optional
 
 from nicegui import events, ui
 
@@ -8,7 +9,7 @@ from nicegui import events, ui
 class local_file_picker(ui.dialog):
 
     def __init__(self, directory: str, *,
-                 upper_limit: Optional[str] = ..., multiple: bool = False, show_hidden_files: bool = False) -> None:
+                 upper_limit: str | None = ..., multiple: bool = False, show_hidden_files: bool = False) -> None:
         """Local File Picker
 
         This is a simple file picker that allows you to select a file from the local filesystem where NiceGUI is running.

--- a/examples/search_as_you_type/main.py
+++ b/examples/search_as_you_type/main.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import asyncio
-from typing import Optional
 
 import httpx
 
 from nicegui import events, ui
 
 api = httpx.AsyncClient()
-running_query: Optional[asyncio.Task] = None
+running_query: asyncio.Task | None = None
 
 
 async def search(e: events.ValueChangeEventArguments) -> None:

--- a/examples/signature_pad/signature_pad.py
+++ b/examples/signature_pad/signature_pad.py
@@ -1,11 +1,11 @@
-from typing import Optional
+from __future__ import annotations
 
 from nicegui import ui
 
 
 class SignaturePad(ui.element, component='signature_pad.js', esm={'signature_pad': 'dist'}):
 
-    def __init__(self, options: Optional[dict] = None) -> None:
+    def __init__(self, options: dict | None = None) -> None:
         """SignaturePad
 
         An element that integrates the `Signature Pad library <https://szimek.github.io/signature_pad/>`_.

--- a/examples/simpy/async_realtime_environment.py
+++ b/examples/simpy/async_realtime_environment.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import asyncio
 from time import monotonic
-from typing import Any, Optional, Union
+from typing import Any
 
 from simpy.core import EmptySchedule, Environment, Infinity, SimTime, StopSimulation
 from simpy.events import URGENT, Event
@@ -50,8 +52,8 @@ class AsyncRealtimeEnvironment(RealtimeEnvironment):
         Environment.step(self)
 
     async def run(
-        self, until: Optional[Union[SimTime, Event]] = None
-    ) -> Optional[Any]:
+        self, until: None | SimTime | Event = None
+    ) -> Any | None:
         """Executes :meth:`step()` until the given criterion *until* is met.
 
         - If it is ``None`` (which is the default), this method will return

--- a/examples/vue_vite/vue_vite/counters.py
+++ b/examples/vue_vite/vue_vite/counters.py
@@ -1,11 +1,13 @@
-from typing import Callable, Optional
+from __future__ import annotations
+
+from typing import Callable
 
 from nicegui import ui
 
 
 class CounterOptions(ui.element, component='components/CounterOptions.js'):
 
-    def __init__(self, title: str, *, on_change: Optional[Callable] = None) -> None:
+    def __init__(self, title: str, *, on_change: Callable | None = None) -> None:
         super().__init__()
         self._props['title'] = title
         self.on('change', on_change)
@@ -16,7 +18,7 @@ class CounterOptions(ui.element, component='components/CounterOptions.js'):
 
 class CounterComposition(ui.element, component='components/CounterComposition.js'):
 
-    def __init__(self, title: str, *, on_change: Optional[Callable] = None) -> None:
+    def __init__(self, title: str, *, on_change: Callable | None = None) -> None:
         super().__init__()
         self._props['title'] = title
         self.on('change', on_change)

--- a/nicegui/api_router.py
+++ b/nicegui/api_router.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Optional, Union
 
 import fastapi
 
@@ -10,10 +12,10 @@ class APIRouter(fastapi.APIRouter):
 
     def page(self,
              path: str, *,
-             title: Optional[str] = None,
-             viewport: Optional[str] = None,
-             favicon: Optional[Union[str, Path]] = None,
-             dark: Optional[bool] = ...,  # type: ignore
+             title: str | None = None,
+             viewport: str | None = None,
+             favicon: str | Path | None = None,
+             dark: bool | None = ...,  # type: ignore
              response_timeout: float = 3.0,
              **kwargs,
              ) -> Callable:

--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import asyncio
 import inspect
 import os
 import platform
 import signal
 import urllib
-from collections.abc import Awaitable, Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Optional, Union
+from typing import Any
 
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import FileResponse
@@ -42,13 +44,13 @@ class App(FastAPI):
         self._state: State = State.STOPPED
         self.config = AppConfig()
 
-        self._startup_handlers: list[Union[Callable[..., Any], Awaitable]] = []
-        self._shutdown_handlers: list[Union[Callable[..., Any], Awaitable]] = []
-        self._connect_handlers: list[Union[Callable[..., Any], Awaitable]] = []
-        self._disconnect_handlers: list[Union[Callable[..., Any], Awaitable]] = []
-        self._delete_handlers: list[Union[Callable[..., Any], Awaitable]] = []
+        self._startup_handlers: list[Callable[..., Any] | Awaitable] = []
+        self._shutdown_handlers: list[Callable[..., Any] | Awaitable] = []
+        self._connect_handlers: list[Callable[..., Any] | Awaitable] = []
+        self._disconnect_handlers: list[Callable[..., Any] | Awaitable] = []
+        self._delete_handlers: list[Callable[..., Any] | Awaitable] = []
         self._exception_handlers: list[Callable[..., Any]] = [log.exception]
-        self._page_exception_handler: Optional[Callable[..., Any]] = None
+        self._page_exception_handler: Callable[..., Any] | None = None
 
     @property
     def is_starting(self) -> bool:
@@ -91,7 +93,7 @@ class App(FastAPI):
                     await result
         self._state = State.STOPPED
 
-    def safe_invoke(self, func: Union[Callable[..., Any], Awaitable]) -> None:
+    def safe_invoke(self, func: Callable[..., Any] | Awaitable) -> None:
         """Invoke the potentially async function and catch any exceptions."""
         func_name = func.__name__ if hasattr(func, '__name__') else str(func)
         try:
@@ -108,14 +110,14 @@ class App(FastAPI):
         except Exception as e:
             self.handle_exception(e)
 
-    def on_connect(self, handler: Union[Callable, Awaitable]) -> None:
+    def on_connect(self, handler: Callable | Awaitable) -> None:
         """Called every time a new client connects to NiceGUI.
 
         The callback has an optional parameter of `nicegui.Client`.
         """
         self._connect_handlers.append(handler)
 
-    def on_disconnect(self, handler: Union[Callable, Awaitable]) -> None:
+    def on_disconnect(self, handler: Callable | Awaitable) -> None:
         """Called every time a new client disconnects from NiceGUI.
 
         The callback has an optional parameter of `nicegui.Client`.
@@ -124,7 +126,7 @@ class App(FastAPI):
         """
         self._disconnect_handlers.append(handler)
 
-    def on_delete(self, handler: Union[Callable, Awaitable]) -> None:
+    def on_delete(self, handler: Callable | Awaitable) -> None:
         """Called when a client is deleted.
 
         The callback has an optional parameter of `nicegui.Client`.
@@ -133,7 +135,7 @@ class App(FastAPI):
         """
         self._delete_handlers.append(handler)
 
-    def on_startup(self, handler: Union[Callable, Awaitable]) -> None:
+    def on_startup(self, handler: Callable | Awaitable) -> None:
         """Called when NiceGUI is started or restarted.
 
         Needs to be called before `ui.run()`.
@@ -144,7 +146,7 @@ class App(FastAPI):
             raise RuntimeError('Unable to register another startup handler. NiceGUI has already been started.')
         self._startup_handlers.append(handler)
 
-    def on_shutdown(self, handler: Union[Callable, Awaitable]) -> None:
+    def on_shutdown(self, handler: Callable | Awaitable) -> None:
         """Called when NiceGUI is shut down or restarted.
 
         When NiceGUI is shut down or restarted, all tasks still in execution will be automatically canceled.
@@ -190,7 +192,7 @@ class App(FastAPI):
 
     def add_static_files(self,
                          url_path: str,
-                         local_directory: Union[str, Path],
+                         local_directory: str | Path,
                          *,
                          follow_symlink: bool = False,
                          max_cache_age: int = 3600) -> None:
@@ -222,8 +224,8 @@ class App(FastAPI):
             return await handler.get_response(path, request.scope)
 
     def add_static_file(self, *,
-                        local_file: Union[str, Path],
-                        url_path: Optional[str] = None,
+                        local_file: str | Path,
+                        url_path: str | None = None,
                         single_use: bool = False,
                         strict: bool = True,
                         max_cache_age: int = 3600) -> str:
@@ -258,7 +260,7 @@ class App(FastAPI):
 
         return urllib.parse.quote(path)
 
-    def add_media_files(self, url_path: str, local_directory: Union[str, Path]) -> None:
+    def add_media_files(self, url_path: str, local_directory: str | Path) -> None:
         """Add directory of media files.
 
         `add_media_files()` allows a local files to be streamed from a specified endpoint, e.g. `'/media'`.
@@ -280,8 +282,8 @@ class App(FastAPI):
             return get_range_response(filepath, request, chunk_size=nicegui_chunk_size)
 
     def add_media_file(self, *,
-                       local_file: Union[str, Path],
-                       url_path: Optional[str] = None,
+                       local_file: str | Path,
+                       url_path: str | None = None,
                        single_use: bool = False,
                        strict: bool = True) -> str:
         """Add a single media file.

--- a/nicegui/app/app_config.py
+++ b/nicegui/app/app_config.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Literal
 
 from ..dataclasses import KWONLY_SLOTS
 from ..language import Language
@@ -32,8 +34,8 @@ class AppConfig:
     reload: bool = field(init=False)
     title: str = field(init=False)
     viewport: str = field(init=False)
-    favicon: Optional[Union[str, Path]] = field(init=False)
-    dark: Optional[bool] = field(init=False)
+    favicon: str | Path | None = field(init=False)
+    dark: bool | None = field(init=False)
     language: Language = field(init=False)
     binding_refresh_interval: float = field(init=False)
     reconnect_timeout: float = field(init=False)
@@ -49,8 +51,8 @@ class AppConfig:
                        reload: bool,
                        title: str,
                        viewport: str,
-                       favicon: Optional[Union[str, Path]],
-                       dark: Optional[bool],
+                       favicon: str | Path | None,
+                       dark: bool | None,
                        language: Language,
                        binding_refresh_interval: float,
                        reconnect_timeout: float,

--- a/nicegui/awaitable_response.py
+++ b/nicegui/awaitable_response.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 from . import background_tasks
 

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Coroutine, Generator
-from typing import Any, Callable, TypeVar, cast
+from collections.abc import Awaitable, Callable, Coroutine, Generator
+from typing import Any, TypeVar, cast
 
 from . import core
 from .logging import log

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -6,9 +6,9 @@ import dataclasses
 import time
 import weakref
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from typing_extensions import dataclass_transform
 

--- a/nicegui/classes.py
+++ b/nicegui/classes.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import weakref
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from .observables import ObservableList
 
@@ -43,10 +45,10 @@ class Classes(ObservableList, Generic[T]):
             element.update()
 
     def __call__(self,
-                 add: Optional[str] = None, *,
-                 remove: Optional[str] = None,
-                 toggle: Optional[str] = None,
-                 replace: Optional[str] = None) -> T:
+                 add: str | None = None, *,
+                 remove: str | None = None,
+                 toggle: str | None = None,
+                 replace: str | None = None) -> T:
         """Apply, remove, toggle, or replace HTML classes.
 
         This allows modifying the look of the element or its layout using `Tailwind <https://tailwindcss.com/>`_ or `Quasar <https://quasar.dev/>`_ classes.
@@ -66,10 +68,10 @@ class Classes(ObservableList, Generic[T]):
 
     @staticmethod
     def update_list(classes: list[str],
-                    add: Optional[str] = None,
-                    remove: Optional[str] = None,
-                    toggle: Optional[str] = None,
-                    replace: Optional[str] = None) -> list[str]:
+                    add: str | None = None,
+                    remove: str | None = None,
+                    toggle: str | None = None,
+                    replace: str | None = None) -> list[str]:
         """Update a list of classes."""
         class_list = classes if replace is None else []
         class_list = [c for c in class_list if c not in (remove or '').split()]

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -5,9 +5,9 @@ import inspect
 import time
 import uuid
 from collections import defaultdict
-from collections.abc import Awaitable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from fastapi import Request
 from fastapi.responses import Response

--- a/nicegui/core.py
+++ b/nicegui/core.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from socketio import AsyncServer
 

--- a/nicegui/dependencies.py
+++ b/nicegui/dependencies.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from . import core
 from .dataclasses import KWONLY_SLOTS

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import inspect
 import re
 import weakref
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from copy import copy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from typing_extensions import Self
 

--- a/nicegui/elements/aggrid/aggrid.py
+++ b/nicegui/elements/aggrid/aggrid.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import importlib.util
-from typing import TYPE_CHECKING, Literal, Optional, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from typing_extensions import Self
 
@@ -23,7 +25,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
     def __init__(self,
                  options: dict, *,
                  html_columns: list[int] = [],  # noqa: B006
-                 theme: Optional[Literal['quartz', 'balham', 'material', 'alpine']] = None,
+                 theme: Literal['quartz', 'balham', 'material', 'alpine'] | None = None,
                  auto_size_columns: bool = True,
                  ) -> None:
         """AG Grid
@@ -49,9 +51,9 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
 
     @classmethod
     def from_pandas(cls,
-                    df: 'pd.DataFrame', *,
+                    df: pd.DataFrame, *,
                     html_columns: list[int] = [],  # noqa: B006
-                    theme: Optional[Literal['quartz', 'balham', 'material', 'alpine']] = None,
+                    theme: Literal['quartz', 'balham', 'material', 'alpine'] | None = None,
                     auto_size_columns: bool = True,
                     options: dict = {}) -> Self:  # noqa: B006
         """Create an AG Grid from a Pandas DataFrame.
@@ -96,9 +98,9 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
 
     @classmethod
     def from_polars(cls,
-                    df: 'pl.DataFrame', *,
+                    df: pl.DataFrame, *,
                     html_columns: list[int] = [],  # noqa: B006
-                    theme: Optional[Literal['quartz', 'balham', 'material', 'alpine']] = None,
+                    theme: Literal['quartz', 'balham', 'material', 'alpine'] | None = None,
                     auto_size_columns: bool = True,
                     options: dict = {}) -> Self:  # noqa: B006
         """Create an AG Grid from a Polars DataFrame.
@@ -142,12 +144,12 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         self._props['html_columns'] = value[:]
 
     @property
-    def theme(self) -> Optional[Literal['quartz', 'balham', 'material', 'alpine']]:
+    def theme(self) -> Literal['quartz', 'balham', 'material', 'alpine'] | None:
         """The AG Grid theme."""
         return self._props['options'].get('theme')
 
     @theme.setter
-    def theme(self, value: Optional[Literal['quartz', 'balham', 'material', 'alpine']]) -> None:
+    def theme(self, value: Literal['quartz', 'balham', 'material', 'alpine'] | None) -> None:
         self._props['options']['theme'] = value
 
     @property
@@ -207,7 +209,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         result = await self.run_grid_method('getSelectedRows')
         return cast(list[dict], result)
 
-    async def get_selected_row(self) -> Optional[dict]:
+    async def get_selected_row(self) -> dict | None:
         """Get the single currently selected row.
 
         This method is especially useful when the grid is configured with ``rowSelection: 'single'``.

--- a/nicegui/elements/audio.py
+++ b/nicegui/elements/audio.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Union
 
 from .mixins.source_element import SourceElement
 
@@ -7,7 +8,7 @@ from .mixins.source_element import SourceElement
 class Audio(SourceElement, component='audio.js'):
     SOURCE_IS_MEDIA_FILE = True
 
-    def __init__(self, src: Union[str, Path], *,
+    def __init__(self, src: str | Path, *,
                  controls: bool = True,
                  autoplay: bool = False,
                  muted: bool = False,
@@ -32,7 +33,7 @@ class Audio(SourceElement, component='audio.js'):
         self._props['muted'] = muted
         self._props['loop'] = loop
 
-    def set_source(self, source: Union[str, Path]) -> None:
+    def set_source(self, source: str | Path) -> None:
         return super().set_source(source)
 
     def seek(self, seconds: float) -> None:

--- a/nicegui/elements/avatar.py
+++ b/nicegui/elements/avatar.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from .mixins.color_elements import BackgroundColorElement, TextColorElement
 from .mixins.icon_element import IconElement
@@ -8,11 +8,11 @@ class Avatar(IconElement, BackgroundColorElement, TextColorElement):
     TEXT_COLOR_PROP = 'text-color'
 
     def __init__(self,
-                 icon: Optional[str] = None, *,
-                 color: Optional[str] = 'primary',
-                 text_color: Optional[str] = None,
-                 size: Optional[str] = None,
-                 font_size: Optional[str] = None,
+                 icon: str | None = None, *,
+                 color: str | None = 'primary',
+                 text_color: str | None = None,
+                 size: str | None = None,
+                 font_size: str | None = None,
                  square: bool = False,
                  rounded: bool = False,
                  ) -> None:

--- a/nicegui/elements/badge.py
+++ b/nicegui/elements/badge.py
@@ -1,4 +1,5 @@
-from typing import Optional
+
+from __future__ import annotations
 
 from .mixins.color_elements import BackgroundColorElement, TextColorElement
 from .mixins.text_element import TextElement
@@ -9,8 +10,8 @@ class Badge(TextElement, BackgroundColorElement, TextColorElement):
 
     def __init__(self,
                  text: str = '', *,
-                 color: Optional[str] = 'primary',
-                 text_color: Optional[str] = None,
+                 color: str | None = 'primary',
+                 text_color: str | None = None,
                  outline: bool = False) -> None:
         """Badge
 

--- a/nicegui/elements/button.py
+++ b/nicegui/elements/button.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import asyncio
-from typing import Optional
 
 from typing_extensions import Self
 
@@ -14,9 +15,9 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
 
     def __init__(self,
                  text: str = '', *,
-                 on_click: Optional[Handler[ClickEventArguments]] = None,
-                 color: Optional[str] = 'primary',
-                 icon: Optional[str] = None,
+                 on_click: Handler[ClickEventArguments] | None = None,
+                 color: str | None = 'primary',
+                 icon: str | None = None,
                  ) -> None:
         """Button
 

--- a/nicegui/elements/button_dropdown.py
+++ b/nicegui/elements/button_dropdown.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from typing_extensions import Self
 
@@ -15,12 +15,12 @@ class DropdownButton(IconElement, TextElement, DisableableElement, BackgroundCol
     def __init__(self,
                  text: str = '', *,
                  value: bool = False,
-                 on_value_change: Optional[Handler[ValueChangeEventArguments]] = None,
-                 on_click: Optional[Handler[ClickEventArguments]] = None,
-                 color: Optional[str] = 'primary',
-                 icon: Optional[str] = None,
-                 auto_close: Optional[bool] = False,
-                 split: Optional[bool] = False,
+                 on_value_change: Handler[ValueChangeEventArguments] | None = None,
+                 on_click: Handler[ClickEventArguments] | None = None,
+                 color: str | None = 'primary',
+                 icon: str | None = None,
+                 auto_close: bool | None = False,
+                 split: bool | None = False,
                  ) -> None:
         """Dropdown Button
 

--- a/nicegui/elements/card.py
+++ b/nicegui/elements/card.py
@@ -1,4 +1,6 @@
-from typing import Literal, Optional
+from __future__ import annotations
+
+from typing import Literal
 
 from typing_extensions import Self
 
@@ -8,7 +10,7 @@ from ..element import Element
 class Card(Element, default_classes='nicegui-card'):
 
     def __init__(self, *,
-                 align_items: Optional[Literal['start', 'end', 'center', 'baseline', 'stretch']] = None,
+                 align_items: Literal['start', 'end', 'center', 'baseline', 'stretch'] | None = None,
                  ) -> None:
         """Card
 

--- a/nicegui/elements/chat_message.py
+++ b/nicegui/elements/chat_message.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import html
-from typing import Callable, Literal
+from collections.abc import Callable
+from typing import Literal
 
 from .html import Html
 from .mixins.label_element import LabelElement

--- a/nicegui/elements/checkbox.py
+++ b/nicegui/elements/checkbox.py
@@ -1,4 +1,5 @@
-from typing import Optional
+
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -10,8 +11,8 @@ class Checkbox(TextElement, ValueElement, DisableableElement):
 
     def __init__(self,
                  text: str = '', *,
-                 value: Optional[bool] = False,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None) -> None:
+                 value: bool | None = False,
+                 on_change: Handler[ValueChangeEventArguments] | None = None) -> None:
         """Checkbox
 
         This element is based on Quasar's `QCheckbox <https://quasar.dev/vue-components/checkbox>`_ component.

--- a/nicegui/elements/chip.py
+++ b/nicegui/elements/chip.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from typing_extensions import Self
 
@@ -17,15 +17,15 @@ class Chip(IconElement, ValueElement, TextElement, BackgroundColorElement, TextC
     def __init__(self,
                  text: str = '',
                  *,
-                 icon: Optional[str] = None,
-                 color: Optional[str] = 'primary',
-                 text_color: Optional[str] = None,
-                 on_click: Optional[Handler[ClickEventArguments]] = None,
+                 icon: str | None = None,
+                 color: str | None = 'primary',
+                 text_color: str | None = None,
+                 on_click: Handler[ClickEventArguments] | None = None,
                  selectable: bool = False,
                  selected: bool = False,
-                 on_selection_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_selection_change: Handler[ValueChangeEventArguments] | None = None,
                  removable: bool = False,
-                 on_value_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_value_change: Handler[ValueChangeEventArguments] | None = None,
                  ) -> None:
         """Chip
 

--- a/nicegui/elements/choice_element.py
+++ b/nicegui/elements/choice_element.py
@@ -1,4 +1,6 @@
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.value_element import ValueElement
@@ -7,10 +9,10 @@ from .mixins.value_element import ValueElement
 class ChoiceElement(ValueElement):
 
     def __init__(self, *,
-                 tag: Optional[str] = None,
-                 options: Union[list, dict],
+                 tag: str | None = None,
+                 options: list | dict,
                  value: Any,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  ) -> None:
         self.options = options
         self._values: list[str] = []
@@ -38,7 +40,7 @@ class ChoiceElement(ValueElement):
             self._update_options()
         super().update()
 
-    def set_options(self, options: Union[list, dict], *, value: Any = ...) -> None:
+    def set_options(self, options: list | dict, *, value: Any = ...) -> None:
         """Set the options of this choice element.
 
         :param options: The new options.

--- a/nicegui/elements/code.py
+++ b/nicegui/elements/code.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import asyncio
 import time
-from typing import Optional
 
 from .button import Button as button
 from .markdown import Markdown as markdown
@@ -11,7 +12,7 @@ from .timer import Timer as timer
 
 class Code(ContentElement, component='code.js', default_classes='nicegui-code'):
 
-    def __init__(self, content: str = '', *, language: Optional[str] = 'python') -> None:
+    def __init__(self, content: str = '', *, language: str | None = 'python') -> None:
         """Code
 
         This element displays a code block with syntax highlighting.

--- a/nicegui/elements/codemirror/codemirror.py
+++ b/nicegui/elements/codemirror/codemirror.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from itertools import accumulate, chain, repeat
-from typing import Literal, Optional, get_args
+from typing import Literal, get_args
 
 from nicegui.elements.mixins.disableable_element import DisableableElement
 from nicegui.elements.mixins.value_element import ValueElement
@@ -256,8 +258,8 @@ class CodeMirror(ValueElement, DisableableElement,
         self,
         value: str = '',
         *,
-        on_change: Optional[Handler[ValueChangeEventArguments]] = None,
-        language: Optional[SUPPORTED_LANGUAGES] = None,
+        on_change: Handler[ValueChangeEventArguments] | None = None,
+        language: SUPPORTED_LANGUAGES | None = None,
         theme: SUPPORTED_THEMES = 'basicLight',
         indent: str = ' ' * 4,
         line_wrapping: bool = False,
@@ -320,10 +322,10 @@ class CodeMirror(ValueElement, DisableableElement,
         return self._props['language']
 
     @language.setter
-    def language(self, language: Optional[SUPPORTED_LANGUAGES] = None) -> None:
+    def language(self, language: SUPPORTED_LANGUAGES | None = None) -> None:
         self._props['language'] = language
 
-    def set_language(self, language: Optional[SUPPORTED_LANGUAGES] = None) -> None:
+    def set_language(self, language: SUPPORTED_LANGUAGES | None = None) -> None:
         """Sets the language of the editor (case-insensitive)."""
         self._props['language'] = language
 

--- a/nicegui/elements/color_input.py
+++ b/nicegui/elements/color_input.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import re
 from colorsys import rgb_to_yiq
-from typing import Any, Optional
+from typing import Any
 
 from ..events import Handler, ValueChangeEventArguments
 from .button import Button as button
@@ -17,10 +19,10 @@ class ColorInput(LabelElement, ValueElement, DisableableElement):
     LOOPBACK = False
 
     def __init__(self,
-                 label: Optional[str] = None, *,
-                 placeholder: Optional[str] = None,
+                 label: str | None = None, *,
+                 placeholder: str | None = None,
                  value: str = '',
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  preview: bool = False,
                  ) -> None:
         """Color Input

--- a/nicegui/elements/color_picker.py
+++ b/nicegui/elements/color_picker.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from typing_extensions import Self
 
@@ -10,7 +10,7 @@ from .menu import Menu
 class ColorPicker(Menu):
 
     def __init__(self, *,
-                 on_pick: Optional[Handler[ColorPickEventArguments]] = None,
+                 on_pick: Handler[ColorPickEventArguments] | None = None,
                  value: bool = False,
                  ) -> None:
         """Color Picker

--- a/nicegui/elements/column.py
+++ b/nicegui/elements/column.py
@@ -1,4 +1,6 @@
-from typing import Literal, Optional
+from __future__ import annotations
+
+from typing import Literal
 
 from ..element import Element
 
@@ -7,7 +9,7 @@ class Column(Element, default_classes='nicegui-column'):
 
     def __init__(self, *,
                  wrap: bool = False,
-                 align_items: Optional[Literal['start', 'end', 'center', 'baseline', 'stretch']] = None,
+                 align_items: Literal['start', 'end', 'center', 'baseline', 'stretch'] | None = None,
                  ) -> None:
         """Column Element
 

--- a/nicegui/elements/dark_mode.py
+++ b/nicegui/elements/dark_mode.py
@@ -1,4 +1,5 @@
-from typing import Optional
+
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.value_element import ValueElement
@@ -7,7 +8,7 @@ from .mixins.value_element import ValueElement
 class DarkMode(ValueElement, component='dark_mode.js'):
     VALUE_PROP = 'value'
 
-    def __init__(self, value: Optional[bool] = False, *, on_change: Optional[Handler[ValueChangeEventArguments]] = None) -> None:
+    def __init__(self, value: bool | None = False, *, on_change: Handler[ValueChangeEventArguments] | None = None) -> None:
         """Dark mode
 
         You can use this element to enable, disable or toggle dark mode on the page.

--- a/nicegui/elements/date.py
+++ b/nicegui/elements/date.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -8,12 +8,10 @@ from .mixins.value_element import ValueElement
 class Date(ValueElement, DisableableElement):
 
     def __init__(self,
-                 value: Optional[
-                     Union[str, dict[str, str], list[str], list[Union[str, dict[str, str]]]]
-                 ] = None,
+                 value: str | dict[str, str] | list[str] | list[str | dict[str, str]] | None = None,
                  *,
                  mask: str = 'YYYY-MM-DD',
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None) -> None:
+                 on_change: Handler[ValueChangeEventArguments] | None = None) -> None:
         """Date Picker
 
         This element is based on Quasar's `QDate <https://quasar.dev/vue-components/date>`_ component.

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import asyncio
-from typing import Any, Optional
+from typing import Any
 
 from .mixins.value_element import ValueElement
 
@@ -21,7 +23,7 @@ class Dialog(ValueElement, component='dialog.js'):
         """
         super().__init__(value=value, on_value_change=None)
         self._result: Any = None
-        self._submitted: Optional[asyncio.Event] = None
+        self._submitted: asyncio.Event | None = None
 
     @property
     def submitted(self) -> asyncio.Event:

--- a/nicegui/elements/drawer.py
+++ b/nicegui/elements/drawer.py
@@ -1,4 +1,6 @@
-from typing import Literal, Optional
+from __future__ import annotations
+
+from typing import Literal
 
 from ..context import context
 from ..helpers import require_top_level_layout
@@ -11,7 +13,7 @@ class Drawer(ValueElement, default_classes='nicegui-drawer'):
 
     def __init__(self,
                  side: DrawerSides, *,
-                 value: Optional[bool] = None,
+                 value: bool | None = None,
                  fixed: bool = True,
                  bordered: bool = False,
                  elevated: bool = False,
@@ -83,7 +85,7 @@ class Drawer(ValueElement, default_classes='nicegui-drawer'):
 class LeftDrawer(Drawer):
 
     def __init__(self, *,
-                 value: Optional[bool] = None,
+                 value: bool | None = None,
                  fixed: bool = True,
                  bordered: bool = False,
                  elevated: bool = False,
@@ -120,7 +122,7 @@ class LeftDrawer(Drawer):
 class RightDrawer(Drawer):
 
     def __init__(self, *,
-                 value: Optional[bool] = None,
+                 value: bool | None = None,
                  fixed: bool = True,
                  bordered: bool = False,
                  elevated: bool = False,

--- a/nicegui/elements/echart/echart.py
+++ b/nicegui/elements/echart/echart.py
@@ -1,4 +1,7 @@
-from typing import Callable, Literal, Optional, Union
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Literal
 
 from typing_extensions import Self
 
@@ -21,10 +24,10 @@ class EChart(Element, component='echart.js', esm={'nicegui-echart': 'dist'}, def
 
     def __init__(self,
                  options: dict,
-                 on_point_click: Optional[Handler[EChartPointClickEventArguments]] = None, *,
+                 on_point_click: Handler[EChartPointClickEventArguments] | None = None, *,
                  enable_3d: bool = False,
                  renderer: Literal['canvas', 'svg'] = 'canvas',
-                 theme: Optional[Union[str, dict]] = None,
+                 theme: str | dict | None = None,
                  ) -> None:
         """Apache EChart
 
@@ -77,7 +80,7 @@ class EChart(Element, component='echart.js', esm={'nicegui-echart': 'dist'}, def
         return self
 
     @classmethod
-    def from_pyecharts(cls, chart: 'Chart', on_point_click: Optional[Callable] = None) -> Self:
+    def from_pyecharts(cls, chart: Chart, on_point_click: Callable | None = None) -> Self:
         """Create an echart element from a pyecharts object.
 
         :param chart: pyecharts chart object

--- a/nicegui/elements/editor.py
+++ b/nicegui/elements/editor.py
@@ -1,4 +1,6 @@
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import Any
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -11,9 +13,9 @@ class Editor(ValueElement, DisableableElement, component='editor.js', default_cl
 
     def __init__(self,
                  *,
-                 placeholder: Optional[str] = None,
+                 placeholder: str | None = None,
                  value: str = '',
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  ) -> None:
         """Editor
 

--- a/nicegui/elements/expansion.py
+++ b/nicegui/elements/expansion.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -11,11 +11,11 @@ class Expansion(IconElement, TextElement, ValueElement, DisableableElement, defa
 
     def __init__(self,
                  text: str = '', *,
-                 caption: Optional[str] = None,
-                 icon: Optional[str] = None,
-                 group: Optional[str] = None,
+                 caption: str | None = None,
+                 icon: str | None = None,
+                 group: str | None = None,
                  value: bool = False,
-                 on_value_change: Optional[Handler[ValueChangeEventArguments]] = None
+                 on_value_change: Handler[ValueChangeEventArguments] | None = None
                  ) -> None:
         """Expansion Element
 

--- a/nicegui/elements/fab.py
+++ b/nicegui/elements/fab.py
@@ -1,4 +1,6 @@
-from typing import Literal, Optional
+from __future__ import annotations
+
+from typing import Literal
 
 from typing_extensions import Self
 
@@ -16,7 +18,7 @@ class Fab(ValueElement, LabelElement, IconElement, BackgroundColorElement, Disab
                  icon: str, *,
                  value: bool = False,
                  label: str = '',
-                 color: Optional[str] = 'primary',
+                 color: str | None = 'primary',
                  direction: Literal['up', 'down', 'left', 'right'] = 'right',
                  ) -> None:
         """Floating Action Button (FAB)
@@ -50,8 +52,8 @@ class FabAction(LabelElement, IconElement, BackgroundColorElement, DisableableEl
 
     def __init__(self, icon: str, *,
                  label: str = '',
-                 on_click: Optional[Handler[ClickEventArguments]] = None,
-                 color: Optional[str] = 'primary',
+                 on_click: Handler[ClickEventArguments] | None = None,
+                 color: str | None = 'primary',
                  auto_close: bool = True,
                  ) -> None:
         """Floating Action Button Action

--- a/nicegui/elements/fullscreen.py
+++ b/nicegui/elements/fullscreen.py
@@ -1,4 +1,5 @@
-from typing import Optional
+
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.value_element import ValueElement
@@ -9,7 +10,7 @@ class Fullscreen(ValueElement, component='fullscreen.js'):
 
     def __init__(self, *,
                  require_escape_hold: bool = False,
-                 on_value_change: Optional[Handler[ValueChangeEventArguments]] = None) -> None:
+                 on_value_change: Handler[ValueChangeEventArguments] | None = None) -> None:
         """Fullscreen control element
 
         This element is based on Quasar's `AppFullscreen <https://quasar.dev/quasar-plugins/app-fullscreen>`_ plugin

--- a/nicegui/elements/grid.py
+++ b/nicegui/elements/grid.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from __future__ import annotations
 
 from ..element import Element
 
@@ -7,8 +7,8 @@ class Grid(Element, default_classes='nicegui-grid'):
 
     def __init__(self,
                  *,
-                 rows: Optional[Union[int, str]] = None,
-                 columns: Optional[Union[int, str]] = None,
+                 rows: int | str | None = None,
+                 columns: int | str | None = None,
                  ) -> None:
         """Grid Element
 

--- a/nicegui/elements/html.py
+++ b/nicegui/elements/html.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, Literal
+from collections.abc import Callable
+from typing import Literal
 
 from .mixins.content_element import ContentElement
 

--- a/nicegui/elements/icon.py
+++ b/nicegui/elements/icon.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from .mixins.color_elements import TextColorElement
 from .mixins.name_element import NameElement
@@ -9,8 +9,8 @@ class Icon(NameElement, TextColorElement):
     def __init__(self,
                  name: str,
                  *,
-                 size: Optional[str] = None,
-                 color: Optional[str] = None,
+                 size: str | None = None,
+                 color: str | None = None,
                  ) -> None:
         """Icon
 

--- a/nicegui/elements/image.py
+++ b/nicegui/elements/image.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import base64
 import io
 import time
 from pathlib import Path
-from typing import Union
 
 from .. import optional_features
 from ..logging import log
@@ -18,7 +19,7 @@ except ImportError:
 class Image(SourceElement, component='image.js'):
     PIL_CONVERT_FORMAT = 'PNG'
 
-    def __init__(self, source: Union[str, Path, 'PIL_Image'] = '') -> None:
+    def __init__(self, source: str | Path | PIL_Image = '') -> None:
         """Image
 
         Displays an image.
@@ -28,10 +29,10 @@ class Image(SourceElement, component='image.js'):
         """
         super().__init__(source=source)
 
-    def set_source(self, source: Union[str, Path, 'PIL_Image']) -> None:
+    def set_source(self, source: str | Path | PIL_Image) -> None:
         return super().set_source(source)
 
-    def _set_props(self, source: Union[str, Path, 'PIL_Image']) -> None:
+    def _set_props(self, source: str | Path | PIL_Image) -> None:
         if optional_features.has('pillow') and isinstance(source, PIL_Image):
             source = pil_to_base64(source, self.PIL_CONVERT_FORMAT)
         super()._set_props(source)
@@ -44,7 +45,7 @@ class Image(SourceElement, component='image.js'):
         self._props['t'] = time.time()
 
 
-def pil_to_base64(pil_image: 'PIL_Image', image_format: str) -> str:
+def pil_to_base64(pil_image: PIL_Image, image_format: str) -> str:
     """Convert a PIL image to a base64 string which can be used as image source.
 
     :param pil_image: the PIL image

--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -1,4 +1,6 @@
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 from ..events import Handler, ValueChangeEventArguments
 from .icon import Icon
@@ -12,14 +14,14 @@ class Input(LabelElement, ValidationElement, DisableableElement, component='inpu
     LOOPBACK = False
 
     def __init__(self,
-                 label: Optional[str] = None, *,
-                 placeholder: Optional[str] = None,
+                 label: str | None = None, *,
+                 placeholder: str | None = None,
                  value: str = '',
                  password: bool = False,
                  password_toggle_button: bool = False,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
-                 autocomplete: Optional[list[str]] = None,
-                 validation: Optional[Union[ValidationFunction, ValidationDict]] = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
+                 autocomplete: list[str] | None = None,
+                 validation: ValidationFunction | ValidationDict | None = None,
                  ) -> None:
         """Text Input
 
@@ -66,7 +68,7 @@ class Input(LabelElement, ValidationElement, DisableableElement, component='inpu
 
         self._props['_autocomplete'] = autocomplete or []
 
-    def set_autocomplete(self, autocomplete: Optional[list[str]]) -> None:
+    def set_autocomplete(self, autocomplete: list[str] | None) -> None:
         """Set the autocomplete list."""
         self._props['_autocomplete'] = autocomplete
 

--- a/nicegui/elements/input_chips.py
+++ b/nicegui/elements/input_chips.py
@@ -1,4 +1,6 @@
-from typing import Any, Literal, Optional, Union
+from __future__ import annotations
+
+from typing import Any, Literal
 
 from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -9,13 +11,13 @@ from .mixins.validation_element import ValidationDict, ValidationElement, Valida
 class InputChips(LabelElement, ValidationElement, DisableableElement):
 
     def __init__(self,
-                 label: Optional[str] = None,
+                 label: str | None = None,
                  *,
-                 value: Optional[list[str]] = None,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 value: list[str] | None = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  new_value_mode: Literal['add', 'add-unique', 'toggle'] = 'toggle',
                  clearable: bool = False,
-                 validation: Optional[Union[ValidationFunction, ValidationDict]] = None,
+                 validation: ValidationFunction | ValidationDict | None = None,
                  ) -> None:
         """Input Chips
 

--- a/nicegui/elements/item.py
+++ b/nicegui/elements/item.py
@@ -1,4 +1,5 @@
-from typing import Optional
+
+from __future__ import annotations
 
 from typing_extensions import Self
 
@@ -9,7 +10,7 @@ from .mixins.text_element import TextElement
 
 class Item(DisableableElement):
 
-    def __init__(self, text: str = '', *, on_click: Optional[Handler[ClickEventArguments]] = None) -> None:
+    def __init__(self, text: str = '', *, on_click: Handler[ClickEventArguments] | None = None) -> None:
         """List Item
 
         Creates a clickable list item based on Quasar's

--- a/nicegui/elements/joystick/joystick.py
+++ b/nicegui/elements/joystick/joystick.py
@@ -1,4 +1,6 @@
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import Any
 
 from typing_extensions import Self
 
@@ -9,9 +11,9 @@ from ...events import GenericEventArguments, Handler, JoystickEventArguments, ha
 class Joystick(Element, component='joystick.vue', esm={'nicegui-joystick': 'dist'}, default_classes='nicegui-joystick'):
 
     def __init__(self, *,
-                 on_start: Optional[Handler[JoystickEventArguments]] = None,
-                 on_move: Optional[Handler[JoystickEventArguments]] = None,
-                 on_end: Optional[Handler[JoystickEventArguments]] = None,
+                 on_start: Handler[JoystickEventArguments] | None = None,
+                 on_move: Handler[JoystickEventArguments] | None = None,
+                 on_end: Handler[JoystickEventArguments] | None = None,
                  throttle: float = 0.05,
                  **options: Any) -> None:
         """Joystick

--- a/nicegui/elements/json_editor/json_editor.py
+++ b/nicegui/elements/json_editor/json_editor.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from typing_extensions import Self
 
@@ -17,9 +17,9 @@ class JsonEditor(Element, component='json_editor.js', esm={'nicegui-json-editor'
 
     def __init__(self,
                  properties: dict, *,
-                 on_select: Optional[Handler[JsonEditorSelectEventArguments]] = None,
-                 on_change: Optional[Handler[JsonEditorChangeEventArguments]] = None,
-                 schema: Optional[dict] = None,
+                 on_select: Handler[JsonEditorSelectEventArguments] | None = None,
+                 on_change: Handler[JsonEditorChangeEventArguments] | None = None,
+                 schema: dict | None = None,
                  ) -> None:
         """JSONEditor
 

--- a/nicegui/elements/keyboard.py
+++ b/nicegui/elements/keyboard.py
@@ -1,4 +1,6 @@
-from typing import Literal, Optional
+from __future__ import annotations
+
+from typing import Literal
 
 from typing_extensions import Self
 
@@ -19,7 +21,7 @@ class Keyboard(Element, component='keyboard.js'):
     active = BindableProperty()
 
     def __init__(self,
-                 on_key: Optional[Handler[KeyEventArguments]] = None, *,
+                 on_key: Handler[KeyEventArguments] | None = None, *,
                  active: bool = True,
                  repeating: bool = True,
                  ignore: list[Literal['input', 'select', 'button', 'textarea']] =

--- a/nicegui/elements/knob.py
+++ b/nicegui/elements/knob.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .label import Label
@@ -15,12 +15,12 @@ class Knob(ValueElement, DisableableElement, TextColorElement):
                  min: float = 0.0,  # pylint: disable=redefined-builtin
                  max: float = 1.0,  # pylint: disable=redefined-builtin
                  step: float = 0.01,
-                 color: Optional[str] = 'primary',
-                 center_color: Optional[str] = None,
-                 track_color: Optional[str] = None,
-                 size: Optional[str] = None,
+                 color: str | None = 'primary',
+                 center_color: str | None = None,
+                 track_color: str | None = None,
+                 size: str | None = None,
                  show_value: bool = False,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  ) -> None:
         """Knob
 
@@ -54,7 +54,7 @@ class Knob(ValueElement, DisableableElement, TextColorElement):
         if size:
             self._props['size'] = size
 
-        self.label: Optional[Label] = None
+        self.label: Label | None = None
         if show_value:
             with self:
                 self.label = Label().bind_text_from(self, 'value')

--- a/nicegui/elements/leaflet/leaflet.py
+++ b/nicegui/elements/leaflet/leaflet.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import asyncio
 from pathlib import Path
-from typing import Any, Optional, Union, cast
+from typing import Any, cast
 
 from typing_extensions import Self
 
@@ -28,9 +30,9 @@ class Leaflet(Element, component='leaflet.js', esm={'nicegui-leaflet': 'dist'}, 
                  zoom: int = 13,
                  *,
                  options: dict = {},  # noqa: B006
-                 draw_control: Union[bool, dict] = False,
+                 draw_control: bool | dict = False,
                  hide_drawn_items: bool = False,
-                 additional_resources: Optional[list[str]] = None,
+                 additional_resources: list[str] | None = None,
                  ) -> None:
         """Leaflet map
 

--- a/nicegui/elements/leaflet/leaflet_layers.py
+++ b/nicegui/elements/leaflet/leaflet_layers.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Any, Union
+from typing import Any
 
 from typing_extensions import Self
 
@@ -58,7 +60,7 @@ class ImageOverlay(Layer):
 
 @dataclass(**KWONLY_SLOTS)
 class VideoOverlay(Layer):
-    url: Union[str, list[str]]
+    url: str | list[str]
     bounds: list[list[float]]
     options: dict = field(default_factory=dict)
 

--- a/nicegui/elements/line_plot.py
+++ b/nicegui/elements/line_plot.py
@@ -1,4 +1,6 @@
-from typing import Any, Literal, Union
+from __future__ import annotations
+
+from typing import Any, Literal
 
 from .pyplot import Pyplot
 
@@ -46,8 +48,8 @@ class LinePlot(Pyplot):
              x: list[float],
              Y: list[list[float]],
              *,
-             x_limits: Union[None, Literal['auto'], tuple[float, float]] = 'auto',
-             y_limits: Union[None, Literal['auto'], tuple[float, float]] = 'auto',
+             x_limits: None | Literal['auto'] | tuple[float, float] = 'auto',
+             y_limits: None | Literal['auto'] | tuple[float, float] = 'auto',
              ) -> None:
         """Push new data to the plot.
 

--- a/nicegui/elements/link.py
+++ b/nicegui/elements/link.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Union
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
 
 from ..client import Client
 from ..element import Element
@@ -9,7 +12,7 @@ class Link(TextElement, component='link.js', default_classes='nicegui-link'):
 
     def __init__(self,
                  text: str = '',
-                 target: Union[Callable[..., Any], str, Element] = '#',
+                 target: Callable[..., Any] | str | Element = '#',
                  new_tab: bool = False,
                  ) -> None:
         """Link

--- a/nicegui/elements/log.py
+++ b/nicegui/elements/log.py
@@ -1,4 +1,6 @@
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import Any
 
 from ..element import Element
 from .label import Label
@@ -6,7 +8,7 @@ from .label import Label
 
 class Log(Element, component='log.js', default_classes='nicegui-log'):
 
-    def __init__(self, max_lines: Optional[int] = None) -> None:
+    def __init__(self, max_lines: int | None = None) -> None:
         """Log View
 
         Create a log view that allows to add new lines without re-transmitting the whole history to the client.
@@ -17,9 +19,9 @@ class Log(Element, component='log.js', default_classes='nicegui-log'):
         self.max_lines = max_lines
 
     def push(self, line: Any, *,
-             classes: Optional[str] = None,
-             style: Optional[str] = None,
-             props: Optional[str] = None) -> None:
+             classes: str | None = None,
+             style: str | None = None,
+             props: str | None = None) -> None:
         """Add a new line to the log.
 
         :param line: the line to add (can contain line breaks)

--- a/nicegui/elements/menu.py
+++ b/nicegui/elements/menu.py
@@ -1,4 +1,5 @@
-from typing import Optional
+
+from __future__ import annotations
 
 from ..events import ClickEventArguments, Handler
 from .context_menu import ContextMenu
@@ -43,7 +44,7 @@ class MenuItem(Item):
 
     def __init__(self,
                  text: str = '',
-                 on_click: Optional[Handler[ClickEventArguments]] = None, *,
+                 on_click: Handler[ClickEventArguments] | None = None, *,
                  auto_close: bool = True,
                  ) -> None:
         """Menu Item

--- a/nicegui/elements/mermaid/mermaid.py
+++ b/nicegui/elements/mermaid/mermaid.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from typing_extensions import Self
 
@@ -11,9 +11,9 @@ class Mermaid(ContentElement, component='mermaid.js', esm={'nicegui-mermaid': 'd
 
     def __init__(self,
                  content: str,
-                 config: Optional[dict] = None,
+                 config: dict | None = None,
                  *,
-                 on_node_click: Optional[Handler[MermaidNodeClickEventArguments]] = None,
+                 on_node_click: Handler[MermaidNodeClickEventArguments] | None = None,
                  ) -> None:
         """Mermaid Diagrams
 

--- a/nicegui/elements/mixins/color_elements.py
+++ b/nicegui/elements/mixins/color_elements.py
@@ -1,4 +1,6 @@
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import Any
 
 from ...element import Element
 
@@ -20,7 +22,7 @@ TAILWIND_COLORS = {
 class BackgroundColorElement(Element):
     BACKGROUND_COLOR_PROP = 'color'
 
-    def __init__(self, *, background_color: Optional[str], **kwargs: Any) -> None:
+    def __init__(self, *, background_color: str | None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         if background_color in QUASAR_COLORS:
             self._props[self.BACKGROUND_COLOR_PROP] = background_color
@@ -33,7 +35,7 @@ class BackgroundColorElement(Element):
 class TextColorElement(Element):
     TEXT_COLOR_PROP = 'color'
 
-    def __init__(self, *, text_color: Optional[str], **kwargs: Any) -> None:
+    def __init__(self, *, text_color: str | None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         if text_color in QUASAR_COLORS:
             self._props[self.TEXT_COLOR_PROP] = text_color

--- a/nicegui/elements/mixins/content_element.py
+++ b/nicegui/elements/mixins/content_element.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Optional, cast
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
 
 from typing_extensions import Self
 
@@ -19,8 +22,8 @@ class ContentElement(Element):
     def bind_content_to(self,
                         target_object: Any,
                         target_name: str = 'content',
-                        forward: Optional[Callable[[Any], Any]] = None, *,
-                        strict: Optional[bool] = None,
+                        forward: Callable[[Any], Any] | None = None, *,
+                        strict: bool | None = None,
                         ) -> Self:
         """Bind the content of this element to the target object's target_name property.
 
@@ -39,8 +42,8 @@ class ContentElement(Element):
     def bind_content_from(self,
                           target_object: Any,
                           target_name: str = 'content',
-                          backward: Optional[Callable[[Any], Any]] = None, *,
-                          strict: Optional[bool] = None,
+                          backward: Callable[[Any], Any] | None = None, *,
+                          strict: bool | None = None,
                           ) -> Self:
         """Bind the content of this element from the target object's target_name property.
 
@@ -59,9 +62,9 @@ class ContentElement(Element):
     def bind_content(self,
                      target_object: Any,
                      target_name: str = 'content', *,
-                     forward: Optional[Callable[[Any], Any]] = None,
-                     backward: Optional[Callable[[Any], Any]] = None,
-                     strict: Optional[bool] = None,
+                     forward: Callable[[Any], Any] | None = None,
+                     backward: Callable[[Any], Any] | None = None,
+                     strict: bool | None = None,
                      ) -> Self:
         """Bind the content of this element to the target object's target_name property.
 

--- a/nicegui/elements/mixins/disableable_element.py
+++ b/nicegui/elements/mixins/disableable_element.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Optional, cast
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
 
 from typing_extensions import Self
 
@@ -33,8 +36,8 @@ class DisableableElement(Element):
     def bind_enabled_to(self,
                         target_object: Any,
                         target_name: str = 'enabled',
-                        forward: Optional[Callable[[Any], Any]] = None, *,
-                        strict: Optional[bool] = None,
+                        forward: Callable[[Any], Any] | None = None, *,
+                        strict: bool | None = None,
                         ) -> Self:
         """Bind the enabled state of this element to the target object's target_name property.
 
@@ -53,8 +56,8 @@ class DisableableElement(Element):
     def bind_enabled_from(self,
                           target_object: Any,
                           target_name: str = 'enabled',
-                          backward: Optional[Callable[[Any], Any]] = None, *,
-                          strict: Optional[bool] = None,
+                          backward: Callable[[Any], Any] | None = None, *,
+                          strict: bool | None = None,
                           ) -> Self:
         """Bind the enabled state of this element from the target object's target_name property.
 
@@ -73,9 +76,9 @@ class DisableableElement(Element):
     def bind_enabled(self,
                      target_object: Any,
                      target_name: str = 'enabled', *,
-                     forward: Optional[Callable[[Any], Any]] = None,
-                     backward: Optional[Callable[[Any], Any]] = None,
-                     strict: Optional[bool] = None,
+                     forward: Callable[[Any], Any] | None = None,
+                     backward: Callable[[Any], Any] | None = None,
+                     strict: bool | None = None,
                      ) -> Self:
         """Bind the enabled state of this element to the target object's target_name property.
 

--- a/nicegui/elements/mixins/filter_element.py
+++ b/nicegui/elements/mixins/filter_element.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Optional, cast
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
 
 from typing_extensions import Self
 
@@ -11,7 +14,7 @@ class FilterElement(Element):
     filter = BindableProperty(
         on_change=lambda sender, filter: cast(Self, sender)._handle_filter_change(filter))  # pylint: disable=protected-access
 
-    def __init__(self, *, filter: Optional[str] = None, **kwargs: Any) -> None:  # pylint: disable=redefined-builtin
+    def __init__(self, *, filter: str | None = None, **kwargs: Any) -> None:  # pylint: disable=redefined-builtin
         super().__init__(**kwargs)
         self.filter = filter
         self._props[self.FILTER_PROP] = filter
@@ -19,8 +22,8 @@ class FilterElement(Element):
     def bind_filter_to(self,
                        target_object: Any,
                        target_name: str = 'filter',
-                       forward: Optional[Callable[[Any], Any]] = None, *,
-                       strict: Optional[bool] = None,
+                       forward: Callable[[Any], Any] | None = None, *,
+                       strict: bool | None = None,
                        ) -> Self:
         """Bind the filter of this element to the target object's target_name property.
 
@@ -39,8 +42,8 @@ class FilterElement(Element):
     def bind_filter_from(self,
                          target_object: Any,
                          target_name: str = 'filter',
-                         backward: Optional[Callable[[Any], Any]] = None, *,
-                         strict: Optional[bool] = None,
+                         backward: Callable[[Any], Any] | None = None, *,
+                         strict: bool | None = None,
                          ) -> Self:
         """Bind the filter of this element from the target object's target_name property.
 
@@ -59,9 +62,9 @@ class FilterElement(Element):
     def bind_filter(self,
                     target_object: Any,
                     target_name: str = 'filter', *,
-                    forward: Optional[Callable[[Any], Any]] = None,
-                    backward: Optional[Callable[[Any], Any]] = None,
-                    strict: Optional[bool] = None,
+                    forward: Callable[[Any], Any] | None = None,
+                    backward: Callable[[Any], Any] | None = None,
+                    strict: bool | None = None,
                     ) -> Self:
         """Bind the filter of this element to the target object's target_name property.
 

--- a/nicegui/elements/mixins/icon_element.py
+++ b/nicegui/elements/mixins/icon_element.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Optional, cast
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
 
 from typing_extensions import Self
 
@@ -10,7 +13,7 @@ class IconElement(Element):
     icon = BindableProperty(
         on_change=lambda sender, icon: cast(Self, sender)._handle_icon_change(icon))  # pylint: disable=protected-access
 
-    def __init__(self, *, icon: Optional[str] = None, **kwargs: Any) -> None:  # pylint: disable=redefined-builtin
+    def __init__(self, *, icon: str | None = None, **kwargs: Any) -> None:  # pylint: disable=redefined-builtin
         super().__init__(**kwargs)
         self.icon = icon
         if icon is not None:
@@ -19,8 +22,8 @@ class IconElement(Element):
     def bind_icon_to(self,
                      target_object: Any,
                      target_name: str = 'icon',
-                     forward: Optional[Callable[[Any], Any]] = None, *,
-                     strict: Optional[bool] = None,
+                     forward: Callable[[Any], Any] | None = None, *,
+                     strict: bool | None = None,
                      ) -> Self:
         """Bind the icon of this element to the target object's target_name property.
 
@@ -39,8 +42,8 @@ class IconElement(Element):
     def bind_icon_from(self,
                        target_object: Any,
                        target_name: str = 'icon',
-                       backward: Optional[Callable[[Any], Any]] = None, *,
-                       strict: Optional[bool] = None,
+                       backward: Callable[[Any], Any] | None = None, *,
+                       strict: bool | None = None,
                        ) -> Self:
         """Bind the icon of this element from the target object's target_name property.
 
@@ -59,9 +62,9 @@ class IconElement(Element):
     def bind_icon(self,
                   target_object: Any,
                   target_name: str = 'icon', *,
-                  forward: Optional[Callable[[Any], Any]] = None,
-                  backward: Optional[Callable[[Any], Any]] = None,
-                  strict: Optional[bool] = None,
+                  forward: Callable[[Any], Any] | None = None,
+                  backward: Callable[[Any], Any] | None = None,
+                  strict: bool | None = None,
                   ) -> Self:
         """Bind the icon of this element to the target object's target_name property.
 
@@ -81,14 +84,14 @@ class IconElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_icon(self, icon: Optional[str]) -> None:
+    def set_icon(self, icon: str | None) -> None:
         """Set the icon of this element.
 
         :param icon: The new icon.
         """
         self.icon = icon
 
-    def _handle_icon_change(self, icon: Optional[str]) -> None:
+    def _handle_icon_change(self, icon: str | None) -> None:
         """Called when the icon of this element changes.
 
         :param icon: The new icon.

--- a/nicegui/elements/mixins/label_element.py
+++ b/nicegui/elements/mixins/label_element.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Optional, cast
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
 
 from typing_extensions import Self
 
@@ -10,7 +13,7 @@ class LabelElement(Element):
     label = BindableProperty(
         on_change=lambda sender, label: cast(Self, sender)._handle_label_change(label))  # pylint: disable=protected-access
 
-    def __init__(self, *, label: Optional[str], **kwargs: Any) -> None:
+    def __init__(self, *, label: str | None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.label = label
         if label is not None:
@@ -19,8 +22,8 @@ class LabelElement(Element):
     def bind_label_to(self,
                       target_object: Any,
                       target_name: str = 'label',
-                      forward: Optional[Callable[[Any], Any]] = None, *,
-                      strict: Optional[bool] = None,
+                      forward: Callable[[Any], Any] | None = None, *,
+                      strict: bool | None = None,
                       ) -> Self:
         """Bind the label of this element to the target object's target_name property.
 
@@ -39,8 +42,8 @@ class LabelElement(Element):
     def bind_label_from(self,
                         target_object: Any,
                         target_name: str = 'label',
-                        backward: Optional[Callable[[Any], Any]] = None, *,
-                        strict: Optional[bool] = None,
+                        backward: Callable[[Any], Any] | None = None, *,
+                        strict: bool | None = None,
                         ) -> Self:
         """Bind the label of this element from the target object's target_name property.
 
@@ -59,9 +62,9 @@ class LabelElement(Element):
     def bind_label(self,
                    target_object: Any,
                    target_name: str = 'label', *,
-                   forward: Optional[Callable[[Any], Any]] = None,
-                   backward: Optional[Callable[[Any], Any]] = None,
-                   strict: Optional[bool] = None,
+                   forward: Callable[[Any], Any] | None = None,
+                   backward: Callable[[Any], Any] | None = None,
+                   strict: bool | None = None,
                    ) -> Self:
         """Bind the label of this element to the target object's target_name property.
 
@@ -81,14 +84,14 @@ class LabelElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_label(self, label: Optional[str]) -> None:
+    def set_label(self, label: str | None) -> None:
         """Set the label of this element.
 
         :param label: The new label.
         """
         self.label = label
 
-    def _handle_label_change(self, label: Optional[str]) -> None:
+    def _handle_label_change(self, label: str | None) -> None:
         """Called when the label of this element changes.
 
         :param label: The new label.

--- a/nicegui/elements/mixins/name_element.py
+++ b/nicegui/elements/mixins/name_element.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Optional, cast
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
 
 from typing_extensions import Self
 
@@ -18,8 +21,8 @@ class NameElement(Element):
     def bind_name_to(self,
                      target_object: Any,
                      target_name: str = 'name',
-                     forward: Optional[Callable[[Any], Any]] = None, *,
-                     strict: Optional[bool] = None,
+                     forward: Callable[[Any], Any] | None = None, *,
+                     strict: bool | None = None,
                      ) -> Self:
         """Bind the name of this element to the target object's target_name property.
 
@@ -38,8 +41,8 @@ class NameElement(Element):
     def bind_name_from(self,
                        target_object: Any,
                        target_name: str = 'name',
-                       backward: Optional[Callable[[Any], Any]] = None, *,
-                       strict: Optional[bool] = None,
+                       backward: Callable[[Any], Any] | None = None, *,
+                       strict: bool | None = None,
                        ) -> Self:
         """Bind the name of this element from the target object's target_name property.
 
@@ -58,9 +61,9 @@ class NameElement(Element):
     def bind_name(self,
                   target_object: Any,
                   target_name: str = 'name', *,
-                  forward: Optional[Callable[[Any], Any]] = None,
-                  backward: Optional[Callable[[Any], Any]] = None,
-                  strict: Optional[bool] = None,
+                  forward: Callable[[Any], Any] | None = None,
+                  backward: Callable[[Any], Any] | None = None,
+                  strict: bool | None = None,
                   ) -> Self:
         """Bind the name of this element to the target object's target_name property.
 

--- a/nicegui/elements/mixins/selectable_element.py
+++ b/nicegui/elements/mixins/selectable_element.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Optional, cast
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
 
 from typing_extensions import Self
 
@@ -14,7 +17,7 @@ class SelectableElement(Element):
     def __init__(self, *,
                  selectable: bool,
                  selected: bool,
-                 on_selection_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_selection_change: Handler[ValueChangeEventArguments] | None = None,
                  **kwargs: Any) -> None:
         super().__init__(**kwargs)
         if not selectable:
@@ -39,8 +42,8 @@ class SelectableElement(Element):
     def bind_selected_to(self,
                          target_object: Any,
                          target_name: str = 'selected',
-                         forward: Optional[Callable[[Any], Any]] = None, *,
-                         strict: Optional[bool] = None,
+                         forward: Callable[[Any], Any] | None = None, *,
+                         strict: bool | None = None,
                          ) -> Self:
         """Bind the selection state of this element to the target object's target_name property.
 
@@ -59,8 +62,8 @@ class SelectableElement(Element):
     def bind_selected_from(self,
                            target_object: Any,
                            target_name: str = 'selected',
-                           backward: Optional[Callable[[Any], Any]] = None, *,
-                           strict: Optional[bool] = None,
+                           backward: Callable[[Any], Any] | None = None, *,
+                           strict: bool | None = None,
                            ) -> Self:
         """Bind the selection state of this element from the target object's target_name property.
 
@@ -79,9 +82,9 @@ class SelectableElement(Element):
     def bind_selected(self,
                       target_object: Any,
                       target_name: str = 'selected', *,
-                      forward: Optional[Callable[[Any], Any]] = None,
-                      backward: Optional[Callable[[Any], Any]] = None,
-                      strict: Optional[bool] = None,
+                      forward: Callable[[Any], Any] | None = None,
+                      backward: Callable[[Any], Any] | None = None,
+                      strict: bool | None = None,
                       ) -> Self:
         """Bind the selection state of this element to the target object's target_name property.
 

--- a/nicegui/elements/mixins/source_element.py
+++ b/nicegui/elements/mixins/source_element.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Optional, cast
+from typing import Any, cast
 
 from typing_extensions import Self
 
@@ -17,15 +20,15 @@ class SourceElement(Element):
 
     def __init__(self, *, source: Any, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.auto_route: Optional[str] = None
+        self.auto_route: str | None = None
         self.source = source
         self._set_props(source)
 
     def bind_source_to(self,
                        target_object: Any,
                        target_name: str = 'source',
-                       forward: Optional[Callable[[Any], Any]] = None, *,
-                       strict: Optional[bool] = None,
+                       forward: Callable[[Any], Any] | None = None, *,
+                       strict: bool | None = None,
                        ) -> Self:
         """Bind the source of this element to the target object's target_name property.
 
@@ -44,8 +47,8 @@ class SourceElement(Element):
     def bind_source_from(self,
                          target_object: Any,
                          target_name: str = 'source',
-                         backward: Optional[Callable[[Any], Any]] = None, *,
-                         strict: Optional[bool] = None,
+                         backward: Callable[[Any], Any] | None = None, *,
+                         strict: bool | None = None,
                          ) -> Self:
         """Bind the source of this element from the target object's target_name property.
 
@@ -64,9 +67,9 @@ class SourceElement(Element):
     def bind_source(self,
                     target_object: Any,
                     target_name: str = 'source', *,
-                    forward: Optional[Callable[[Any], Any]] = None,
-                    backward: Optional[Callable[[Any], Any]] = None,
-                    strict: Optional[bool] = None,
+                    forward: Callable[[Any], Any] | None = None,
+                    backward: Callable[[Any], Any] | None = None,
+                    strict: bool | None = None,
                     ) -> Self:
         """Bind the source of this element to the target object's target_name property.
 

--- a/nicegui/elements/mixins/text_element.py
+++ b/nicegui/elements/mixins/text_element.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Optional, cast
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
 
 from typing_extensions import Self
 
@@ -18,8 +21,8 @@ class TextElement(Element):
     def bind_text_to(self,
                      target_object: Any,
                      target_name: str = 'text',
-                     forward: Optional[Callable[[Any], Any]] = None, *,
-                     strict: Optional[bool] = None,
+                     forward: Callable[[Any], Any] | None = None, *,
+                     strict: bool | None = None,
                      ) -> Self:
         """Bind the text of this element to the target object's target_name property.
 
@@ -38,8 +41,8 @@ class TextElement(Element):
     def bind_text_from(self,
                        target_object: Any,
                        target_name: str = 'text',
-                       backward: Optional[Callable[[Any], Any]] = None, *,
-                       strict: Optional[bool] = None,
+                       backward: Callable[[Any], Any] | None = None, *,
+                       strict: bool | None = None,
                        ) -> Self:
         """Bind the text of this element from the target object's target_name property.
 
@@ -58,9 +61,9 @@ class TextElement(Element):
     def bind_text(self,
                   target_object: Any,
                   target_name: str = 'text', *,
-                  forward: Optional[Callable[[Any], Any]] = None,
-                  backward: Optional[Callable[[Any], Any]] = None,
-                  strict: Optional[bool] = None,
+                  forward: Callable[[Any], Any] | None = None,
+                  backward: Callable[[Any], Any] | None = None,
+                  strict: bool | None = None,
                   ) -> Self:
         """Bind the text of this element to the target object's target_name property.
 

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -1,5 +1,7 @@
-from collections.abc import Awaitable
-from typing import Any, Callable, Optional, Union
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, Optional, Union
 
 from typing_extensions import Self
 
@@ -12,20 +14,20 @@ ValidationDict = dict[str, Callable[[Any], bool]]
 
 class ValidationElement(ValueElement):
 
-    def __init__(self, validation: Optional[Union[ValidationFunction, ValidationDict]], **kwargs: Any) -> None:
+    def __init__(self, validation: ValidationFunction | ValidationDict | None, **kwargs: Any) -> None:
         self._validation = validation
         self._auto_validation = True
-        self._error: Optional[str] = None
+        self._error: str | None = None
         super().__init__(**kwargs)
         self._props['error'] = None if validation is None else False  # NOTE: reserve bottom space for error message
 
     @property
-    def validation(self) -> Optional[Union[ValidationFunction, ValidationDict]]:
+    def validation(self) -> ValidationFunction | ValidationDict | None:
         """The validation function or dictionary of validation functions."""
         return self._validation
 
     @validation.setter
-    def validation(self, validation: Optional[Union[ValidationFunction, ValidationDict]]) -> None:
+    def validation(self, validation: ValidationFunction | ValidationDict | None) -> None:
         """Sets the validation function or dictionary of validation functions.
 
         :param validation: validation function or dictionary of validation functions (``None`` to disable validation)
@@ -34,12 +36,12 @@ class ValidationElement(ValueElement):
         self.validate(return_result=False)
 
     @property
-    def error(self) -> Optional[str]:
+    def error(self) -> str | None:
         """The latest error message from the validation functions."""
         return self._error
 
     @error.setter
-    def error(self, error: Optional[str]) -> None:
+    def error(self, error: str | None) -> None:
         """Sets the error message.
 
         :param error: The optional error message

--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Optional, cast
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
 
 from typing_extensions import Self
 
@@ -11,7 +14,7 @@ class ValueElement(Element):
     VALUE_PROP: str = 'model-value'
     '''Name of the prop that holds the value of the element'''
 
-    LOOPBACK: Optional[bool] = True
+    LOOPBACK: bool | None = True
     '''Whether to set the new value directly on the client or after getting an update from the server.
 
     - ``True``: The value is updated by sending a change event to the server which responds with an update.
@@ -24,7 +27,7 @@ class ValueElement(Element):
 
     def __init__(self, *,
                  value: Any,
-                 on_value_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_value_change: Handler[ValueChangeEventArguments] | None = None,
                  throttle: float = 0,
                  **kwargs: Any,
                  ) -> None:
@@ -49,8 +52,8 @@ class ValueElement(Element):
     def bind_value_to(self,
                       target_object: Any,
                       target_name: str = 'value',
-                      forward: Optional[Callable[[Any], Any]] = None, *,
-                      strict: Optional[bool] = None,
+                      forward: Callable[[Any], Any] | None = None, *,
+                      strict: bool | None = None,
                       ) -> Self:
         """Bind the value of this element to the target object's target_name property.
 
@@ -69,8 +72,8 @@ class ValueElement(Element):
     def bind_value_from(self,
                         target_object: Any,
                         target_name: str = 'value',
-                        backward: Optional[Callable[[Any], Any]] = None, *,
-                        strict: Optional[bool] = None,
+                        backward: Callable[[Any], Any] | None = None, *,
+                        strict: bool | None = None,
                         ) -> Self:
         """Bind the value of this element from the target object's target_name property.
 
@@ -89,9 +92,9 @@ class ValueElement(Element):
     def bind_value(self,
                    target_object: Any,
                    target_name: str = 'value', *,
-                   forward: Optional[Callable[[Any], Any]] = None,
-                   backward: Optional[Callable[[Any], Any]] = None,
-                   strict: Optional[bool] = None,
+                   forward: Callable[[Any], Any] | None = None,
+                   backward: Callable[[Any], Any] | None = None,
+                   strict: bool | None = None,
                    ) -> Self:
         """Bind the value of this element to the target object's target_name property.
 

--- a/nicegui/elements/mixins/visibility.py
+++ b/nicegui/elements/mixins/visibility.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, cast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, cast
 
 from typing_extensions import Self
 

--- a/nicegui/elements/notification.py
+++ b/nicegui/elements/notification.py
@@ -1,4 +1,6 @@
-from typing import Any, Literal, Optional, Union
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
 
 from typing_extensions import Self
 
@@ -32,15 +34,15 @@ class Notification(Element, component='notification.js'):
     def __init__(self,
                  message: Any = '', *,
                  position: NotificationPosition = 'bottom',
-                 close_button: Union[bool, str] = False,
+                 close_button: bool | str = False,
                  type: NotificationType = None,  # pylint: disable=redefined-builtin
-                 color: Optional[str] = None,
+                 color: str | None = None,
                  multi_line: bool = False,
-                 icon: Optional[str] = None,
+                 icon: str | None = None,
                  spinner: bool = False,
-                 timeout: Optional[float] = 5.0,
-                 on_dismiss: Optional[Handler[UiEventArguments]] = None,
-                 options: Optional[dict] = None,
+                 timeout: float | None = 5.0,
+                 on_dismiss: Handler[UiEventArguments] | None = None,
+                 options: dict | None = None,
                  **kwargs: Any,
                  ) -> None:
         """Notification element
@@ -126,12 +128,12 @@ class Notification(Element, component='notification.js'):
             self._props['options']['type'] = value
 
     @property
-    def color(self) -> Optional[str]:
+    def color(self) -> str | None:
         """Color of the notification."""
         return self._props['options'].get('color')
 
     @color.setter
-    def color(self, value: Optional[str]) -> None:
+    def color(self, value: str | None) -> None:
         if value is None:
             self._props['options'].pop('color', None)
         else:
@@ -147,12 +149,12 @@ class Notification(Element, component='notification.js'):
         self._props['options']['multiLine'] = value
 
     @property
-    def icon(self) -> Optional[str]:
+    def icon(self) -> str | None:
         """Icon of the notification."""
         return self._props['options'].get('icon')
 
     @icon.setter
-    def icon(self, value: Optional[str]) -> None:
+    def icon(self, value: str | None) -> None:
         if value is None:
             self._props['options'].pop('icon', None)
         else:
@@ -176,16 +178,16 @@ class Notification(Element, component='notification.js'):
         return self._props['options']['timeout'] / 1000
 
     @timeout.setter
-    def timeout(self, value: Optional[float]) -> None:
+    def timeout(self, value: float | None) -> None:
         self._props['options']['timeout'] = (value or 0) * 1000
 
     @property
-    def close_button(self) -> Union[bool, str]:
+    def close_button(self) -> bool | str:
         """Whether the notification has a close button."""
         return self._props['options']['closeBtn']
 
     @close_button.setter
-    def close_button(self, value: Union[bool, str]) -> None:
+    def close_button(self, value: bool | str) -> None:
         self._props['options']['closeBtn'] = value
 
     def on_dismiss(self, callback: Handler[UiEventArguments]) -> Self:

--- a/nicegui/elements/number.py
+++ b/nicegui/elements/number.py
@@ -1,4 +1,6 @@
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -10,18 +12,18 @@ class Number(LabelElement, ValidationElement, DisableableElement):
     LOOPBACK = False
 
     def __init__(self,
-                 label: Optional[str] = None, *,
-                 placeholder: Optional[str] = None,
-                 value: Optional[float] = None,
-                 min: Optional[float] = None,  # pylint: disable=redefined-builtin
-                 max: Optional[float] = None,  # pylint: disable=redefined-builtin
-                 precision: Optional[int] = None,
-                 step: Optional[float] = None,
-                 prefix: Optional[str] = None,
-                 suffix: Optional[str] = None,
-                 format: Optional[str] = None,  # pylint: disable=redefined-builtin
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
-                 validation: Optional[Union[ValidationFunction, ValidationDict]] = None,
+                 label: str | None = None, *,
+                 placeholder: str | None = None,
+                 value: float | None = None,
+                 min: float | None = None,  # pylint: disable=redefined-builtin
+                 max: float | None = None,  # pylint: disable=redefined-builtin
+                 precision: int | None = None,
+                 step: float | None = None,
+                 prefix: str | None = None,
+                 suffix: str | None = None,
+                 format: str | None = None,  # pylint: disable=redefined-builtin
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
+                 validation: ValidationFunction | ValidationDict | None = None,
                  ) -> None:
         """Number Input
 
@@ -90,12 +92,12 @@ class Number(LabelElement, ValidationElement, DisableableElement):
         self.sanitize()
 
     @property
-    def precision(self) -> Optional[int]:
+    def precision(self) -> int | None:
         """The number of decimal places allowed (default: no limit, negative: decimal places before the dot)."""
         return self._precision
 
     @precision.setter
-    def precision(self, value: Optional[int]) -> None:
+    def precision(self, value: int | None) -> None:
         self._precision = value
         self.sanitize()
 

--- a/nicegui/elements/pagination.py
+++ b/nicegui/elements/pagination.py
@@ -1,4 +1,5 @@
-from typing import Optional
+
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -10,8 +11,8 @@ class Pagination(ValueElement, DisableableElement):
     def __init__(self,
                  min: int, max: int, *,  # pylint: disable=redefined-builtin
                  direction_links: bool = False,
-                 value: Optional[int] = ...,  # type: ignore
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None) -> None:
+                 value: int | None = ...,  # type: ignore
+                 on_change: Handler[ValueChangeEventArguments] | None = None) -> None:
         """Pagination
 
         A pagination element wrapping Quasar's `QPagination <https://quasar.dev/vue-components/pagination>`_ component.

--- a/nicegui/elements/progress.py
+++ b/nicegui/elements/progress.py
@@ -1,4 +1,5 @@
-from typing import Optional
+
+from __future__ import annotations
 
 from .label import Label as label
 from .mixins.color_elements import TextColorElement
@@ -10,9 +11,9 @@ class LinearProgress(ValueElement, TextColorElement):
 
     def __init__(self,
                  value: float = 0.0, *,
-                 size: Optional[str] = None,
+                 size: str | None = None,
                  show_value: bool = True,
-                 color: Optional[str] = 'primary',
+                 color: str | None = 'primary',
                  ) -> None:
         """Linear Progress
 
@@ -41,7 +42,7 @@ class CircularProgress(ValueElement, TextColorElement):
                  max: float = 1.0,  # pylint: disable=redefined-builtin
                  size: str = 'xl',
                  show_value: bool = True,
-                 color: Optional[str] = 'primary',
+                 color: str | None = 'primary',
                  ) -> None:
         """Circular Progress
 

--- a/nicegui/elements/query.py
+++ b/nicegui/elements/query.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import weakref
-from typing import Optional
 
 from typing_extensions import Self
 
@@ -47,10 +48,10 @@ class Query:
         return element
 
     def classes(self,
-                add: Optional[str] = None, *,
-                remove: Optional[str] = None,
-                toggle: Optional[str] = None,
-                replace: Optional[str] = None,
+                add: str | None = None, *,
+                remove: str | None = None,
+                toggle: str | None = None,
+                replace: str | None = None,
                 ) -> Self:
         """Apply, remove, toggle, or replace HTML classes.
 
@@ -74,7 +75,7 @@ class Query:
         element.props['classes'] = classes
         return self
 
-    def style(self, add: Optional[str] = None, *, remove: Optional[str] = None, replace: Optional[str] = None) \
+    def style(self, add: str | None = None, *, remove: str | None = None, replace: str | None = None) \
             -> Self:
         """Apply, remove, or replace CSS definitions.
 
@@ -96,7 +97,7 @@ class Query:
             element.run_method('add_style', element.props['style'])
         return self
 
-    def props(self, add: Optional[str] = None, *, remove: Optional[str] = None) -> Self:
+    def props(self, add: str | None = None, *, remove: str | None = None) -> Self:
         """Add or remove props.
 
         This allows modifying the look of the element or its layout using `Quasar <https://quasar.dev/>`_ props.

--- a/nicegui/elements/radio.py
+++ b/nicegui/elements/radio.py
@@ -1,4 +1,6 @@
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
 from .choice_element import ChoiceElement
@@ -8,9 +10,9 @@ from .mixins.disableable_element import DisableableElement
 class Radio(ChoiceElement, DisableableElement):
 
     def __init__(self,
-                 options: Union[list, dict], *,
+                 options: list | dict, *,
                  value: Any = None,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  ) -> None:
         """Radio Selection
 

--- a/nicegui/elements/range.py
+++ b/nicegui/elements/range.py
@@ -1,4 +1,5 @@
-from typing import Optional
+
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -11,8 +12,8 @@ class Range(ValueElement, DisableableElement):
                  min: float,  # pylint: disable=redefined-builtin
                  max: float,  # pylint: disable=redefined-builtin
                  step: float = 1.0,
-                 value: Optional[dict[str, int]] = None,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 value: dict[str, int] | None = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  ) -> None:
         """Range
 

--- a/nicegui/elements/rating.py
+++ b/nicegui/elements/rating.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -8,14 +8,14 @@ from .mixins.value_element import ValueElement
 class Rating(ValueElement, DisableableElement):
 
     def __init__(self,
-                 value: Optional[float] = None,
+                 value: float | None = None,
                  max: int = 5,  # pylint: disable=redefined-builtin
-                 icon: Optional[str] = None,
-                 icon_selected: Optional[str] = None,
-                 icon_half: Optional[str] = None,
-                 color: Optional[Union[str, list[str]]] = 'primary',
-                 size: Optional[str] = None,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 icon: str | None = None,
+                 icon_selected: str | None = None,
+                 icon_half: str | None = None,
+                 color: str | list[str] | None = 'primary',
+                 size: str | None = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  ) -> None:
         """Rating
 

--- a/nicegui/elements/row.py
+++ b/nicegui/elements/row.py
@@ -1,4 +1,6 @@
-from typing import Literal, Optional
+from __future__ import annotations
+
+from typing import Literal
 
 from ..element import Element
 
@@ -7,7 +9,7 @@ class Row(Element, default_classes='nicegui-row'):
 
     def __init__(self, *,
                  wrap: bool = True,
-                 align_items: Optional[Literal['start', 'end', 'center', 'baseline', 'stretch']] = None,
+                 align_items: Literal['start', 'end', 'center', 'baseline', 'stretch'] | None = None,
                  ) -> None:
         """Row Element
 

--- a/nicegui/elements/scene/scene.py
+++ b/nicegui/elements/scene/scene.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Any, Literal
 
 from typing_extensions import Self
 
@@ -62,12 +65,12 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
                  width: int = 400,
                  height: int = 300,
                  # DEPRECATED: enforce keyword-only arguments in NiceGUI 4.0
-                 grid: Union[bool, tuple[int, int]] = True,
-                 camera: Optional[SceneCamera] = None,
-                 on_click: Optional[Handler[SceneClickEventArguments]] = None,
+                 grid: bool | tuple[int, int] = True,
+                 camera: SceneCamera | None = None,
+                 on_click: Handler[SceneClickEventArguments] | None = None,
                  click_events: list[str] = ['click', 'dblclick'],  # noqa: B006
-                 on_drag_start: Optional[Handler[SceneDragEventArguments]] = None,
-                 on_drag_end: Optional[Handler[SceneDragEventArguments]] = None,
+                 on_drag_start: Handler[SceneDragEventArguments] | None = None,
+                 on_drag_end: Handler[SceneDragEventArguments] | None = None,
                  drag_constraints: str = '',
                  background_color: str = '#eee',
                  fps: int = 20,
@@ -104,7 +107,7 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
         self._props['camera_type'] = self.camera.type
         self._props['camera_params'] = self.camera.params
         self.objects: dict[str, Object3D] = {}
-        self.stack: list[Union[Object3D, SceneObject]] = [SceneObject()]
+        self.stack: list[Object3D | SceneObject] = [SceneObject()]
         self._click_handlers = [on_click] if on_click else []
         self._props['click_events'] = click_events[:]
         self._drag_start_handlers = [on_drag_start] if on_drag_start else []
@@ -217,15 +220,15 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
         return len(self.objects)
 
     def move_camera(self,
-                    x: Optional[float] = None,
-                    y: Optional[float] = None,
-                    z: Optional[float] = None,
-                    look_at_x: Optional[float] = None,
-                    look_at_y: Optional[float] = None,
-                    look_at_z: Optional[float] = None,
-                    up_x: Optional[float] = None,
-                    up_y: Optional[float] = None,
-                    up_z: Optional[float] = None,
+                    x: float | None = None,
+                    y: float | None = None,
+                    z: float | None = None,
+                    look_at_x: float | None = None,
+                    look_at_y: float | None = None,
+                    look_at_z: float | None = None,
+                    up_x: float | None = None,
+                    up_y: float | None = None,
+                    up_z: float | None = None,
                     duration: float = 0.5) -> None:
         """Move the camera to a new position.
 

--- a/nicegui/elements/scene/scene_objects.py
+++ b/nicegui/elements/scene/scene_objects.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import math
-from typing import Optional
 
 from .scene_object3d import Object3D
 
@@ -266,7 +267,7 @@ class Texture(Object3D):
 
     def __init__(self,
                  url: str,
-                 coordinates: list[list[Optional[list[float]]]],
+                 coordinates: list[list[list[float] | None]],
                  ) -> None:
         """Texture
 
@@ -282,7 +283,7 @@ class Texture(Object3D):
         self.args[0] = url
         self.scene.run_method('set_texture_url', self.id, url)
 
-    def set_coordinates(self, coordinates: list[list[Optional[list[float]]]]) -> None:
+    def set_coordinates(self, coordinates: list[list[list[float] | None]]) -> None:
         """Change the texture coordinates."""
         self.args[1] = coordinates
         self.scene.run_method('set_texture_coordinates', self.id, coordinates)
@@ -317,7 +318,7 @@ class PointCloud(Object3D):
 
     def __init__(self,
                  points: list[list[float]],
-                 colors: Optional[list[list[float]]] = None,
+                 colors: list[list[float]] | None = None,
                  point_size: float = 1.0,
                  ) -> None:
         """Point Cloud
@@ -332,7 +333,7 @@ class PointCloud(Object3D):
         if colors is not None:
             self.material(color=None)
 
-    def set_points(self, points: list[list[float]], colors: Optional[list[list[float]]] = None) -> None:
+    def set_points(self, points: list[list[float]], colors: list[list[float]] | None = None) -> None:
         """Change the points and colors of the point cloud."""
         self.args[0] = points
         self.args[1] = colors

--- a/nicegui/elements/scene/scene_view.py
+++ b/nicegui/elements/scene/scene_view.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import asyncio
-from typing import Optional
 
 from typing_extensions import Self
 
@@ -23,8 +24,8 @@ class SceneView(Element, component='scene_view.js', default_classes='nicegui-sce
                  # DEPRECATED: enforce keyword-only arguments in NiceGUI 4.0
                  width: int = 400,
                  height: int = 300,
-                 camera: Optional[SceneCamera] = None,
-                 on_click: Optional[Handler[ClickEventArguments]] = None,
+                 camera: SceneCamera | None = None,
+                 on_click: Handler[ClickEventArguments] | None = None,
                  fps: int = 20,
                  show_stats: bool = False,
                  ) -> None:
@@ -95,15 +96,15 @@ class SceneView(Element, component='scene_view.js', default_classes='nicegui-sce
             handle_event(handler, arguments)
 
     def move_camera(self,
-                    x: Optional[float] = None,
-                    y: Optional[float] = None,
-                    z: Optional[float] = None,
-                    look_at_x: Optional[float] = None,
-                    look_at_y: Optional[float] = None,
-                    look_at_z: Optional[float] = None,
-                    up_x: Optional[float] = None,
-                    up_y: Optional[float] = None,
-                    up_z: Optional[float] = None,
+                    x: float | None = None,
+                    y: float | None = None,
+                    z: float | None = None,
+                    look_at_x: float | None = None,
+                    look_at_y: float | None = None,
+                    look_at_z: float | None = None,
+                    up_x: float | None = None,
+                    up_y: float | None = None,
+                    up_z: float | None = None,
                     duration: float = 0.5) -> None:
         """Move the camera to a new position.
 

--- a/nicegui/elements/scroll_area.py
+++ b/nicegui/elements/scroll_area.py
@@ -1,4 +1,6 @@
-from typing import Literal, Optional
+from __future__ import annotations
+
+from typing import Literal
 
 from typing_extensions import Self
 
@@ -8,7 +10,7 @@ from ..events import GenericEventArguments, Handler, ScrollEventArguments, handl
 
 class ScrollArea(Element, default_classes='nicegui-scroll-area'):
 
-    def __init__(self, *, on_scroll: Optional[Handler[ScrollEventArguments]] = None) -> None:
+    def __init__(self, *, on_scroll: Handler[ScrollEventArguments] | None = None) -> None:
         """Scroll Area
 
         A way of customizing the scrollbars by encapsulating your content.
@@ -35,7 +37,7 @@ class ScrollArea(Element, default_classes='nicegui-scroll-area'):
         ])
         return self
 
-    def _handle_scroll(self, handler: Optional[Handler[ScrollEventArguments]], e: GenericEventArguments) -> None:
+    def _handle_scroll(self, handler: Handler[ScrollEventArguments] | None, e: GenericEventArguments) -> None:
         handle_event(handler, ScrollEventArguments(
             sender=self,
             client=self.client,
@@ -50,8 +52,8 @@ class ScrollArea(Element, default_classes='nicegui-scroll-area'):
         ))
 
     def scroll_to(self, *,
-                  pixels: Optional[float] = None,
-                  percent: Optional[float] = None,
+                  pixels: float | None = None,
+                  percent: float | None = None,
                   axis: Literal['vertical', 'horizontal'] = 'vertical',
                   duration: float = 0.0,
                   ) -> None:

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -1,6 +1,8 @@
-from collections.abc import Generator, Iterable, Iterator
+from __future__ import annotations
+
+from collections.abc import Callable, Generator, Iterable, Iterator
 from copy import deepcopy
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Any, Literal
 
 from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
 from .choice_element import ChoiceElement
@@ -12,16 +14,16 @@ from .mixins.validation_element import ValidationDict, ValidationElement, Valida
 class Select(LabelElement, ValidationElement, ChoiceElement, DisableableElement, component='select.js'):
 
     def __init__(self,
-                 options: Union[list, dict], *,
-                 label: Optional[str] = None,
+                 options: list | dict, *,
+                 label: str | None = None,
                  value: Any = None,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  with_input: bool = False,
-                 new_value_mode: Optional[Literal['add', 'add-unique', 'toggle']] = None,
+                 new_value_mode: Literal['add', 'add-unique', 'toggle'] | None = None,
                  multiple: bool = False,
                  clearable: bool = False,
-                 validation: Optional[Union[ValidationFunction, ValidationDict]] = None,
-                 key_generator: Optional[Union[Callable[[Any], Any], Iterator[Any]]] = None,
+                 validation: ValidationFunction | ValidationDict | None = None,
+                 key_generator: Callable[[Any], Any] | Iterator[Any] | None = None,
                  ) -> None:
         """Dropdown Selection
 

--- a/nicegui/elements/skeleton.py
+++ b/nicegui/elements/skeleton.py
@@ -1,4 +1,6 @@
-from typing import Literal, Optional
+from __future__ import annotations
+
+from typing import Literal
 
 from ..element import Element
 
@@ -36,9 +38,9 @@ class Skeleton(Element):
                  animation_speed: float = 1.5,
                  square: bool = False,
                  bordered: bool = False,
-                 size: Optional[str] = None,
-                 width: Optional[str] = None,
-                 height: Optional[str] = None,
+                 size: str | None = None,
+                 width: str | None = None,
+                 height: str | None = None,
                  ) -> None:
         """Skeleton
 

--- a/nicegui/elements/slider.py
+++ b/nicegui/elements/slider.py
@@ -1,4 +1,5 @@
-from typing import Optional
+
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -11,8 +12,8 @@ class Slider(ValueElement, DisableableElement):
                  min: float,  # pylint: disable=redefined-builtin
                  max: float,  # pylint: disable=redefined-builtin
                  step: float = 1.0,
-                 value: Optional[float] = None,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 value: float | None = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  ) -> None:
         """Slider
 

--- a/nicegui/elements/spinner.py
+++ b/nicegui/elements/spinner.py
@@ -1,4 +1,6 @@
-from typing import Literal, Optional
+from __future__ import annotations
+
+from typing import Literal
 
 from .mixins.color_elements import TextColorElement
 
@@ -32,9 +34,9 @@ SpinnerTypes = Literal[
 class Spinner(TextColorElement):
 
     def __init__(self,
-                 type: Optional[SpinnerTypes] = 'default', *,  # pylint: disable=redefined-builtin
+                 type: SpinnerTypes | None = 'default', *,  # pylint: disable=redefined-builtin
                  size: str = '1em',
-                 color: Optional[str] = 'primary',
+                 color: str | None = 'primary',
                  thickness: float = 5.0,
                  ) -> None:
         """Spinner

--- a/nicegui/elements/splitter.py
+++ b/nicegui/elements/splitter.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -8,11 +8,11 @@ from .mixins.value_element import ValueElement
 class Splitter(ValueElement, DisableableElement, default_classes='nicegui-splitter'):
 
     def __init__(self, *,
-                 horizontal: Optional[bool] = False,
-                 reverse: Optional[bool] = False,
-                 limits: Optional[tuple[float, float]] = (0, 100),
-                 value: Optional[float] = 50,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 horizontal: bool | None = False,
+                 reverse: bool | None = False,
+                 limits: tuple[float, float] | None = (0, 100),
+                 value: float | None = 50,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  ) -> None:
         """Splitter
 

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import asyncio
 import inspect
 import re
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 from urllib.parse import urlparse
 
 from starlette.datastructures import QueryParams

--- a/nicegui/elements/switch.py
+++ b/nicegui/elements/switch.py
@@ -1,4 +1,5 @@
-from typing import Optional
+
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -10,8 +11,8 @@ class Switch(TextElement, ValueElement, DisableableElement):
 
     def __init__(self,
                  text: str = '', *,
-                 value: Optional[bool] = False,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None) -> None:
+                 value: bool | None = False,
+                 on_change: Handler[ValueChangeEventArguments] | None = None) -> None:
         """Switch
 
         This element is based on Quasar's `QToggle <https://quasar.dev/vue-components/toggle>`_ component.

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import importlib.util
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from typing_extensions import Self
 
@@ -31,14 +33,14 @@ class Table(FilterElement, component='table.js'):
     def __init__(self,
                  *,
                  rows: list[dict],
-                 columns: Optional[list[dict]] = None,
-                 column_defaults: Optional[dict] = None,
+                 columns: list[dict] | None = None,
+                 column_defaults: dict | None = None,
                  row_key: str = 'id',
-                 title: Optional[str] = None,
+                 title: str | None = None,
                  selection: Literal[None, 'single', 'multiple'] = None,
-                 pagination: Optional[Union[int, dict]] = None,
-                 on_select: Optional[Handler[TableSelectionEventArguments]] = None,
-                 on_pagination_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 pagination: int | dict | None = None,
+                 on_select: Handler[TableSelectionEventArguments] | None = None,
+                 on_pagination_change: Handler[ValueChangeEventArguments] | None = None,
                  ) -> None:
         """Table
 
@@ -141,14 +143,14 @@ class Table(FilterElement, component='table.js'):
 
     @classmethod
     def from_pandas(cls,
-                    df: 'pd.DataFrame', *,
-                    columns: Optional[list[dict]] = None,
-                    column_defaults: Optional[dict] = None,
+                    df: pd.DataFrame, *,
+                    columns: list[dict] | None = None,
+                    column_defaults: dict | None = None,
                     row_key: str = 'id',
-                    title: Optional[str] = None,
-                    selection: Optional[Literal['single', 'multiple']] = None,
-                    pagination: Optional[Union[int, dict]] = None,
-                    on_select: Optional[Handler[TableSelectionEventArguments]] = None) -> Self:
+                    title: str | None = None,
+                    selection: Literal['single', 'multiple'] | None = None,
+                    pagination: int | dict | None = None,
+                    on_select: Handler[TableSelectionEventArguments] | None = None) -> Self:
         """Create a table from a Pandas DataFrame.
 
         Note:
@@ -185,14 +187,14 @@ class Table(FilterElement, component='table.js'):
 
     @classmethod
     def from_polars(cls,
-                    df: 'pl.DataFrame', *,
-                    columns: Optional[list[dict]] = None,
-                    column_defaults: Optional[dict] = None,
+                    df: pl.DataFrame, *,
+                    columns: list[dict] | None = None,
+                    column_defaults: dict | None = None,
                     row_key: str = 'id',
-                    title: Optional[str] = None,
-                    selection: Optional[Literal['single', 'multiple']] = None,
-                    pagination: Optional[Union[int, dict]] = None,
-                    on_select: Optional[Handler[TableSelectionEventArguments]] = None) -> Self:
+                    title: str | None = None,
+                    selection: Literal['single', 'multiple'] | None = None,
+                    pagination: int | dict | None = None,
+                    on_select: Handler[TableSelectionEventArguments] | None = None) -> Self:
         """Create a table from a Polars DataFrame.
 
         Note:
@@ -226,10 +228,10 @@ class Table(FilterElement, component='table.js'):
         return table
 
     def update_from_pandas(self,
-                           df: 'pd.DataFrame', *,
+                           df: pd.DataFrame, *,
                            clear_selection: bool = True,
-                           columns: Optional[list[dict]] = None,
-                           column_defaults: Optional[dict] = None) -> None:
+                           columns: list[dict] | None = None,
+                           column_defaults: dict | None = None) -> None:
         """Update the table from a Pandas DataFrame.
 
         See `from_pandas()` for more information about the conversion of non-serializable columns.
@@ -246,10 +248,10 @@ class Table(FilterElement, component='table.js'):
         self._update_table(rows, columns_from_df, clear_selection, columns, column_defaults)
 
     def update_from_polars(self,
-                           df: 'pl.DataFrame', *,
+                           df: pl.DataFrame, *,
                            clear_selection: bool = True,
-                           columns: Optional[list[dict]] = None,
-                           column_defaults: Optional[dict] = None) -> None:
+                           columns: list[dict] | None = None,
+                           column_defaults: dict | None = None) -> None:
         """Update the table from a Polars DataFrame.
 
         :param df: Polars DataFrame
@@ -264,8 +266,8 @@ class Table(FilterElement, component='table.js'):
                       rows: list[dict],
                       columns_from_df: list[dict],
                       clear_selection: bool,
-                      columns: Optional[list[dict]],
-                      column_defaults: Optional[dict]) -> None:
+                      columns: list[dict] | None,
+                      column_defaults: dict | None) -> None:
         """Helper function to update the table."""
         self.rows[:] = rows
         if column_defaults is not None:
@@ -276,7 +278,7 @@ class Table(FilterElement, component='table.js'):
             self.selected.clear()
 
     @staticmethod
-    def _pandas_df_to_rows_and_columns(df: 'pd.DataFrame') -> tuple[list[dict], list[dict]]:
+    def _pandas_df_to_rows_and_columns(df: pd.DataFrame) -> tuple[list[dict], list[dict]]:
         import pandas as pd  # pylint: disable=import-outside-toplevel
 
         def is_special_dtype(dtype):
@@ -298,7 +300,7 @@ class Table(FilterElement, component='table.js'):
         return df.to_dict('records'), [{'name': col, 'label': col, 'field': col} for col in df.columns]
 
     @staticmethod
-    def _polars_df_to_rows_and_columns(df: 'pl.DataFrame') -> tuple[list[dict], list[dict]]:
+    def _polars_df_to_rows_and_columns(df: pl.DataFrame) -> tuple[list[dict], list[dict]]:
         return df.to_dicts(), [{'name': col, 'label': col, 'field': col} for col in df.columns]
 
     @property
@@ -320,12 +322,12 @@ class Table(FilterElement, component='table.js'):
         self._props['columns'] = self._normalize_columns(value)
 
     @property
-    def column_defaults(self) -> Optional[dict]:
+    def column_defaults(self) -> dict | None:
         """Default column properties."""
         return self._column_defaults
 
     @column_defaults.setter
-    def column_defaults(self, value: Optional[dict]) -> None:
+    def column_defaults(self, value: dict | None) -> None:
         self._column_defaults = value
         self.columns = self.columns  # re-normalize columns
 

--- a/nicegui/elements/teleport.py
+++ b/nicegui/elements/teleport.py
@@ -1,11 +1,11 @@
-from typing import Union
+from __future__ import annotations
 
 from ..element import Element
 
 
 class Teleport(Element, component='teleport.js'):
 
-    def __init__(self, to: Union[str, Element]) -> None:
+    def __init__(self, to: str | Element) -> None:
         """Teleport
 
         An element that allows us to transmit the content from within a component to any location on the page.

--- a/nicegui/elements/textarea.py
+++ b/nicegui/elements/textarea.py
@@ -1,4 +1,6 @@
-from typing import Callable, Optional, Union
+from __future__ import annotations
+
+from collections.abc import Callable
 
 from ..events import Handler, ValueChangeEventArguments
 from .input import Input
@@ -7,11 +9,11 @@ from .input import Input
 class Textarea(Input, component='input.js'):
 
     def __init__(self,
-                 label: Optional[str] = None, *,
-                 placeholder: Optional[str] = None,
+                 label: str | None = None, *,
+                 placeholder: str | None = None,
                  value: str = '',
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
-                 validation: Optional[Union[Callable[..., Optional[str]], dict[str, Callable[..., bool]]]] = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
+                 validation: Callable[..., str | None] | dict[str, Callable[..., bool]] | None = None,
                  ) -> None:
         """Textarea
 

--- a/nicegui/elements/time.py
+++ b/nicegui/elements/time.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -8,9 +8,9 @@ from .mixins.value_element import ValueElement
 class Time(ValueElement, DisableableElement):
 
     def __init__(self,
-                 value: Optional[str] = None, *,
+                 value: str | None = None, *,
                  mask: str = 'HH:mm',
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  ) -> None:
         """Time Picker
 

--- a/nicegui/elements/time_input.py
+++ b/nicegui/elements/time_input.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from ..events import Handler, ValueChangeEventArguments
 from .button import Button as button
@@ -13,10 +13,10 @@ class TimeInput(LabelElement, ValueElement, DisableableElement):
     LOOPBACK = False
 
     def __init__(self,
-                 label: Optional[str] = None, *,
-                 placeholder: Optional[str] = None,
+                 label: str | None = None, *,
+                 placeholder: str | None = None,
                  value: str = '',
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  ) -> None:
         """Time Input
 

--- a/nicegui/elements/timeline.py
+++ b/nicegui/elements/timeline.py
@@ -1,4 +1,6 @@
-from typing import Literal, Optional
+from __future__ import annotations
+
+from typing import Literal
 
 from ..element import Element
 from .mixins.icon_element import IconElement
@@ -10,7 +12,7 @@ class Timeline(Element):
                  *,
                  side: Literal['left', 'right'] = 'left',
                  layout: Literal['dense', 'comfortable', 'loose'] = 'dense',
-                 color: Optional[str] = None,
+                 color: str | None = None,
                  ) -> None:
         """Timeline
 
@@ -30,16 +32,16 @@ class Timeline(Element):
 class TimelineEntry(IconElement, default_classes='nicegui-timeline-entry'):
 
     def __init__(self,
-                 body: Optional[str] = None,
+                 body: str | None = None,
                  *,
                  side: Literal['left', 'right'] = 'left',
                  heading: bool = False,
-                 tag: Optional[str] = None,
-                 icon: Optional[str] = None,
-                 avatar: Optional[str] = None,
-                 title: Optional[str] = None,
-                 subtitle: Optional[str] = None,
-                 color: Optional[str] = None,
+                 tag: str | None = None,
+                 icon: str | None = None,
+                 avatar: str | None = None,
+                 title: str | None = None,
+                 subtitle: str | None = None,
+                 color: str | None = None,
                  ) -> None:
         """Timeline Entry
 

--- a/nicegui/elements/toggle.py
+++ b/nicegui/elements/toggle.py
@@ -1,4 +1,6 @@
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
 from .choice_element import ChoiceElement
@@ -8,9 +10,9 @@ from .mixins.disableable_element import DisableableElement
 class Toggle(ChoiceElement, DisableableElement):
 
     def __init__(self,
-                 options: Union[list, dict], *,
+                 options: list | dict, *,
                  value: Any = None,
-                 on_change: Optional[Handler[ValueChangeEventArguments]] = None,
+                 on_change: Handler[ValueChangeEventArguments] | None = None,
                  clearable: bool = False,
                  ) -> None:
         """Toggle

--- a/nicegui/elements/tree.py
+++ b/nicegui/elements/tree.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from collections.abc import Iterator
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from typing_extensions import Self
 
@@ -14,10 +16,10 @@ class Tree(FilterElement):
                  node_key: str = 'id',
                  label_key: str = 'label',
                  children_key: str = 'children',
-                 on_select: Optional[Handler[ValueChangeEventArguments]] = None,
-                 on_expand: Optional[Handler[ValueChangeEventArguments]] = None,
-                 on_tick: Optional[Handler[ValueChangeEventArguments]] = None,
-                 tick_strategy: Optional[Literal['leaf', 'leaf-filtered', 'strict']] = None,
+                 on_select: Handler[ValueChangeEventArguments] | None = None,
+                 on_expand: Handler[ValueChangeEventArguments] | None = None,
+                 on_tick: Handler[ValueChangeEventArguments] | None = None,
+                 tick_strategy: Literal['leaf', 'leaf-filtered', 'strict'] | None = None,
                  ) -> None:
         """Tree
 
@@ -95,7 +97,7 @@ class Tree(FilterElement):
         self._select_handlers.append(callback)
         return self
 
-    def select(self, node_key: Optional[str]) -> Self:
+    def select(self, node_key: str | None) -> Self:
         """Select the given node.
 
         :param node_key: node key to select
@@ -122,7 +124,7 @@ class Tree(FilterElement):
         self._tick_handlers.append(callback)
         return self
 
-    def tick(self, node_keys: Optional[list[str]] = None) -> Self:
+    def tick(self, node_keys: list[str] | None = None) -> Self:
         """Tick the given nodes.
 
         :param node_keys: list of node keys to tick or ``None`` to tick all nodes (default: ``None``)
@@ -131,7 +133,7 @@ class Tree(FilterElement):
         self._props['ticked'][:] = self._find_node_keys(node_keys).union(self._props['ticked'])
         return self
 
-    def untick(self, node_keys: Optional[list[str]] = None) -> Self:
+    def untick(self, node_keys: list[str] | None = None) -> Self:
         """Remove tick from the given nodes.
 
         :param node_keys: list of node keys to untick or ``None`` to untick all nodes (default: ``None``)
@@ -140,7 +142,7 @@ class Tree(FilterElement):
         self._props['ticked'][:] = set(self._props['ticked']).difference(self._find_node_keys(node_keys))
         return self
 
-    def expand(self, node_keys: Optional[list[str]] = None) -> Self:
+    def expand(self, node_keys: list[str] | None = None) -> Self:
         """Expand the given nodes.
 
         :param node_keys: list of node keys to expand (default: all nodes)
@@ -149,7 +151,7 @@ class Tree(FilterElement):
         self._props['expanded'][:] = self._find_node_keys(node_keys).union(self._props['expanded'])
         return self
 
-    def collapse(self, node_keys: Optional[list[str]] = None) -> Self:
+    def collapse(self, node_keys: list[str] | None = None) -> Self:
         """Collapse the given nodes.
 
         :param node_keys: list of node keys to collapse (default: all nodes)
@@ -158,7 +160,7 @@ class Tree(FilterElement):
         self._props['expanded'][:] = set(self._props['expanded']).difference(self._find_node_keys(node_keys))
         return self
 
-    def nodes(self, *, visible: Optional[bool] = None) -> Iterator[dict]:
+    def nodes(self, *, visible: bool | None = None) -> Iterator[dict]:
         """Iterate over all nodes.
 
         :param visible: if ``True``, only visible nodes are returned; if ``False``, only invisible nodes are returned; if ``None``, all nodes are returned (default: ``None``)
@@ -174,7 +176,7 @@ class Tree(FilterElement):
                     yield from iterate_nodes(node.get(CHILDREN_KEY, []))
         return iterate_nodes(self._props['nodes'])
 
-    def _find_node_keys(self, node_keys: Optional[list[str]] = None) -> set[str]:
+    def _find_node_keys(self, node_keys: list[str] | None = None) -> set[str]:
         if node_keys is not None:
             return set(node_keys)
         return {node[self._props['node-key']] for node in self.nodes()}

--- a/nicegui/elements/upload.py
+++ b/nicegui/elements/upload.py
@@ -1,4 +1,6 @@
-from typing import Optional, cast
+from __future__ import annotations
+
+from typing import cast
 
 from fastapi import Request
 from starlette.datastructures import UploadFile
@@ -17,13 +19,13 @@ class Upload(LabelElement, DisableableElement, component='upload.js'):
 
     def __init__(self, *,
                  multiple: bool = False,
-                 max_file_size: Optional[int] = None,
-                 max_total_size: Optional[int] = None,
-                 max_files: Optional[int] = None,
-                 on_begin_upload: Optional[Handler[UiEventArguments]] = None,
-                 on_upload: Optional[Handler[UploadEventArguments]] = None,
-                 on_multi_upload: Optional[Handler[MultiUploadEventArguments]] = None,
-                 on_rejected: Optional[Handler[UiEventArguments]] = None,
+                 max_file_size: int | None = None,
+                 max_total_size: int | None = None,
+                 max_files: int | None = None,
+                 on_begin_upload: Handler[UiEventArguments] | None = None,
+                 on_upload: Handler[UploadEventArguments] | None = None,
+                 on_multi_upload: Handler[MultiUploadEventArguments] | None = None,
+                 on_rejected: Handler[UiEventArguments] | None = None,
                  label: str = '',
                  auto_upload: bool = False,
                  ) -> None:

--- a/nicegui/elements/video.py
+++ b/nicegui/elements/video.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Union
 
 from .mixins.source_element import SourceElement
 
@@ -7,7 +8,7 @@ from .mixins.source_element import SourceElement
 class Video(SourceElement, component='video.js'):
     SOURCE_IS_MEDIA_FILE = True
 
-    def __init__(self, src: Union[str, Path], *,
+    def __init__(self, src: str | Path, *,
                  controls: bool = True,
                  autoplay: bool = False,
                  muted: bool = False,
@@ -32,7 +33,7 @@ class Video(SourceElement, component='video.js'):
         self._props['muted'] = muted
         self._props['loop'] = loop
 
-    def set_source(self, source: Union[str, Path]) -> None:
+    def set_source(self, source: str | Path) -> None:
         return super().set_source(source)
 
     def seek(self, seconds: float) -> None:

--- a/nicegui/error.py
+++ b/nicegui/error.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Union
 
 from .elements.column import Column as column
 from .elements.html import Html as html
@@ -8,7 +9,7 @@ from .elements.label import Label as label
 SAD_FACE_SVG = (Path(__file__).parent / 'static' / 'sad_face.svg').read_text(encoding='utf-8')
 
 
-def error_content(status_code: int, exception: Union[str, Exception] = '') -> None:
+def error_content(status_code: int, exception: str | Exception = '') -> None:
     """Create an error page.
 
     :param status_code: HTTP status code

--- a/nicegui/event_listener.py
+++ b/nicegui/event_listener.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import uuid
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import Any
 
 from fastapi import Request
 
@@ -13,13 +15,13 @@ class EventListener:
     id: str = field(init=False)
     element_id: int
     type: str
-    args: Sequence[Optional[Sequence[str]]]
-    handler: Optional[Callable]
-    js_handler: Optional[str]
+    args: Sequence[Sequence[str] | None]
+    handler: Callable | None
+    js_handler: str | None
     throttle: float
     leading_events: bool
     trailing_events: bool
-    request: Optional[Request]
+    request: Request | None
 
     def __post_init__(self) -> None:
         self.id = str(uuid.uuid4())

--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast
 
 from . import background_tasks, core, helpers
 from .awaitable_response import AwaitableResponse

--- a/nicegui/functions/clipboard.py
+++ b/nicegui/functions/clipboard.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import io
-from typing import Optional, Union
 
 from .. import json, optional_features
 from ..logging import log
@@ -12,7 +13,7 @@ except ImportError:
     pass
 
 
-async def read() -> Optional[str]:
+async def read() -> str | None:
     """Read text from the clipboard.
 
     Note: This function only works in secure contexts (HTTPS or localhost).
@@ -47,7 +48,7 @@ def write(text: str) -> None:
     ''')
 
 
-async def read_image() -> Union['PIL_Image.Image', None]:
+async def read_image() -> PIL_Image.Image | None:
     """Read PIL images from the clipboard.
 
     Note: This function only works in secure contexts (HTTPS or localhost) and requires Pillow to be installed.

--- a/nicegui/functions/download.py
+++ b/nicegui/functions/download.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Optional, Union
 
 from .. import core, helpers
 from ..context import context
@@ -14,7 +15,7 @@ class Download:
     *Added in version 2.14.0*
     """
 
-    def __call__(self, src: Union[str, Path, bytes], filename: Optional[str] = None, media_type: str = '') -> None:
+    def __call__(self, src: str | Path | bytes, filename: str | None = None, media_type: str = '') -> None:
         """Download
 
         Function to trigger the download of a file, URL or bytes.
@@ -31,7 +32,7 @@ class Download:
             src = str(src)
             self.from_url(src, filename, media_type)
 
-    def file(self, path: Union[str, Path], filename: Optional[str] = None, media_type: str = '') -> None:
+    def file(self, path: str | Path, filename: str | None = None, media_type: str = '') -> None:
         """Download file from local path
 
         Function to trigger the download of a file.
@@ -45,7 +46,7 @@ class Download:
         src = core.app.add_static_file(local_file=path, single_use=True)
         context.client.download(src, filename, media_type)
 
-    def from_url(self, url: str, filename: Optional[str] = None, media_type: str = '') -> None:
+    def from_url(self, url: str, filename: str | None = None, media_type: str = '') -> None:
         """Download from a relative URL
 
         Function to trigger the download from a relative URL.
@@ -73,7 +74,7 @@ class Download:
                         'Please refer to the documentation for more details.')
         context.client.download(url, filename, media_type)
 
-    def content(self, content: Union[bytes, str], filename: Optional[str] = None, media_type: str = '') -> None:
+    def content(self, content: bytes | str, filename: str | None = None, media_type: str = '') -> None:
         """Download raw bytes or string content
 
         Function to trigger the download of raw data.

--- a/nicegui/functions/navigate.py
+++ b/nicegui/functions/navigate.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Union
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
 from urllib.parse import urlparse
 
 from .. import background_tasks
@@ -44,7 +47,7 @@ class Navigate:
         """
         run_javascript('history.go(0)')
 
-    def to(self, target: Union[Callable[..., Any], str, Element], new_tab: bool = False) -> None:
+    def to(self, target: Callable[..., Any] | str | Element, new_tab: bool = False) -> None:
         """ui.navigate.to (formerly ui.open)
 
         Can be used to programmatically open a different page or URL.

--- a/nicegui/functions/notify.py
+++ b/nicegui/functions/notify.py
@@ -1,4 +1,6 @@
-from typing import Any, Literal, Optional, Union
+from __future__ import annotations
+
+from typing import Any, Literal
 
 from ..context import context
 
@@ -21,15 +23,9 @@ def notify(message: Any, *,
                'right',
                'center',
            ] = 'bottom',
-           close_button: Union[bool, str] = False,
-           type: Optional[Literal[  # pylint: disable=redefined-builtin
-               'positive',
-               'negative',
-               'warning',
-               'info',
-               'ongoing',
-           ]] = None,
-           color: Optional[str] = None,
+           close_button: bool | str = False,
+           type: Literal['positive', 'negative', 'warning', 'info', 'ongoing'] | None = None,
+           color: str | None = None,
            multi_line: bool = False,
            **kwargs: Any,
            ) -> None:

--- a/nicegui/functions/on.py
+++ b/nicegui/functions/on.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
-from typing import Optional, Union
 
 from ..context import context
 from ..events import GenericEventArguments, Handler
 
 
 def on(type: str,  # pylint: disable=redefined-builtin
-       handler: Optional[Handler[GenericEventArguments]] = None,
-       args: Union[None, Sequence[str], Sequence[Optional[Sequence[str]]]] = None, *,
+       handler: Handler[GenericEventArguments] | None = None,
+       args: None | Sequence[str] | Sequence[Sequence[str] | None] = None, *,
        throttle: float = 0.0,
        leading_events: bool = True,
        trailing_events: bool = True,

--- a/nicegui/functions/refreshable.py
+++ b/nicegui/functions/refreshable.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable, ClassVar, Generic, TypeVar, cast
+from typing import Any, ClassVar, Generic, TypeVar, cast
 
 from typing_extensions import Concatenate, ParamSpec, Self
 

--- a/nicegui/functions/style.py
+++ b/nicegui/functions/style.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Union
 
 from .. import helpers, json
 from .html import add_head_html
 
 
-def add_css(content: Union[str, Path], *, shared: bool = False) -> None:
+def add_css(content: str | Path, *, shared: bool = False) -> None:
     """Add CSS style definitions to the page.
 
     This function can be used to add CSS style definitions to the head of the HTML page.
@@ -20,7 +21,7 @@ def add_css(content: Union[str, Path], *, shared: bool = False) -> None:
     add_head_html(f'<style>{content}</style>', shared=shared)
 
 
-def add_scss(content: Union[str, Path], *, indented: bool = False, shared: bool = False) -> None:  # DEPRECATED
+def add_scss(content: str | Path, *, indented: bool = False, shared: bool = False) -> None:  # DEPRECATED
     """Add SCSS style definitions to the page (deprecated).
 
     This function can be used to add SCSS style definitions to the head of the HTML page.
@@ -45,7 +46,7 @@ def add_scss(content: Union[str, Path], *, indented: bool = False, shared: bool 
     ''', shared=shared)
 
 
-def add_sass(content: Union[str, Path], *, shared: bool = False) -> None:  # DEPRECATED
+def add_sass(content: str | Path, *, shared: bool = False) -> None:  # DEPRECATED
     """Add SASS style definitions to the page (deprecated).
 
     This function can be used to add SASS style definitions to the head of the HTML page.

--- a/nicegui/html.py
+++ b/nicegui/html.py
@@ -1,11 +1,11 @@
-from typing import Optional
+from __future__ import annotations
 
 from .element import Element
 
 
 def _create_html_element(tag: str):
     class HTMLElement(Element):
-        def __init__(self, inner_html: Optional[str] = None, **kwargs) -> None:
+        def __init__(self, inner_html: str | None = None, **kwargs) -> None:
             super().__init__(tag)
             self._text = inner_html
             self.props.update(**kwargs)

--- a/nicegui/json/builtin_wrapper.py
+++ b/nicegui/json/builtin_wrapper.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import importlib.util
 import json
 from datetime import date, datetime
-from typing import Any, Optional
+from typing import Any
 
 from fastapi import Response
 
@@ -10,7 +12,7 @@ HAS_NUMPY = importlib.util.find_spec('numpy') is not None
 
 def dumps(obj: Any,
           sort_keys: bool = False,
-          separators: Optional[tuple[str, str]] = None, *,
+          separators: tuple[str, str] | None = None, *,
           indent: bool = False) -> str:
     """Serializes a Python object to a JSON-encoded string.
 

--- a/nicegui/json/orjson_wrapper.py
+++ b/nicegui/json/orjson_wrapper.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import importlib.util
 from decimal import Decimal
-from typing import Any, Optional
+from typing import Any
 
 # pylint: disable=no-member
 import orjson
@@ -13,7 +15,7 @@ ORJSON_OPTS = orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NON_STR_KEYS
 
 def dumps(obj: Any,
           sort_keys: bool = False,
-          separators: Optional[tuple[str, str]] = None, *,
+          separators: tuple[str, str] | None = None, *,
           indent: bool = False) -> str:
     """Serializes a Python object to a JSON-encoded string.
 

--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -1,14 +1,17 @@
 # pylint: disable=C0116
+from __future__ import annotations
+
 import inspect
 import warnings
+from collections.abc import Callable
 from multiprocessing import Queue
-from typing import Any, Callable, Optional
+from typing import Any
 
 from .. import run
 from ..logging import log
 
-method_queue: Optional[Queue] = None
-response_queue: Optional[Queue] = None
+method_queue: Queue | None = None
+response_queue: Queue | None = None
 
 
 def create_queues() -> None:
@@ -127,7 +130,7 @@ try:
             allow_multiple: bool = False,
             save_filename: str = '',
             file_types: tuple[str, ...] = (),
-        ) -> Optional[tuple[str, ...]]:
+        ) -> tuple[str, ...] | None:
             return await self._request(
                 dialog_type=dialog_type,
                 directory=directory,

--- a/nicegui/native/native_config.py
+++ b/nicegui/native/native_config.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from ..dataclasses import KWONLY_SLOTS
 from .native import WindowProxy
@@ -10,4 +12,4 @@ class NativeConfig:
     start_args: dict[str, Any] = field(default_factory=dict)
     window_args: dict[str, Any] = field(default_factory=dict)
     settings: dict[str, Any] = field(default_factory=dict)
-    main_window: Optional[WindowProxy] = None
+    main_window: WindowProxy | None = None

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -7,8 +7,9 @@ import socket
 import sys
 import time
 import warnings
+from collections.abc import Callable
 from threading import Event, Thread
-from typing import Any, Callable
+from typing import Any
 
 from .. import core, helpers, optional_features
 from ..logging import log

--- a/nicegui/observables.py
+++ b/nicegui/observables.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import abc
 import time
-from collections.abc import Collection, Iterable
+from collections.abc import Callable, Collection, Iterable
 from copy import deepcopy
-from typing import Any, Callable, SupportsIndex
+from typing import Any, SupportsIndex
 
 from typing_extensions import Self
 

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+from collections.abc import Callable
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, Request, Response
 

--- a/nicegui/page_arguments.py
+++ b/nicegui/page_arguments.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Union, get_args, get_origin
+from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
 
 from starlette.datastructures import QueryParams
 

--- a/nicegui/persistence/file_persistent_dict.py
+++ b/nicegui/persistence/file_persistent_dict.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Optional
 
 import aiofiles
 
@@ -11,7 +12,7 @@ from .persistent_dict import PersistentDict
 
 class FilePersistentDict(PersistentDict):
 
-    def __init__(self, filepath: Path, encoding: Optional[str] = None, *, indent: bool = False) -> None:
+    def __init__(self, filepath: Path, encoding: str | None = None, *, indent: bool = False) -> None:
         self.filepath = filepath
         self.encoding = encoding
         self.indent = indent

--- a/nicegui/props.py
+++ b/nicegui/props.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import ast
 import re
 import weakref
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from . import helpers
 from .observables import ObservableDict
@@ -92,8 +94,8 @@ class Props(ObservableDict, Generic[T]):
         self._warnings[prop] = message
 
     def __call__(self,
-                 add: Optional[str] = None, *,
-                 remove: Optional[str] = None) -> T:
+                 add: str | None = None, *,
+                 remove: str | None = None) -> T:
         """Add or remove props.
 
         This allows modifying the look of the element or its layout using `Quasar <https://quasar.dev/>`_ props.
@@ -118,7 +120,7 @@ class Props(ObservableDict, Generic[T]):
         return element
 
     @staticmethod
-    def parse(text: Optional[str]) -> dict[str, Any]:
+    def parse(text: str | None) -> dict[str, Any]:
         """Parse a string of props into a dictionary."""
         if not text:
             return {}

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -1,17 +1,20 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import traceback
+from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 from functools import partial
 from pickle import PicklingError
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, TypeVar
 
 from typing_extensions import ParamSpec
 
 from . import core, helpers
 
-process_pool: Optional[ProcessPoolExecutor] = None
+process_pool: ProcessPoolExecutor | None = None
 thread_pool = ThreadPoolExecutor()
 
 P = ParamSpec('P')

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import contextvars
 import os
 import uuid
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -17,7 +19,7 @@ from .observables import ObservableDict
 from .persistence import FilePersistentDict, PersistentDict, ReadOnlyDict, RedisPersistentDict
 from .persistence.peudo_persistent_dict import PseudoPersistentDict
 
-request_contextvar: contextvars.ContextVar[Optional[Request]] = contextvars.ContextVar('request_var', default=None)
+request_contextvar: contextvars.ContextVar[Request | None] = contextvars.ContextVar('request_var', default=None)
 
 
 class RequestTrackingMiddleware(BaseHTTPMiddleware):
@@ -35,8 +37,8 @@ class RequestTrackingMiddleware(BaseHTTPMiddleware):
         return response
 
 
-def set_storage_secret(storage_secret: Optional[str] = None,
-                       session_middleware_kwargs: Optional[dict[str, Any]] = None) -> None:
+def set_storage_secret(storage_secret: str | None = None,
+                       session_middleware_kwargs: dict[str, Any] | None = None) -> None:
     """Set storage_secret and add request tracking middleware."""
     if any(m.cls == SessionMiddleware for m in core.app.user_middleware):
         # NOTE not using "add_middleware" because it would be the wrong order
@@ -48,7 +50,7 @@ def set_storage_secret(storage_secret: Optional[str] = None,
 
 
 class Storage:
-    secret: Optional[str] = None
+    secret: str | None = None
     '''Secret key for session storage.'''
 
     path = Path(os.environ.get('NICEGUI_STORAGE_PATH', '.nicegui')).resolve()
@@ -76,7 +78,7 @@ class Storage:
             return FilePersistentDict(Storage.path / f'storage-{id}.json', encoding='utf-8')
 
     @property
-    def browser(self) -> Union[ReadOnlyDict, dict]:
+    def browser(self) -> ReadOnlyDict | dict:
         """Small storage that is saved directly within the user's browser (encrypted cookie).
 
         The data is shared between all browser tabs and can only be modified before the initial request has been submitted.
@@ -85,7 +87,7 @@ class Storage:
         """
         if core.is_script_mode_preflight():
             return {}
-        request: Optional[Request] = request_contextvar.get()
+        request: Request | None = request_contextvar.get()
         if request is None:
             if Storage.secret is None:
                 raise RuntimeError('app.storage.browser needs a storage_secret passed in ui.run()')
@@ -106,7 +108,7 @@ class Storage:
         """
         if core.is_script_mode_preflight():
             return PseudoPersistentDict()
-        request: Optional[Request] = request_contextvar.get()
+        request: Request | None = request_contextvar.get()
         if request is None:
             if Storage.secret is None:
                 raise RuntimeError('app.storage.user needs a storage_secret passed in ui.run()')

--- a/nicegui/style.py
+++ b/nicegui/style.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import weakref
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from .observables import ObservableDict
 
@@ -43,9 +45,9 @@ class Style(ObservableDict, Generic[T]):
             element.update()
 
     def __call__(self,
-                 add: Optional[str] = None, *,
-                 remove: Optional[str] = None,
-                 replace: Optional[str] = None) -> T:
+                 add: str | None = None, *,
+                 remove: str | None = None,
+                 replace: str | None = None) -> T:
         """Apply, remove, or replace CSS definitions.
 
         Removing or replacing styles can be helpful if the predefined style is not desired.
@@ -66,7 +68,7 @@ class Style(ObservableDict, Generic[T]):
         return element
 
     @staticmethod
-    def parse(text: Optional[str]) -> dict[str, str]:
+    def parse(text: str | None) -> dict[str, str]:
         """Parse a string of styles into a dictionary."""
         result = {}
         for word in (text or '').split(';'):

--- a/nicegui/sub_pages_router.py
+++ b/nicegui/sub_pages_router.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from fastapi import Request
 from starlette.routing import Match, Route

--- a/nicegui/testing/general_fixtures.py
+++ b/nicegui/testing/general_fixtures.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Optional
 
 import pytest
 
@@ -18,7 +19,7 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line('markers', 'nicegui_main_file: specify the main file for the test')
 
 
-def get_path_to_main_file(request: pytest.FixtureRequest) -> Optional[Path]:
+def get_path_to_main_file(request: pytest.FixtureRequest) -> Path | None:
     """Get the path to the main file from the test marker or global config."""
     marker = next((m for m in request.node.iter_markers('nicegui_main_file')), None)
     main_file = marker.args[0] if marker else request.config.getini('main_file')

--- a/nicegui/testing/screen.py
+++ b/nicegui/testing/screen.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 import re
 import runpy
 import threading
 import time
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, Optional, Union, overload
+from typing import Any, overload
 from urllib.parse import urlparse
 
 import pytest
@@ -32,10 +34,10 @@ class Screen:
     SCREENSHOT_DIR = Path('screenshots')
     CATCH_JS_ERRORS = True
 
-    def __init__(self, selenium: webdriver.Chrome, caplog: pytest.LogCaptureFixture, request: Optional[pytest.FixtureRequest] = None) -> None:
+    def __init__(self, selenium: webdriver.Chrome, caplog: pytest.LogCaptureFixture, request: pytest.FixtureRequest | None = None) -> None:
         self.selenium = selenium
         self.caplog = caplog
-        self.server_thread: Optional[threading.Thread] = None
+        self.server_thread: threading.Thread | None = None
         self.pytest_request = request
         self.ui_run_kwargs: dict[str, Any] = {'port': self.PORT, 'show': False, 'reload': False}
         self.connected = threading.Event()
@@ -127,7 +129,7 @@ class Screen:
     def wait_for(self, target: Callable[..., bool]) -> None:
         """Wait until the given condition is met."""
 
-    def wait_for(self, target: Union[str, Callable[..., bool]]) -> None:
+    def wait_for(self, target: str | Callable[..., bool]) -> None:
         """Wait until the page contains the given text or the given condition is met."""
         if isinstance(target, str):
             self.should_contain(target)
@@ -259,7 +261,7 @@ class Screen:
         print(f'Storing screenshot to {filename}')
         self.selenium.get_screenshot_as_file(filename)
 
-    def assert_py_logger(self, level: str, message: Union[str, re.Pattern]) -> None:
+    def assert_py_logger(self, level: str, message: str | re.Pattern) -> None:
         """Assert that the Python logger has received a message with the given level and text or regex pattern."""
         try:
             assert self.caplog.records, 'Expected a log message'

--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import re
-from typing import Any, Callable, TypeVar, overload
+from collections.abc import Callable
+from typing import Any, TypeVar, overload
 from uuid import uuid4
 
 import httpx

--- a/nicegui/testing/user_navigate.py
+++ b/nicegui/testing/user_navigate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from nicegui import Client, background_tasks
 from nicegui.element import Element

--- a/nicegui/testing/user_plugin.py
+++ b/nicegui/testing/user_plugin.py
@@ -1,5 +1,4 @@
-from collections.abc import AsyncGenerator
-from typing import Callable
+from collections.abc import AsyncGenerator, Callable
 
 import httpx
 import pytest

--- a/nicegui/testing/user_simulation.py
+++ b/nicegui/testing/user_simulation.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import os
 import runpy
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Callable
 
 import httpx
 

--- a/nicegui/timer.py
+++ b/nicegui/timer.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import asyncio
 import time
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from contextlib import AbstractContextManager, nullcontext
-from typing import Any, Callable, Optional
+from typing import Any
 
 from . import background_tasks, core
 from .awaitable_response import AwaitableResponse
@@ -34,11 +36,11 @@ class Timer:
         """
         super().__init__()
         self.interval = interval
-        self.callback: Optional[Callable[..., Any]] = callback
+        self.callback: Callable[..., Any] | None = callback
         self.active = active
         self._is_canceled = False
         self._immediate = immediate
-        self._current_invocation: Optional[asyncio.Task] = None
+        self._current_invocation: asyncio.Task | None = None
 
         coroutine = self._run_once if once else self._run_in_loop
         if core.is_script_mode_preflight():

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import multiprocessing
 import os
 import runpy
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional, TypedDict, Union
+from typing import Any, Literal, TypedDict
 
 from fastapi.middleware.gzip import GZipMiddleware
 from starlette.routing import Route
@@ -26,44 +29,44 @@ APP_IMPORT_STRING = 'nicegui:app'
 
 
 class ContactDict(TypedDict):
-    name: Optional[str]
-    url: Optional[str]
-    email: Optional[str]
+    name: str | None
+    url: str | None
+    email: str | None
 
 
 class LicenseInfoDict(TypedDict):
     name: str
-    identifier: Optional[str]
-    url: Optional[str]
+    identifier: str | None
+    url: str | None
 
 
 class DocsConfig(TypedDict):
-    title: Optional[str]
-    summary: Optional[str]
-    description: Optional[str]
-    version: Optional[str]
-    terms_of_service: Optional[str]
-    contact: Optional[ContactDict]
-    license_info: Optional[LicenseInfoDict]
+    title: str | None
+    summary: str | None
+    description: str | None
+    version: str | None
+    terms_of_service: str | None
+    contact: ContactDict | None
+    license_info: LicenseInfoDict | None
 
 
-def run(root: Optional[Callable] = None, *,
-        host: Optional[str] = None,
-        port: Optional[int] = None,
+def run(root: Callable | None = None, *,
+        host: str | None = None,
+        port: int | None = None,
         title: str = 'NiceGUI',
         viewport: str = 'width=device-width, initial-scale=1',
-        favicon: Optional[Union[str, Path]] = None,
-        dark: Optional[bool] = False,
+        favicon: str | Path | None = None,
+        dark: bool | None = False,
         language: Language = 'en-US',
         binding_refresh_interval: float = 0.1,
         reconnect_timeout: float = 3.0,
         message_history_length: int = 1000,
         cache_control_directives: str = 'public, max-age=31536000, immutable, stale-while-revalidate=31536000',
-        fastapi_docs: Union[bool, DocsConfig] = False,
+        fastapi_docs: bool | DocsConfig = False,
         show: bool = True,
-        on_air: Optional[Union[str, Literal[True]]] = None,
+        on_air: str | Literal[True] | None = None,
         native: bool = False,
-        window_size: Optional[tuple[int, int]] = None,
+        window_size: tuple[int, int] | None = None,
         fullscreen: bool = False,
         frameless: bool = False,
         reload: bool = True,
@@ -74,8 +77,8 @@ def run(root: Optional[Callable] = None, *,
         tailwind: bool = True,
         prod_js: bool = True,
         endpoint_documentation: Literal['none', 'internal', 'page', 'all'] = 'none',
-        storage_secret: Optional[str] = None,
-        session_middleware_kwargs: Optional[dict[str, Any]] = None,
+        storage_secret: str | None = None,
+        session_middleware_kwargs: dict[str, Any] | None = None,
         show_welcome_message: bool = True,
         **kwargs: Any,
         ) -> None:

--- a/nicegui/ui_run_with.py
+++ b/nicegui/ui_run_with.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Any, Literal
 
 from fastapi import FastAPI
 from fastapi.middleware.gzip import GZipMiddleware
@@ -14,22 +17,22 @@ from .nicegui import _shutdown, _startup
 
 def run_with(
     app: FastAPI, *,
-    root: Optional[Callable] = None,
+    root: Callable | None = None,
     title: str = 'NiceGUI',
     viewport: str = 'width=device-width, initial-scale=1',
-    favicon: Optional[Union[str, Path]] = None,
-    dark: Optional[bool] = False,
+    favicon: str | Path | None = None,
+    dark: bool | None = False,
     language: Language = 'en-US',
     binding_refresh_interval: float = 0.1,
     reconnect_timeout: float = 3.0,
     message_history_length: int = 1000,
     cache_control_directives: str = 'public, max-age=31536000, immutable, stale-while-revalidate=31536000',
     mount_path: str = '/',
-    on_air: Optional[Union[str, Literal[True]]] = None,
+    on_air: str | Literal[True] | None = None,
     tailwind: bool = True,
     prod_js: bool = True,
-    storage_secret: Optional[str] = None,
-    session_middleware_kwargs: Optional[dict[str, Any]] = None,
+    storage_secret: str | None = None,
+    session_middleware_kwargs: dict[str, Any] | None = None,
     show_welcome_message: bool = True,
 ) -> None:
     """Run NiceGUI with FastAPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,8 @@ fixable = [
     "Q002",  # bad quotes docstring
     "Q003",  # avoidable escaped quote
     "Q004",  # unnecessary escaped quote
+    "UP007", # PEP 604 union types
+    "UP045", # PEP 604 optional types
 ]
 ignore = [
     "E501", # line too long

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import weakref
-from typing import Optional
 
 import pytest
 from selenium.webdriver.common.by import By
@@ -58,7 +59,7 @@ def test_classes(screen: Screen):
     ('transform: translate(120.0px, 50%)', {'transform': 'translate(120.0px, 50%)'}),
     ('box-shadow: 0 0 0.5em #1976d2', {'box-shadow': '0 0 0.5em #1976d2'}),
 ])
-def test_style_parsing(value: Optional[str], expected: dict[str, str]):
+def test_style_parsing(value: str | None, expected: dict[str, str]):
     assert Style.parse(value) == expected
 
 
@@ -89,7 +90,7 @@ def test_style_parsing(value: Optional[str], expected: dict[str, str]):
     ('''object={'one': "foo"} baz''', {'object': {'one': 'foo'}, 'baz': True}),
     ('''object={'one': "foo", "two": "bar"}''', {'object': {'one': 'foo', 'two': 'bar'}}),
 ])
-def test_props_parsing(value: Optional[str], expected: dict[str, str]):
+def test_props_parsing(value: str | None, expected: dict[str, str]):
     assert Props.parse(value) == expected
 
 

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Union
 
 import httpx
 import pytest
@@ -15,7 +16,7 @@ def get_favicon_url(screen: Screen) -> str:
     return screen.find_by_css('link[rel="shortcut icon"]').get_attribute('href')
 
 
-def assert_favicon(content: Union[Path, str, bytes], url_path: str = '/favicon.ico'):
+def assert_favicon(content: Path | str | bytes, url_path: str = '/favicon.ico'):
     response = httpx.get(f'http://localhost:{Screen.PORT}{url_path}', timeout=5)
     assert response.status_code == 200
     if isinstance(content, Path):

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Literal, Optional
+from typing import Literal
 
 import pytest
 from selenium.webdriver.common.by import By
@@ -77,7 +77,7 @@ def test_input_validation(method: Literal['dict', 'sync', 'async'], screen: Scre
             input_ = ui.input('Name',
                               validation={'Short': lambda x: len(x) >= 3, 'Still short': lambda x: len(x) >= 5})
         else:
-            async def validate(x: str) -> Optional[str]:
+            async def validate(x: str) -> str | None:
                 await asyncio.sleep(0.1)
                 return 'Short' if len(x) < 3 else 'Still short' if len(x) < 5 else None
             input_ = ui.input('Name', validation=validate)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import asyncio
 import re
-from typing import Optional
 
 from fastapi.responses import PlainTextResponse
 from selenium.webdriver.common.by import By
@@ -64,7 +65,7 @@ def test_creating_new_page_after_startup(screen: Screen):
 
 
 def test_wait_for_connected(screen: Screen):
-    label: Optional[ui.label] = None
+    label: ui.label | None = None
 
     async def load() -> None:
         assert label

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 from selenium.webdriver import Keys
 
@@ -112,7 +110,7 @@ def test_set_options(screen:  Screen):
 @pytest.mark.parametrize('option_dict', [False, True])
 @pytest.mark.parametrize('multiple', [False, True])
 @pytest.mark.parametrize('new_value_mode', ['add', 'add-unique', 'toggle', None])
-def test_add_new_values(screen:  Screen, option_dict: bool, multiple: bool, new_value_mode: Optional[str]):
+def test_add_new_values(screen:  Screen, option_dict: bool, multiple: bool, new_value_mode: str | None):
     @ui.page('/')
     def page():
         options = {'a': 'A', 'b': 'B', 'c': 'C'} if option_dict else ['a', 'b', 'c']

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import asyncio
-from typing import Optional
 
 import httpx
 import pytest
@@ -787,7 +788,7 @@ def test_optional_parameters(screen: Screen):
         name: str,
         count: int = 1,
         active: str = 'no',
-        source: Optional[str] = None,
+        source: str | None = None,
         missing: str = 'default',
     ):
         ui.label(f'name={name}, count={count}, active={active}, source={source}, missing={missing}')
@@ -813,7 +814,7 @@ def test_page_arguments_with_optional_parameters(screen: Screen):
         args: PageArguments,
         user_id: str,
         role: str = 'guest',
-        app_name: Optional[str] = None,
+        app_name: str | None = None,
     ):
         ui.label(f'path={args.path}, user_id={user_id}, role={role}, app={app_name}')
 

--- a/tests/test_teleport.py
+++ b/tests/test_teleport.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from nicegui import ui
 from nicegui.testing import Screen
@@ -39,7 +39,7 @@ def test_teleport_with_element(screen: Screen):
 def test_update(screen: Screen):
     @ui.page('/')
     def page():
-        teleport: Optional[ui.teleport] = None
+        teleport: ui.teleport | None = None
 
         card = ui.card().classes('card')
 

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import csv
 import re
 import sys
 import textwrap
-from typing import Any, Callable, Union
+from typing import Any, Callable
 
 import pytest
 from fastapi.responses import PlainTextResponse
@@ -535,7 +537,7 @@ async def test_upload_table(user: User) -> None:
 
 
 @pytest.mark.parametrize('data', ['/data', b'Hello'])
-async def test_download_file(user: User, data: Union[str, bytes]) -> None:
+async def test_download_file(user: User, data: str | bytes) -> None:
     @app.get('/data')
     def get_data() -> PlainTextResponse:
         return PlainTextResponse('Hello')

--- a/website/documentation/content/doc/part.py
+++ b/website/documentation/content/doc/part.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Callable, Literal, Optional, Union
+from typing import Callable, Literal
 
 from nicegui.dataclasses import KWONLY_SLOTS
 
@@ -10,21 +12,21 @@ from ....style import create_anchor_name
 class Demo:
     function: Callable
     lazy: bool = True
-    tab: Optional[Union[str, Callable]] = None
+    tab: str | Callable | None = None
 
 
 @dataclass(**KWONLY_SLOTS)
 class DocumentationPart:
-    title: Optional[str] = None
-    description: Optional[str] = None
+    title: str | None = None
+    description: str | None = None
     description_format: Literal['md', 'rst'] = 'md'
-    link: Optional[str] = None
-    ui: Optional[Callable] = None
-    demo: Optional[Demo] = None
-    reference: Optional[type] = None
-    search_text: Optional[str] = None
+    link: str | None = None
+    ui: Callable | None = None
+    demo: Demo | None = None
+    reference: type | None = None
+    search_text: str | None = None
 
     @property
-    def link_target(self) -> Optional[str]:
+    def link_target(self) -> str | None:
         """Return the link target for in-page navigation."""
         return create_anchor_name(self.title) if self.title else None

--- a/website/documentation/demo.py
+++ b/website/documentation/demo.py
@@ -1,4 +1,6 @@
-from typing import Callable, Optional, Union
+from __future__ import annotations
+
+from typing import Callable
 
 from nicegui import helpers, json, ui
 
@@ -7,7 +9,7 @@ from .intersection_observer import IntersectionObserver as intersection_observer
 from .windows import browser_window, python_window
 
 
-def demo(f: Callable, *, lazy: bool = True, tab: Optional[Union[str, Callable]] = None) -> Callable:
+def demo(f: Callable, *, lazy: bool = True, tab: str | Callable | None = None) -> Callable:
     """Render a callable as a demo with Python code and browser window."""
     with ui.column().classes('w-full items-stretch gap-8 no-wrap min-[1500px]:flex-row'):
         full_code = get_full_code(f)

--- a/website/documentation/windows.py
+++ b/website/documentation/windows.py
@@ -1,4 +1,6 @@
-from typing import Callable, Literal, Optional, Union
+from __future__ import annotations
+
+from typing import Callable, Literal
 
 from nicegui import ui
 
@@ -18,7 +20,7 @@ def _dots() -> None:
         ui.icon('circle').classes('text-[13px] text-green-400')
 
 
-def _window(type_: WindowType, *, title: str = '', tab: Union[str, Callable] = '', classes: str = '') -> ui.column:
+def _window(type_: WindowType, *, title: str = '', tab: str | Callable = '', classes: str = '') -> ui.column:
     bar_color = ('#00000010', '#ffffff10')
     color = WINDOW_BG_COLORS[type_]
     with ui.card() \
@@ -46,7 +48,7 @@ def _window(type_: WindowType, *, title: str = '', tab: Union[str, Callable] = '
         return ui.column().classes('w-full h-full overflow-auto')
 
 
-def python_window(title: Optional[str] = None, *, classes: str = '') -> ui.column:
+def python_window(title: str | None = None, *, classes: str = '') -> ui.column:
     """Create a window for Python code."""
     return _window('python', title=title or 'main.py', classes=classes).classes('px-4 py-2 python-window')
 
@@ -56,6 +58,6 @@ def bash_window(*, classes: str = '') -> ui.column:
     return _window('bash', title='bash', classes=classes).classes('px-4 py-2 bash-window')
 
 
-def browser_window(title: Optional[Union[str, Callable]] = None, *, classes: str = '') -> ui.column:
+def browser_window(title: str | Callable | None = None, *, classes: str = '') -> ui.column:
     """Create a browser window."""
     return _window('browser', tab=title or 'NiceGUI', classes=classes).classes('p-4 browser-window')

--- a/website/style.py
+++ b/website/style.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import re
-from typing import Optional
 
 from nicegui import ui
 
@@ -61,7 +62,7 @@ def side_menu() -> ui.left_drawer:
         .style('height: calc(100% + 20px) !important')
 
 
-def subheading(text: str, *, link: Optional[str] = None, major: bool = False, anchor_name: Optional[str] = None) -> None:
+def subheading(text: str, *, link: str | None = None, major: bool = False, anchor_name: str | None = None) -> None:
     """Render a subheading with an anchor that can be linked to with a hash."""
     name = anchor_name or create_anchor_name(text)
     ui.html(f'<div id="{name}"></div>', sanitize=False).style('position: relative; top: -90px')


### PR DESCRIPTION
### Motivation

Ref: https://github.com/zauberzeug/nicegui/pull/5380#issuecomment-3548069208

- I don't think we should mix new and old code. 
- And I wanted to see how big the diff is

### Implementation

Add `from __future__ import annotations` such that Py3.9 pylint does not throw up. 

Then we can use the new syntax. 

We end up with a huge diff, really. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.

### Final notes

Not sure whether this is for 3.x or 4.0. 