### PR TITLE
Fix `_add_javascript` used for `ui.add_css`

### DIFF
--- a/nicegui/functions/style.py
+++ b/nicegui/functions/style.py
@@ -61,11 +61,11 @@ def add_sass(content: Union[str, Path], *, shared: bool = False) -> None:  # DEP
 
 def _add_javascript(code: str, *, shared: bool = False) -> None:
     script_html = f'<script>{code}</script>'
-    client = context.client if Slot.get_stack() else None
     if shared:
+        client = context.client if Slot.get_stack() else None  # NOTE: don't auto-create a client if shared=True
         Client.shared_head_html += script_html + '\n'
     else:
         client = context.client
         client._head_html += script_html + '\n'
-    if client is not None and client.has_socket_connection:
+    if client is not None and client.has_socket_connection:  # NOTE: no need to run JavaScript if there is no client yet
         client.run_javascript(code)


### PR DESCRIPTION
### Motivation

#5628 killed the functionality of `ui.add_css(..., shared=True)` when being ran global (not inside `@ui.page` or anything)

### Analysis

Note the original code:

```py
def _add_javascript(code: str, *, shared: bool = False) -> None:
    script_html = f'<script>{code}</script>'
    client = context.client
    if shared:
        Client.shared_head_html += script_html + '\n'
    else:
        client._head_html += script_html + '\n' # we care that there is a client here
    if client.has_socket_connection: # we do not care there is a client here
        client.run_javascript(code) # nor here
```

Reason being:

- If you have shared=False, and you are outside of any client, then it should invoke script mode. 
  - Otherwise we literally have no where non-shared to store the added JavaScript. 
- However, if you are otherwise doing `shared=True` at the top of the page, we don't necessarily need to invoke script mode just to run the JavaScript. 
  - That newly-created client never will have `has_socket_connection=True`
  - As an un-connected client, on-connet either the `_head_html` or the `shared_head_html` takes care of the execution

### Implementation

Thus, it is modified appropriately:

```py
def _add_javascript(code: str, *, shared: bool = False) -> None:
    script_html = f'<script>{code}</script>'
    client = context.client if Slot.get_stack() else None # client = do not care
    if shared:
        Client.shared_head_html += script_html + '\n'
    else:
        client = context.client # client = do care
        client._head_html += script_html + '\n' # we care that there is a client here, and client = do care
    if client is not None and client.has_socket_connection: # we do not care there is a client here, and client = do not care
        client.run_javascript(code) # nor here
```

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [ ] Should we pytest for anti-regression? But script mode pytest is unsupported...
- [x] Documentation is not necessary for a bugfix.
