### PR TITLE
Refactor socket handlers and add log message forwarding for On Air

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -226,28 +226,20 @@ def _on_event(_: str, msg: dict) -> None:
 
 @sio.on('javascript_response')
 def _on_javascript_response(_: str, msg: dict) -> None:
-    client = Client.instances.get(msg['client_id'])
-    if not client:
-        return
-    client.handle_javascript_response(msg)
+    if client := Client.instances.get(msg['client_id']):
+        client.handle_javascript_response(msg)
 
 
 @sio.on('ack')
 def _on_ack(_: str, msg: dict) -> None:
-    client = Client.instances.get(msg['client_id'])
-    if not client:
-        return
-    client.outbox.prune_history(msg['next_message_id'])
+    if client := Client.instances.get(msg['client_id']):
+        client.outbox.prune_history(msg['next_message_id'])
 
 
 @sio.on('log')
 def _on_log(_: str, msg: dict) -> None:
-    {
-        'debug': log.debug,
-        'info': log.info,
-        'warning': log.warning,
-        'error': log.error,
-    }[msg['level']](msg['message'])
+    if client := Client.instances.get(msg['client_id']):
+        client.handle_log_message(msg)
 
 
 async def prune_tab_storage(*, force: bool = False) -> None:

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -109,7 +109,7 @@ function logAndEmit(level, message) {
   } else {
     console.log(message);
   }
-  window.socket.emit("log", { level, message });
+  window.socket.emit("log", { client_id: window.clientId, level, message });
 }
 
 function stringifyEventArgs(args, event_args) {
@@ -381,7 +381,7 @@ function createApp(elements, options) {
               if (typeof msg === "string" && msg.length > MAX_WEBSOCKET_MESSAGE_SIZE) {
                 const errorMessage = `Payload size ${msg.length} exceeds the maximum allowed limit.`;
                 console.error(errorMessage);
-                args[0] = `42["log",{"level":"error","message":"${errorMessage}"}]`;
+                args[0] = `42["log",{"client_id":"${window.clientId}","level":"error","message":"${errorMessage}"}]`;
                 if (window.tooLongMessageTimerId) clearTimeout(window.tooLongMessageTimerId);
                 const popup = document.getElementById("too_long_message_popup");
                 popup.ariaHidden = false;


### PR DESCRIPTION
### Motivation

Log messages from client-side JavaScript were not forwarded through the On Air relay, unlike other socket events (events, javascript_response, ack). This inconsistency meant that client-side errors wouldn't be logged when using On Air.

Additionally, the socket event handlers in `air.py` and `nicegui.py` used a verbose pattern of checking `if key in dict` followed by a separate lookup, which could be simplified.

~~Note: This PR serves as a preparation for #5500 which adds another socket event.~~ As it turns out, #5500 is already working On Air.

### Implementation

- **Add `client_id` to JavaScript log messages** in `nicegui.js` so they can be properly routed to the corresponding client
- **Add `_handle_log` relay handler** in `air.py` to forward log messages through On Air
- **Add `Client.handle_log_message()`** method to centralize log message handling
- **Refactor all socket handlers** in both `air.py` and `nicegui.py` to use the walrus operator with `dict.get()`, eliminating double lookups and reducing code verbosity
- **Mark internal `handle_*` methods** with "(For internal use only.)" in their docstrings to clarify the API boundary

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.