### PR TITLE
Have `ui.joystick` use `.js` component instead

### DIFF
--- a/nicegui/elements/joystick/joystick.js
+++ b/nicegui/elements/joystick/joystick.js
@@ -1,11 +1,8 @@
-<template>
-  <div><div></div></div>
-</template>
+import { nipplejs } from "nicegui-joystick";
 
-<script>
 export default {
-  async mounted() {
-    const { nipplejs } = await import("nicegui-joystick");
+  template: "<div><div></div></div>",
+  mounted() {
     const joystick = nipplejs.create({
       zone: this.$el.children[0],
       position: { left: "50%", top: "50%" },
@@ -20,12 +17,3 @@ export default {
     options: Object,
   },
 };
-</script>
-
-<style scoped>
-:scope > div {
-  width: 100%;
-  height: 100%;
-  position: relative;
-}
-</style>

--- a/nicegui/elements/joystick/joystick.py
+++ b/nicegui/elements/joystick/joystick.py
@@ -6,7 +6,7 @@ from ...element import Element
 from ...events import GenericEventArguments, Handler, JoystickEventArguments, handle_event
 
 
-class Joystick(Element, component='joystick.vue', esm={'nicegui-joystick': 'dist'}, default_classes='nicegui-joystick'):
+class Joystick(Element, component='joystick.js', esm={'nicegui-joystick': 'dist'}, default_classes='nicegui-joystick'):
 
     def __init__(self, *,
                  on_start: Optional[Handler[JoystickEventArguments]] = None,

--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -259,6 +259,11 @@ h6.q-timeline__title {
   height: 10em;
   background-color: AliceBlue;
 }
+.nicegui-joystick > div {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
 .nicegui-scene[data-initializing],
 .nicegui-scene-view[data-initializing] {
   visibility: hidden;


### PR DESCRIPTION
### Motivation

Vue components have the problem in that they are always loaded into the HTML regardless of whether the element is on-sceeen because of the need of HTML and CSS. 

I don't quite like that, so this PR seeks to have `ui.joystick` use `.js` component instead

### Implementation

- Template is in the JS now. 
- Import nipplejs statically is possible (perf).
- Scoped style is achieved via targeting `.nicegui-joystick`, similar to the other elements. 
  - We already had `.nicegui-joystick` selector in `nicegui.css` so I figured it is no harm to add another one. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Existing pytest do us good. 
- [x] Documentation no need for a background improvement. 
