### PR TITLE
Pin chrome version 142

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Install dependencies
         run: uv sync
       - uses: nanasess/setup-chromedriver@v2.3.0
+        with:
+          chromedriver-version: '142.0.7444.175'
       - name: ${{ matrix.python }} / ${{ matrix.scope }}
         if: matrix.scope == 'pytest'
         run: uv run pytest


### PR DESCRIPTION
### Motivation

speculative loading test fail on several branches.

Chrome 143 broke something

### Implementation

This pull request makes a minor update to the GitHub Actions workflow by specifying the exact version of Chromedriver to use during test runs. This change helps ensure more consistent and reliable browser-based testing results.

* Workflow update:
  * [`.github/workflows/_test.yml`](diffhunk://#diff-d30e144e1a94b9125c97915d4bd55eeb00d136257f96c9c753c255b66b1c00b4R36-R37): Explicitly sets the `chromedriver-version` to `'142.0.7444.175'` in the Chromedriver setup step.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
