### PR TITLE
Make sure the crosshair overlay matches the image

### DIFF
--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -10,7 +10,7 @@ export default {
         v-on="onUserEvents"
         draggable="false"
       />
-      <svg ref="svg" style="position:absolute;top:0;left:0;pointer-events:none" :viewBox="viewBox">
+      <svg ref="svg" style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none" :viewBox="viewBox" preserveAspectRatio="none">
         <g :style="{ display: showCross ? 'block' : 'none' }">
           <line v-if="cross" :x1="x" y1="0" :x2="x" y2="100%" :stroke="cross === true ? 'black' : cross" />
           <line v-if="cross" x1="0" :y1="y" x2="100%" :y2="y" :stroke="cross === true ? 'black' : cross" />


### PR DESCRIPTION
### Motivation

In #5479 we noticed that the crosshair of a `ui.interactive_image` with non-default aspect ratio is displayed incorrectly:
```py
ui.interactive_image('https://picsum.photos/id/565/640/360', on_mouse=ui.notify, cross=True).classes('size-100')
```

### Implementation

This PR simply adds `width:100%;height:100%` and `preserveAspectRatio="none"`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
