### PR TITLE
Initial-load element definition never needed component key nor tag so we drop it

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -226,7 +226,6 @@ class Element(Visibility):
                     'children': [child.id for child in self.default_slot.children],
                     'events': [listener.to_dict() for listener in self._event_listeners.values()],
                     'update_method': self._update_method,
-                    'component': self.component.name if self.component else None,
                 }.items()
                 if value
             },

--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -108,15 +108,17 @@ class Outbox:
                         for element_id, element in self.updates.items()
                     }
                     js_components = [
-                        {'key': component.key, 'name': component.name, 'tag': component.tag}
+                        component
                         for element in self.updates.values()
                         if not isinstance(element, Deleted)
                         and isinstance((component := element.component), JsComponent)
                         and component.name not in self._loaded_components
                     ]
                     if js_components:
-                        coros.append(self._emit((client.id, 'load_js_components', {'components': js_components})))
-                        self._loaded_components.update(c['name'] for c in js_components)
+                        coros.append(self._emit((client.id, 'load_js_components', {
+                            'components': [{'key': c.key, 'tag': c.tag} for c in js_components],
+                        })))
+                        self._loaded_components.update(c.name for c in js_components)
                     coros.append(self._emit((client.id, 'update', data)))
                     self.updates.clear()
 

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -43,7 +43,6 @@ function replaceUndefinedAttributes(element) {
   element.text ??= null;
   element.events ??= [];
   element.update_method ??= null;
-  element.component ??= null;
   element.slots = {
     default: { ids: element.children || [] },
     ...(element.slots ?? {}),


### PR DESCRIPTION
### Motivation

While working on https://github.com/zauberzeug/nicegui/pull/5495#issuecomment-3568186974, I realize there's literally space savings on-the-table, by inspecting code behaviour. 

### Implementation

#### Observation: Only 2 places where JS dependencies are loaded

1. In the HTML, we add JS imports statically

https://github.com/zauberzeug/nicegui/blob/eea9a48071f274657e65409571c255b9b35830e8/nicegui/dependencies.py#L193-L206

2. In JS, we load them

https://github.com/zauberzeug/nicegui/blob/eea9a48071f274657e65409571c255b9b35830e8/nicegui/static/nicegui.js#L281-L290

There is no other place. I looked. 

#### Fulfill the bare-minimum for the code logic

For 1 to not trigger 2, we do the following:

https://github.com/zauberzeug/nicegui/blob/eea9a48071f274657e65409571c255b9b35830e8/nicegui/static/nicegui.js#L148-L149

But note we only care about the `.name`, nothing else. So why ship the bulk? 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
  - [x] Does existing tests pass?
- [x] Documentation is not necessary (identical behaviour but faster).

### Final note

This re-affirms the belief in #5495 that we key by name, not by hash-key. 

**Is this a simple-win? I think it is if you memorize the codebase.**