### PR TITLE
Modulepreload Vue

### DIFF
--- a/nicegui/dependencies.py
+++ b/nicegui/dependencies.py
@@ -172,7 +172,7 @@ def generate_resources(prefix: str, elements: Iterable[Element]) -> tuple[list[s
         'immutable': f'{prefix}/_nicegui/{__version__}/static/immutable.es.js',
     }
     js_imports: list[str] = []
-    js_imports_urls: list[str] = []
+    js_imports_urls: list[str] = [imports['vue']]
 
     # build the importmap structure for libraries
     for key, library in libraries.items():


### PR DESCRIPTION
### Motivation

Sorry I forgot to ensure Vue was modulepreloaded (need is brought about by #5351, misse it in #5496)

It is the largest piece of crucial ES module. Should not have missed it 🤡 

### Implementation

Add it back. `js_imports_urls: list[str] = [imports['vue']]`. 

**Custom preset: 1s lag, infinite bandwidth. This makes such late-loading very obvious.**

Before:

<img width="621" alt="image" src="https://github.com/user-attachments/assets/6a613842-1caf-4fd5-b8c6-773252badb83" />


After: 

<img width="621" alt="image" src="https://github.com/user-attachments/assets/3879b36d-fe85-4976-9f4d-36f67c09302f" />


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests no need. 
- [x] Documentation no need. 

### Final notes

**Simple win lets go**
