### PR TITLE
ui.log scroll-to-bottom working in ui.tab_panel using onScroll

### DIFF
--- a/nicegui/elements/log.js
+++ b/nicegui/elements/log.js
@@ -7,13 +7,12 @@ export default {
     };
   },
   updated() {
-    if (this.$refs.qRef && this.shouldScroll) {
+    if (this.shouldScroll) {
       this.$nextTick(() => this.$refs.qRef.setScrollPosition("vertical", Number.MAX_SAFE_INTEGER));
     }
   },
   methods: {
     onScroll(info) {
-      if (!this.$refs.qRef) return;
       if (info.verticalContainerSize === 0 || info.horizontalContainerSize === 0) return;
       if (info.verticalContainerSize !== this.lastHeight) {
         this.lastHeight = info.verticalContainerSize;


### PR DESCRIPTION
### Motivation

Fix #5118, where we find #5112 (or, actually, the reimplementation of it in 3.0, since we do `q-scroll-area` for `ui.log`) does not work inside `ui.tab`. 

### Implementation

Compared to the predecessor, #5220, the following are the realizations:

- The core reason behind flaky `verticalPercentage` measurements is that, during the animation, `clientHeight` degenerates to 0px tall. We can ignore it with `if (!this.$refs.qRef.$el.childNodes[0].clientHeight) return;`
- During tab animate-in, the DOM during `beforeUpdate` is really messy. I just cannot find a reliable measure. 
- Use `onScroll`, because the user's intention on whether to scroll-to-bottom changes on scroll. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] We probably can't easily pytest this...
- [x] Documentation is not necessary.