### PR TITLE
Test `.vue` component

### DIFF
--- a/tests/test_vue_component.py
+++ b/tests/test_vue_component.py
@@ -1,66 +1,45 @@
-import os
-import tempfile
-
-import pytest
+from pathlib import Path
 
 from nicegui import ui
-from nicegui.element import Element
 from nicegui.testing.screen import Screen
 
-SOURCE_CODE = '''
-<template>
-  <div>
-  <div>Template content shows up</div>
-  <div>{{ js_check }}</div>
-  </div>
-</template>
 
-<script>
-export default {
-  data() {
-    return {
-      js_check: 'JS content shows up'
-    };
-  },
-};
-</script>
+def test_vue_element(screen: Screen, tmp_path: Path):
+    vue_component_path = tmp_path / 'component.vue'
+    vue_component_path.write_text('''
+        <template>
+            <div>
+                <div>Template shows up</div>
+                <div>{{ js_content }}</div>
+            </div>
+        </template>
 
-<style scoped>
-:scope > div {
-  color: red;
-}
-</style>
-'''
+        <script>
+            export default {
+                data() {
+                    return {
+                        js_content: "JavaScript runs",
+                    };
+                },
+            };
+        </script>
 
+        <style scoped>
+            :scope > div {
+                color: red;
+            }
+        </style>
+    ''')
 
-@pytest.fixture
-def vue_component_file():
-    tmp_file = tempfile.NamedTemporaryFile(suffix='.vue', delete=False)
-    temp_file_path = tmp_file.name
-    tmp_file.write(SOURCE_CODE.encode('utf-8'))
-    tmp_file.close()
-
-    print(f'Temporary Vue file created at: {temp_file_path}')
-
-    yield temp_file_path
-
-    os.unlink(temp_file_path)
-
-
-def test_vue_element(screen: Screen, vue_component_file):
-    class MyVueElement(Element, component=str(vue_component_file)):
-        def __init__(self) -> None:
-            super().__init__()
+    class MyVueElement(ui.element, component=vue_component_path):
+        pass
 
     @ui.page('/')
     def page():
         MyVueElement()
-        ui.label('This should not be red')
+        ui.label('This is not red')
+
     screen.open('/')
-    samples = [
-        ('Template content shows up', 'rgba(255, 0, 0, 1)'),
-        ('JS content shows up', 'rgba(255, 0, 0, 1)'),
-        ('This should not be red', 'rgba(0, 0, 0, 1)'),
-    ]
-    for text, color in samples:
-        assert screen.find(text).value_of_css_property('color') == color
+    assert screen.find('Template shows up').value_of_css_property('color') == 'rgba(255, 0, 0, 1)'
+    assert screen.find('JavaScript runs').value_of_css_property('color') == 'rgba(255, 0, 0, 1)'
+    assert screen.find('This is not red').value_of_css_property('color') == 'rgba(0, 0, 0, 1)'


### PR DESCRIPTION
### Motivation

#5567 and #5568 would move `ui.joystick` and `ui.plotly` away from `.vue` components considering performance. However, this would leave `.vue` components to be totally un-pytested, which is not something we want. 

### Implementation

This tests:

- HTML content shows up
- JS runs and its relevant content shows up
- Scoped CSS works and do not leak into outside

Which is all we are asking for the `.vue` component integration. All else should be tested in `test_vbuild.py`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary for a pytest.
- [x] Documentation is not necessary for a pytest.
