### PR TITLE
Add CLAUDE.md with native @AGENTS.md import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
### Motivation

Claude Code doesn't read `AGENTS.md` natively — it only loads `CLAUDE.md` on startup. Two earlier PRs explored ways to bridge this gap:

- **#5720** — symlink (`ln -s AGENTS.md CLAUDE.md`) — closed because symlinks [break on Windows](https://github.com/zauberzeug/nicegui/pull/5720#issuecomment-3852780579)
- **#5722** — full copy with pre-commit sync hook — works but duplicates the entire file and adds a Python hook

Inspired by [this recommendation](https://github.com/anthropics/claude-code/issues/6235#issuecomment-3217884068).

### Implementation

A minimal `CLAUDE.md` containing just `@AGENTS.md`. Claude Code's native `@file` directive inlines the referenced file into the system prompt at session start. This keeps `AGENTS.md` as the single source of truth — no duplication, no sync hooks, no symlinks. Works cross-platform.

Supersedes #5720 and #5722.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).