### PR TITLE
Document input validation thoroughly

### DIFF
--- a/website/documentation/content/input_documentation.py
+++ b/website/documentation/content/input_documentation.py
@@ -48,8 +48,10 @@ def styling():
     - by passing a callable that returns an error message or `None`, or
     - by passing a dictionary that maps error messages to callables that return `True` if the input is valid.
 
-    Both of these validations **run on Python-side**, bringing security against client-side circumventions and flexibility in validation logic.
-    However they do not correspond to Quasar's validation-related props and methods, and require server communication and processing.
+    Both of these validations **run on Python-side**,
+    bringing security against client-side circumventions and flexibility in validation logic.
+    However they do not correspond to Quasar's validation-related props and methods,
+    and require server communication and processing.
 
     *Since version 2.7.0:*
     The callable validation function can also be an async coroutine.
@@ -67,14 +69,18 @@ def validation():
 @doc.demo('Lazy validation', '''
     To run validation lazily, you can consider:
 
-    - adding a debounce with the `debounce` prop, so that validation is only triggered after the user stops typing for a certain amount of time,
-    - disable automatic validation with `without_auto_validation()` and call the `validate` method manually whenever appropriate, e.g., on blur, on form submission,
-    - or a combination of both approaches.
+    - adding a debounce with the `debounce` prop,
+      so that validation is only triggered after the user stops typing for a certain amount of time,
+    - disabling automatic validation with `without_auto_validation()`
+      and calling the `validate` method manually whenever appropriate, e.g., on blur or on form submission,
+    - or using a combination of both approaches.
 ''')
 def lazy_validation():
-    ui.input('name (debounce)', validation={'Too short': lambda v: len(v) > 5}).props('debounce=1000')
+    ui.input('name (debounce)', validation={'Too short': lambda v: len(v) > 5}) \
+        .props('debounce=1000')
 
-    name = ui.input('name (on blur)', validation={'Too short': lambda v: len(v) > 5}).without_auto_validation()
+    name = ui.input('name (on blur)', validation={'Too short': lambda v: len(v) > 5}) \
+        .without_auto_validation()
     name.on('blur', name.validate)
 
 
@@ -84,11 +90,12 @@ def lazy_validation():
 
     This way the Quasar props such as `lazy-rules` and methods such as `resetValidation` can also be used.
 
-    Note the use of `:` prefix to denote a JavaScript expression string, and treating `props` as a dictionary to simplify string-escaping.
+    Note the use of `:` prefix to denote a JavaScript expression string,
+    and treating `props` as a dictionary to simplify string-escaping.
 ''')
 def client_side_validation():
     name = ui.input('name (client-side)').props('lazy-rules')
-    name.props[':rules'] = '''[ val => val.length > 5 || 'Too short' ]'''
+    name.props[':rules'] = '[ val => val.length > 5 || "Too short" ]'
     ui.button('Reset Validation', on_click=lambda: name.run_method('resetValidation'))
 
 


### PR DESCRIPTION
### Motivation

Having validation at Python-side is a design decision made by NiceGUI. However, current docs pointing the user to Quasar documentation for extra props may make it sound like our validation is not working right. 

### Implementation

- Fully document why validation at Python-side: Security and flexibility. 
- Offer common use cases of customized validation (debounced, on-blur) in Python-side. 
- Inform the user how to have the validation at JS-side while letting them know of the consequences. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
