### PR TITLE
Client-side input value persistence

### DIFF
--- a/nicegui/elements/input.js
+++ b/nicegui/elements/input.js
@@ -19,15 +19,14 @@ export default {
   props: {
     _autocomplete: Array,
     value: String,
-    internal_id: String,
+    clientStorageId: String,
   },
   unmounted() {
-    window.__nicegui_input_values__[this.internal_id] = this.inputValue;
+    setClientStorageValue(this.clientStorageId, "oldInputValue", this.inputValue);
   },
   data() {
-    if (!window.__nicegui_input_values__) window.__nicegui_input_values__ = {};
     return {
-      inputValue: window.__nicegui_input_values__[this.internal_id] || this.value,
+      inputValue: getClientStorageValue(this.clientStorageId, "oldInputValue") || this.value,
       emitting: true,
     };
   },

--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -1,14 +1,14 @@
-import uuid
 from typing import Any, Optional, Union
 
 from ..events import Handler, ValueChangeEventArguments
 from .icon import Icon
+from .mixins.client_storage_element import ClientStorageElement
 from .mixins.disableable_element import DisableableElement
 from .mixins.label_element import LabelElement
 from .mixins.validation_element import ValidationDict, ValidationElement, ValidationFunction
 
 
-class Input(LabelElement, ValidationElement, DisableableElement, component='input.js'):
+class Input(LabelElement, ValidationElement, DisableableElement, ClientStorageElement, component='input.js'):
     VALUE_PROP: str = 'value'
     LOOPBACK = False
 
@@ -56,7 +56,6 @@ class Input(LabelElement, ValidationElement, DisableableElement, component='inpu
         :param validation: dictionary of validation rules or a callable that returns an optional error message (default: None for no validation)
         """
         super().__init__(label=label, value=value, on_value_change=on_change, validation=validation)
-        self._props['internal_id'] = str(uuid.uuid4())
         self._props['for'] = self.html_id
         if placeholder is not None:
             self._props['placeholder'] = placeholder

--- a/nicegui/elements/mixins/client_storage_element.py
+++ b/nicegui/elements/mixins/client_storage_element.py
@@ -1,0 +1,11 @@
+from uuid import uuid4
+
+from ...element import Element
+
+
+class ClientStorageElement(Element):
+    """An element which requires client storage to re-mount itself after un-mounting."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._props['client-storage-id'] = str(uuid4())

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -7,6 +7,24 @@ let mounted_app = undefined;
 
 const loaded_components = new Set();
 
+let clientStorage = {};
+
+function getClientStorageValue(clientStorageId, key) {
+  return clientStorage?.[clientStorageId]?.[key];
+}
+
+function setClientStorageValue(clientStorageId, key, value) {
+  if (!(clientStorageId in clientStorage)) {
+    clientStorage[clientStorageId] = {};
+  }
+  clientStorage[clientStorageId][key] = value;
+}
+
+function deleteClientStorage(clientStorageId) {
+  if (!clientStorageId) return;
+  delete clientStorage[clientStorageId];
+}
+
 function parseElements(raw_elements) {
   return JSON.parse(
     raw_elements
@@ -399,6 +417,7 @@ function createApp(elements, options) {
           await Promise.all(loadPromises);
 
           for (const [id, element] of Object.entries(msg)) {
+            if (id in this.elements) deleteClientStorage(this.elements[id].props?.["client-storage-id"]);
             if (element === null) {
               delete this.elements[id];
               continue;

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -389,7 +389,7 @@ async def test_page_to_string_output_used_in_error_messages(user: User) -> None:
               Button \[markers=second, label=World\]
               Icon \[markers=third, name=thumbs-up\]
             Avatar \[icon=star\]
-            Input \[value=typed, label=some input, internal_id=[^\]]+, for=c10, placeholder=type here, type=text\]
+            Input \[client-storage-id=[^\]]+, value=typed, label=some input, for=c10, placeholder=type here, type=text\]
             Markdown \[content=\#\# Markdown..., resource_name=[^\]]+\]
             Card
              Image \[src=/image.jpg\]


### PR DESCRIPTION
### Motivation

Fixes https://github.com/zauberzeug/nicegui/issues/2149

Let us recap the problem space:

https://github.com/zauberzeug/nicegui/blob/b11972f063b976174f0cd4a4af4a9ead18ac2a10/nicegui/elements/input.js#L19-L28

- When an `ui.input` is unmounted then remounted client-side (from being inside `ui.dialog`, for example), the JS component is supposed to mount itself **without involving the server**.
- `this.value` does not change with user input (you can't even set it), only `this.inputValue` does. 
- But the value in the latter is tossed on unmount, and re-initialized to `this.value` which is stale. 

This prompts for the titled solution: **Client-side input value persistence**

### Implementation

- Identify each `ui.input` with a `internal_id`
- When the element is unmounted, keep the value with `window.__nicegui_input_values__[this.internal_id] = this.inputValue;`
- When the element is remounted, prioritize the value in `window.__nicegui_input_values__[this.internal_id]` over `this.value`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [ ] Oh this is going to be tough to pytest. I will try it
- [x] Documentation is not necessary for a bugfix.

### Testing code

For https://github.com/zauberzeug/nicegui/discussions/1125

```py
from nicegui import app, ui

if not app.storage.general.get('name'):
    app.storage.general['name'] = 'NiceGUI User'

with ui.label() as label:
    label.bind_text_from(app.storage.general, 'name')
    with ui.element('q-popup-edit'):
        ui.input().bind_value(app.storage.general, 'name')

with ui.dialog() as mydialog, ui.card():
    ui.input().bind_value(app.storage.general, 'name')
ui.button('Edit name in dialog', on_click=mydialog.open)

ui.run()
```


