### PR TITLE
Capture query_parameters with wildcard routing

### DIFF
--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import re
 from typing import Any, Callable
-from urllib.parse import urlparse
+from urllib.parse import urlparse, ParseResult
 
 from starlette.datastructures import QueryParams
 from typing_extensions import Self
@@ -147,6 +147,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
 
     def _find_matching_path(self) -> RouteMatch | None:
         match: RouteMatch | None = None
+        query_params: QueryParams | None = None
         relative_path = self._router.current_path[len(self._root_path or ''):]
         if not relative_path.startswith('/'):
             relative_path = '/' + relative_path
@@ -155,17 +156,22 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
             path = '/'.join(segments)
             if not path:
                 path = '/'
-            match = self._match_route(path)
+            parsed_url = urlparse(path)
+
+            if query_params is None and parsed_url.query:
+                query_params = QueryParams(parsed_url.query)
+
+            match = self._match_route(parsed_url, query_params)
             if match is not None:
                 match.remaining_path = urlparse(relative_path).path.rstrip('/')[len(match.path):]
                 break
             segments.pop()
         return match
 
-    def _match_route(self, path: str) -> RouteMatch | None:
-        parsed_url = urlparse(path)
+    def _match_route(self, parsed_url: ParseResult, query_params: QueryParams | None) -> RouteMatch | None:
         path_only = parsed_url.path.rstrip('/')
-        query_params = QueryParams(parsed_url.query) if parsed_url.query else QueryParams()
+        if query_params is None:
+            query_params = QueryParams(parsed_url.query) if parsed_url.query else QueryParams()
         fragment = parsed_url.fragment
         if not path_only.startswith('/'):
             path_only = '/' + path_only

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -693,7 +693,8 @@ def test_async_sub_pages(screen: Screen):
 
 
 @pytest.mark.parametrize('use_page_arguments', [True, False])
-def test_sub_page_with_query_parameters(screen: Screen, use_page_arguments: bool):
+@pytest.mark.parametrize('show_404', [True, False])
+def test_sub_page_with_query_parameters(screen: Screen, use_page_arguments: bool, show_404: bool):
     calls = {'index': 0, 'main_content': 0}
 
     @ui.page('/')
@@ -701,7 +702,7 @@ def test_sub_page_with_query_parameters(screen: Screen, use_page_arguments: bool
         calls['index'] += 1
         ui.link('Link to main', '/?access=link')
         ui.button('Button to main', on_click=lambda: ui.navigate.to('/?access=button'))
-        ui.sub_pages({'/': with_page_arguments if use_page_arguments else with_parameter})
+        ui.sub_pages({'/': with_page_arguments if use_page_arguments else with_parameter}, show_404=show_404)
 
     def with_page_arguments(args: PageArguments):
         calls['main_content'] += 1
@@ -1250,3 +1251,19 @@ def test_remaining_path_for_wildcard_routing(screen: Screen):
 
     screen.open('/sub/x/2/a')
     screen.should_contain('remaining=/x/2/a')
+
+
+def test_query_parameters_wildcard_routing(screen: Screen):
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index():
+        ui.sub_pages({'/sub': sub_page}, show_404=False)
+
+    def sub_page(args: PageArguments):
+        ui.label(f'query_parameters={args.query_parameters}')
+
+    screen.open('/sub?color=red')
+    screen.should_contain('query_parameters=color=red')
+
+    screen.open('/sub/x/2/a?color=blue')
+    screen.should_contain('query_parameters=color=blue')


### PR DESCRIPTION
### Motivation

- https://github.com/zauberzeug/nicegui/issues/5529

### Implementation

Since a URL can only have query params once, we collect it as we go and apply to `match` when found.

I also added coverage for `show_404` behavior to `test_sub_page_with_query_parameters` while testing, just to be sure it's specifically wildcard routing causing the problem (it is).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
