### PR TITLE
Fix Docker bind-mount regression after uv migration

### DIFF
--- a/release.dockerfile
+++ b/release.dockerfile
@@ -5,6 +5,9 @@ LABEL maintainer="Zauberzeug GmbH <info@zauberzeug.com>"
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
 WORKDIR /app
 
 # Copy dependency files first for better layer caching
@@ -31,4 +34,4 @@ EXPOSE 8080
 ENV PYTHONUNBUFFERED=True
 
 ENTRYPOINT ["/resources/docker-entrypoint.sh"]
-CMD ["uv", "run", "--no-sync", "main.py"]
+CMD ["/opt/venv/bin/python", "main.py"]


### PR DESCRIPTION
This restores compatibility with the documented `-v $(pwd):/app` workflow.

Since 3.4.0 (uv migration), the Docker image installs its runtime environment under `/app` and uses `uv run` at runtime. When users bind-mount `/app` (as documented), this hides the image’s `pyproject.toml` and venv, leading to `ModuleNotFoundError: nicegui` (and `uv` warns that `--no-sync` has no effect outside a project).

This PR:
- moves the uv project environment outside `/app` (UV_PROJECT_ENVIRONMENT=/opt/venv)
- runs the venv Python directly at runtime (CMD ["/opt/venv/bin/python", "main.py"])

Build-time dependency resolution and installation still use `uv`; the change is purely to make `/app` safe to bind-mount again.

Verified locally with 3.4.1 using a host directory containing only `main.py`:
- `zauberzeug/nicegui:3.4.1` fails with `ModuleNotFoundError`
- the patched image runs successfully with the same bind-mount

Fixes #5593