### PR TITLE
set timeout_graceful_shutdown to prevent hanging on ConnectionResetError

### DIFF
--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -278,6 +278,7 @@ def run(root: Callable | None = None, *,
         reload_dirs=split_args(uvicorn_reload_dirs) if reload else None,
         log_level=uvicorn_logging_level,
         ws='wsproto',
+        timeout_graceful_shutdown=kwargs.pop('timeout_graceful_shutdown', 10),
         **kwargs,
     )
     config.storage_secret = storage_secret


### PR DESCRIPTION
### Motivation

Fixes #5443, where when ConnectionResetError occurs (particularly with multiple videos in native mode on Windows), the server may hang indefinitely, unresponsive to Ctrl+C termination. 

Additional debugging context in #5700's comments. 

### Implementation

By setting timeout_graceful_shutdown (default 10 seconds, which is plenty long, considering Redis also times out in 10 seconds), the server will forcefully terminate requests after this timeout elapses, ensuring the application exits rather than hanging.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Final notes

It appears that `ConnectionResetError` is inevitable on Windows. Nevertheless I think this PR is also good to ensure a bounded-wait termination (surprised it isn't originally the case tbh)

CC @python-and-novella 

At this point we can consider to cherry-pick:

- https://github.com/zauberzeug/nicegui/pull/5700/commits/1ce1a72b46d75389197e47f5facb560c4d531a02
- https://github.com/zauberzeug/nicegui/pull/5700/commits/1c656164e9e8d37a4b0ff747c52b88a05600f43d
- https://github.com/zauberzeug/nicegui/pull/5700/commits/6c245ceaee3ea840b205e27807dfc988beeb2600
