### PR TITLE
`NiceGUIJSONResponse` inherit from `JSONResponse`

### DIFF
--- a/nicegui/json/builtin_wrapper.py
+++ b/nicegui/json/builtin_wrapper.py
@@ -3,7 +3,7 @@ import json
 from datetime import date, datetime
 from typing import Any, Optional
 
-from fastapi import Response
+from fastapi.responses import JSONResponse
 
 HAS_NUMPY = importlib.util.find_spec('numpy') is not None
 
@@ -36,9 +36,8 @@ def loads(value: str) -> Any:
     return json.loads(value)
 
 
-class NiceGUIJSONResponse(Response):
+class NiceGUIJSONResponse(JSONResponse):
     """FastAPI response class to support our custom json serializer implementation."""
-    media_type = 'application/json'
 
     def render(self, content: Any) -> bytes:
         return dumps(content).encode('utf-8')

--- a/nicegui/json/orjson_wrapper.py
+++ b/nicegui/json/orjson_wrapper.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 # pylint: disable=no-member
 import orjson
-from fastapi import Response
+from fastapi.responses import JSONResponse
 
 HAS_NUMPY = importlib.util.find_spec('numpy') is not None
 
@@ -59,12 +59,11 @@ def _orjson_converter(obj):
     raise TypeError(f'Object of type {obj.__class__.__name__} is not JSON serializable')
 
 
-class NiceGUIJSONResponse(Response):
+class NiceGUIJSONResponse(JSONResponse):
     """FastAPI response class to support our custom json serializer implementation.
 
     Uses package `orjson` internally.
     """
-    media_type = 'application/json'
 
     def render(self, content: Any) -> bytes:
         return orjson.dumps(content, option=ORJSON_OPTS, default=_orjson_converter)


### PR DESCRIPTION
### Motivation

Fix #5688, where Response Model schema always shows up as string in Swagger when using NiceGUI’s FastAPI 

It is not the case when using FastAPI directly, so we messed something up on our side. 

### Implementation

Bisecting revealed that removing `default_response_class=NiceGUIJSONResponse` fixes it:

https://github.com/zauberzeug/nicegui/blob/4e3af342a1ff5d2633fb1ab053b250777c7f6311/nicegui/nicegui.py#L49

But that's not the way to go, so I looked further. I found that doing `default_response_class=ORJSONResponse` also fixes it:

https://github.com/fastapi/fastapi/blob/8c32e91c10cbf13da8be4d27f03d9fdaa9a6730c/fastapi/responses.py#L36-L48

But note how it inherits from `JSONResponse` and does not set `media_type`? I simply followed suit. 

NOTE: It was not right since day 1: https://github.com/zauberzeug/nicegui/commit/c95ab6b6ae0a391880cb8c6e1fd41d40eccfa0c2, root cause likely because inheriting from `Response` is recommended by FastAPI docs https://fastapi.tiangolo.com/advanced/custom-response/#custom-response-class and don't ask me why...

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Existing Pytests cover us for regressions.
- [x] Documentation not necessary for bugfix.
