### PR TITLE
Identify NiceGUI defaults using `new_class` type marker and let `default_props` win

### DIFF
--- a/nicegui/elements/button.py
+++ b/nicegui/elements/button.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from typing_extensions import Self
 
+from nicegui.helpers import default_props_or
+
 from ..events import ClickEventArguments, Handler, handle_event
 from .mixins.color_elements import BackgroundColorElement
 from .mixins.disableable_element import DisableableElement
@@ -15,7 +17,7 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
     def __init__(self,
                  text: str = '', *,
                  on_click: Optional[Handler[ClickEventArguments]] = None,
-                 color: Optional[str] = 'primary',
+                 color: Optional[str] = default_props_or('primary'),
                  icon: Optional[str] = None,
                  ) -> None:
         """Button

--- a/nicegui/helpers.py
+++ b/nicegui/helpers.py
@@ -8,11 +8,12 @@ import struct
 import sys
 import threading
 import time
+import types
 import webbrowser
 from collections.abc import Callable
 from inspect import Parameter, signature
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from .context import context
 from .logging import log
@@ -26,6 +27,22 @@ if sys.version_info < (3, 13):
     from asyncio import iscoroutinefunction
 else:
     from inspect import iscoroutinefunction
+
+T = TypeVar('T')
+
+SPECIAL_MARKER = 'nicegui!default_'  # intentional use of !
+
+
+def default_props_or(value: T) -> T:
+    """User's default_props are honored over this value.
+
+    Done by wrapping a value into a lightweight marker class that indicates it is a default value."""
+    return types.new_class(f'{SPECIAL_MARKER}{type(value).__name__}', (type(value),), {})(value)
+
+
+def is_default_value(value: Any) -> bool:
+    """Check if the value is wrapped as a default value."""
+    return type(value).__name__.startswith(SPECIAL_MARKER)
 
 
 def warn_once(message: str, *, stack_info: bool = False) -> None:

--- a/nicegui/props.py
+++ b/nicegui/props.py
@@ -138,3 +138,8 @@ class Props(ObservableDict, Generic[T]):
                     props[key] = True
 
         return props
+
+    def __setitem__(self, __key, __value):
+        if helpers.is_default_value(__value) and __key in self:
+            return
+        return super().__setitem__(__key, __value)


### PR DESCRIPTION
### Motivation

As stated in https://github.com/zauberzeug/nicegui/issues/4857, we want user's default props to win NiceGUI's default values. 

### Implementation

We mark NiceGUI values with `default_props_or`, which, say passed `str`, returns a special type with name `nicegui!default_str` inheriting from `str`. 

Exclamation mark was used because we want to avoid user creating their own class which conflict with ours. And so this would never happen because it is invalid Python syntax: 

```py
class nicegui!default_str(str): # Causes SyntaxError: invalid syntax
    pass # imagine it was something else other than a pass
```

The cleverness comes from the inheritance: comparisons should simply work, because of Python's duck typing. 

Only at `__setitem__` of `Props` do we break away from the duck typing and check explicitly the type name, revealing that it is a default value, and skipping when `__key in self`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).

### Inspiration

This PR is inspired by https://github.com/zauberzeug/nicegui/pull/4900/files, but more generic because `default_props_or` can wrap value of _any_ type. 

### Discussion

Seems like a brighter future than https://github.com/zauberzeug/nicegui/pull/5476 because for that, we are passing stuff with type `_DefaultSentinel` around code which expects `str`s and `int`s. 

But then actually I don't think we should let user's styles and classes win NiceGUI's, because:

- For classes, there is no key-value relationship, and so if user did `bg-red-500` and NiceGUI did `bg-gray-500`, it is difficult to then recognize user's `bg-red-500` as being able to conflict with our `bg-gray-500` and then give up the setting. 
- For styles, are you really sure you want to endorse, say, `ui.row.default_style('flex-wrap: wrap')`?
  - One thing to follow Quasar docs and then complain to us that Quasar props are not working. 
  - Another thing to pull `.default_style('flex-wrap: wrap')` out of thin air and expect it to work...