### PR TITLE
Fix vertical stepper animation jitter

### DIFF
--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -57,14 +57,9 @@
 .nicegui-stepper .q-stepper__content {
   flex-grow: 1;
 }
-.nicegui-stepper .q-stepper__step-content,
-.nicegui-stepper .q-stepper__step-inner {
+.nicegui-stepper.q-stepper--horizontal .q-stepper__step-content,
+.nicegui-stepper.q-stepper--horizontal .q-stepper__step-inner {
   height: 100%;
-}
-/* fix vertical stepper animation jitter (#3881) */
-.nicegui-stepper.q-stepper--vertical .q-stepper__step-content,
-.nicegui-stepper.q-stepper--vertical .q-stepper__step-inner {
-  height: auto;
 }
 .nicegui-step .q-stepper__nav {
   padding-top: 8px;


### PR DESCRIPTION
### Motivation

Fixes #3881

When using `ui.stepper().props('vertical animated')`, clicking navigation buttons causes visible jitter - the stepper expands during the transition animation and then snaps back to its final height.

The root cause is the `height: 100%` rule added to fix #1788 (to let step content fill the stepper for easier layout manipulation). During Quasar's vertical stepper animation, this percentage-based height causes children to resize mid-transition as the parent's height animates, resulting in the expand-then-snapback pattern.

### Implementation

Override `height: 100%` → `height: auto` specifically for vertical steppers:

```css
.nicegui-stepper.q-stepper--vertical .q-stepper__step-content,
.nicegui-stepper.q-stepper--vertical .q-stepper__step-inner {
  height: auto;
}
```

This preserves the #1788 behavior for horizontal steppers while fixing the animation jitter for vertical ones. The more specific selector ensures it only applies when both `.nicegui-stepper` and `.q-stepper--vertical` classes are present.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [ ] Pytests have been added (or are not necessary).
  - @falkoschindler We agreed not to test UI glitches in Pytest, right?
- [x] Documentation is not necessary for a bugfix. 

### Final notes

Yes, this PR and description above is AI agenrated. How we reached here is:

1. Ask Claude to write the script which detects the jitter at https://github.com/zauberzeug/nicegui/issues/3881#issuecomment-3851005229 - 1 context window consumed
2. Ask Claude to iterate rapidly in a loop until the issue is gone - 1 context window consumed
3. Ask Claude to bisect the 50+ lines of CSS it just wrote in (2) into the minimal changes we see now - 1 context window consumed
4. Ask Claude to write this PR description

So yeah, this task took **2 `/compact`s** and is easily the hardest I have worked with Claude Opus 4.5 so far 💪 