### PR TITLE
Forward `--clean` and `--noconfirm` to pyinstaller in nicegui-pack

### DIFF
--- a/nicegui/scripts/pack.py
+++ b/nicegui/scripts/pack.py
@@ -53,7 +53,7 @@ def main() -> None:
         'Clean PyInstaller cache (in ./build folder) and remove temporary files before building.'
     ))
     parser.add_argument('--noconfirm', action='store_true', default=False, help=(
-        'Replace output directory (./dist/SPECNAME) without asking for confirmation'
+        'Replace output directory (./dist/SPECNAME) without asking for confirmation.'
     ))
     parser.add_argument('main', default='main.py', help='Main file which calls `ui.run()`.')
     args = parser.parse_args()

--- a/website/documentation/content/section_configuration_deployment.py
+++ b/website/documentation/content/section_configuration_deployment.py
@@ -319,7 +319,6 @@ doc.text('', '''
 
     - Specifying `--noconfirm` to `nicegui-pack` will replace the output directory (`./dist/SPECNAME`) without asking for confirmation.
 
-
     - Summary of user experience for different options:
 
         | `nicegui-pack`           | `ui.run(...)`  | Explanation |


### PR DESCRIPTION
### Motivation

Currently, `nicegui-pack` attempts to delete the `build` and `dist` folders before a new build with PyInstaller. 
However, the implementation 
```python
for directory in ['build', 'dist']:
    if Path(directory).exists():
        Path(directory).rmdir()
```
fails to delete these folders with an error, and cancels the build, if there is any content of a previous build. This is because `Path.rmdir()` only works if directory is not empty. 

I think this is not the intended behaviour. The user must manually delete these folders after every build. And deleting these folders if they are already empty has no effect on the build.

This PR instead introduces the optional arguments `--clean` and `--noconfirm` for `nicegui-pack`, which are directly forwarded to PyInstaller. 
- `--clean`: Clean PyInstaller cache (build folder) and remove temporary files before building.
- `--noconfirm`:  Replace output directory (default: SPECPATH/dist/SPECNAME) without asking for confirmation

If arguments are **not** given, no cleanup is performed, which allows the user to rely on pyinstaller caching. 
This is currently prevented because one would run into the error raised from `rmdir()` before reaching PyInstaller.

### Implementation

Two more args for nicegui-pack have been introduced, directly forwarded to pyinstaller.
CLI documentation and logic are borrowed directly from PyInstaller, similar to most other arguments. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary) -> currently there are no tests at all for `nicegui-pack`.
- [x] Documentation has been added (or is not necessary).
