### PR TITLE
Implement per-element and easily-customizable caching policy

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ def _main_page() -> None:
             .style('height: calc(100% + 20px) !important') as menu:
         tree = ui.tree(documentation.tree.nodes, label_key='title',
                        on_select=lambda e: ui.navigate.to(f'/documentation/{e.value}')) \
-            .classes('w-full').props('accordion no-connectors no-selection-unset')
+            .classes('w-full').props('accordion no-connectors no-selection-unset').cache('nicegui-doc-tree')
     menu_button = header.add_header(menu)
 
     window_state = {'is_desktop': None}

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -147,7 +147,7 @@ class Client:
         self.outbox.updates.clear()
         prefix = request.headers.get('X-Forwarded-Prefix', '') + request.scope.get('root_path', '')
         elements = json.dumps({
-            id: element._to_dict(client_hash=request.cookies.get(f'nicegui_cache_{element._cache_name}') if element.caching_enabled() else None) for id, element in self.elements.items()  # pylint: disable=protected-access
+            id: element._to_cached_dict(client_hash=request.cookies.get(f'nicegui_cache_{element._cache_name}') if element.caching_enabled() else None) for id, element in self.elements.items()  # pylint: disable=protected-access
         })
         socket_io_js_query_params = {
             **core.app.config.socket_io_js_query_params,

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -147,7 +147,7 @@ class Client:
         self.outbox.updates.clear()
         prefix = request.headers.get('X-Forwarded-Prefix', '') + request.scope.get('root_path', '')
         elements = json.dumps({
-            id: element._to_dict() for id, element in self.elements.items()  # pylint: disable=protected-access
+            id: element._to_dict(client_hash=request.cookies.get(f'nicegui_cache_{element._cache_name}') if element.caching_enabled() else None) for id, element in self.elements.items()  # pylint: disable=protected-access
         })
         socket_io_js_query_params = {
             **core.app.config.socket_io_js_query_params,

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -255,7 +255,7 @@ class Element(Visibility):
                     target = target.setdefault(key, {})
                 if keys[-1] in source:
                     target[keys[-1]] = source[keys[-1]]
-            if client_hash == hashlib.sha256(json.dumps(cache_data, sort_keys=True).encode()).hexdigest():
+            if client_hash == hashlib.sha256(json.dumps(cache_data).encode()).hexdigest():
                 for keys in self._cache_keys:  # nested traversal to remove cached data
                     d = data
                     for key in keys[:-1]:

--- a/nicegui/elements/html.py
+++ b/nicegui/elements/html.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Callable, Literal
+from typing import Callable, ClassVar, Literal
 
 from .mixins.content_element import ContentElement
 
 
 class Html(ContentElement):
+    default_cache_keys: ClassVar[list[list[str]]] = [['props', 'innerHTML']]
 
     def __init__(self, content: str = '', *, sanitize: Callable[[str], str] | Literal[False], tag: str = 'div') -> None:
         """HTML Element

--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -1,5 +1,6 @@
 import os
 from functools import lru_cache
+from typing import ClassVar
 
 import markdown2
 from fastapi.responses import PlainTextResponse
@@ -10,6 +11,7 @@ from .mixins.content_element import ContentElement
 
 class Markdown(ContentElement, component='markdown.js', default_classes='nicegui-markdown'):
     # NOTE: The Mermaid ESM is already registered in mermaid.py.
+    default_cache_keys: ClassVar[list[list[str]]] = [['props', 'innerHTML']]
 
     def __init__(self,
                  content: str = '', *,

--- a/nicegui/elements/tree.py
+++ b/nicegui/elements/tree.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator
-from typing import Any, Literal, Optional
+from typing import Any, ClassVar, Literal, Optional
 
 from typing_extensions import Self
 
@@ -8,6 +8,7 @@ from .mixins.filter_element import FilterElement
 
 
 class Tree(FilterElement):
+    default_cache_keys: ClassVar[list[list[str]]] = [['props', 'nodes']]
 
     def __init__(self,
                  nodes: list[dict], *,

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -477,7 +477,6 @@ function createApp(elements, options) {
           document.getElementById("popup").ariaHidden = false;
         },
         update: async (msg) => {
-          cachify(msg);
           const loadPromises = Object.entries(msg)
             .filter(([_, element]) => element && element.component)
             .map(([_, element]) => loadDependencies(element, options.prefix, options.version));

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,17 @@
+from nicegui import ui
+from nicegui.testing.screen import Screen
+
+
+def test_caching(screen: Screen):
+    @ui.page('/')
+    def page():
+        ui.markdown('Test **caching**').cache('basic_markdown_cache')
+
+    screen.open('/')
+    assert '"hit":false' in screen.selenium.page_source  # Python-land
+    assert 'innerHTML":"&lt;p&gt;Test' in screen.selenium.page_source  # JS-land
+    screen.should_contain('Test')
+    screen.open('/')
+    assert '"hit":true' in screen.selenium.page_source  # Python-land
+    assert 'innerHTML":"&lt;p&gt;Test' not in screen.selenium.page_source  # JS-land
+    screen.should_contain('Test')

--- a/website/svg.py
+++ b/website/svg.py
@@ -14,20 +14,20 @@ def face(half: bool = False) -> ui.html:
     code = HAPPY_FACE_SVG
     if half:
         code = code.replace('viewBox="0 0 62.44 71.74"', 'viewBox="31.22 0 31.22 71.74"')
-    return ui.html(code, sanitize=False)
+    return ui.html(code, sanitize=False).cache('nicegui-svg-face' + ('-half' if half else ''))
 
 
 def word() -> ui.html:
-    return ui.html(NICEGUI_WORD_SVG, sanitize=False)
+    return ui.html(NICEGUI_WORD_SVG, sanitize=False).cache('nicegui-svg-word')
 
 
 def github() -> ui.html:
-    return ui.html(GITHUB_SVG, sanitize=False)
+    return ui.html(GITHUB_SVG, sanitize=False).cache('nicegui-svg-github')
 
 
 def discord() -> ui.html:
-    return ui.html(DISCORD_SVG, sanitize=False)
+    return ui.html(DISCORD_SVG, sanitize=False).cache('nicegui-svg-discord')
 
 
 def reddit() -> ui.html:
-    return ui.html(REDDIT_SVG, sanitize=False)
+    return ui.html(REDDIT_SVG, sanitize=False).cache('nicegui-svg-reddit')


### PR DESCRIPTION
### Motivation

NiceGUI can benefit from per-element caching to boost page load speeds on the second load afterwards, assuming element definitions remain constant. 

There are previous attempts #4796 and #4900, which I will mainly compare the differences at the end. 

### Implementation

Python-land:

- Used "named element" approach (see https://github.com/zauberzeug/nicegui/pull/4796#issuecomment-2913109144)
- Element's caching policy defined via `default_cache_keys`, which is a list of nested keys. 
  - May be customized by the user if they know what they are doing. 
- Name and (optionally) caching policy passed to `.cache()` to enable caching. 
- `_to_dict` expects a hash from cookie (3), and:
  - Indicate whethere there is a cache hit (1)
  - Add caching metadata, including the caching policy (2)
  - Drop data if cache hit, or leave it in-place if not
- Cookie is stored per element to avoid making one exceptionally long cookie string
  - Later can more easily implement cache last-use to enable LRU cache eviction in case too many cookie / localStorage entries. 


JS-land: 

- If there is no cache hit, we know that the data must have been left in place (1), and so with the caching policy (2), the client can infer how to populate the data into cache, with no meaningful changes to the original element dictionary. 
- If there is a cache hit, we know that the data must have been dropped (1), we simply take the cache and shove it into element, and in edge case (should not occur) the original element's data take precedence. 
- Cache status is actively reflected in the cookies (3)

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).

Past todo list entries:

Inherited from #4796 

- [x] ~~Cookies have 4KB size limits; could the hash data exceed this?~~ Not in this PR since we use each cookie to store 1 element
- [ ] But we bump into the max cookies count, then. And if we lose the `session` then things break massively. 
  - Old single-cookie method may still have its merits. Not sure. 
- [x] ~~Synchronous localStorage` operations might freeze UI~~ [In short - just use it. It takes no time. 0.0007 of 1 millisecond.](https://stackoverflow.com/a/46779140)
- [x] Could the async hash computation lead to inconsistencies?
  - While yes, worst case is that the cached entry is not used. Sync hash computation is (1) unavailable from browser and (2) even worse of an idea in performance... 
- [x] We need tests to ensure caching works as expected
- [ ] How can we help developers to understand / manage cache size limits

### Comparison with past PRs

#4796 

Boy is that an old PR. My coding style is much more drastic back then. 

- The API is much more clean in this PR. 
- User would not need any knowledge of NiceGUI inner workings if they stick with the default cache policy (and possibly curated cache policies)
- A much smaller diff. 
- Accomplishes the basic suggested improvements in https://github.com/zauberzeug/nicegui/pull/4796#pullrequestreview-2929210335:
  - Less members per element introduced. 
  - No _to_dict_internal and _to_dict division - handled by `_to_dict` entirely


#4900 

It's promising but several issues still:

- "CACHE_" prefix lacks robustness: Inherent limitation of in-band communication for caching - there will always exist a user data which triggers the detection. 
- The "special treatment for elements which need it" leaks into the element's definition, which requires explicit `isinstance` checks to restore `CachedStr` class
  - It makes it impossible to cache an element with logic which does not have a default cache policy yet. 
- Requires maintenance of `known_hashes` of client, whereas this is done by the cookies in this PR. 
- Caches per item rather than per element, higher overhead. 
