### PR TITLE
Check if property is None to avoid extraneous "The type of the None singleton."

### DIFF
--- a/website/documentation/reference.py
+++ b/website/documentation/reference.py
@@ -32,7 +32,7 @@ def generate_class_doc(class_obj: type, part_title: str) -> None:
         with ui.column().classes('gap-2 w-full overflow-x-auto'):
             for name, property_ in sorted(properties.items()):
                 ui.markdown(f'**`{name}`**`{_generate_property_signature_description(property_)}`')
-                if property_.__doc__:
+                if property_ is not None and property_.__doc__:
                     _render_docstring(property_.__doc__).classes('ml-8')
     if methods:
         subheading('Methods', anchor_name=create_anchor_name(part_title.replace('Reference', 'Methods')))


### PR DESCRIPTION
### Motivation

Fix #5488. It is best if the documentation works identically, when ran locally VS on the official website. 

But now, due to additional docstring for `None`, there is extraneous "The type of the None singleton."

### Implementation

Check explicitly if `property_ is not None` before proceeding with the rest of the docstring rendering

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Final notes

**Too simple-win for me to take a screenshot, look at https://github.com/zauberzeug/nicegui/issues/5488 for the results showcase**
