### PR TITLE
expandable ajv by ajv_addins parameter

### DIFF
--- a/nicegui/elements/json_editor/json_editor.js
+++ b/nicegui/elements/json_editor/json_editor.js
@@ -22,7 +22,14 @@ export default {
   methods: {
     checkValidation() {
       if (this.schema !== undefined) {
-        this.properties.validator = createAjvValidator({ schema: this.schema, schemaDefinitions: {}, ajvOptions: {} });
+        this.properties.validator = createAjvValidator({
+          schema: this.schema,
+          schemaDefinitions: {},
+          ajvOptions: {},
+          onCreateAjv: (ajv) => {
+            for (const ajvAddin of this.ajvAddins) eval(ajvAddin)(ajv);
+          },
+        });
       }
     },
     update_editor() {
@@ -49,5 +56,6 @@ export default {
   props: {
     properties: Object,
     schema: Object,
+    ajvAddins: Array,
   },
 };

--- a/nicegui/elements/json_editor/json_editor.py
+++ b/nicegui/elements/json_editor/json_editor.py
@@ -20,6 +20,7 @@ class JsonEditor(Element, component='json_editor.js', esm={'nicegui-json-editor'
                  on_select: Optional[Handler[JsonEditorSelectEventArguments]] = None,
                  on_change: Optional[Handler[JsonEditorChangeEventArguments]] = None,
                  schema: Optional[dict] = None,
+                 ajv_addins: Optional[list[str]] = None,
                  ) -> None:
         """JSONEditor
 
@@ -30,6 +31,9 @@ class JsonEditor(Element, component='json_editor.js', esm={'nicegui-json-editor'
         :param on_select: callback which is invoked when some of the content has been selected
         :param on_change: callback which is invoked when the content has changed
         :param schema: optional `JSON schema <https://json-schema.org/>`_ for validating the data being edited (*added in version 2.8.0*)
+        :param ajv_addins: optional list of JavaScript-side functions to extend the AJV validator, e.g. to add custom formats (*added in version 3.5.0*)
+
+        Note: Do not let user control the input to `ajv_addins` as `eval` is used and this will cause XSS vulnerabilities!
         """
         super().__init__()
         self._props['properties'] = properties
@@ -43,6 +47,8 @@ class JsonEditor(Element, component='json_editor.js', esm={'nicegui-json-editor'
 
         if on_change:
             self.on_change(on_change)
+
+        self._props['ajvAddins'] = ajv_addins or []
 
     def on_change(self, callback: Handler[JsonEditorChangeEventArguments]) -> Self:
         """Add a callback to be invoked when the content changes."""


### PR DESCRIPTION
### Motivation

Owing to [just so many addins and extensions for AJV](https://www.perplexity.ai/search/now-i-know-that-for-ajv-i-can-oK0LuUMJQgec3N93IG5BJQ) I believe it is not feasible to carry-through the "see something? Add it to NiceGUI" approach in #4749, especially with shenanigans such as [tough to pack `ajv-formats` into our own ESM module](https://github.com/zauberzeug/nicegui/issues/4748#issuecomment-3628309903)

But we still want those extensions...

### Implementation

This is a "batteries not included" PR but it enables the use of AJV addins. 

Users are supposed to "bring their own addins" then register using `ajv_addins` parameter. 

Example code:

```py
from nicegui import ui

ui.add_head_html('''
<script type="module">
import ajvFormats from 'https://cdn.jsdelivr.net/npm/ajv-formats@3.0.1/+esm';
window.ajvFormats = ajvFormats;
</script>''')

schema = {
    'type': 'object',
    'properties': {
        'uuid': {
            'type': 'string',
            'format': 'uuid',  # breaks on main, not on this PR
        },
    },
    'required': ['uuid'],
}
data = {
    'uuid': '123e4567-e89b-12d3-a456-426614174000',
}
ui.json_editor({'content': {'json': data}}, schema=schema, ajv_addins=['ajvFormats'])

ui.run()
```

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests are pending. 
- [ ] Documentation is needed (several showcases, I'd imagine).
