### PR TITLE
Fix video loading issues in Windows in native mode

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -149,14 +149,6 @@ async def _startup() -> None:
     air.connect()
 
 
-def _exception_handler(loop: asyncio.AbstractEventLoop, context: dict) -> None:
-    """Custom exception handler to suppress connection reset errors on Windows."""
-    exception = context.get('exception')
-    if isinstance(exception, ConnectionResetError) and getattr(exception, 'winerror', None) == 10054:
-        return  # https://bugs.python.org/issue39010
-    loop.default_exception_handler(context)
-
-
 async def _shutdown() -> None:
     """Handle the shutdown event."""
     if app.native.main_window:


### PR DESCRIPTION
### Motivation

The following fails:

```py
from nicegui import ui

N = 2 #4970

for _ in range(N):
    ui.video("test.mp4")

ui.run(native=True, reload=False)
```

with `RuntimeError: No response returned.`

### Implementation

Fix 1: async generator fixes #4970

I just let Claude to hammer on it for half an hour. Apparently switching to an async generator fixed it. 

I **do not** speak for or against its reasoning attached below, but I **can** confirm that this consistently fixes it on my machine out of 10 trials without the fix, 10 trials with. 

I triple-checked that the error-masking [`ApparentlyUselessMiddleware`](https://github.com/zauberzeug/nicegui/issues/4970#issuecomment-3830672666) was not used the whole time. 

<details>
<summary> Its reasoning </summary>

When you have 2+ video elements requesting the same file:

1. Multiple concurrent range requests hit the same streaming endpoint
2. The synchronous generator blocks the event loop during file I/O
3. Starlette's middleware coordination gets disrupted when generators don't yield control
4. This causes the "No response returned" error when clients disconnect or make concurrent requests

</details>

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests is non-feasible as we do not have Windows worker configured right now. 
- [x] Documentation is not necessary for a bugfix. 

### Final notes

CC @MaidScientistIzutsumiMarin @python-and-novella, kindly test and see if this does the trick. Thanks!

`pip install git+https://github.com/evnchn/nicegui.git@mysterious-fix-4970`

