### PR TITLE
Add dnspython to website dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ types = [
     "types-requests>=2.32.4",
 ]
 website = [
+    "dnspython>=2.4.0,<3",
     "html-sanitizer>=2.6.0,<3",
     "isort>=6.0.0,<7.0.0",
     "latex2mathml>=3.78.1,<4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -847,6 +847,34 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload-time = "2024-10-05T20:14:59.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload-time = "2024-10-05T20:14:57.687Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.20.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2313,6 +2341,8 @@ dev = [
     { name = "autopep8" },
     { name = "cssbeautifier" },
     { name = "debugpy" },
+    { name = "dnspython", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "dnspython", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "html-sanitizer" },
     { name = "isort" },
     { name = "latex2mathml" },
@@ -2363,6 +2393,8 @@ types = [
     { name = "types-requests" },
 ]
 website = [
+    { name = "dnspython", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "dnspython", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "html-sanitizer" },
     { name = "isort" },
     { name = "latex2mathml" },
@@ -2408,6 +2440,7 @@ dev = [
     { name = "autopep8", specifier = ">=1.5.7,<3.0.0" },
     { name = "cssbeautifier", specifier = ">=1.15.4,<2" },
     { name = "debugpy", specifier = ">=1.3.0,<2" },
+    { name = "dnspython", specifier = ">=2.4.0,<3" },
     { name = "html-sanitizer", specifier = ">=2.6.0,<3" },
     { name = "isort", specifier = ">=6.0.0,<7.0.0" },
     { name = "latex2mathml", specifier = ">=3.78.1,<4.0.0" },
@@ -2456,6 +2489,7 @@ types = [
     { name = "types-requests", specifier = ">=2.32.4" },
 ]
 website = [
+    { name = "dnspython", specifier = ">=2.4.0,<3" },
     { name = "html-sanitizer", specifier = ">=2.6.0,<3" },
     { name = "isort", specifier = ">=6.0.0,<7.0.0" },
     { name = "latex2mathml", specifier = ">=3.78.1,<4.0.0" },


### PR DESCRIPTION
### Motivation

The fly.io middleware in `website/fly.py` uses `dns.resolver` to check if a target instance is still online before replaying WebSocket requests. Previously this was installed only on the fly.io image but not declared in `pyproject.toml`, causing local runs to fail without manual installation.

### Implementation

This adds `dnspython>=2.4.0,<3` to the `website` optional dependency group, making it explicit and ensuring `uv sync` installs it for website development.

No impact on core library or public API: website-with-fly-only change.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
