### PR TITLE
Immediate eagerness for speculative loading tests

### DIFF
--- a/tests/test_speculative_loading.py
+++ b/tests/test_speculative_loading.py
@@ -123,7 +123,7 @@ def test_prefetch_connects_after_navigation(screen: Screen, event_log: EventLog)
 
 
 def add_speculation_rule(url: str, *, kind: str = 'prerender') -> None:
-    rules = {kind: [{'source': 'list', 'urls': [url], 'eagerness': 'eager'}]}
+    rules = {kind: [{'source': 'list', 'urls': [url], 'eagerness': 'immediate'}]}
     script = '<script type="speculationrules">' + json.dumps(rules) + '</script>'
     ui.add_head_html(script)
 


### PR DESCRIPTION
### Motivation

Speculative tests fail on several branches

Chrome 143 changed how the eagerness works. https://developer.chrome.com/release-notes/143#speculation_rules_mobile_eager_eagerness_improvements

This PR fixes it in the root cause. Supersedes #5572 

Tests pass on my branches until. It should also pass here. 

### Implementation

This pull request makes a minor change to the test setup for speculative loading by adjusting the eagerness setting in the rules.

- Changed the `eagerness` value from `'eager'` to `'immediate'` in the `add_speculation_rule` helper function in `tests/test_speculative_loading.py` to better reflect the intended loading behavior.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
