### PR TITLE
Click-to-reload when `ui.scene` WebGL context lost

### DIFF
--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -71,10 +71,7 @@ export default {
       <canvas style="position:relative"></canvas>
       <div style="position:absolute;pointer-events:none;top:0"></div>
       <div style="position:absolute;pointer-events:none;top:0"></div>
-      <div style="position:absolute;display:none;inset:0;padding:8px;color:black;background-color:#ffffffcc;cursor:pointer">
-        WebGL context lost.
-        Click to re-initialize.
-      </div>
+      <div style="position:absolute;display:none;inset:0;cursor:pointer">WebGL context lost. Click to re-initialize.</div>
     </div>`,
 
   mounted() {
@@ -138,6 +135,20 @@ export default {
     this.renderer.setClearColor(this.backgroundColor);
     this.renderer.setSize(this.width, this.height);
 
+    this.renderer.domElement.addEventListener("webglcontextlost", (event) => {
+      event.preventDefault();
+      this.$el.children[0].style.visibility = "hidden";
+      this.$el.children[1].style.visibility = "hidden";
+      this.$el.children[2].style.visibility = "hidden";
+      this.$el.children[3].style.display = "block";
+      this.$el.addEventListener("click", () => {
+        const elementDefinition = mounted_app.elements[this.$el.id.slice(1)];
+        const originalTag = elementDefinition.tag;
+        elementDefinition.tag = "";
+        this.$nextTick(() => (elementDefinition.tag = originalTag));
+      }, { once: true });
+    });
+
     this.text_renderer = new CSS2DRenderer({
       element: this.$el.children[1],
     });
@@ -195,16 +206,6 @@ export default {
     this.drag_controls.addEventListener("dragend", handleDrag);
 
     const render = () => {
-      if (this.renderer.getContext().drawingBufferHeight === 0 && this.renderer.getContext().drawingBufferWidth === 0) {
-        this.$el.children[3].style.display = "block";
-        this.$el.addEventListener("click", () => {
-          const elementDefinition = mounted_app.elements[this.$el.id.slice(1)];
-          const originalTag = elementDefinition.tag;
-          elementDefinition.tag = "";
-          this.$nextTick(() => (elementDefinition.tag = originalTag));
-        });
-        return;
-      }
       requestAnimationFrame(() => setTimeout(() => render(), 1000 / this.fps));
       this.camera_tween?.update();
       this.renderer.render(this.scene, this.camera);


### PR DESCRIPTION
### Motivation

Fixes #5360, where some `ui.scene` suffers irrevocably from lost WebGL context and there is no way to get it work again without a page reload. 

### Implementation

When detect the context is gone (`this.renderer.getContext().drawingBufferHeight === 0 && this.renderer.getContext().drawingBufferWidth === 0`), force Vue to re-render by temporarily setting `tag` to be `''` then restoring it on the next tick

### Test script

```py
from nicegui import ui

with ui.grid(columns=5):
    for _ in range(25):
        ui.scene(width=100, height=100)

ui.run(prod_js=True, dark=True) # to ensure the overlay shows up in dark mode
```

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b3e71a62-cce8-4f97-839a-50572fd88536" />


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] I am not sure if it is worthwhile to pytest this?
- [x] Documentation is not necessary for a quality-of-life improvement.
