### PR TITLE
Fix material settings not applying to GLTF models

### DIFF
--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -324,7 +324,7 @@ export default {
             if (mesh.userData.pendingMaterialInfo) {
               const { color, opacity, side } = mesh.userData.pendingMaterialInfo;
               delete mesh.userData.pendingMaterialInfo;
-              this.material(mesh.object_id, color, opacity, side);
+              this.material(id, color, opacity, side);
             }
           },
           undefined,

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -321,10 +321,8 @@ export default {
             mesh.add(gltf.scene);
             if (mesh.pendingMaterialInfo) {
               const { color, opacity, side } = mesh.pendingMaterialInfo;
-              mesh.traverse((child) => {
-                if (child.isMesh && child.material) this.applyMaterialSettings(child.material, color, opacity, side);
-              });
               delete mesh.pendingMaterialInfo;
+              this.material(mesh.object_id, color, opacity, side);
             }
           },
           undefined,
@@ -384,30 +382,29 @@ export default {
       if (!this.objects.has(object_id)) return;
       this.objects.get(object_id).name = name;
     },
-    applyMaterialSettings(material, color, opacity, side) {
-      if (!material) return;
-      const vertexColors = color === null;
-      material.color.set(vertexColors ? "#ffffff" : color);
-      material.needsUpdate = material.vertexColors != vertexColors;
-      material.vertexColors = vertexColors;
-      material.opacity = opacity;
-      if (side == "front") material.side = THREE.FrontSide;
-      else if (side == "back") material.side = THREE.BackSide;
-      else material.side = THREE.DoubleSide;
-    },
     material(object_id, color, opacity, side) {
       const object = this.objects.get(object_id);
       if (!object) return;
+      if (object.isGltf && object.children.length === 0) {
+        object.pendingMaterialInfo = { color, opacity, side };
+        return;
+      }
+      const vertexColors = color === null;
+      const apply = (material) => {
+        material.color.set(vertexColors ? "#ffffff" : color);
+        material.needsUpdate = material.vertexColors != vertexColors;
+        material.vertexColors = vertexColors;
+        material.opacity = opacity;
+        if (side == "front") material.side = THREE.FrontSide;
+        else if (side == "back") material.side = THREE.BackSide;
+        else material.side = THREE.DoubleSide;
+      };
       if (object.isGltf) {
-        if (object.children.length > 0) {
-          object.traverse((child) => {
-            if (child.isMesh && child.material) this.applyMaterialSettings(child.material, color, opacity, side);
-          });
-        } else {
-          object.pendingMaterialInfo = { color, opacity, side };
-        }
+        object.traverse((child) => {
+          if (child.isMesh && child.material) apply(child.material);
+        });
       } else if (object.material) {
-        this.applyMaterialSettings(object.material, color, opacity, side);
+        apply(object.material);
       }
     },
     move(object_id, x, y, z) {

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -314,6 +314,7 @@ export default {
       } else if (type == "gltf") {
         const url = args[0];
         mesh = new THREE.Group();
+        mesh.isGltf = true;
         this.gltf_loader.load(
           url,
           (gltf) => {
@@ -397,8 +398,14 @@ export default {
     material(object_id, color, opacity, side) {
       const object = this.objects.get(object_id);
       if (!object) return;
-      if (object.isGroup) {
-        object.pendingMaterialInfo = { color, opacity, side };
+      if (object.isGltf) {
+        if (object.children.length > 0) {
+          object.traverse((child) => {
+            if (child.isMesh && child.material) this.applyMaterialSettings(child.material, color, opacity, side);
+          });
+        } else {
+          object.pendingMaterialInfo = { color, opacity, side };
+        }
       } else if (object.material) {
         this.applyMaterialSettings(object.material, color, opacity, side);
       }

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -314,14 +314,16 @@ export default {
       } else if (type == "gltf") {
         const url = args[0];
         mesh = new THREE.Group();
-        mesh.isGltf = true;
+        mesh.userData.isGltf = true;
+        mesh.userData.loaded = false;
         this.gltf_loader.load(
           url,
           (gltf) => {
             mesh.add(gltf.scene);
-            if (mesh.pendingMaterialInfo) {
-              const { color, opacity, side } = mesh.pendingMaterialInfo;
-              delete mesh.pendingMaterialInfo;
+            mesh.userData.loaded = true;
+            if (mesh.userData.pendingMaterialInfo) {
+              const { color, opacity, side } = mesh.userData.pendingMaterialInfo;
+              delete mesh.userData.pendingMaterialInfo;
               this.material(mesh.object_id, color, opacity, side);
             }
           },
@@ -385,8 +387,8 @@ export default {
     material(object_id, color, opacity, side) {
       const object = this.objects.get(object_id);
       if (!object) return;
-      if (object.isGltf && object.children.length === 0) {
-        object.pendingMaterialInfo = { color, opacity, side };
+      if (object.userData.isGltf && !object.userData.loaded) {
+        object.userData.pendingMaterialInfo = { color, opacity, side };
         return;
       }
       const vertexColors = color === null;
@@ -399,12 +401,16 @@ export default {
         else if (side == "back") material.side = THREE.BackSide;
         else material.side = THREE.DoubleSide;
       };
-      if (object.isGltf) {
+      const applyTo = (material) => {
+        if (Array.isArray(material)) material.forEach(apply);
+        else apply(material);
+      };
+      if (object.userData.isGltf) {
         object.traverse((child) => {
-          if (child.isMesh && child.material) apply(child.material);
+          if (child.isMesh && child.material) applyTo(child.material);
         });
       } else if (object.material) {
-        apply(object.material);
+        applyTo(object.material);
       }
     },
     move(object_id, x, y, z) {

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -393,24 +393,20 @@ export default {
       }
       const vertexColors = color === null;
       const apply = (material) => {
-        material.color.set(vertexColors ? "#ffffff" : color);
-        material.needsUpdate = material.vertexColors != vertexColors;
-        material.vertexColors = vertexColors;
-        material.opacity = opacity;
-        if (side == "front") material.side = THREE.FrontSide;
-        else if (side == "back") material.side = THREE.BackSide;
-        else material.side = THREE.DoubleSide;
-      };
-      const applyTo = (material) => {
-        if (Array.isArray(material)) material.forEach(apply);
-        else apply(material);
+        (Array.isArray(material) ? material : [material]).forEach((m) => {
+          m.color.set(vertexColors ? "#ffffff" : color);
+          m.needsUpdate = m.vertexColors != vertexColors;
+          m.vertexColors = vertexColors;
+          m.opacity = opacity;
+          if (side == "front") m.side = THREE.FrontSide;
+          else if (side == "back") m.side = THREE.BackSide;
+          else m.side = THREE.DoubleSide;
+        });
       };
       if (object.userData.isGltf) {
-        object.traverse((child) => {
-          if (child.isMesh && child.material) applyTo(child.material);
-        });
+        object.traverse((child) => child.isMesh && child.material && apply(child.material));
       } else if (object.material) {
-        applyTo(object.material);
+        apply(object.material);
       }
     },
     move(object_id, x, y, z) {

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -199,11 +199,14 @@ def test_gltf(screen: Screen):
         nonlocal scene
         app.add_static_file(local_file=TEST_DIR / 'media' / 'box.glb', url_path='/box.glb')
         with ui.scene() as scene:
-            scene.gltf('/box.glb')
+            scene.gltf('/box.glb').material('#ff0000')
 
     screen.open('/')
     screen.wait(1.0)
     assert screen.selenium.execute_script(f'return scene_{scene.html_id}.children.length') == 5
+    assert screen.selenium.execute_script(
+        f'return scene_{scene.html_id}.children[4].getObjectByProperty("isMesh", true).material.color.getHexString()'
+    ) == 'ff0000'
 
 
 def test_no_cyclic_references(screen: Screen):


### PR DESCRIPTION
### Motivation

Fix #3515, where GLTF models load asynchronously as Groups, so material settings were being ignored.

Particularly, there are 3 cases to resolve (from https://github.com/zauberzeug/nicegui/issues/3515#issuecomment-2325885092):

> 1. Calling `material()` on a group (or GLTF object) does not work, because the JavaScript implementation of the `material()` method doesn't traverse children of groups.
> 2. Calling `material()` on a group (or GLTF object) does not work, because the group is added first and their children are added later. So traversing the group doesn't help, because there are no children yet.
> 3. Calling `material()` immediately after creating the GLTF object does not work, because the GLTF loader loads the object(s) asynchronously. Only when this is finished, `material()` can actually find the corresponding objects.

**NOTE: right now the test sample I can only test the GLTF case, not the `group` case though.**

### Implementation

TL-DR: Now stores pending material info on Group objects and applies settings to all mesh children after the model loads.

**Material handling improvements:**

- Refactored the `material` method: Now, if the target object is a GLTF model that has not finished loading, material settings are stashed in `userData.pendingMaterialInfo` and applied to all child meshes (including `Material[]` arrays) once the model is loaded. For non-GLTF objects, material settings are applied directly as before.
- Consolidated the per-material update logic into a local `apply` closure inside `material()`, used for both direct meshes and the GLTF traversal path.

**GLTF loading enhancements:**

- Modified the GLTF loader callback to set a `userData.loaded` flag and re-enter `material()` with any stashed `pendingMaterialInfo`, so material updates requested before model load are not lost.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytest has been extended.
- [x] Documentation is not necessary for a bugfix.
