### PR TITLE
modulepreload the vue components

### DIFF
--- a/nicegui/dependencies.py
+++ b/nicegui/dependencies.py
@@ -193,6 +193,7 @@ def generate_resources(prefix: str, elements: Iterable[Element]) -> tuple[list[s
             js_imports.append(f'import {{ default as {vue_component.name} }} from "{url}";')
             js_imports.append(f"{vue_component.name}.template = '#tpl-{vue_component.name}';")
             js_imports.append(f'app.component("{vue_component.tag}", {vue_component.name});')
+            js_imports_urls.append(url)
             vue_styles.append(vue_component.style)
             done_components.add(key)
 


### PR DESCRIPTION
### Motivation

Both #4673 and #5257 forgot to `js_imports_urls.append(url)`, and so the `.vue` components are not modulepreloaded. 

### Implementation

Add `js_imports_urls.append(url)`

### Results

<img width="2055" height="107" alt="image" src="https://github.com/user-attachments/assets/45bb1b80-0e88-4d6f-96fc-4d9240dc1545" />

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Final notes

We are serving with `text/javascript` and so the browser happily module-preloads the file, irrespective of the `.vue` suffix

https://github.com/zauberzeug/nicegui/blob/eea9a48071f274657e65409571c255b9b35830e8/nicegui/nicegui.py#L79-L85

**simple-win let's merge ASAP**
