### PR TITLE
Fix REPL detection for Python 3.13's new pyrepl

### DIFF
--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -12,8 +12,6 @@ from starlette.types import ASGIApp
 from uvicorn.main import STARTUP_FAILURE
 from uvicorn.supervisors import ChangeReload, Multiprocess
 
-import __main__
-
 from . import core, helpers
 from . import native as native_module
 from .air import Air
@@ -217,8 +215,9 @@ def run(root: Callable | None = None, *,
     if multiprocessing.current_process().name != 'MainProcess':
         return
 
-    if reload and not hasattr(__main__, '__file__'):
-        log.warning('disabling auto-reloading because is is only supported when running from a file')
+    is_repl = bool(getattr(sys, 'ps1', sys.flags.interactive))
+    if reload and is_repl:
+        log.warning('disabling auto-reloading because it is only supported when running from a file')
         core.app.config.reload = reload = False
 
     if kwargs.get('ssl_certfile') and kwargs.get('ssl_keyfile'):


### PR DESCRIPTION
### Motivation

Fixes #5675

In Python 3.13, the new `_pyrepl` REPL sets `__main__.__file__` to an actual file path (`/path/to/python3.13/_pyrepl/__main__.py`), causing the REPL detection to fail. This results in uvicorn spawning a subprocess where `ui.run()` was never called, producing a confusing error instead of the helpful "NiceGUI doesn't work in REPL" hint.

### Implementation

Changed the REPL detection from checking `__main__.__file__` to using `sys.ps1` and `sys.flags.interactive`:

```python
is_repl = bool(getattr(sys, 'ps1', sys.flags.interactive))
```

- `sys.ps1` exists when Python is running interactively (REPL mode)
- `sys.flags.interactive` is set when Python is started with the `-i` flag

This approach works reliably across all Python versions, including 3.13.

Also fixed a typo in the warning message: "is is only" → "it is only".

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This is not a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
