### PR TITLE
Let GPU-free Chrome 144 work

### DIFF
--- a/nicegui/testing/screen_plugin.py
+++ b/nicegui/testing/screen_plugin.py
@@ -34,7 +34,11 @@ def nicegui_chrome_options(chrome_options: webdriver.ChromeOptions) -> webdriver
     chrome_options.add_argument('disable-search-engine-choice-screen')
     chrome_options.add_argument('no-sandbox')
     chrome_options.add_argument('headless')
-    chrome_options.add_argument('disable-gpu' if 'GITHUB_ACTIONS' in os.environ else '--use-gl=angle')
+    if 'GITHUB_ACTIONS' in os.environ:
+        chrome_options.add_argument('disable-gpu')
+        chrome_options.add_argument('enable-unsafe-swiftshader')
+    else:
+        chrome_options.add_argument('--use-gl=angle')
     chrome_options.add_argument('window-size=600x600')
     chrome_options.add_experimental_option('prefs', {
         'download.default_directory': str(DOWNLOAD_DIR),


### PR DESCRIPTION
### Motivation

Chrome 144 WebGL (`ui.scene`, `ui.scene_view`) test fail: https://github.com/zauberzeug/nicegui/actions/runs/21280447781/job/61251073069

### Implementation

Need additional flag: https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/gpu/swiftshader.md

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete. (wait for pipeline and see)
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
