### PR TITLE
Configurable defaults using `resolve_defaults`

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -45,6 +45,7 @@ class Element(Visibility):
     _default_props: ClassVar[dict[str, Any]] = {}
     _default_classes: ClassVar[list[str]] = []
     _default_style: ClassVar[dict[str, str]] = {}
+    _defaults: ClassVar[dict[str, Any]] = {}
 
     def __init__(self, tag: str | None = None, *, _client: Client | None = None) -> None:
         """Generic Element

--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -7,15 +7,17 @@ from fastapi.responses import PlainTextResponse
 from pygments.formatters import HtmlFormatter  # pylint: disable=no-name-in-module
 
 from .. import core
+from ..defaults import DEFAULTS, resolve_defaults
 from .mixins.content_element import ContentElement
 
 
 class Markdown(ContentElement, component='markdown.js', default_classes='nicegui-markdown'):
     # NOTE: The Mermaid ESM is already registered in mermaid.py.
 
+    @resolve_defaults
     def __init__(self,
                  content: str = '', *,
-                 extras: list[str] = ['fenced-code-blocks', 'tables'],  # noqa: B006
+                 extras: list[str] = DEFAULTS | ['fenced-code-blocks', 'tables'],
                  ) -> None:
         """Markdown Element
 

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -33,6 +33,7 @@ __all__ = [
     'dark_mode',
     'date',
     'date_input',
+    'default',
     'dialog',
     'download',
     'drawer',
@@ -138,6 +139,7 @@ __all__ = [
 ]
 
 from .context import context
+from .defaults import default
 from .element import Element as element
 from .elements.aggrid import AgGrid as aggrid
 from .elements.altair import Altair as altair


### PR DESCRIPTION
### Motivation

The discussion in https://github.com/zauberzeug/nicegui/pull/5610 explored:

1. `ui.markdown.defaults(extras=...)` (and `ui.image.defaults(pil_convert_format=...)`?)
2. `ui.markdown.EXTRAS` or `ui.markdown.DEFAULT_EXTRAS`
3. `ui.markdown.default_extras` (and move towards `ui.image.pil_convert_format`?)

But these all come with API surface expansion / code duplication / use of kwargs (or a mix of the three)

1. `.defaults` if implemented at `Element` level is kwargs; if per individual element then the function signature of `.defaults` will duplicate `__init__` leading to maintenance burden
2. So many ClassVars
3. Also so many ClassVars, and they don't look like ClassVars

Can we not? I have an interesting idea. 

### Implementation

For a parameter responsive to this new functionality (marked by `DEFAULTS | ...`), you may mark a parameter which you would like to be a default for subsequent calls with `ui.default(...)`

Once passed into the `__init__` decorated by `@resolve_defaults`, it will unravel the inner value and pass on to the function as usual, but store the value into `_defaults` ClassVar dict. 

Next time when that parameter is unpopulated, it checks `_defaults` and grabs the value from there. 

### Demo code


```py
m = ui.markdown('''
    ```mermaid
    graph TD;
        Node_A --> Node_B;
    ```
''', extras=ui.default(['mermaid', 'fenced-code-blocks']))
ui.code(str(m.extras))
m2 = ui.markdown('''
    ```mermaid
    graph TD;
        Node_A --> Node_B;
    ```
''')  # applied automatically from defaults
ui.code(str(m2.extras))
```

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).
- [ ] Apply to all elements if see fit.
- [ ] Code currently simply does not work if try to use `ui.default` on non-marked / `DEFAULT_PROP`-marked / `DEFAULT_PROPS[...]`-marked elements. 
  - Either always warn, or better for the props one, we can write directly to the default props on behalf of the user's intention. 