### PR TITLE
Capture query_parameters with wildcard routing

### DIFF
--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -151,21 +151,22 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         if not relative_path.startswith('/'):
             relative_path = '/' + relative_path
         segments = relative_path.split('/')
+        query_params: QueryParams | None = None
         while segments:
             path = '/'.join(segments)
             if not path:
                 path = '/'
-            match = self._match_route(path)
+            match, query_params = self._match_route(path, query_params)
             if match is not None:
                 match.remaining_path = urlparse(relative_path).path.rstrip('/')[len(match.path):]
                 break
             segments.pop()
         return match
 
-    def _match_route(self, path: str) -> RouteMatch | None:
+    def _match_route(self, path: str, query_params: QueryParams | None) -> tuple[RouteMatch | None, QueryParams | None]:
         parsed_url = urlparse(path)
         path_only = parsed_url.path.rstrip('/')
-        query_params = QueryParams(parsed_url.query) if parsed_url.query else QueryParams()
+        query_params = query_params or QueryParams(parsed_url.query)
         fragment = parsed_url.fragment
         if not path_only.startswith('/'):
             path_only = '/' + path_only
@@ -180,8 +181,8 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
                     parameters=parameters,
                     query_params=query_params,
                     fragment=fragment,
-                )
-        return None
+                ), query_params
+        return None, query_params
 
     @staticmethod
     def _match_path(pattern: str, path: str) -> dict[str, str] | None:

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -693,7 +693,8 @@ def test_async_sub_pages(screen: Screen):
 
 
 @pytest.mark.parametrize('use_page_arguments', [True, False])
-def test_sub_page_with_query_parameters(screen: Screen, use_page_arguments: bool):
+@pytest.mark.parametrize('show_404', [True, False])
+def test_sub_page_with_query_parameters(screen: Screen, use_page_arguments: bool, show_404: bool):
     calls = {'index': 0, 'main_content': 0}
 
     @ui.page('/')
@@ -701,7 +702,7 @@ def test_sub_page_with_query_parameters(screen: Screen, use_page_arguments: bool
         calls['index'] += 1
         ui.link('Link to main', '/?access=link')
         ui.button('Button to main', on_click=lambda: ui.navigate.to('/?access=button'))
-        ui.sub_pages({'/': with_page_arguments if use_page_arguments else with_parameter})
+        ui.sub_pages({'/': with_page_arguments if use_page_arguments else with_parameter}, show_404=show_404)
 
     def with_page_arguments(args: PageArguments):
         calls['main_content'] += 1
@@ -1250,3 +1251,19 @@ def test_remaining_path_for_wildcard_routing(screen: Screen):
 
     screen.open('/sub/x/2/a')
     screen.should_contain('remaining=/x/2/a')
+
+
+def test_query_parameters_wildcard_routing(screen: Screen):
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index():
+        ui.sub_pages({'/sub': sub_page}, show_404=False)
+
+    def sub_page(args: PageArguments):
+        ui.label(f'query_parameters: {args.query_parameters}')
+
+    screen.open('/sub?color=red')
+    screen.should_contain('query_parameters: color=red')
+
+    screen.open('/sub/x/2/a?color=blue')
+    screen.should_contain('query_parameters: color=blue')


### PR DESCRIPTION
### Motivation

As noticed in #5529, the new wildcard routing drops query parameters:

```py
def item_page(args: PageArguments):
    ui.label(f'Query parameters: {args.query_parameters}')

ui.sub_pages({
    '/': lambda: ui.link('Go to item 123 with color red', '/item/123?color=red'),
    '/item': item_page,
}, show_404=False)
```

After clicking the link, we should see "color=red", but we don't.

### Implementation

As an alternative to PR #5530, this PR follows @evnchn's suggestion from https://github.com/zauberzeug/nicegui/pull/5530#issuecomment-3600294963.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
