### PR TITLE
Treat task id 0 as always running for Slot

### DIFF
--- a/nicegui/slot.py
+++ b/nicegui/slot.py
@@ -61,13 +61,12 @@ class Slot:
     async def prune_stacks(cls) -> None:
         """Remove stale slot stacks."""
         try:
-            running = [id(task) for task in asyncio.tasks.all_tasks() if not task.done() and not task.cancelled()]
+            running = {id(task) for task in asyncio.tasks.all_tasks() if not task.done() and not task.cancelled()}
 
-            # Id 0 is the special id used in cases where no task is active (see
-            # get_task_id). Since it has no associated task, we always assume
-            # it to be active in order to avoid pruning the associated stack
-            # while the Slot is active.
-            running.append(0)
+            # ID 0 is the special ID used in cases where no task is active (see get_task_id).
+            # Since it has no associated task, we always assume it to be active
+            # in order to avoid pruning the associated stack while the slot is active.
+            running.add(0)
 
             stale_ids = [task_id for task_id in cls.stacks if task_id not in running]
             for task_id in stale_ids:


### PR DESCRIPTION
Previously, a long running (or unlucky) callback running with a Slot context outside of an async task could have its stack pruned between `__enter__` (pushing on the stack) and `__exit__` (poping from the stack). The latter would find the stack missing or empty and would crash.

### Motivation

Consider the following MRE (courtesy of @falkoschindler):
```python
PING = Event[[]]()

app.timer(1, lambda: run.io_bound(PING.emit), once=True)

@ui.page('/')
def page():
    PING.subscribe(lambda: time.sleep(11))
```
Running this will always crash with the following stacktrace:
```
Traceback (most recent call last):
  File "/home/dominik/git/nicegui-test/.venv/lib/python3.12/site-packages/nicegui/event.py", line 145, in _invoke_and_forget
    result = callback.run(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dominik/git/nicegui-test/.venv/lib/python3.12/site-packages/nicegui/event.py", line 34, in run
    with (self.slot and self.slot()) or nullcontext():
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dominik/git/nicegui-test/.venv/lib/python3.12/site-packages/nicegui/slot.py", line 39, in __exit__
    self.get_stack().pop()
IndexError: pop from empty list
```


The issue is that the task is run without an active task, resulting a the task id of 0 within the Slot context. Entering the context will push an entry to the stack associated with id 0, but exiting will find the stack missing (or recreated and empty) since the periodic pruning task (running every 10 seconds) has not treated id 0 as associated with a running task and pruned the corresponding stack.

Notably, this is the same underlying issue as in #4985, but while there it was decided to be unsupported to create ui elements outside of the corresponding context, here it surfaced by simply emitting an event.

### Implementation

We simply add task id 0 to the list of running tasks as a special case. This will mean that the associated stack is never pruned, but the memory cost of this is miniscule.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
