### PR TITLE
Add missing link in `ui.sub_pages` demo

### DIFF
--- a/website/documentation/content/sub_pages_documentation.py
+++ b/website/documentation/content/sub_pages_documentation.py
@@ -289,6 +289,7 @@ def nested_sub_pages_demo():
 
     def other():
         ui.label('sub page')
+        # ui.link('Go to main', '/')
         # ui.link('Go to A', '/other/a')
         # ui.link('Go to B', '/other/b')
         # ui.sub_pages({


### PR DESCRIPTION
### Motivation

In #5498 we noticed that the displayed code doesn't produce the exact same output as the online demo.
https://nicegui.io/documentation/sub_pages#nested_sub_pages

### Implementation

This PR adds the missing link.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
