### PR TITLE
Destroy the AGGrid API on update_grid and unmounted

### DIFF
--- a/nicegui/elements/aggrid/aggrid.js
+++ b/nicegui/elements/aggrid/aggrid.js
@@ -13,6 +13,7 @@ export default {
     updateTheme();
   },
   unmounted() {
+    this.api?.destroy();
     this.themeObserver.disconnect();
   },
   methods: {
@@ -63,6 +64,7 @@ export default {
           this.handle_event("gridReady", params);
         }
       };
+      this.api?.destroy();
       this.api = AgGrid.createGrid(this.$el, this.gridOptions);
       this.api.addGlobalListener(this.handle_event);
     },


### PR DESCRIPTION
### Motivation

As mentioned in a privately-made but rejected vulnerability report, `ui.aggrid` leaks on `update` and on unmounted. 

### Implementation

Destroy `this.api` if available for:
- `update_grid` (invoked on update since it is the `_update_method`)
- `unmounted` (invoked on unmount)

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] It is too tough to pytest client-side memory leaks and we generally do not bother.
- [x] Documentation is not necessary.

### Notes

Were this to be scored by CVSS 3.1, it yields, 3.7/10.0. As such, after discussion, it was decided that this bug does not constitute a vulnerability worthy of a GHSA let alone a CVE ID. 

Nevertheless, if your code **renders AG Grid based on external-controlled event source** and **expect to have long-life and unmanned browser clients** (such as electronic billboards) then you may still want to watch out. 