### PR TITLE
Use `import_names` and `component_names` to error on dependency.py conflicts

### DIFF
--- a/nicegui/dependencies.py
+++ b/nicegui/dependencies.py
@@ -26,8 +26,8 @@ class Component:
 
     def __post_init__(self) -> None:
         assert self.key not in self._keys, f'Duplicate key "{self.key}" for {self.__class__.__name__} {self.path}'
-        self._keys.add(self.key)
         assert self.name not in self._names, f'Duplicate name "{self.name}" for {self.__class__.__name__} {self.path}'
+        self._keys.add(self.key)
         self._names.add(self.name)
 
     @property


### PR DESCRIPTION
### Motivation

**TL-DR: `dependency.py` isn't coded as tightly as it should, silently letting (possibly critical) errors slide into client-side instead of stopping them right away and preventing the server from launching in a verbose and attention-grabbing manner.** 

I was working on #5493 and looking for space savings, when I found some interesting behaviour with regards to our dependency.py implementation. 

1. We set key for `imports` at 2 places, libraries and ESM modules

https://github.com/zauberzeug/nicegui/blob/eea9a48071f274657e65409571c255b9b35830e8/nicegui/dependencies.py#L180-L186

If ESM modules are to have the same name as a library, the library would be shadowed. 

2. We append JS `import`s into `js_imports` at 2 places, one for `.js` components, one for `.vue` components

https://github.com/zauberzeug/nicegui/blob/eea9a48071f274657e65409571c255b9b35830e8/nicegui/dependencies.py#L193-L207

This one is a bit more serious: If you run import twice with same name, browser JS errors out entirely, and the page grinds to a halt (white screen)

`Uncaught SyntaxError: Identifier 'BLAH' has already been declared`

### Implementation

- 2 sets: `import_names` and `component_names`
- Do assertations before registration
- Update the set before returning

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Final notes

May break existing code which works (barely) in case 1, but I think we should break it, because the code isn't valid in the first place. 
