### PR TITLE
Segment  direct&inherited properties/methods in reference documentation to enhance readability

### DIFF
--- a/website/documentation/reference.py
+++ b/website/documentation/reference.py
@@ -13,7 +13,7 @@ from .custom_restructured_text import CustomRestructuredText as custom_restructu
 @dataclass(**KWONLY_SLOTS)
 class Attribute:
     name: str
-    obj: object | None
+    obj: Optional[object]
     base: type
 
 


### PR DESCRIPTION
### Motivation

Proposal:
This PR segments the properties and methods in the documentation into direct class properties/methods first, then an “Inherited” subsection with bracketed gray notes on the originating class. 
(At least for me) This significantly improves the readability of the reference documentation, surfacing the direct features, before the large amount of inherited ones which are common between most components. 

See, for example, the first properties of `ui.table`
<img width="870" height="756" alt="image" src="https://github.com/user-attachments/assets/e1a1fa23-0f7e-4bd1-b82c-74630fa660ef" />

Before, they were interleaved with `client`, `classes`, etc.

Now, they are in a dedicated section directly after:
<img width="600" height="465" alt="image" src="https://github.com/user-attachments/assets/42d49b8f-6c9a-4ac6-a3da-4de18e25435b" />



### Implementation

Modification of `website/documentation/reference.py` where the ancestor classes - already part of `mro` -- are surfaced in the documentation markdown. Segmentation of properties and methods into direct and inherited ones is based on these values, too. 



### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
