### PR TITLE
ECharts events handle click label

### DIFF
--- a/nicegui/elements/echart/echart.py
+++ b/nicegui/elements/echart/echart.py
@@ -53,15 +53,15 @@ class EChart(Element, component='echart.js', esm={'nicegui-echart': 'dist'}, def
             handle_event(callback, EChartPointClickEventArguments(
                 sender=self,
                 client=self.client,
-                component_type=e.args['componentType'],
-                series_type=e.args['seriesType'],
-                series_index=e.args['seriesIndex'],
-                series_name=e.args['seriesName'],
-                name=e.args['name'],
-                data_index=e.args['dataIndex'],
-                data=e.args['data'],
+                component_type=e.args['componentType'],  # Must be there
+                series_type=e.args.get('seriesType'),
+                series_index=e.args.get('seriesIndex'),
+                series_name=e.args.get('seriesName'),
+                name=e.args['name'],  # Must be there
+                data_index=e.args.get('dataIndex'),
+                data=e.args.get('data'),
                 data_type=e.args.get('dataType'),
-                value=e.args['value'],
+                value=e.args.get('value'),
             ))
         self.on('pointClick', handle_point_click, [
             'componentType',

--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -53,14 +53,14 @@ class SlideEventArguments(UiEventArguments):
 @dataclass(**KWONLY_SLOTS)
 class EChartPointClickEventArguments(UiEventArguments):
     component_type: str
-    series_type: str
-    series_index: int
-    series_name: str
+    series_type: str | None
+    series_index: int | None
+    series_name: str | None
     name: str
-    data_index: int
-    data: float | int | str
-    data_type: str
-    value: float | int | list
+    data_index: int | None
+    data: float | int | str | None
+    data_type: str | None
+    value: float | int | list | None
 
 
 @dataclass(**KWONLY_SLOTS)


### PR DESCRIPTION
### Motivation

Fix #5576, where in the case of clicking indicator label, all we have in `e.args` is key `componentType` and `name`, causing library code to throw an error. 

### Implementation

For all the keys which may be absent: 

- use `.get(...)`
- **(slightly controversial)** Apply `| None` to the event arguments
  - Can be considered a breaking change?

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).
