### PR TITLE
Leftovers from PR "resolve default parameter values with a decorator"

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -213,6 +213,7 @@ class Element(Visibility):
         }
 
     def _to_dict(self) -> dict[str, Any]:
+        self._props._invoke_checks()  # pylint: disable=protected-access
         return {
             'tag': self.tag,
             **({'text': self._text} if self._text is not None else {}),

--- a/nicegui/props.py
+++ b/nicegui/props.py
@@ -126,6 +126,10 @@ class Props(ObservableDict, Generic[T]):
                     self[rename] = self[name]
                 helpers.warn_once(f'The prop "{name}" is deprecated. Use "{rename}" instead.')
 
+    def _invoke_checks(self) -> None:
+        self._check_warnings()
+        self._check_renames()
+
     def __call__(self,
                  add: Optional[str] = None, *,
                  remove: Optional[str] = None) -> T:


### PR DESCRIPTION
### Motivation

2 issues:

May not readback the old props

```py
myaggid = ui.aggrid({
    'columnDefs': [{'headerName': 'Name', 'field': 'name'}],
    'rowData': [{'name': 'M&uuml;nster'}],
}).props('html_columns=[0]').classes('h-24')
ui.label(myaggid.props.get('html_columns', 'missing, how come?'))
```

Wrong props name in `default_props` uncaught

```py
ui.aggrid.default_props('html_columns=[0]')({
    'columnDefs': [{'headerName': 'Name', 'field': 'name'}],
    'rowData': [{'name': 'M&uuml;nster'}],
}).classes('h-24')
```



### Implementation

- [Do not toss the old prop to facilitate readback](https://github.com/zauberzeug/nicegui/commit/3db1d854fc9cbbedae263931c1d6716a60264efe)
- [Run checks preflight to check on default_props](https://github.com/zauberzeug/nicegui/commit/bacba42625c2e634d65a3b6fd5613cbaad3f36a6)

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
