### PR TITLE
Allow propagation of nested updates back to frontend in AnyWidget

### DIFF
--- a/tests/test_anywidget.py
+++ b/tests/test_anywidget.py
@@ -36,24 +36,19 @@ def test_anywidget(screen: Screen):
     screen.click('NiceGUI: 43')
     screen.should_contain('anywidget: 44')
 
+
 def test_nested_update(screen: Screen):
     class UpdateWidget(anywidget.AnyWidget):  # pylint: disable=abstract-method
         _esm = '''
-        function render({model, el}) {
-            const div = document.createElement("div");
-            div.innerText = "nothing";
-            el.appendChild(div);
-
-            model.on("change:b", () => {
-                const b = model.get("b");
-                div.innerText = `b=${b}`;
-            });
-
-            model.set("a", 1);
-            model.save_changes();
-        }
-
-        export default { render };
+            function render({model, el}) {
+                const div = document.createElement("div");
+                div.innerText = "nothing";
+                el.appendChild(div);
+                model.on("change:b", () => div.innerText = `b=${model.get("b")}`);
+                model.set("a", 1);
+                model.save_changes();
+            }
+            export default { render };
         '''
         a = traitlets.Int(0).tag(sync=True)
         b = traitlets.Int(0).tag(sync=True)
@@ -61,7 +56,9 @@ def test_nested_update(screen: Screen):
     @ui.page('/')
     def page():
         uw = UpdateWidget()
+
         def change_b(change):
+            """Change the value of `b` while handling the change of `a`."""
             assert change['name'] == 'a'
             assert change['new'] == 1
             uw.b = 1


### PR DESCRIPTION
### Motivation

Closes #5626

As mentioned there, altair charts don't render when using the vegafusion data_transformer. I think it uses traitlets to communicate with the frontend.

<details>
<summary> Altair Example</summary>

```python
from nicegui import ui
import altair as alt
import pandas as pd

alt.data_transformers.enable("vegafusion")
c = alt.Chart(pd.DataFrame({"data": [0,1,2,3]})).mark_point().encode(x="data")

ui.altair(c)
ui.run()
```

</details>

### Implementation

It keeps track of the current dictionary of changes made as a result of the front-end code, and avoids calling `update_traits` if there's been no new changes.

The one concern I have with NaNs, since NaNs are always not-equal to each other, the check will return True, perhaps causing more updates than intended.

### Progress

- [X] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [X] The implementation is complete.
- [X] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [X] Pytests have been added (or are not necessary).
- [X] Documentation has been added (or is not necessary).
