### PR TITLE
Fix errorneous late event registration warning

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -414,6 +414,7 @@ function createApp(elements, options) {
           let eventListenersChanged = false;
           for (const [id, element] of Object.entries(msg)) {
             if (element === null) continue;
+            if (!(id in this.elements)) continue;
             const oldListenerIds = new Set((this.elements[id]?.events || []).map((ev) => ev.listener_id));
             if (element.events?.some((e) => !oldListenerIds.has(e.listener_id))) {
               delete this.elements[id];


### PR DESCRIPTION
### Motivation

In #5663, newly added elements also trigger late event registration warning

### Implementation

Skip the check if the new element's ID does not exist in `this.elements`, or else `this.elements[id]?.events || []` becomes `[]` and **all new elements with an event gets trigger the warning.** 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Do we need pytest for anti-regression?
- [x] Documentation is not necessary.

### Final notes

**A simple-win**
