### PR TITLE
Pass protocol all-the-way to window_kwargs['url'] when SSL in use

### DIFF
--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -26,14 +26,14 @@ except ModuleNotFoundError:
 
 
 def _open_window(
-    host: str, port: int, title: str, width: int, height: int, fullscreen: bool, frameless: bool,
+    protocol: str, host: str, port: int, title: str, width: int, height: int, fullscreen: bool, frameless: bool,
     method_queue: mp.Queue, response_queue: mp.Queue,
 ) -> None:
     while not helpers.is_port_open(host, port):
         time.sleep(0.1)
 
     window_kwargs = {
-        'url': f'http://{host}:{port}',
+        'url': f'{protocol}://{host}:{port}',
         'title': title,
         'width': width,
         'height': height,
@@ -95,7 +95,7 @@ def _start_window_method_executor(window: webview.Window,
     Thread(target=window_method_executor).start()
 
 
-def activate(host: str, port: int, title: str, width: int, height: int, fullscreen: bool, frameless: bool) -> None:
+def activate(protocol: str, host: str, port: int, title: str, width: int, height: int, fullscreen: bool, frameless: bool) -> None:
     """Activate native mode."""
     def check_shutdown() -> None:
         while process.is_alive():
@@ -113,7 +113,7 @@ def activate(host: str, port: int, title: str, width: int, height: int, fullscre
 
     mp.freeze_support()
     native.create_queues()
-    args = host, port, title, width, height, fullscreen, frameless, native.method_queue, native.response_queue
+    args = protocol, host, port, title, width, height, fullscreen, frameless, native.method_queue, native.response_queue
     process = mp.Process(target=_open_window, args=args, daemon=True)
     process.start()
 

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -217,6 +217,11 @@ def run(root: Optional[Callable] = None, *,
         log.warning('disabling auto-reloading because is is only supported when running from a file')
         core.app.config.reload = reload = False
 
+    if kwargs.get('ssl_certfile') and kwargs.get('ssl_keyfile'):
+        protocol = 'https'
+    else:
+        protocol = 'http'
+
     if fullscreen:
         native = True
     if frameless:
@@ -229,7 +234,7 @@ def run(root: Optional[Callable] = None, *,
         port = port or native_module.find_open_port()
         width, height = window_size or (800, 600)
         native_host = '127.0.0.1' if host == '0.0.0.0' else host
-        native_module.activate(native_host, port, title, width, height, fullscreen, frameless)
+        native_module.activate(protocol, native_host, port, title, width, height, fullscreen, frameless)
     else:
         port = port or 8080
         host = host or '0.0.0.0'
@@ -242,11 +247,6 @@ def run(root: Optional[Callable] = None, *,
         reload = False
         native = False
         show_welcome_message = False
-
-    if kwargs.get('ssl_certfile') and kwargs.get('ssl_keyfile'):
-        protocol = 'https'
-    else:
-        protocol = 'http'
 
     # NOTE: We save host and port in environment variables so the subprocess started in reload mode can access them.
     os.environ['NICEGUI_HOST'] = host


### PR DESCRIPTION
### Motivation

Fixes #4814 where the native window attempts to open HTTP when SSL is in use (should have opened HTTPS)

### Implementation

I implemented the first variant in https://github.com/zauberzeug/nicegui/issues/4814#issuecomment-2925878614

This is because [it is private and we don't need to care about backwards compatibility](https://github.com/zauberzeug/nicegui/issues/4814#issuecomment-3744731664). 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests are not necessary (we do not have native pytests. Run mypy should be good enough)
- [x] Documentation is not necessary.

### Final notes

Thanks @nachobacanful
