### PR TITLE
`uv.lock` revision = 3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4"
 resolution-markers = [
     "python_full_version >= '3.14'",


### PR DESCRIPTION
### Motivation

This keeps coming up when I try to add dependencies, but I just "revert block" to dodge it for the time being.

### Implementation

By adding a fake dependency then subsequently deleting it, it tricked `uv` into bumping up to `revision = 3`. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Final notes

**A very very quick win. Please merge ASAP to get this friction point away.**
