### PR TITLE
Docs homepage do not load Material Symbols just for 1 icon

### DIFF
--- a/website/main_page.py
+++ b/website/main_page.py
@@ -186,7 +186,7 @@ def create() -> None:
             with ui.link(target='https://github.com/sponsors/zauberzeug').style('color: black !important') \
                     .classes('rounded-full mx-auto px-12 py-2 border-2 border-[#3e6a94] font-medium text-lg md:text-xl'):
                 with ui.row(wrap=False).classes('items-center gap-4'):
-                    ui.icon('sym_o_favorite', color='#3e6a94')
+                    ui.icon('favorite_border', color='#3e6a94')
                     ui.label('Become a sponsor').classes('text-[#3e6a94] whitespace-nowrap')
 
     with ui.row().classes('dark-box min-h-screen mt-16'):


### PR DESCRIPTION
### Motivation

In NiceGUI documentation, Material Symbols of **254KB** in size, is loaded in just for 1 icon in the main page. 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6532dedc-7857-4af0-a03a-2160d16edb50" />

### Implementation

I found that, in Material Icons, `favorite_border` looks almost exactly the same as `sym_o_favorite`. Let's just do that. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Notes

**A simple-win PR.**

While there are other pages which use Material Symbols, I figured it's fine for now. 

### Visual demo

<img width="300" alt="image" src="https://github.com/user-attachments/assets/808305c9-e44a-42f0-aabc-f533dd8c9828" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/8425eb2c-2942-49b3-9569-3e0800af687c" />


### Lighthouse

Desktop's getting saturated so let me do Mobile

Before:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/9e833c18-6dee-4f1c-b618-2ef3f8ac4ead" />

After: 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/73befa75-a194-41e8-99f5-9ea92dcc14c1" />