### PR TITLE
[WIP] Try to shared the Screen fixture among tests

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -422,7 +422,7 @@ class Client:
         self._deleted_event.set()
         self.remove_all_elements()
         self.outbox.stop()
-        del Client.instances[self.id]
+        Client.instances.pop(self.id, None)  # Use pop to avoid KeyError if already removed
         self._deleted = True
         self._connected.set()  # for terminating connected() waits
         self._connected.clear()

--- a/nicegui/testing/__init__.py
+++ b/nicegui/testing/__init__.py
@@ -1,10 +1,11 @@
 try:
-    from .screen import Screen
+    from .screen import Screen, SharedScreen
 except ImportError:
     # we simply define Screen as None if selenium is not installed
     # this allows simpler dependency management when only using the "User" fixture
     # (see discussion in #3510)
     Screen = None  # type: ignore
+    SharedScreen = None  # type: ignore
 
 from .user import User
 from .user_interaction import UserInteraction
@@ -12,6 +13,7 @@ from .user_simulation import user_simulation
 
 __all__ = [
     'Screen',
+    'SharedScreen',
     'User',
     'UserInteraction',
     'user_simulation',

--- a/nicegui/testing/general.py
+++ b/nicegui/testing/general.py
@@ -1,12 +1,30 @@
 import contextlib
 import gc
 import sys
-from copy import copy
+from copy import copy, deepcopy
+from dataclasses import MISSING, fields
 
 from starlette.routing import Route
 
 from .. import app, binding, core, dependencies, event, run, ui
+from ..app.app_config import AppConfig
 from ..client import Client
+from ..logging import log
+
+
+def _get_default_config_values() -> dict:
+    """Get default values for AppConfig fields that can be modified by tests."""
+    defaults = {}
+    for f in fields(AppConfig):
+        if f.name in ('vue_config_script', 'quasar_config'):
+            if f.default is not MISSING:
+                defaults[f.name] = f.default
+            elif f.default_factory is not MISSING:  # type: ignore[comparison-overlap]
+                defaults[f.name] = f.default_factory()
+    return defaults
+
+
+_DEFAULT_CONFIG_VALUES = _get_default_config_values()
 
 
 def prepare_simulation() -> None:
@@ -87,3 +105,91 @@ def _find_all_subclasses(cls: type) -> list[type]:
         subclasses.append(subclass)
         subclasses.extend(_find_all_subclasses(subclass))
     return subclasses
+
+
+def _reset_app_handlers_only() -> None:
+    """Reset app handlers without touching the config (for shared server tests)."""
+    app.storage.clear()
+    app._startup_handlers.clear()  # pylint: disable=protected-access
+    app._shutdown_handlers.clear()  # pylint: disable=protected-access
+    app._connect_handlers.clear()  # pylint: disable=protected-access
+    app._disconnect_handlers.clear()  # pylint: disable=protected-access
+    app._delete_handlers.clear()  # pylint: disable=protected-access
+    app._exception_handlers[:] = [log.exception]  # pylint: disable=protected-access
+    # NOTE: do NOT reset run config fields (title, reload, etc.) as they are needed by the server
+    app.colors()  # reset colors to default
+
+
+def _reset_app_config_modifiable_fields() -> None:
+    """Reset config fields that can be modified by tests but don't require server restart."""
+    # If run config was lost (e.g., after User fixture reset), restore it
+    if not app.config.has_run_config:
+        prepare_simulation()
+    app.config.vue_config_script = _DEFAULT_CONFIG_VALUES['vue_config_script']
+    app.config.quasar_config = deepcopy(_DEFAULT_CONFIG_VALUES['quasar_config'])
+    # Reset CSS framework config that tests may have modified
+    app.config.unocss = None
+    app.config.tailwind = True
+
+
+@contextlib.contextmanager
+def nicegui_reset_globals_for_shared_server():
+    """Reset the global state of the NiceGUI package while keeping the server running.
+
+    This is a lighter version of nicegui_reset_globals() that doesn't touch the event loop,
+    server instance, or app config, allowing tests to share a single server for faster execution.
+    """
+    for route in list(app.routes):
+        if isinstance(route, Route) and (
+            not route.path.startswith('/_nicegui/')
+            or route.path.startswith('/_nicegui/auto/static')
+            or route.path.startswith('/_nicegui/client/')
+        ):
+            app.remove_route(route.path)
+
+    app.openapi_schema = None
+    app.middleware_stack = None
+    app.user_middleware.clear()
+    app.urls.clear()
+    # NOTE: do NOT call core.reset() as it would clear the event loop
+
+    element_types: list[type[ui.element]] = [ui.element, *_find_all_subclasses(ui.element)]
+    default_classes = {t: copy(t._default_classes) for t in element_types}  # pylint: disable=protected-access
+    default_styles = {t: copy(t._default_style) for t in element_types}  # pylint: disable=protected-access
+    default_props = {t: copy(t._default_props) for t in element_types}  # pylint: disable=protected-access
+
+    dependencies.importmap_overrides.clear()
+    # NOTE: do NOT clear Client.instances here as background tasks may still reference them
+    # Client cleanup happens naturally when the browser disconnects or navigates away
+    Client.page_routes.clear()
+    Client.shared_head_html = ''
+    Client.shared_body_html = ''
+    # NOTE: reset config FIRST, then handlers (which calls app.colors() to set defaults)
+    _reset_app_config_modifiable_fields()
+    _reset_app_handlers_only()
+    binding.reset()
+
+    gc.collect()
+
+    try:
+        yield
+    finally:
+        gc.collect()
+
+        # NOTE: reset config FIRST, then handlers (which calls app.colors() to set defaults)
+        _reset_app_config_modifiable_fields()
+        _reset_app_handlers_only()
+        event.reset()
+        # NOTE: do NOT call run.reset() as it would shut down pools used by the running server
+
+        for t in element_types:
+            t._default_classes = default_classes[t]  # pylint: disable=protected-access
+            t._default_style = default_styles[t]  # pylint: disable=protected-access
+            t._default_props = default_props[t]  # pylint: disable=protected-access
+
+        page_routes_snapshot = list(Client.page_routes)  # snapshot to avoid modification during iteration
+        for func in page_routes_snapshot:
+            if not func.__module__.startswith('tests.'):
+                parts = func.__module__.split('.')
+                for i in range(len(parts)):
+                    sys.modules.pop('.'.join(parts[:i+1]), None)  # remove the module and all its parents

--- a/nicegui/testing/general_fixtures.py
+++ b/nicegui/testing/general_fixtures.py
@@ -35,3 +35,10 @@ def nicegui_reset_globals():
     """Reset the global state of the NiceGUI package."""
     with general.nicegui_reset_globals():
         yield
+
+
+@pytest.fixture
+def nicegui_reset_globals_for_shared_server():
+    """Reset the global state while keeping the server running."""
+    with general.nicegui_reset_globals_for_shared_server():
+        yield

--- a/nicegui/testing/plugin.py
+++ b/nicegui/testing/plugin.py
@@ -1,10 +1,17 @@
 # pylint: disable=unused-import
-from .general_fixtures import nicegui_reset_globals, pytest_addoption, pytest_configure  # noqa: F401
+from .general_fixtures import (  # noqa: F401
+    nicegui_reset_globals,
+    nicegui_reset_globals_for_shared_server,
+    pytest_addoption,
+    pytest_configure,
+)
 from .screen_plugin import (  # noqa: F401
     nicegui_chrome_options,
     nicegui_driver,
     nicegui_remove_all_screenshots,
+    nicegui_shared_server_cleanup,
     pytest_runtest_makereport,
     screen,
+    shared_screen,
 )
 from .user_plugin import create_user, user  # noqa: F401

--- a/tests/test_add_html.py
+++ b/tests/test_add_html.py
@@ -1,27 +1,27 @@
 import pytest
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_add_head_html(screen: Screen) -> None:
+def test_add_head_html(shared_screen: SharedScreen) -> None:
     @ui.page('/')
     def page():
         ui.add_head_html(r'<style>.my-label {background: rgb(0, 0, 255)}</style>')
         ui.label('Label').classes('my-label')
         ui.button('Green', on_click=lambda: ui.add_head_html(r'<style>.my-label {background: rgb(0, 255, 0)}</style>'))
 
-    screen.open('/')
-    assert screen.find('Label').value_of_css_property('background-color') == 'rgba(0, 0, 255, 1)'
+    shared_screen.open('/')
+    assert shared_screen.find('Label').value_of_css_property('background-color') == 'rgba(0, 0, 255, 1)'
 
-    screen.click('Green')
-    screen.wait(0.5)
-    assert screen.find('Label').value_of_css_property('background-color') == 'rgba(0, 255, 0, 1)'
+    shared_screen.click('Green')
+    shared_screen.wait(0.5)
+    assert shared_screen.find('Label').value_of_css_property('background-color') == 'rgba(0, 255, 0, 1)'
 
 
 @pytest.mark.parametrize('shared', [False, True])
 @pytest.mark.parametrize('delayed', [False, True])
-def test_css(screen: Screen, shared: bool, delayed: bool):
+def test_css(shared_screen: SharedScreen, shared: bool, delayed: bool):
     @ui.page('/')
     async def page():
         if delayed:
@@ -33,15 +33,15 @@ def test_css(screen: Screen, shared: bool, delayed: bool):
         ''', shared=shared)
         ui.label('This is red with CSS.').classes('red')
 
-    screen.open('/')
-    label = screen.find('This is red with CSS.')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    label = shared_screen.find('This is red with CSS.')
+    shared_screen.wait(0.5)
     assert label.value_of_css_property('color') == 'rgba(255, 0, 0, 1)'
 
 
 @pytest.mark.parametrize('shared', [False, True])
 @pytest.mark.parametrize('delayed', [False, True])
-def test_scss(screen: Screen, shared: bool, delayed: bool):
+def test_scss(shared_screen: SharedScreen, shared: bool, delayed: bool):
     @ui.page('/')
     async def page():
         if delayed:
@@ -57,15 +57,15 @@ def test_scss(screen: Screen, shared: bool, delayed: bool):
         with ui.element().classes('green'):
             ui.label('This is blue on green with SCSS.').classes('blue')
 
-    screen.open('/')
-    label = screen.find('This is blue on green with SCSS.')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    label = shared_screen.find('This is blue on green with SCSS.')
+    shared_screen.wait(0.5)
     assert label.value_of_css_property('color') == 'rgba(0, 0, 255, 1)'
 
 
 @pytest.mark.parametrize('shared', [False, True])
 @pytest.mark.parametrize('delayed', [False, True])
-def test_sass(screen: Screen, shared: bool, delayed: bool):
+def test_sass(shared_screen: SharedScreen, shared: bool, delayed: bool):
     @ui.page('/')
     async def page():
         if delayed:
@@ -79,30 +79,30 @@ def test_sass(screen: Screen, shared: bool, delayed: bool):
         with ui.element().classes('yellow'):
             ui.label('This is purple on yellow with SASS.').classes('purple')
 
-    screen.open('/')
-    label = screen.find('This is purple on yellow with SASS.')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    label = shared_screen.find('This is purple on yellow with SASS.')
+    shared_screen.wait(0.5)
     assert label.value_of_css_property('color') == 'rgba(128, 0, 128, 1)'
 
 
-def test_add_css_with_script(screen: Screen):
+def test_add_css_with_script(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.add_css("</style></script><script>document.write('XSS');</script>")
         ui.label('Hello, World!')
 
-    screen.open('/')
-    screen.should_contain('Hello, World!')
-    screen.should_not_contain('XSS')
+    shared_screen.open('/')
+    shared_screen.should_contain('Hello, World!')
+    shared_screen.should_not_contain('XSS')
 
 
-def test_add_scss_with_script(screen: Screen):
+def test_add_scss_with_script(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.add_scss("</style></script><script>document.write('XSS');</script>")
         ui.label('Hello, World!')
 
-    screen.allowed_js_errors.append('static/sass.dart.js')
-    screen.open('/')
-    screen.should_contain('Hello, World!')
-    screen.should_not_contain('XSS')
+    shared_screen.allowed_js_errors.append('static/sass.dart.js')
+    shared_screen.open('/')
+    shared_screen.should_contain('Hello, World!')
+    shared_screen.should_not_contain('XSS')

--- a/tests/test_aggrid.py
+++ b/tests/test_aggrid.py
@@ -10,10 +10,10 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 
 from nicegui import Event, app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_update_table(screen: Screen):
+def test_update_table(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         grid = ui.aggrid({
@@ -22,17 +22,17 @@ def test_update_table(screen: Screen):
         })
         ui.button('Change age', on_click=lambda: grid.options['rowData'][0].update(age=42))
 
-    screen.open('/')
-    screen.should_contain('Name')
-    screen.should_contain('Age')
-    screen.should_contain('Alice')
-    screen.should_contain('18')
+    shared_screen.open('/')
+    shared_screen.should_contain('Name')
+    shared_screen.should_contain('Age')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('18')
 
-    screen.click('Change age')
-    screen.should_contain('42')
+    shared_screen.click('Change age')
+    shared_screen.should_contain('42')
 
 
-def test_add_row(screen: Screen):
+def test_add_row(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         grid = ui.aggrid({
@@ -43,19 +43,19 @@ def test_add_row(screen: Screen):
         ui.button('Add Alice', on_click=lambda: grid.options['rowData'].append({'name': 'Alice', 'age': 18}))
         ui.button('Add Bob', on_click=lambda: grid.options['rowData'].append({'name': 'Bob', 'age': 21}))
 
-    screen.open('/')
-    screen.click('Add Alice')
-    screen.click('Update')
-    screen.should_contain('Alice')
-    screen.should_contain('18')
+    shared_screen.open('/')
+    shared_screen.click('Add Alice')
+    shared_screen.click('Update')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('18')
 
-    screen.click('Add Bob')
-    screen.click('Update')
-    screen.should_contain('Bob')
-    screen.should_contain('21')
+    shared_screen.click('Add Bob')
+    shared_screen.click('Update')
+    shared_screen.should_contain('Bob')
+    shared_screen.should_contain('21')
 
 
-def test_click_cell(screen: Screen):
+def test_click_cell(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         grid = ui.aggrid({
@@ -64,12 +64,12 @@ def test_click_cell(screen: Screen):
         })
         grid.on('cellClicked', lambda e: ui.label(f'{e.args["data"]["name"]} has been clicked!'))
 
-    screen.open('/')
-    screen.click('Alice')
-    screen.should_contain('Alice has been clicked!')
+    shared_screen.open('/')
+    shared_screen.click('Alice')
+    shared_screen.should_contain('Alice has been clicked!')
 
 
-def test_html_columns(screen: Screen):
+def test_html_columns(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.aggrid({
@@ -77,13 +77,13 @@ def test_html_columns(screen: Screen):
             'rowData': [{'name': '<span class="text-bold">Alice</span>', 'age': 18}],
         }, html_columns=[0])
 
-    screen.open('/')
-    screen.should_contain('Alice')
-    screen.should_not_contain('<span')
-    assert 'text-bold' in screen.find('Alice').get_attribute('class')
+    shared_screen.open('/')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_not_contain('<span')
+    assert 'text-bold' in shared_screen.find('Alice').get_attribute('class')
 
 
-def test_dynamic_method(screen: Screen):
+def test_dynamic_method(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.aggrid({
@@ -92,8 +92,8 @@ def test_dynamic_method(screen: Screen):
             ':getRowHeight': 'params => params.data.age > 35 ? 50 : 25',
         })
 
-    screen.open('/')
-    trs = screen.find_all_by_class('ag-row')
+    shared_screen.open('/')
+    trs = shared_screen.find_all_by_class('ag-row')
     assert len(trs) == 3
     heights = [int(tr.get_attribute('clientHeight')) for tr in trs]
     assert 23 <= heights[0] <= 25
@@ -101,7 +101,7 @@ def test_dynamic_method(screen: Screen):
     assert 48 <= heights[2] <= 50
 
 
-def test_run_grid_method_with_argument(screen: Screen):
+def test_run_grid_method_with_argument(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         grid = ui.aggrid({
@@ -111,19 +111,19 @@ def test_run_grid_method_with_argument(screen: Screen):
         filter_model = {'name': {'filterType': 'text', 'type': 'equals', 'filter': 'Alice'}}
         ui.button('Filter', on_click=lambda: grid.run_grid_method('setFilterModel', filter_model))
 
-    screen.open('/')
-    screen.should_contain('Alice')
-    screen.should_contain('Bob')
-    screen.should_contain('Carol')
+    shared_screen.open('/')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('Bob')
+    shared_screen.should_contain('Carol')
 
-    screen.click('Filter')
-    screen.wait(0.5)
-    screen.should_contain('Alice')
-    screen.should_not_contain('Bob')
-    screen.should_not_contain('Carol')
+    shared_screen.click('Filter')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Alice')
+    shared_screen.should_not_contain('Bob')
+    shared_screen.should_not_contain('Carol')
 
 
-def test_get_selected_rows(screen: Screen):
+def test_get_selected_rows(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         grid = ui.aggrid({
@@ -140,18 +140,18 @@ def test_get_selected_rows(screen: Screen):
             ui.label(str(await grid.get_selected_row()))
         ui.button('Get selected row', on_click=get_selected_row)
 
-    screen.open('/')
-    screen.click('Alice')
-    screen.find('Bob')
-    ActionChains(screen.selenium).key_down(Keys.SHIFT).click(screen.find('Bob')).key_up(Keys.SHIFT).perform()
-    screen.click('Get selected rows')
-    screen.should_contain("[{'name': 'Alice'}, {'name': 'Bob'}]")
+    shared_screen.open('/')
+    shared_screen.click('Alice')
+    shared_screen.find('Bob')
+    ActionChains(shared_screen.selenium).key_down(Keys.SHIFT).click(shared_screen.find('Bob')).key_up(Keys.SHIFT).perform()
+    shared_screen.click('Get selected rows')
+    shared_screen.should_contain("[{'name': 'Alice'}, {'name': 'Bob'}]")
 
-    screen.click('Get selected row')
-    screen.should_contain("{'name': 'Alice'}")
+    shared_screen.click('Get selected row')
+    shared_screen.should_contain("{'name': 'Alice'}")
 
 
-def test_replace_aggrid(screen: Screen):
+def test_replace_aggrid(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.row().classes('w-full') as container:
@@ -162,16 +162,16 @@ def test_replace_aggrid(screen: Screen):
                 ui.aggrid({'columnDefs': [{'field': 'name'}], 'rowData': [{'name': 'Bob'}]})
         ui.button('Replace', on_click=replace)
 
-    screen.open('/')
-    screen.should_contain('Alice')
+    shared_screen.open('/')
+    shared_screen.should_contain('Alice')
 
-    screen.click('Replace')
-    screen.should_contain('Bob')
-    screen.should_not_contain('Alice')
+    shared_screen.click('Replace')
+    shared_screen.should_contain('Bob')
+    shared_screen.should_not_contain('Alice')
 
 
 @pytest.mark.parametrize('df_type', ['pandas', 'polars'])
-def test_create_from_dataframe(screen: Screen, df_type: str):
+def test_create_from_dataframe(shared_screen: SharedScreen, df_type: str):
     @ui.page('/')
     def page():
         if df_type == 'pandas':
@@ -181,38 +181,38 @@ def test_create_from_dataframe(screen: Screen, df_type: str):
             df = pl.DataFrame({'name': ['Alice', 'Bob'], 'age': [18, 21], '42': 'answer'})
             ui.aggrid.from_polars(df)
 
-    screen.open('/')
-    screen.should_contain('Alice')
-    screen.should_contain('Bob')
-    screen.should_contain('18')
-    screen.should_contain('21')
-    screen.should_contain('42')
-    screen.should_contain('answer')
+    shared_screen.open('/')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('Bob')
+    shared_screen.should_contain('18')
+    shared_screen.should_contain('21')
+    shared_screen.should_contain('42')
+    shared_screen.should_contain('answer')
 
 
-def test_create_dynamically(screen: Screen):
+def test_create_dynamically(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('Create',
                   on_click=lambda: ui.aggrid({'columnDefs': [{'field': 'name'}], 'rowData': [{'name': 'Alice'}]}))
 
-    screen.open('/')
-    screen.click('Create')
-    screen.should_contain('Alice')
+    shared_screen.open('/')
+    shared_screen.click('Create')
+    shared_screen.should_contain('Alice')
 
 
-def test_api_method_after_creation(screen: Screen):
+def test_api_method_after_creation(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         options = {'columnDefs': [{'field': 'name'}], 'rowData': [{'name': 'Ed'}], 'rowSelection': {'mode': 'multiRow'}}
         ui.button('Create', on_click=lambda: ui.aggrid(options).run_grid_method('selectAll'))
 
-    screen.open('/')
-    screen.click('Create')
-    assert screen.find_by_class('ag-row-selected')
+    shared_screen.open('/')
+    shared_screen.click('Create')
+    assert shared_screen.find_by_class('ag-row-selected')
 
 
-def test_set_module_source(screen: Screen):
+def test_set_module_source(shared_screen: SharedScreen):
     get_aggrid: Event[[]] = Event()
 
     @app.get('/custom-aggrid.js')
@@ -233,15 +233,15 @@ def test_set_module_source(screen: Screen):
             is_registered = await ui.run_javascript(f'getElement({aggrid.id}).api.isModuleRegistered("{module}")')
             ui.label(f'{module}: {is_registered}')
 
-    screen.open('/')
-    screen.should_contain('Load custom bundle')
-    screen.should_contain('ClipboardModule: False')
-    screen.should_contain('ColumnAutoSizeModule: True')
-    screen.should_contain('EventApiModule: True')
+    shared_screen.open('/')
+    shared_screen.should_contain('Load custom bundle')
+    shared_screen.should_contain('ClipboardModule: False')
+    shared_screen.should_contain('ColumnAutoSizeModule: True')
+    shared_screen.should_contain('EventApiModule: True')
 
 
 @pytest.mark.parametrize('df_type', ['pandas', 'polars'])
-def test_problematic_datatypes(screen: Screen, df_type: str):
+def test_problematic_datatypes(shared_screen: SharedScreen, df_type: str):
     @ui.page('/')
     def page():
         if df_type == 'pandas':
@@ -260,21 +260,21 @@ def test_problematic_datatypes(screen: Screen, df_type: str):
             })
             ui.aggrid.from_polars(df)
 
-    screen.open('/')
-    screen.should_contain('Datetime_col')
-    screen.should_contain('2020-01-01')
-    screen.should_contain('Datetime_col_tz')
-    screen.should_contain('2020-01-02')
+    shared_screen.open('/')
+    shared_screen.should_contain('Datetime_col')
+    shared_screen.should_contain('2020-01-01')
+    shared_screen.should_contain('Datetime_col_tz')
+    shared_screen.should_contain('2020-01-02')
     if df_type == 'pandas':
-        screen.should_contain('Timedelta_col')
-        screen.should_contain('5 days')
-        screen.should_contain('Complex_col')
-        screen.should_contain('(1+2j)')
-        screen.should_contain('Period_col')
-        screen.should_contain('2021-01')
+        shared_screen.should_contain('Timedelta_col')
+        shared_screen.should_contain('5 days')
+        shared_screen.should_contain('Complex_col')
+        shared_screen.should_contain('(1+2j)')
+        shared_screen.should_contain('Period_col')
+        shared_screen.should_contain('2021-01')
 
 
-def test_run_row_method(screen: Screen):
+def test_run_row_method(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         grid = ui.aggrid({
@@ -284,16 +284,16 @@ def test_run_row_method(screen: Screen):
         })
         ui.button('Update', on_click=lambda: grid.run_row_method('Alice', 'setDataValue', 'age', 42))
 
-    screen.open('/')
-    screen.should_contain('Alice')
-    screen.should_contain('18')
+    shared_screen.open('/')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('18')
 
-    screen.click('Update')
-    screen.should_contain('Alice')
-    screen.should_contain('42')
+    shared_screen.click('Update')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('42')
 
 
-def test_run_method_with_function(screen: Screen):
+def test_run_method_with_function(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         grid = ui.aggrid({'columnDefs': [{'field': 'name'}], 'rowData': [{'name': 'Alice'}, {'name': 'Bob'}]})
@@ -303,12 +303,12 @@ def test_run_method_with_function(screen: Screen):
 
         ui.button('Print Row 0', on_click=lambda: print_row(0))
 
-    screen.open('/')
-    screen.click('Print Row 0')
-    screen.should_contain("Row 0: {'name': 'Alice'}")
+    shared_screen.open('/')
+    shared_screen.click('Print Row 0')
+    shared_screen.should_contain("Row 0: {'name': 'Alice'}")
 
 
-def test_get_client_data(screen: Screen):
+def test_get_client_data(shared_screen: SharedScreen):
     data: list = []
 
     @ui.page('/')
@@ -333,11 +333,11 @@ def test_get_client_data(screen: Screen):
             data[:] = await grid.get_client_data(method='filtered_sorted')
         ui.button('Get Sorted Data', on_click=get_sorted_data)
 
-    screen.open('/')
-    screen.click('Get Data')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.click('Get Data')
+    shared_screen.wait(0.5)
     assert data == [{'name': 'Alice', 'age': 18}, {'name': 'Bob', 'age': 21}, {'name': 'Carol', 'age': 42}]
 
-    screen.click('Get Sorted Data')
-    screen.wait(0.5)
+    shared_screen.click('Get Sorted Data')
+    shared_screen.wait(0.5)
     assert data == [{'name': 'Carol', 'age': 42}, {'name': 'Bob', 'age': 21}, {'name': 'Alice', 'age': 18}]

--- a/tests/test_altair.py
+++ b/tests/test_altair.py
@@ -2,10 +2,10 @@ import altair as alt
 import pandas as pd
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_construction(screen: Screen):
+def test_construction(shared_screen: SharedScreen):
     def chart():
         df = pd.DataFrame([{'x': 1, 'y': 3}, {'x': 2, 'y': 5}, {'x': 3, 'y': 4}, {'x': 4, 'y': 6}])
         return alt.Chart(df).mark_point().encode(alt.X('x:Q'), alt.Y('y:Q'))
@@ -20,5 +20,5 @@ def test_construction(screen: Screen):
         ui.altair(alt.vconcat(chart(), chart())).classes('my-chart')
         ui.altair(chart().repeat(column=['x', 'y'], row=['x', 'y'])).classes('my-chart')
 
-    screen.open('/')
-    assert len(screen.find_all_by_class('my-chart')) == 7
+    shared_screen.open('/')
+    assert len(shared_screen.find_all_by_class('my-chart')) == 7

--- a/tests/test_alternate_ui_frameworks.py
+++ b/tests/test_alternate_ui_frameworks.py
@@ -1,17 +1,17 @@
 from nicegui import app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_quasar(screen: Screen):
+def test_quasar(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.element('q-btn')
 
-    screen.open('/')
-    assert screen.find_by_tag('button')
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('button')
 
 
-def test_element_plus(screen: Screen):
+def test_element_plus(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.add_body_html('<script defer src="https://unpkg.com/element-plus"></script>')
@@ -19,5 +19,5 @@ def test_element_plus(screen: Screen):
 
         ui.element('el-button')
 
-    screen.open('/')
-    assert screen.find_by_tag('button')
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('button')

--- a/tests/test_anywidget.py
+++ b/tests/test_anywidget.py
@@ -2,10 +2,10 @@ import anywidget
 import traitlets
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_anywidget(screen: Screen):
+def test_anywidget(shared_screen: SharedScreen):
     class CounterWidget(anywidget.AnyWidget):  # pylint: disable=abstract-method
         _esm = '''
             function render({ model, el }) {
@@ -31,13 +31,13 @@ def test_anywidget(screen: Screen):
         def increment_counter() -> None:
             counter.value += 1
 
-    screen.open('/')
-    screen.click('anywidget: 42')
-    screen.click('NiceGUI: 43')
-    screen.should_contain('anywidget: 44')
+    shared_screen.open('/')
+    shared_screen.click('anywidget: 42')
+    shared_screen.click('NiceGUI: 43')
+    shared_screen.should_contain('anywidget: 44')
 
 
-def test_nested_update(screen: Screen):
+def test_nested_update(shared_screen: SharedScreen):
     class UpdateWidget(anywidget.AnyWidget):  # pylint: disable=abstract-method
         _esm = '''
             function render({model, el}) {
@@ -65,5 +65,5 @@ def test_nested_update(screen: Screen):
         uw.observe(change_b, names=['a'])
         ui.anywidget(uw)
 
-    screen.open('/')
-    screen.should_contain('b=1')
+    shared_screen.open('/')
+    shared_screen.should_contain('b=1')

--- a/tests/test_api_router.py
+++ b/tests/test_api_router.py
@@ -1,8 +1,8 @@
 from nicegui import APIRouter, app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_prefix(screen: Screen):
+def test_prefix(shared_screen: SharedScreen):
     router = APIRouter(prefix='/some-prefix')
 
     @router.page('/')
@@ -11,12 +11,12 @@ def test_prefix(screen: Screen):
 
     app.include_router(router)
 
-    screen.open('/some-prefix')
-    screen.should_contain('NiceGUI')
-    screen.should_contain('Hello, world!')
+    shared_screen.open('/some-prefix')
+    shared_screen.should_contain('NiceGUI')
+    shared_screen.should_contain('Hello, world!')
 
 
-def test_passing_page_parameters(screen: Screen):
+def test_passing_page_parameters(shared_screen: SharedScreen):
     router = APIRouter()
 
     @router.page('/', title='My Custom Title')
@@ -25,5 +25,5 @@ def test_passing_page_parameters(screen: Screen):
 
     app.include_router(router)
 
-    screen.open('/')
-    screen.should_contain('My Custom Title')
+    shared_screen.open('/')
+    shared_screen.should_contain('My Custom Title')

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,5 +1,5 @@
 from nicegui import app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
 def _serve_empty_file(path: str):
@@ -8,7 +8,7 @@ def _serve_empty_file(path: str):
         return b''
 
 
-def test_replace_audio(screen: Screen):
+def test_replace_audio(shared_screen: SharedScreen):
     _serve_empty_file(SONG1 := '/audio1.wav')
     _serve_empty_file(SONG2 := '/audio2.wav')
 
@@ -22,15 +22,15 @@ def test_replace_audio(screen: Screen):
                 ui.audio(SONG2)
         ui.button('Replace', on_click=replace)
 
-    screen.open('/')
-    assert screen.find_by_tag('audio').get_attribute('src').endswith(SONG1)
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('audio').get_attribute('src').endswith(SONG1)
 
-    screen.click('Replace')
-    screen.wait(0.5)
-    assert screen.find_by_tag('audio').get_attribute('src').endswith(SONG2)
+    shared_screen.click('Replace')
+    shared_screen.wait(0.5)
+    assert shared_screen.find_by_tag('audio').get_attribute('src').endswith(SONG2)
 
 
-def test_change_source(screen: Screen):
+def test_change_source(shared_screen: SharedScreen):
     _serve_empty_file(SONG1 := '/audio1.wav')
     _serve_empty_file(SONG2 := '/audio2.wav')
 
@@ -39,9 +39,9 @@ def test_change_source(screen: Screen):
         audio = ui.audio(SONG1)
         ui.button('Change source', on_click=lambda: audio.set_source(SONG2))
 
-    screen.open('/')
-    assert screen.find_by_tag('audio').get_attribute('src').endswith(SONG1)
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('audio').get_attribute('src').endswith(SONG1)
 
-    screen.click('Change source')
-    screen.wait(0.5)
-    assert screen.find_by_tag('audio').get_attribute('src').endswith(SONG2)
+    shared_screen.click('Change source')
+    shared_screen.wait(0.5)
+    assert shared_screen.find_by_tag('audio').get_attribute('src').endswith(SONG2)

--- a/tests/test_auto_context.py
+++ b/tests/test_auto_context.py
@@ -3,30 +3,30 @@ import asyncio
 from selenium.webdriver.common.by import By
 
 from nicegui import background_tasks, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_adding_element_to_shared_index_page(screen: Screen):
+def test_adding_element_to_shared_index_page(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('add label', on_click=lambda: ui.label('added'))
 
-    screen.open('/')
-    screen.click('add label')
-    screen.should_contain('added')
+    shared_screen.open('/')
+    shared_screen.click('add label')
+    shared_screen.should_contain('added')
 
 
-def test_adding_element_to_private_page(screen: Screen):
+def test_adding_element_to_private_page(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('add label', on_click=lambda: ui.label('added'))
 
-    screen.open('/')
-    screen.click('add label')
-    screen.should_contain('added')
+    shared_screen.open('/')
+    shared_screen.click('add label')
+    shared_screen.should_contain('added')
 
 
-def test_adding_elements_with_async_await(screen: Screen):
+def test_adding_elements_with_async_await(shared_screen: SharedScreen):
     cardA = None
     cardB = None
 
@@ -46,17 +46,17 @@ def test_adding_elements_with_async_await(screen: Screen):
         with ui.card() as cardB:
             ui.timer(1.5, add_b, once=True)
 
-    screen.open('/')
-    with screen.implicitly_wait(10.0):
-        screen.should_contain('A')
-        screen.should_contain('B')
-    cA = screen.find_element(cardA)
+    shared_screen.open('/')
+    with shared_screen.implicitly_wait(10.0):
+        shared_screen.should_contain('A')
+        shared_screen.should_contain('B')
+    cA = shared_screen.find_element(cardA)
     cA.find_element(By.XPATH, './/*[contains(text(), "A")]')
-    cB = screen.find_element(cardB)
+    cB = shared_screen.find_element(cardB)
     cB.find_element(By.XPATH, './/*[contains(text(), "B")]')
 
 
-def test_autoupdate_after_connected(screen: Screen):
+def test_autoupdate_after_connected(shared_screen: SharedScreen):
     @ui.page('/')
     async def page():
         ui.label('before connected')
@@ -69,18 +69,18 @@ def test_autoupdate_after_connected(screen: Screen):
         await asyncio.sleep(1)
         ui.label('three')
 
-    screen.open('/')
-    screen.should_contain('before connected')
-    screen.should_contain('after connected')
-    screen.should_not_contain('one')
-    screen.wait_for('one')
-    screen.should_not_contain('two')
-    screen.wait_for('two')
-    screen.should_not_contain('three')
-    screen.wait_for('three')
+    shared_screen.open('/')
+    shared_screen.should_contain('before connected')
+    shared_screen.should_contain('after connected')
+    shared_screen.should_not_contain('one')
+    shared_screen.wait_for('one')
+    shared_screen.should_not_contain('two')
+    shared_screen.wait_for('two')
+    shared_screen.should_not_contain('three')
+    shared_screen.wait_for('three')
 
 
-def test_autoupdate_on_async_event_handler(screen: Screen):
+def test_autoupdate_on_async_event_handler(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         async def open_dialog():
@@ -92,14 +92,14 @@ def test_autoupdate_on_async_event_handler(screen: Screen):
 
         ui.button('Dialog', on_click=open_dialog)
 
-    screen.open('/')
-    screen.click('Dialog')
-    screen.should_contain('This should be visible')
-    screen.should_not_contain('New text after 1 second')
-    screen.should_contain('New text after 1 second')
+    shared_screen.open('/')
+    shared_screen.click('Dialog')
+    shared_screen.should_contain('This should be visible')
+    shared_screen.should_not_contain('New text after 1 second')
+    shared_screen.should_contain('New text after 1 second')
 
 
-def test_autoupdate_on_async_timer_callback(screen: Screen):
+def test_autoupdate_on_async_timer_callback(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         async def update():
@@ -109,16 +109,16 @@ def test_autoupdate_on_async_timer_callback(screen: Screen):
         ui.label('0')
         ui.button('start', on_click=lambda: ui.timer(2.0, update, once=True))
 
-    screen.open('/')
-    screen.click('start')
-    screen.should_contain('0')
-    screen.should_not_contain('1')
-    screen.wait_for('1')
-    screen.should_not_contain('2')
-    screen.wait_for('2')
+    shared_screen.open('/')
+    shared_screen.click('start')
+    shared_screen.should_contain('0')
+    shared_screen.should_not_contain('1')
+    shared_screen.wait_for('1')
+    shared_screen.should_not_contain('2')
+    shared_screen.wait_for('2')
 
 
-def test_adding_elements_from_different_tasks(screen: Screen):
+def test_adding_elements_from_different_tasks(shared_screen: SharedScreen):
     card1 = None
     card2 = None
 
@@ -142,14 +142,14 @@ def test_adding_elements_from_different_tasks(screen: Screen):
         ui.button('Add label 1', on_click=lambda: background_tasks.create(add_label1()))
         ui.button('Add label 2', on_click=lambda: background_tasks.create(add_label2()))
 
-    screen.open('/')
-    with screen.implicitly_wait(10.0):
-        screen.wait_for('connection established')
-    screen.click('Add label 1')
-    screen.click('Add label 2')
-    screen.should_contain('Label 1')
-    screen.should_contain('Label 2')
-    c1 = screen.find_element(card1)
+    shared_screen.open('/')
+    with shared_screen.implicitly_wait(10.0):
+        shared_screen.wait_for('connection established')
+    shared_screen.click('Add label 1')
+    shared_screen.click('Add label 2')
+    shared_screen.should_contain('Label 1')
+    shared_screen.should_contain('Label 2')
+    c1 = shared_screen.find_element(card1)
     c1.find_element(By.XPATH, './/*[contains(text(), "Label 1")]')
-    c2 = screen.find_element(card2)
+    c2 = shared_screen.find_element(card2)
     c2.find_element(By.XPATH, './/*[contains(text(), "Label 2")]')

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 ColorCase = namedtuple('ColorCase', ['label', 'color', 'result'])
 
@@ -13,7 +13,7 @@ COLOR_CASES = [
 ]
 
 
-def test_colors_via_color_parameter(screen: Screen):
+def test_colors_via_color_parameter(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button()
@@ -21,14 +21,14 @@ def test_colors_via_color_parameter(screen: Screen):
         for case in COLOR_CASES:
             ui.button(color=case.color)
 
-    screen.open('/')
-    assert screen.find_all_by_tag('button')[0].value_of_css_property('background-color') == 'rgba(88, 152, 212, 1)'
-    assert screen.find_all_by_tag('button')[1].value_of_css_property('background-color') == 'rgba(0, 0, 0, 0)'
+    shared_screen.open('/')
+    assert shared_screen.find_all_by_tag('button')[0].value_of_css_property('background-color') == 'rgba(88, 152, 212, 1)'
+    assert shared_screen.find_all_by_tag('button')[1].value_of_css_property('background-color') == 'rgba(0, 0, 0, 0)'
     for i, case in enumerate(COLOR_CASES, start=2):
-        assert screen.find_all_by_tag('button')[i].value_of_css_property('background-color') == case.result
+        assert shared_screen.find_all_by_tag('button')[i].value_of_css_property('background-color') == case.result
 
 
-def test_colors_via_setter(screen: Screen):
+def test_colors_via_setter(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         button = ui.button()
@@ -36,17 +36,17 @@ def test_colors_via_setter(screen: Screen):
         for case in COLOR_CASES:
             ui.button(f'Choose {case.label}', on_click=lambda c=case.color: button.set_background_color(c))
 
-    screen.open('/')
-    screen.should_contain('Button color: primary')
-    assert screen.find_by_tag('button').value_of_css_property('background-color') == 'rgba(88, 152, 212, 1)'
+    shared_screen.open('/')
+    shared_screen.should_contain('Button color: primary')
+    assert shared_screen.find_by_tag('button').value_of_css_property('background-color') == 'rgba(88, 152, 212, 1)'
 
     for case in COLOR_CASES:
-        screen.click(f'Choose {case.label}')
-        screen.should_contain(f'Button color: {case.color}')
-        assert screen.find_by_tag('button').value_of_css_property('background-color') == case.result
+        shared_screen.click(f'Choose {case.label}')
+        shared_screen.should_contain(f'Button color: {case.color}')
+        assert shared_screen.find_by_tag('button').value_of_css_property('background-color') == case.result
 
 
-def test_colors_via_binding(screen: Screen):
+def test_colors_via_binding(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         display = ui.label()
@@ -55,17 +55,17 @@ def test_colors_via_binding(screen: Screen):
         toggle = ui.toggle({case.color: f'Choose {case.label}' for case in COLOR_CASES}, value=COLOR_CASES[0].color)
         button.bind_background_color_from(toggle, 'value')
 
-    screen.open('/')
-    screen.should_contain(f'Button color: {COLOR_CASES[0].color}')
-    assert screen.find_by_tag('button').value_of_css_property('background-color') == COLOR_CASES[0].result
+    shared_screen.open('/')
+    shared_screen.should_contain(f'Button color: {COLOR_CASES[0].color}')
+    assert shared_screen.find_by_tag('button').value_of_css_property('background-color') == COLOR_CASES[0].result
 
     for case in COLOR_CASES:
-        screen.click(f'Choose {case.label}')
-        screen.should_contain(f'Button color: {case.color}')
-        assert screen.find_by_tag('button').value_of_css_property('background-color') == case.result
+        shared_screen.click(f'Choose {case.label}')
+        shared_screen.should_contain(f'Button color: {case.color}')
+        assert shared_screen.find_by_tag('button').value_of_css_property('background-color') == case.result
 
 
-def test_enable_disable(screen: Screen):
+def test_enable_disable(shared_screen: SharedScreen):
     events = []
 
     @ui.page('/')
@@ -74,14 +74,14 @@ def test_enable_disable(screen: Screen):
         ui.button('Enable', on_click=b.enable)
         ui.button('Disable', on_click=b.disable)
 
-    screen.open('/')
-    screen.click('Button')
+    shared_screen.open('/')
+    shared_screen.click('Button')
     assert events == [1]
 
-    screen.click('Disable')
-    screen.click('Button')
+    shared_screen.click('Disable')
+    shared_screen.click('Button')
     assert events == [1]
 
-    screen.click('Enable')
-    screen.click('Button')
+    shared_screen.click('Enable')
+    shared_screen.click('Button')
     assert events == [1, 1]

--- a/tests/test_button_dropdown.py
+++ b/tests/test_button_dropdown.py
@@ -1,22 +1,22 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_dropdown_button(screen: Screen):
+def test_dropdown_button(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.dropdown_button('Button', on_click=lambda: ui.label('Button clicked')):
             ui.item('Item', on_click=lambda: ui.label('Item clicked'))
 
-    screen.open('/')
-    screen.click('Button')
-    screen.should_contain('Button clicked')
+    shared_screen.open('/')
+    shared_screen.click('Button')
+    shared_screen.should_contain('Button clicked')
 
-    screen.click('Item')
-    screen.should_contain('Item clicked')
+    shared_screen.click('Item')
+    shared_screen.should_contain('Item clicked')
 
 
-def test_auto_close(screen: Screen):
+def test_auto_close(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.dropdown_button('Button 1', auto_close=False):
@@ -24,13 +24,13 @@ def test_auto_close(screen: Screen):
         with ui.dropdown_button('Button 2', auto_close=True):
             ui.label('Item 2')
 
-    screen.open('/')
-    screen.click('Button 1')
-    screen.click('Item 1')
-    screen.wait(0.5)
-    screen.should_contain('Item 1')
+    shared_screen.open('/')
+    shared_screen.click('Button 1')
+    shared_screen.click('Item 1')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Item 1')
 
-    screen.click('Button 2')
-    screen.click('Item 2')
-    screen.wait(0.5)
-    screen.should_not_contain('Item 2')
+    shared_screen.click('Button 2')
+    shared_screen.click('Item 2')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Item 2')

--- a/tests/test_button_group.py
+++ b/tests/test_button_group.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_button_group(screen: Screen):
+def test_button_group(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.button_group():
@@ -11,15 +11,15 @@ def test_button_group(screen: Screen):
             with ui.dropdown_button('Button 3', on_click=lambda: ui.label('Button 3 clicked')):
                 ui.item('Item', on_click=lambda: ui.label('Item clicked'))
 
-    screen.open('/')
-    screen.click('Button 1')
-    screen.should_contain('Button 1 clicked')
+    shared_screen.open('/')
+    shared_screen.click('Button 1')
+    shared_screen.should_contain('Button 1 clicked')
 
-    screen.click('Button 2')
-    screen.should_contain('Button 2 clicked')
+    shared_screen.click('Button 2')
+    shared_screen.should_contain('Button 2 clicked')
 
-    screen.click('Button 3')
-    screen.should_contain('Button 3 clicked')
+    shared_screen.click('Button 3')
+    shared_screen.should_contain('Button 3 clicked')
 
-    screen.click('Item')
-    screen.should_contain('Item clicked')
+    shared_screen.click('Item')
+    shared_screen.should_contain('Item clicked')

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_preserve_borders(screen: Screen):
+def test_preserve_borders(shared_screen: SharedScreen):
     a = b = None
 
     @ui.page('/')
@@ -13,6 +13,6 @@ def test_preserve_borders(screen: Screen):
         with ui.card().tight():
             b = ui.table(rows=[]).props('bordered flat')
 
-    screen.open('/')
-    assert screen.find_element(a).value_of_css_property('border') == '1px solid rgba(0, 0, 0, 0.12)'
-    assert screen.find_element(b).value_of_css_property('border') == '0px none rgb(0, 0, 0)'
+    shared_screen.open('/')
+    assert shared_screen.find_element(a).value_of_css_property('border') == '1px solid rgba(0, 0, 0, 0.12)'
+    assert shared_screen.find_element(b).value_of_css_property('border') == '0px none rgb(0, 0, 0)'

--- a/tests/test_carousel.py
+++ b/tests/test_carousel.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_carousel(screen: Screen):
+def test_carousel(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.carousel(arrows=True).props('control-color=primary'):
@@ -10,17 +10,17 @@ def test_carousel(screen: Screen):
                 with ui.carousel_slide():
                     ui.label(name).classes('w-32')
 
-    screen.open('/')
-    screen.should_contain('Alice')
+    shared_screen.open('/')
+    shared_screen.should_contain('Alice')
 
-    screen.click('chevron_right')
-    screen.should_contain('Bob')
+    shared_screen.click('chevron_right')
+    shared_screen.should_contain('Bob')
 
-    screen.click('chevron_right')
-    screen.should_contain('Carol')
+    shared_screen.click('chevron_right')
+    shared_screen.should_contain('Carol')
 
-    screen.click('chevron_left')
-    screen.should_contain('Bob')
+    shared_screen.click('chevron_left')
+    shared_screen.should_contain('Bob')
 
-    screen.click('chevron_left')
-    screen.should_contain('Alice')
+    shared_screen.click('chevron_left')
+    shared_screen.should_contain('Alice')

--- a/tests/test_chat_message.py
+++ b/tests/test_chat_message.py
@@ -2,10 +2,10 @@ from html_sanitizer import Sanitizer
 from selenium.webdriver.common.by import By
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_text_vs_html(screen: Screen):
+def test_text_vs_html(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.chat_message('10&euro;')
@@ -21,43 +21,43 @@ def test_text_vs_html(screen: Screen):
         ui.chat_message('80&euro;', text_html=True)
         ui.chat_message('90&euro;', text_html=True, sanitize=False)
 
-    screen.allowed_js_errors.append('/x - Failed to load resource')
-    screen.open('/')
-    screen.should_contain('10&euro;')
-    screen.should_contain('20€')
-    screen.should_contain('30€')
-    screen.should_contain('40€')
-    screen.should_contain('50€')
-    screen.should_contain('60EUR')
-    screen.should_not_contain('70€')
-    screen.should_contain('80€')
-    screen.should_contain('90€')
+    shared_screen.allowed_js_errors.append('/x - Failed to load resource')
+    shared_screen.open('/')
+    shared_screen.should_contain('10&euro;')
+    shared_screen.should_contain('20€')
+    shared_screen.should_contain('30€')
+    shared_screen.should_contain('40€')
+    shared_screen.should_contain('50€')
+    shared_screen.should_contain('60EUR')
+    shared_screen.should_not_contain('70€')
+    shared_screen.should_contain('80€')
+    shared_screen.should_contain('90€')
 
 
-def test_newline(screen: Screen):
+def test_newline(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.chat_message('Hello\nNiceGUI!')
 
-    screen.open('/')
-    assert screen.find('Hello').find_element(By.TAG_NAME, 'br')
+    shared_screen.open('/')
+    assert shared_screen.find('Hello').find_element(By.TAG_NAME, 'br')
 
 
-def test_slot(screen: Screen):
+def test_slot(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.chat_message():
             ui.label('slot')
 
-    screen.open('/')
-    screen.should_contain('slot')
+    shared_screen.open('/')
+    shared_screen.should_contain('slot')
 
 
-def test_xss_sanitization(screen: Screen):
+def test_xss_sanitization(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.chat_message('<img src=x onerror="alert(\'XSS\')">', text_html=True)
 
-    screen.allowed_js_errors.append('/x - Failed to load resource')
-    screen.open('/')
-    assert screen.find_by_tag('img').get_attribute('onerror') is None
+    shared_screen.allowed_js_errors.append('/x - Failed to load resource')
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('img').get_attribute('onerror') is None

--- a/tests/test_chip.py
+++ b/tests/test_chip.py
@@ -1,32 +1,32 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_removable_chip(screen: Screen):
+def test_removable_chip(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         chip = ui.chip('Chip', removable=True)
         ui.button('Set value to False', on_click=lambda: chip.set_value(False))
 
-    screen.open('/')
-    screen.should_contain('Chip')
+    shared_screen.open('/')
+    shared_screen.should_contain('Chip')
 
-    screen.click('Set value to False')
-    screen.wait(0.5)
-    screen.should_not_contain('Chip')
+    shared_screen.click('Set value to False')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Chip')
 
 
-def test_selectable_chip(screen: Screen):
+def test_selectable_chip(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         chip = ui.chip('Chip', selectable=True)
         ui.label().bind_text_from(chip, 'selected', lambda s: f'Selected: {s}')
 
-    screen.open('/')
-    screen.should_contain('Selected: False')
+    shared_screen.open('/')
+    shared_screen.should_contain('Selected: False')
 
-    screen.click('Chip')
-    screen.should_contain('Selected: True')
+    shared_screen.click('Chip')
+    shared_screen.should_contain('Selected: True')
 
-    screen.click('Chip')
-    screen.should_contain('Selected: False')
+    shared_screen.click('Chip')
+    shared_screen.should_contain('Selected: False')

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_clipboard(screen: Screen):
+def test_clipboard(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('Copy to clipboard', on_click=lambda: ui.clipboard.write('Hello, World!'))
@@ -11,13 +11,13 @@ def test_clipboard(screen: Screen):
             ui.notify('Clipboard: ' + await ui.clipboard.read())
         ui.button('Read from clipboard', on_click=read_clipboard)
 
-    screen.open('/')
-    screen.selenium.set_permissions('clipboard-read', 'granted')
-    screen.selenium.set_permissions('clipboard-write', 'granted')
+    shared_screen.open('/')
+    shared_screen.selenium.set_permissions('clipboard-read', 'granted')
+    shared_screen.selenium.set_permissions('clipboard-write', 'granted')
 
-    screen.click('Copy to clipboard')
-    screen.wait(0.5)
-    assert screen.selenium.execute_script('return navigator.clipboard.readText()') == 'Hello, World!'
+    shared_screen.click('Copy to clipboard')
+    shared_screen.wait(0.5)
+    assert shared_screen.selenium.execute_script('return navigator.clipboard.readText()') == 'Hello, World!'
 
-    screen.click('Read from clipboard')
-    screen.should_contain('Clipboard: Hello, World!')
+    shared_screen.click('Read from clipboard')
+    shared_screen.should_contain('Clipboard: Hello, World!')

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,13 +1,13 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_code(screen: Screen):
+def test_code(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.code('x = 42')
 
-    screen.open('/')
-    assert screen.find_by_class('n').text == 'x'
-    assert screen.find_by_class('o').text == '='
-    assert screen.find_by_class('mi').text == '42'
+    shared_screen.open('/')
+    assert shared_screen.find_by_class('n').text == 'x'
+    assert shared_screen.find_by_class('o').text == '='
+    assert shared_screen.find_by_class('mi').text == '42'

--- a/tests/test_codemirror.py
+++ b/tests/test_codemirror.py
@@ -1,21 +1,21 @@
 import pytest
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 # pylint: disable=protected-access
 
 
-def test_codemirror(screen: Screen):
+def test_codemirror(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.codemirror('Line 1\nLine 2\nLine 3')
 
-    screen.open('/')
-    screen.should_contain('Line 2')
+    shared_screen.open('/')
+    shared_screen.should_contain('Line 2')
 
 
-def test_supported_values(screen: Screen):
+def test_supported_values(shared_screen: SharedScreen):
     values: dict[str, list[str]] = {}
 
     @ui.page('/')
@@ -30,9 +30,9 @@ def test_supported_values(screen: Screen):
             ui.label('Done')
         ui.button('Fetch', on_click=fetch)
 
-    screen.open('/')
-    screen.click('Fetch')
-    screen.wait_for('Done')
+    shared_screen.open('/')
+    shared_screen.click('Fetch')
+    shared_screen.wait_for('Done')
     assert values['languages'] == values['supported_languages']
     assert values['themes'] == values['supported_themes']
 
@@ -50,7 +50,7 @@ def test_supported_values(screen: Screen):
     ('Hey! 🙂', [7, -1, 0, 4], [[], [' Ho!']], 'Hey! 🙂 Ho!'),
     ('Ha 🙂\nha 🙂', [3, -1, 2, 0, 4, -1, 2, 0], [[], [''], [], ['']], 'Ha \nha '),
 ])
-def test_change_set(screen: Screen, doc: str, sections: list[int], inserted: list[list[str]], expected: str):
+def test_change_set(shared_screen: SharedScreen, doc: str, sections: list[int], inserted: list[list[str]], expected: str):
     editor = None
 
     @ui.page('/')
@@ -58,7 +58,7 @@ def test_change_set(screen: Screen, doc: str, sections: list[int], inserted: lis
         nonlocal editor
         editor = ui.codemirror(doc)
 
-    screen.open('/')
+    shared_screen.open('/')
     assert editor._apply_change_set(sections, inserted) == expected
 
 

--- a/tests/test_color_input.py
+++ b/tests/test_color_input.py
@@ -1,23 +1,23 @@
 from selenium.webdriver.common.keys import Keys
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_entering_color(screen: Screen):
+def test_entering_color(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.color_input(label='Color', on_change=lambda e: ui.label(f'content: {e.value}'), preview=True)
 
-    screen.open('/')
-    screen.type(Keys.TAB)
-    screen.type('#001100')
-    screen.should_contain('content: #001100')
-    button = screen.find_by_class('q-btn')
+    shared_screen.open('/')
+    shared_screen.type(Keys.TAB)
+    shared_screen.type('#001100')
+    shared_screen.should_contain('content: #001100')
+    button = shared_screen.find_by_class('q-btn')
     assert button.value_of_css_property('background-color') == 'rgba(0, 17, 0, 1)'
 
 
-def test_picking_color(screen: Screen):
+def test_picking_color(shared_screen: SharedScreen):
     output = None
 
     @ui.page('/')
@@ -26,18 +26,18 @@ def test_picking_color(screen: Screen):
         ui.color_input(label='Color', on_change=lambda e: output.set_text(e.value))
         output = ui.label()
 
-    screen.open('/')
-    screen.click('colorize')
-    screen.click_at_position(screen.find('HEX'), x=0, y=60)
-    content = screen.find_by_class('q-color-picker__header-content')
+    shared_screen.open('/')
+    shared_screen.click('colorize')
+    shared_screen.click_at_position(shared_screen.find('HEX'), x=0, y=60)
+    content = shared_screen.find_by_class('q-color-picker__header-content')
     assert content.value_of_css_property('background-color') in {'rgba(245, 186, 186, 1)', 'rgba(245, 184, 184, 1)'}
     assert output.text in {'#f5baba', '#f5b8b8'}
 
-    screen.type(Keys.ESCAPE)
-    screen.wait(0.5)
-    screen.should_not_contain('HEX')
+    shared_screen.type(Keys.ESCAPE)
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('HEX')
 
-    screen.click('colorize')
-    content = screen.find_by_class('q-color-picker__header-content')
+    shared_screen.click('colorize')
+    content = shared_screen.find_by_class('q-color-picker__header-content')
     assert content.value_of_css_property('background-color') in {'rgba(245, 186, 186, 1)', 'rgba(245, 184, 184, 1)'}
     assert output.text in {'#f5baba', '#f5b8b8'}

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -1,8 +1,8 @@
 from nicegui import app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_appwide_colors(screen: Screen):
+def test_appwide_colors(shared_screen: SharedScreen):
     app.colors(primary='#ff0000', brand='#00ff00')
 
     @ui.page('/')
@@ -10,12 +10,12 @@ def test_appwide_colors(screen: Screen):
         ui.button('Test Button')
         ui.button('Brand Button', color='brand')
 
-    screen.open('/')
-    assert screen.find_all_by_tag('button')[0].value_of_css_property('background-color') == 'rgba(255, 0, 0, 1)'
-    assert screen.find_all_by_tag('button')[1].value_of_css_property('background-color') == 'rgba(0, 255, 0, 1)'
+    shared_screen.open('/')
+    assert shared_screen.find_all_by_tag('button')[0].value_of_css_property('background-color') == 'rgba(255, 0, 0, 1)'
+    assert shared_screen.find_all_by_tag('button')[1].value_of_css_property('background-color') == 'rgba(0, 255, 0, 1)'
 
 
-def test_replace_colors(screen: Screen):
+def test_replace_colors(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.row() as container:
@@ -26,9 +26,9 @@ def test_replace_colors(screen: Screen):
                 ui.colors(primary='red')
         ui.button('Replace', on_click=replace)
 
-    screen.open('/')
-    assert screen.find_by_tag('button').value_of_css_property('background-color') == 'rgba(0, 0, 255, 1)'
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('button').value_of_css_property('background-color') == 'rgba(0, 0, 255, 1)'
 
-    screen.click('Replace')
-    screen.wait(0.5)
-    assert screen.find_by_tag('button').value_of_css_property('background-color') == 'rgba(255, 0, 0, 1)'
+    shared_screen.click('Replace')
+    shared_screen.wait(0.5)
+    assert shared_screen.find_by_tag('button').value_of_css_property('background-color') == 'rgba(255, 0, 0, 1)'

--- a/tests/test_context_menu.py
+++ b/tests/test_context_menu.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_context_menu(screen: Screen):
+def test_context_menu(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.label('Right-click me'):
@@ -11,15 +11,15 @@ def test_context_menu(screen: Screen):
                 ui.menu_item('Item 1', auto_close=False)
                 ui.menu_item('Item 2', on_click=lambda: ui.notify('You clicked'))
 
-    screen.open('/')
-    screen.context_click('Right-click me')
-    screen.should_contain('Menu')
+    shared_screen.open('/')
+    shared_screen.context_click('Right-click me')
+    shared_screen.should_contain('Menu')
 
-    screen.click('Item 1')
-    screen.wait(0.5)
-    screen.should_contain('Menu')
+    shared_screen.click('Item 1')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Menu')
 
-    screen.click('Item 2')
-    screen.wait(0.5)
-    screen.should_not_contain('Menu')
-    screen.should_contain('You clicked')
+    shared_screen.click('Item 2')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Menu')
+    shared_screen.should_contain('You clicked')

--- a/tests/test_dark_mode.py
+++ b/tests/test_dark_mode.py
@@ -3,11 +3,11 @@ from typing import Literal
 import pytest
 
 from nicegui import app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
 @pytest.mark.parametrize('unocss', [None, 'mini', 'wind3', 'wind4'])
-def test_dark_mode(screen: Screen, unocss: Literal['mini', 'wind3', 'wind4'] | None):
+def test_dark_mode(shared_screen: SharedScreen, unocss: Literal['mini', 'wind3', 'wind4'] | None):
     app.config.unocss = unocss
 
     @ui.page('/')
@@ -20,30 +20,30 @@ def test_dark_mode(screen: Screen, unocss: Literal['mini', 'wind3', 'wind4'] | N
         ui.button('Toggle', on_click=dark.toggle)
 
     def assert_dark(value: bool) -> None:
-        classes = (screen.find_by_tag('body').get_attribute('class') or '').split()
+        classes = (shared_screen.find_by_tag('body').get_attribute('class') or '').split()
         assert ('body--dark' in classes) == value
         assert ('body--light' in classes) != value
 
-    screen.open('/')
-    screen.should_contain('Hello')
+    shared_screen.open('/')
+    shared_screen.should_contain('Hello')
     assert_dark(False)
 
-    screen.click('Dark')
-    screen.wait(0.5)
+    shared_screen.click('Dark')
+    shared_screen.wait(0.5)
     assert_dark(True)
 
-    screen.click('Auto')
-    screen.wait(0.5)
+    shared_screen.click('Auto')
+    shared_screen.wait(0.5)
     assert_dark(False)
 
-    screen.click('Toggle')
-    screen.wait(0.5)
-    screen.assert_py_logger('ERROR', 'Cannot toggle dark mode when it is set to auto.')
+    shared_screen.click('Toggle')
+    shared_screen.wait(0.5)
+    shared_screen.assert_py_logger('ERROR', 'Cannot toggle dark mode when it is set to auto.')
 
-    screen.click('Light')
-    screen.wait(0.5)
+    shared_screen.click('Light')
+    shared_screen.wait(0.5)
     assert_dark(False)
 
-    screen.click('Toggle')
-    screen.wait(0.5)
+    shared_screen.click('Toggle')
+    shared_screen.wait(0.5)
     assert_dark(True)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -1,75 +1,75 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_date(screen: Screen):
+def test_date(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.date(value='2023-01-01')
 
-    screen.open('/')
-    screen.should_contain('Sun, Jan 1')
+    shared_screen.open('/')
+    shared_screen.should_contain('Sun, Jan 1')
 
-    screen.click('31')
-    screen.should_contain('Tue, Jan 31')
+    shared_screen.click('31')
+    shared_screen.should_contain('Tue, Jan 31')
 
 
-def test_date_with_range(screen: Screen):
+def test_date_with_range(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.date().props('range default-year-month=2023/01')
 
-    screen.open('/')
-    screen.click('16')
-    screen.click('19')
-    screen.should_contain('4 days')
+    shared_screen.open('/')
+    shared_screen.click('16')
+    shared_screen.click('19')
+    shared_screen.should_contain('4 days')
 
-    screen.click('25')
-    screen.click('28')
-    screen.should_contain('4 days')
+    shared_screen.click('25')
+    shared_screen.click('28')
+    shared_screen.should_contain('4 days')
 
 
-def test_date_with_multi_selection(screen: Screen):
+def test_date_with_multi_selection(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.date().props('multiple default-year-month=2023/01')
 
-    screen.open('/')
-    screen.click('16')
-    screen.click('19')
-    screen.should_contain('2 days')
+    shared_screen.open('/')
+    shared_screen.click('16')
+    shared_screen.click('19')
+    shared_screen.should_contain('2 days')
 
-    screen.click('25')
-    screen.click('28')
-    screen.should_contain('4 days')
+    shared_screen.click('25')
+    shared_screen.click('28')
+    shared_screen.should_contain('4 days')
 
 
-def test_date_with_range_and_multi_selection(screen: Screen):
+def test_date_with_range_and_multi_selection(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.date().props('range multiple default-year-month=2023/01')
 
-    screen.open('/')
-    screen.click('16')
-    screen.click('19')
-    screen.should_contain('4 days')
+    shared_screen.open('/')
+    shared_screen.click('16')
+    shared_screen.click('19')
+    shared_screen.should_contain('4 days')
 
-    screen.click('25')
-    screen.click('28')
-    screen.should_contain('8 days')
+    shared_screen.click('25')
+    shared_screen.click('28')
+    shared_screen.should_contain('8 days')
 
 
-def test_date_with_filter(screen: Screen):
+def test_date_with_filter(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         d = ui.date().props('''default-year-month=2023/01 :options="date => date <= '2023/01/15'"''')
         ui.label().bind_text_from(d, 'value')
 
-    screen.open('/')
-    screen.click('14')
-    screen.should_contain('2023-01-14')
-    screen.click('15')
-    screen.should_contain('2023-01-15')
-    screen.click('16')
-    screen.wait(0.5)
-    screen.should_not_contain('2023-01-16')
+    shared_screen.open('/')
+    shared_screen.click('14')
+    shared_screen.should_contain('2023-01-14')
+    shared_screen.click('15')
+    shared_screen.should_contain('2023-01-15')
+    shared_screen.click('16')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('2023-01-16')

--- a/tests/test_date_input.py
+++ b/tests/test_date_input.py
@@ -2,24 +2,24 @@ import pytest
 from selenium.webdriver.common.by import By
 
 from nicegui import ui
-from nicegui.testing import Screen, User
+from nicegui.testing import SharedScreen, User
 
 
-def test_date_input(screen: Screen):
+def test_date_input(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         date_input = ui.date_input('Date')
         ui.label().bind_text_from(date_input, 'value', lambda value: f'date: {value}')
 
-    screen.open('/')
-    screen.should_contain('Date')
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Date"]')
+    shared_screen.open('/')
+    shared_screen.should_contain('Date')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Date"]')
     element.send_keys('2025-01-01')
-    screen.should_contain('date: 2025-01-01')
+    shared_screen.should_contain('date: 2025-01-01')
 
-    screen.click('edit_calendar')
-    screen.should_contain('Sat')
-    screen.should_contain('Jan 1')
+    shared_screen.click('edit_calendar')
+    shared_screen.should_contain('Sat')
+    shared_screen.should_contain('Jan 1')
 
 
 @pytest.mark.parametrize('range_input', [False, True])

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi.responses import PlainTextResponse
 
 from nicegui import app, ui
-from nicegui.testing import Screen, screen_plugin
+from nicegui.testing import SharedScreen, screen_plugin
 
 
 @pytest.fixture
@@ -15,7 +15,7 @@ def test_route() -> Generator[str, None, None]:
     app.remove_route(TEST_ROUTE)
 
 
-def test_download_text_file(screen: Screen, test_route: str):  # pylint: disable=redefined-outer-name
+def test_download_text_file(shared_screen: SharedScreen, test_route: str):  # pylint: disable=redefined-outer-name
     @app.get(test_route)
     def test(number: str):
         return PlainTextResponse(f'test {number}')
@@ -25,17 +25,17 @@ def test_download_text_file(screen: Screen, test_route: str):  # pylint: disable
         ui.button('Download 1', on_click=lambda: ui.download(test_route + '?number=1', 'test1.txt'))
         ui.button('Download 2', on_click=lambda: ui.download.from_url(test_route + '?number=2', 'test2.txt'))
 
-    screen.open('/')
-    screen.click('Download 1')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.click('Download 1')
+    shared_screen.wait(0.5)
     assert (screen_plugin.DOWNLOAD_DIR / 'test1.txt').read_text(encoding='utf-8') == 'test 1'
 
-    screen.click('Download 2')
-    screen.wait(0.5)
+    shared_screen.click('Download 2')
+    shared_screen.wait(0.5)
     assert (screen_plugin.DOWNLOAD_DIR / 'test2.txt').read_text(encoding='utf-8') == 'test 2'
 
 
-def test_downloading_local_file_as_src(screen: Screen):
+def test_downloading_local_file_as_src(shared_screen: SharedScreen):
     IMAGE_FILE1 = Path(__file__).parent.parent / 'examples' / 'slideshow' / 'slides' / 'slide1.jpg'
     IMAGE_FILE2 = Path(__file__).parent.parent / 'examples' / 'slideshow' / 'slides' / 'slide2.jpg'
 
@@ -44,35 +44,35 @@ def test_downloading_local_file_as_src(screen: Screen):
         ui.button('Download 1', on_click=lambda: ui.download(IMAGE_FILE1))
         ui.button('Download 2', on_click=lambda: ui.download.file(IMAGE_FILE2))
 
-    screen.open('/')
+    shared_screen.open('/')
     route_count_before_download = len(app.routes)
-    screen.click('Download 1')
-    screen.wait(0.5)
+    shared_screen.click('Download 1')
+    shared_screen.wait(0.5)
     assert (screen_plugin.DOWNLOAD_DIR / 'slide1.jpg').exists()
     assert len(app.routes) == route_count_before_download
 
-    screen.click('Download 2')
-    screen.wait(0.5)
+    shared_screen.click('Download 2')
+    shared_screen.wait(0.5)
     assert (screen_plugin.DOWNLOAD_DIR / 'slide2.jpg').exists()
     assert len(app.routes) == route_count_before_download
 
 
-def test_download_raw_data(screen: Screen):
+def test_download_raw_data(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('Download 1', on_click=lambda: ui.download(b'test 1', 'test1.txt'))
         ui.button('Download 2', on_click=lambda: ui.download.content(b'test 2', 'test2.txt'))
         ui.button('Download 3', on_click=lambda: ui.download.content('test 3', 'test3.txt'))
 
-    screen.open('/')
-    screen.click('Download 1')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.click('Download 1')
+    shared_screen.wait(0.5)
     assert (screen_plugin.DOWNLOAD_DIR / 'test1.txt').read_text(encoding='utf-8') == 'test 1'
 
-    screen.click('Download 2')
-    screen.wait(0.5)
+    shared_screen.click('Download 2')
+    shared_screen.wait(0.5)
     assert (screen_plugin.DOWNLOAD_DIR / 'test2.txt').read_text(encoding='utf-8') == 'test 2'
 
-    screen.click('Download 3')
-    screen.wait(0.5)
+    shared_screen.click('Download 3')
+    shared_screen.wait(0.5)
     assert (screen_plugin.DOWNLOAD_DIR / 'test3.txt').read_text(encoding='utf-8') == 'test 3'

--- a/tests/test_echart.py
+++ b/tests/test_echart.py
@@ -6,7 +6,7 @@ from pyecharts.charts import Bar
 from pyecharts.commons import utils
 
 from nicegui import app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def test_route() -> Generator[str, None, None]:
     app.remove_route(TEST_ROUTE)
 
 
-def test_create_dynamically(screen: Screen):
+def test_create_dynamically(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         def create():
@@ -27,12 +27,12 @@ def test_create_dynamically(screen: Screen):
             })
         ui.button('Create', on_click=create)
 
-    screen.open('/')
-    screen.click('Create')
-    assert screen.find_by_tag('canvas')
+    shared_screen.open('/')
+    shared_screen.click('Create')
+    assert shared_screen.find_by_tag('canvas')
 
 
-def test_update(screen: Screen):
+def test_update(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         def update():
@@ -42,14 +42,14 @@ def test_update(screen: Screen):
         chart = ui.echart({})
         ui.button('Update', on_click=update)
 
-    screen.open('/')
-    assert not screen.find_all_by_tag('canvas')
+    shared_screen.open('/')
+    assert not shared_screen.find_all_by_tag('canvas')
 
-    screen.click('Update')
-    assert screen.find_by_tag('canvas')
+    shared_screen.click('Update')
+    assert shared_screen.find_by_tag('canvas')
 
 
-def test_nested_card(screen: Screen):
+def test_nested_card(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.card().style('height: 200px; width: 600px'):
@@ -59,13 +59,13 @@ def test_nested_card(screen: Screen):
                 'series': [{'type': 'line', 'data': [0.1, 0.2, 0.3]}],
             })
 
-    screen.open('/')
-    canvas = screen.find_by_tag('canvas')
+    shared_screen.open('/')
+    canvas = shared_screen.find_by_tag('canvas')
     assert canvas.rect['height'] == 168
     assert canvas.rect['width'] == 568
 
 
-def test_nested_expansion(screen: Screen):
+def test_nested_expansion(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.expansion() as expansion:
@@ -78,15 +78,15 @@ def test_nested_expansion(screen: Screen):
                 })
         ui.button('Open', on_click=expansion.open)
 
-    screen.open('/')
-    screen.click('Open')
-    screen.wait(0.5)
-    canvas = screen.find_by_tag('canvas')
+    shared_screen.open('/')
+    shared_screen.click('Open')
+    shared_screen.wait(0.5)
+    canvas = shared_screen.find_by_tag('canvas')
     assert canvas.rect['height'] == 168
     assert canvas.rect['width'] == 568
 
 
-def test_run_method(screen: Screen):
+def test_run_method(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         echart = ui.echart({
@@ -99,12 +99,12 @@ def test_run_method(screen: Screen):
             ui.label(f'Width: {await echart.run_chart_method("getWidth")}px')
         ui.button('Get Width', on_click=get_width)
 
-    screen.open('/')
-    screen.click('Get Width')
-    screen.should_contain('Width: 600px')
+    shared_screen.open('/')
+    shared_screen.click('Get Width')
+    shared_screen.should_contain('Width: 600px')
 
 
-def test_create_from_pyecharts(screen: Screen):
+def test_create_from_pyecharts(shared_screen: SharedScreen):
     X_AXIS_FORMATTER = r'(val, idx) => `x for ${val}`'
     Y_AXIS_FORMATTER = r'(val, idx) => `${val} kg`'
 
@@ -120,16 +120,16 @@ def test_create_from_pyecharts(screen: Screen):
             )
         ).props('renderer=svg')
 
-    screen.open('/')
-    screen.should_contain('x for A')
-    screen.should_contain('x for B')
-    screen.should_contain('x for C')
-    screen.should_contain('0.1 kg')
-    screen.should_contain('0.2 kg')
-    screen.should_contain('0.3 kg')
+    shared_screen.open('/')
+    shared_screen.should_contain('x for A')
+    shared_screen.should_contain('x for B')
+    shared_screen.should_contain('x for C')
+    shared_screen.should_contain('0.1 kg')
+    shared_screen.should_contain('0.2 kg')
+    shared_screen.should_contain('0.3 kg')
 
 
-def test_chart_events(screen: Screen):
+def test_chart_events(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.echart({
@@ -138,11 +138,11 @@ def test_chart_events(screen: Screen):
             'series': [{'type': 'line', 'data': [1, 2, 3]}],
         }).on('chart:rendered', lambda: ui.label('Chart rendered.'))
 
-    screen.open('/')
-    screen.should_contain('Chart rendered.')
+    shared_screen.open('/')
+    shared_screen.should_contain('Chart rendered.')
 
 
-def test_theme_dictionary(screen: Screen):
+def test_theme_dictionary(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.echart({
@@ -151,11 +151,11 @@ def test_theme_dictionary(screen: Screen):
             'series': [{'type': 'line', 'data': [1, 2, 3]}],
         }, theme={'backgroundColor': 'rgba(254,248,239,1)'}, renderer='svg')
 
-    screen.open('/')
-    assert screen.find_by_tag('rect').value_of_css_property('fill') == 'rgb(254, 248, 239)'
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('rect').value_of_css_property('fill') == 'rgb(254, 248, 239)'
 
 
-def test_theme_url(screen: Screen, test_route: str):  # pylint: disable=redefined-outer-name
+def test_theme_url(shared_screen: SharedScreen, test_route: str):  # pylint: disable=redefined-outer-name
     @app.get(test_route)
     def theme():
         return {'backgroundColor': 'rgba(254,248,239,1)'}
@@ -168,11 +168,11 @@ def test_theme_url(screen: Screen, test_route: str):  # pylint: disable=redefine
             'series': [{'type': 'line', 'data': [1, 2, 3]}],
         }, theme=test_route, renderer='svg')
 
-    screen.open('/')
-    assert screen.find_by_tag('rect').value_of_css_property('fill') == 'rgb(254, 248, 239)'
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('rect').value_of_css_property('fill') == 'rgb(254, 248, 239)'
 
 
-def test_click(screen: Screen):
+def test_click(shared_screen: SharedScreen):
     events = []
 
     @ui.page('/')
@@ -193,11 +193,11 @@ def test_click(screen: Screen):
         }, on_point_click=lambda e: events.append(('point', e)), on_click=lambda e: events.append(('component', e))) \
             .style('width: 200px; height: 200px')
 
-    screen.open('/')
-    echart = screen.find_by_tag('canvas')
+    shared_screen.open('/')
+    echart = shared_screen.find_by_tag('canvas')
     for x, y in [(20, 20), (0, 70), (60, 30)]:
-        screen.click_at_position(echart, x, y)
-    screen.wait(0.5)
+        shared_screen.click_at_position(echart, x, y)
+    shared_screen.wait(0.5)
     assert [(source, event.component_type, event.name) for source, event in events] == [
         ('point', 'series', 'Test'),
         ('component', 'series', 'Test'),

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,10 +1,10 @@
 from selenium.webdriver.common.keys import Keys
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_editor(screen: Screen):
+def test_editor(shared_screen: SharedScreen):
     editor = None
 
     @ui.page('/')
@@ -13,14 +13,14 @@ def test_editor(screen: Screen):
         editor = ui.editor(placeholder='Type something here')
         ui.markdown().bind_content_from(editor, 'value', backward=lambda v: f'HTML code:\n```\n{v}\n```')
 
-    screen.open('/')
-    screen.find_element(editor).click()
-    screen.type('Hello\nworld!')
-    screen.wait(0.5)
-    screen.should_contain('Hello<div>world!</div>')
+    shared_screen.open('/')
+    shared_screen.find_element(editor).click()
+    shared_screen.type('Hello\nworld!')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Hello<div>world!</div>')
 
 
-def test_setting_value_twice(screen: Screen):
+def test_setting_value_twice(shared_screen: SharedScreen):
     # https://github.com/zauberzeug/nicegui/issues/3217
     editor = None
 
@@ -30,12 +30,12 @@ def test_setting_value_twice(screen: Screen):
         editor = ui.editor(value='X')
         ui.button('Reset').on_click(lambda: editor.set_value('X'))
 
-    screen.open('/')
-    screen.should_contain('X')
+    shared_screen.open('/')
+    shared_screen.should_contain('X')
 
-    screen.find_element(editor).click()
-    screen.type(Keys.BACKSPACE + 'ABC')
-    screen.should_contain('ABC')
+    shared_screen.find_element(editor).click()
+    shared_screen.type(Keys.BACKSPACE + 'ABC')
+    shared_screen.should_contain('ABC')
 
-    screen.click('Reset')
-    screen.should_contain('X')
+    shared_screen.click('Reset')
+    shared_screen.should_contain('X')

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -6,10 +6,10 @@ from selenium.webdriver.common.by import By
 from nicegui import background_tasks, ui
 from nicegui.props import Props
 from nicegui.style import Style
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_classes(screen: Screen):
+def test_classes(shared_screen: SharedScreen):
     label = None
 
     @ui.page('/')
@@ -18,11 +18,11 @@ def test_classes(screen: Screen):
         label = ui.label('Some label')
 
     def assert_classes(classes: str) -> None:
-        assert screen.selenium.find_element(By.XPATH,
+        assert shared_screen.selenium.find_element(By.XPATH,
                                             f'//*[normalize-space(@class)="{classes}" and text()="Some label"]')
 
-    screen.open('/')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
     assert_classes('')
 
     label.classes('one')
@@ -92,7 +92,7 @@ def test_props_parsing(value: str | None, expected: dict[str, str]):
     assert Props.parse(value) == expected
 
 
-def test_style(screen: Screen):
+def test_style(shared_screen: SharedScreen):
     label = None
 
     @ui.page('/')
@@ -101,10 +101,10 @@ def test_style(screen: Screen):
         label = ui.label('Some label')
 
     def assert_style(style: str) -> None:
-        assert screen.selenium.find_element(By.XPATH, f'//*[normalize-space(@style)="{style}" and text()="Some label"]')
+        assert shared_screen.selenium.find_element(By.XPATH, f'//*[normalize-space(@style)="{style}" and text()="Some label"]')
 
-    screen.open('/')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
     assert_style('')
 
     label.style('color: red')
@@ -132,7 +132,7 @@ def test_style(screen: Screen):
     assert_style('text-decoration: underline; color: red;')
 
 
-def test_props(screen: Screen):
+def test_props(shared_screen: SharedScreen):
     input_ = None
 
     @ui.page('/')
@@ -142,10 +142,10 @@ def test_props(screen: Screen):
 
     def assert_props(*props: str) -> None:
         class_conditions = [f'contains(@class, "q-field--{prop}")' for prop in props]
-        assert screen.selenium.find_element(By.XPATH, f'//label[{" and ".join(class_conditions)}]')
+        assert shared_screen.selenium.find_element(By.XPATH, f'//label[{" and ".join(class_conditions)}]')
 
-    screen.open('/')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
     assert_props('standard')
 
     input_.props('dark')
@@ -161,7 +161,7 @@ def test_props(screen: Screen):
     assert_props('standard', 'dark')
 
 
-def test_move(screen: Screen):
+def test_move(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.card() as a:
@@ -175,23 +175,23 @@ def test_move(screen: Screen):
         ui.button('Move X to B', on_click=lambda: x.move(b))
         ui.button('Move X to top', on_click=lambda: x.move(target_index=0))
 
-    screen.open('/')
-    assert screen.find('A').location['y'] < screen.find('X').location['y'] < screen.find('B').location['y']
+    shared_screen.open('/')
+    assert shared_screen.find('A').location['y'] < shared_screen.find('X').location['y'] < shared_screen.find('B').location['y']
 
-    screen.click('Move X to B')
-    screen.wait(0.5)
-    assert screen.find('A').location['y'] < screen.find('B').location['y'] < screen.find('X').location['y']
+    shared_screen.click('Move X to B')
+    shared_screen.wait(0.5)
+    assert shared_screen.find('A').location['y'] < shared_screen.find('B').location['y'] < shared_screen.find('X').location['y']
 
-    screen.click('Move X to A')
-    screen.wait(0.5)
-    assert screen.find('A').location['y'] < screen.find('X').location['y'] < screen.find('B').location['y']
+    shared_screen.click('Move X to A')
+    shared_screen.wait(0.5)
+    assert shared_screen.find('A').location['y'] < shared_screen.find('X').location['y'] < shared_screen.find('B').location['y']
 
-    screen.click('Move X to top')
-    screen.wait(0.5)
-    assert screen.find('X').location['y'] < screen.find('A').location['y'] < screen.find('B').location['y']
+    shared_screen.click('Move X to top')
+    shared_screen.wait(0.5)
+    assert shared_screen.find('X').location['y'] < shared_screen.find('A').location['y'] < shared_screen.find('B').location['y']
 
 
-def test_move_slots(screen: Screen):
+def test_move_slots(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.expansion(value=True) as a:
@@ -207,23 +207,23 @@ def test_move_slots(screen: Screen):
         ui.button('Move X to B', on_click=lambda: x.move(b))
         ui.button('Move X to top', on_click=lambda: x.move(target_index=0))
 
-    screen.open('/')
-    assert screen.find('A').location['y'] < screen.find('X').location['y'], 'X is in A.default'
+    shared_screen.open('/')
+    assert shared_screen.find('A').location['y'] < shared_screen.find('X').location['y'], 'X is in A.default'
 
-    screen.click('Move X to header')
-    screen.wait(0.5)
-    assert screen.find('A').location['y'] == screen.find('X').location['y'], 'X is in A.header'
+    shared_screen.click('Move X to header')
+    shared_screen.wait(0.5)
+    assert shared_screen.find('A').location['y'] == shared_screen.find('X').location['y'], 'X is in A.header'
 
-    screen.click('Move X to top')
-    screen.wait(0.5)
-    assert screen.find('A').location['y'] < screen.find('X').location['y'], 'X is in A.default'
+    shared_screen.click('Move X to top')
+    shared_screen.wait(0.5)
+    assert shared_screen.find('A').location['y'] < shared_screen.find('X').location['y'], 'X is in A.default'
 
-    screen.click('Move X to B')
-    screen.wait(0.5)
-    assert screen.find('B').location['y'] < screen.find('X').location['y'], 'X is in B.default'
+    shared_screen.click('Move X to B')
+    shared_screen.wait(0.5)
+    assert shared_screen.find('B').location['y'] < shared_screen.find('X').location['y'], 'X is in B.default'
 
 
-def test_xss(screen: Screen):
+def test_xss(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label('</script><script>alert(1)</script>')
@@ -233,15 +233,15 @@ def test_xss(screen: Screen):
             ui.label('<b>Bold 2</b>, `code`, copy&paste, multi\nline'),
         ))
 
-    screen.open('/')
-    screen.click('Button')
-    screen.should_contain('</script><script>alert(1)</script>')
-    screen.should_contain('</script><script>alert(2)</script>')
-    screen.should_contain('<b>Bold 1</b>, `code`, copy&paste, multi\nline')
-    screen.should_contain('<b>Bold 2</b>, `code`, copy&paste, multi\nline')
+    shared_screen.open('/')
+    shared_screen.click('Button')
+    shared_screen.should_contain('</script><script>alert(1)</script>')
+    shared_screen.should_contain('</script><script>alert(2)</script>')
+    shared_screen.should_contain('<b>Bold 1</b>, `code`, copy&paste, multi\nline')
+    shared_screen.should_contain('<b>Bold 2</b>, `code`, copy&paste, multi\nline')
 
 
-def test_default_props(screen: Screen):
+def test_default_props(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button.default_props('rounded outline')
@@ -277,10 +277,10 @@ def test_default_props(screen: Screen):
         assert button_f.props.get('no-caps') is True
         assert button_f.props.get('no-wrap') is True
 
-    screen.open('/')
+    shared_screen.open('/')
 
 
-def test_default_classes(screen: Screen):
+def test_default_classes(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button.default_classes('bg-white text-green')
@@ -316,10 +316,10 @@ def test_default_classes(screen: Screen):
         assert 'h-40' in button_f.classes
         assert 'max-h-80' in button_f.classes
 
-    screen.open('/')
+    shared_screen.open('/')
 
 
-def test_default_style(screen: Screen):
+def test_default_style(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button.default_style('color: green; font-size: 200%')
@@ -355,10 +355,10 @@ def test_default_style(screen: Screen):
         assert button_f.style.get('border') == '2px'
         assert button_f.style.get('padding') == '30px'
 
-    screen.open('/')
+    shared_screen.open('/')
 
 
-def test_invalid_tags(screen: Screen):
+def test_invalid_tags(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         good_tags = ['div', 'div-1', 'DIV', 'däv', 'div_x']
@@ -369,19 +369,19 @@ def test_invalid_tags(screen: Screen):
             with pytest.raises(ValueError):
                 ui.element(tag)
 
-    screen.open('/')
+    shared_screen.open('/')
 
 
-def test_bad_characters(screen: Screen):
+def test_bad_characters(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label(r'& <test> ` ${foo}')
 
-    screen.open('/')
-    screen.should_contain(r'& <test> ` ${foo}')
+    shared_screen.open('/')
+    shared_screen.should_contain(r'& <test> ` ${foo}')
 
 
-def test_update_before_client_connection(screen: Screen):
+def test_update_before_client_connection(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         label = ui.label('Hello world!')
@@ -390,11 +390,11 @@ def test_update_before_client_connection(screen: Screen):
             label.text = 'Hello again!'
         background_tasks.create(update())
 
-    screen.open('/')
-    screen.should_contain('Hello again!')
+    shared_screen.open('/')
+    shared_screen.should_contain('Hello again!')
 
 
-def test_no_cyclic_references_when_deleting_elements(screen: Screen):
+def test_no_cyclic_references_when_deleting_elements(shared_screen: SharedScreen):
     elements: weakref.WeakSet = weakref.WeakSet()
 
     @ui.page('/')
@@ -406,28 +406,28 @@ def test_no_cyclic_references_when_deleting_elements(screen: Screen):
                 elements.add(ui.query('div'))
         ui.button('Clear', on_click=card.clear).on_click(lambda: ui.notify('Cleared'))
 
-    screen.open('/')
-    screen.click('Clear')
-    screen.should_contain('Cleared')
+    shared_screen.open('/')
+    shared_screen.click('Clear')
+    shared_screen.should_contain('Cleared')
     assert len(elements) == 0, 'all elements should be deleted immediately'
 
 
-def test_no_cyclic_references_when_deleting_clients(screen: Screen):
+def test_no_cyclic_references_when_deleting_clients(shared_screen: SharedScreen):
     labels = weakref.WeakSet()
 
     @ui.page('/', reconnect_timeout=1.0)
     def main():
         labels.add(ui.label())
 
-    screen.open('/')
+    shared_screen.open('/')
     assert len(labels) == 1
 
-    screen.close()
-    screen.wait(1.5)
+    shared_screen.close()
+    shared_screen.wait(1.5)
     assert len(labels) == 0
 
 
-def test_even_special_elements_have_an_html_id(screen: Screen):
+def test_even_special_elements_have_an_html_id(shared_screen: SharedScreen):
 
     @ui.page('/')
     def page():
@@ -455,6 +455,6 @@ def test_even_special_elements_have_an_html_id(screen: Screen):
                 assert await ui.run_javascript(f'document.getElementById("{element.html_id}") !== null')
             ui.notify('All IDs found')
 
-    screen.open('/')
-    screen.click('Check IDs')
-    screen.should_contain('All IDs found')
+    shared_screen.open('/')
+    shared_screen.click('Check IDs')
+    shared_screen.should_contain('All IDs found')

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -1,10 +1,10 @@
 import weakref
 
 from nicegui import binding, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_remove_element_by_reference(screen: Screen):
+def test_remove_element_by_reference(shared_screen: SharedScreen):
     texts = {'a': 'Label A', 'b': 'Label B', 'c': 'Label C'}
     b = row = None
 
@@ -18,19 +18,19 @@ def test_remove_element_by_reference(screen: Screen):
 
         ui.button('Remove', on_click=lambda: row.remove(b))
 
-    screen.open('/')
-    screen.click('Remove')
-    screen.wait(0.5)
-    screen.should_contain('Label A')
-    screen.should_not_contain('Label B')
-    screen.should_contain('Label C')
+    shared_screen.open('/')
+    shared_screen.click('Remove')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Label A')
+    shared_screen.should_not_contain('Label B')
+    shared_screen.should_contain('Label C')
     assert b.is_deleted
     assert b.id not in row.client.elements
     assert len(row.default_slot.children) == 2
     assert len(binding.active_links) == 2
 
 
-def test_remove_element_by_index(screen: Screen):
+def test_remove_element_by_index(shared_screen: SharedScreen):
     texts = {'a': 'Label A', 'b': 'Label B', 'c': 'Label C'}
     b = row = None
 
@@ -44,19 +44,19 @@ def test_remove_element_by_index(screen: Screen):
 
         ui.button('Remove', on_click=lambda: row.remove(1))
 
-    screen.open('/')
-    screen.click('Remove')
-    screen.wait(0.5)
-    screen.should_contain('Label A')
-    screen.should_not_contain('Label B')
-    screen.should_contain('Label C')
+    shared_screen.open('/')
+    shared_screen.click('Remove')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Label A')
+    shared_screen.should_not_contain('Label B')
+    shared_screen.should_contain('Label C')
     assert b.is_deleted
     assert b.id not in row.client.elements
     assert len(row.default_slot.children) == 2
     assert len(binding.active_links) == 2
 
 
-def test_clear(screen: Screen):
+def test_clear(shared_screen: SharedScreen):
     texts = {'a': 'Label A', 'b': 'Label B', 'c': 'Label C'}
     a = b = c = row = None
 
@@ -70,12 +70,12 @@ def test_clear(screen: Screen):
 
         ui.button('Clear', on_click=row.clear)
 
-    screen.open('/')
-    screen.click('Clear')
-    screen.wait(0.5)
-    screen.should_not_contain('Label A')
-    screen.should_not_contain('Label B')
-    screen.should_not_contain('Label C')
+    shared_screen.open('/')
+    shared_screen.click('Clear')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Label A')
+    shared_screen.should_not_contain('Label B')
+    shared_screen.should_not_contain('Label C')
     assert a.is_deleted
     assert b.is_deleted
     assert c.is_deleted
@@ -84,7 +84,7 @@ def test_clear(screen: Screen):
     assert len(binding.active_links) == 0
 
 
-def test_remove_parent(screen: Screen):
+def test_remove_parent(shared_screen: SharedScreen):
     texts = {'a': 'Label A', 'b': 'Label B', 'c': 'Label C'}
     a = b = c = row = container = None
 
@@ -99,12 +99,12 @@ def test_remove_parent(screen: Screen):
 
         ui.button('Remove parent', on_click=lambda: container.remove(row))
 
-    screen.open('/')
-    screen.click('Remove parent')
-    screen.wait(0.5)
-    screen.should_not_contain('Label A')
-    screen.should_not_contain('Label B')
-    screen.should_not_contain('Label C')
+    shared_screen.open('/')
+    shared_screen.click('Remove parent')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Label A')
+    shared_screen.should_not_contain('Label B')
+    shared_screen.should_not_contain('Label C')
     assert row.is_deleted
     assert a.is_deleted
     assert b.is_deleted
@@ -116,7 +116,7 @@ def test_remove_parent(screen: Screen):
     assert len(binding.active_links) == 0
 
 
-def test_delete_element(screen: Screen):
+def test_delete_element(shared_screen: SharedScreen):
     texts = {'a': 'Label A', 'b': 'Label B', 'c': 'Label C'}
     b = row = None
 
@@ -130,19 +130,19 @@ def test_delete_element(screen: Screen):
 
         ui.button('Delete', on_click=b.delete)
 
-    screen.open('/')
-    screen.click('Delete')
-    screen.wait(0.5)
-    screen.should_contain('Label A')
-    screen.should_not_contain('Label B')
-    screen.should_contain('Label C')
+    shared_screen.open('/')
+    shared_screen.click('Delete')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Label A')
+    shared_screen.should_not_contain('Label B')
+    shared_screen.should_contain('Label C')
     assert b.is_deleted
     assert b.id not in row.client.elements
     assert len(row.default_slot.children) == 2
     assert len(binding.active_links) == 2
 
 
-def test_on_delete(screen: Screen):
+def test_on_delete(shared_screen: SharedScreen):
     deleted_labels = []
 
     class CustomLabel(ui.label):
@@ -168,15 +168,15 @@ def test_on_delete(screen: Screen):
         ui.button('Delete B', on_click=lambda: row.remove(b))
         ui.button('Clear row', on_click=row.clear)
 
-    screen.open('/')
-    screen.click('Delete C')
-    screen.click('Delete B')
-    screen.click('Clear row')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.click('Delete C')
+    shared_screen.click('Delete B')
+    shared_screen.click('Clear row')
+    shared_screen.wait(0.5)
     assert deleted_labels == ['Label C', 'Label B', 'Label A']
 
 
-def test_slot_children_cleared_on_delete(screen: Screen):
+def test_slot_children_cleared_on_delete(shared_screen: SharedScreen):
     """Slot children are cleared when parent is deleted and no cyclic references are left behind (issue #5110)."""
     labels = weakref.WeakSet[ui.label]()
 
@@ -190,13 +190,13 @@ def test_slot_children_cleared_on_delete(screen: Screen):
                 labels.add(ui.label('After'))
         ui.button('Delete', on_click=splitter.delete).on_click(lambda: ui.notify('Deleted'))
 
-    screen.open('/')
-    screen.click('Delete')
-    screen.should_contain('Deleted')
+    shared_screen.open('/')
+    shared_screen.click('Delete')
+    shared_screen.should_contain('Deleted')
     assert len(labels) == 0, 'all labels should be deleted immediately'
 
 
-def test_event_listeners_cleared_on_delete(screen: Screen):
+def test_event_listeners_cleared_on_delete(shared_screen: SharedScreen):
     """Event listeners are cleared when element is deleted and no cyclic references are left behind (issue #5110)."""
     buttons = weakref.WeakSet[ui.button]()
 
@@ -208,7 +208,7 @@ def test_event_listeners_cleared_on_delete(screen: Screen):
             buttons.add(button)
         ui.button('Delete', on_click=card.clear).on_click(lambda: ui.notify('Deleted'))
 
-    screen.open('/')
-    screen.click('Delete')
-    screen.should_contain('Deleted')
+    shared_screen.open('/')
+    shared_screen.click('Delete')
+    shared_screen.should_contain('Deleted')
     assert len(buttons) == 0, 'all buttons should be deleted immediately'

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 
 from nicegui import ui
 from nicegui.events import ClickEventArguments
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
 def click_sync_no_args():
@@ -32,7 +32,7 @@ async def click_lambda_with_async_and_parameters(msg: str):
     ui.label(f'click_lambda_with_async_and_parameters: {msg}')
 
 
-def test_click_events(screen: Screen):
+def test_click_events(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('click_sync_no_args', on_click=click_sync_no_args)
@@ -42,20 +42,20 @@ def test_click_events(screen: Screen):
         ui.button('click_lambda_with_async_and_parameters',
                   on_click=lambda: click_lambda_with_async_and_parameters('works'))
 
-    screen.open('/')
-    screen.click('click_sync_no_args')
-    screen.click('click_sync_with_args')
-    screen.click('click_async_no_args')
-    screen.click('click_async_with_args')
-    screen.click('click_lambda_with_async_and_parameters')
-    screen.should_contain('click_sync_no_args')
-    screen.should_contain('click_sync_with_args')
-    screen.should_contain('click_async_no_args')
-    screen.should_contain('click_async_with_args')
-    screen.should_contain('click_lambda_with_async_and_parameters: works')
+    shared_screen.open('/')
+    shared_screen.click('click_sync_no_args')
+    shared_screen.click('click_sync_with_args')
+    shared_screen.click('click_async_no_args')
+    shared_screen.click('click_async_with_args')
+    shared_screen.click('click_lambda_with_async_and_parameters')
+    shared_screen.should_contain('click_sync_no_args')
+    shared_screen.should_contain('click_sync_with_args')
+    shared_screen.should_contain('click_async_no_args')
+    shared_screen.should_contain('click_async_with_args')
+    shared_screen.should_contain('click_lambda_with_async_and_parameters: works')
 
 
-def test_generic_events(screen: Screen):
+def test_generic_events(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label('click_sync_no_args').on('click', click_sync_no_args, [])
@@ -63,18 +63,18 @@ def test_generic_events(screen: Screen):
         ui.label('click_async_no_args').on('click', click_async_no_args, [])
         ui.label('click_async_with_args').on('click', click_async_with_args, [])
 
-    screen.open('/')
-    screen.click('click_sync_no_args')
-    screen.click('click_sync_with_args')
-    screen.click('click_async_no_args')
-    screen.click('click_async_with_args')
-    screen.should_contain('click_sync_no_args')
-    screen.should_contain('click_sync_with_args')
-    screen.should_contain('click_async_no_args')
-    screen.should_contain('click_async_with_args')
+    shared_screen.open('/')
+    shared_screen.click('click_sync_no_args')
+    shared_screen.click('click_sync_with_args')
+    shared_screen.click('click_async_no_args')
+    shared_screen.click('click_async_with_args')
+    shared_screen.should_contain('click_sync_no_args')
+    shared_screen.should_contain('click_sync_with_args')
+    shared_screen.should_contain('click_async_no_args')
+    shared_screen.should_contain('click_async_with_args')
 
 
-def test_event_with_update_before_await(screen: Screen):
+def test_event_with_update_before_await(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         async def update():
@@ -84,14 +84,14 @@ def test_event_with_update_before_await(screen: Screen):
 
         ui.button('update', on_click=update)
 
-    screen.open('/')
-    screen.click('update')
-    screen.should_contain('1')
-    screen.should_not_contain('2')
-    screen.should_contain('2')
+    shared_screen.open('/')
+    shared_screen.click('update')
+    shared_screen.should_contain('1')
+    shared_screen.should_not_contain('2')
+    shared_screen.should_contain('2')
 
 
-def test_event_modifiers(screen: Screen):
+def test_event_modifiers(shared_screen: SharedScreen):
     events = []
 
     @ui.page('/')
@@ -101,37 +101,37 @@ def test_event_modifiers(screen: Screen):
         ui.input('C').on('keydown.once', lambda _: events.append('C'), [])
         ui.input('D').on('keydown.shift.x', lambda _: events.append('D'), [])
 
-    screen.open('/')
-    screen.selenium.find_element(By.XPATH, '//*[@aria-label="A"]').send_keys('x')
-    screen.selenium.find_element(By.XPATH, '//*[@aria-label="B"]').send_keys('xy')
-    screen.selenium.find_element(By.XPATH, '//*[@aria-label="C"]').send_keys('xx')
-    screen.selenium.find_element(By.XPATH, '//*[@aria-label="D"]').send_keys('Xx')
+    shared_screen.open('/')
+    shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="A"]').send_keys('x')
+    shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="B"]').send_keys('xy')
+    shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="C"]').send_keys('xx')
+    shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="D"]').send_keys('Xx')
     assert events == ['A', 'B', 'C', 'D']
 
 
-def test_throttling(screen: Screen):
+def test_throttling(shared_screen: SharedScreen):
     events = []
 
     @ui.page('/')
     def page():
         ui.button('Test', on_click=lambda: events.append(1)).on('click', lambda: events.append(2), [], throttle=1)
 
-    screen.open('/')
-    screen.click('Test')
-    screen.click('Test')
-    screen.click('Test')
+    shared_screen.open('/')
+    shared_screen.click('Test')
+    shared_screen.click('Test')
+    shared_screen.click('Test')
     assert events == [1, 2, 1, 1]
 
-    screen.wait(1.1)
+    shared_screen.wait(1.1)
     assert events == [1, 2, 1, 1, 2]
 
-    screen.click('Test')
-    screen.click('Test')
-    screen.click('Test')
+    shared_screen.click('Test')
+    shared_screen.click('Test')
+    shared_screen.click('Test')
     assert events == [1, 2, 1, 1, 2, 1, 2, 1, 1]
 
 
-def test_throttling_variants(screen: Screen):
+def test_throttling_variants(shared_screen: SharedScreen):
     events = []
     value = 0
 
@@ -141,42 +141,42 @@ def test_throttling_variants(screen: Screen):
         ui.button('Leading').on('click', lambda: events.append(value), [], throttle=1, trailing_events=False)
         ui.button('Trailing').on('click', lambda: events.append(value), [], throttle=1, leading_events=False)
 
-    screen.open('/')
+    shared_screen.open('/')
     value = 1
-    screen.click('Both')
+    shared_screen.click('Both')
     value = 2
-    screen.click('Both')
+    shared_screen.click('Both')
     value = 3
-    screen.click('Both')
+    shared_screen.click('Both')
     assert events == [1]
-    screen.wait(1.1)
+    shared_screen.wait(1.1)
     assert events == [1, 3]
 
     events = []
     value = 1
-    screen.click('Leading')
+    shared_screen.click('Leading')
     value = 2
-    screen.click('Leading')
+    shared_screen.click('Leading')
     value = 3
-    screen.click('Leading')
+    shared_screen.click('Leading')
     assert events == [1]
-    screen.wait(1.1)
+    shared_screen.wait(1.1)
     assert events == [1]
 
     events = []
     value = 1
-    screen.click('Trailing')
+    shared_screen.click('Trailing')
     value = 2
-    screen.click('Trailing')
+    shared_screen.click('Trailing')
     value = 3
-    screen.click('Trailing')
+    shared_screen.click('Trailing')
     assert events == []  # pylint: disable=use-implicit-booleaness-not-comparison
-    screen.wait(1.1)
+    shared_screen.wait(1.1)
     assert events == [3]
 
 
 @pytest.mark.parametrize('attribute', ['disabled', 'hidden'])
-def test_server_side_validation(screen: Screen, attribute: Literal['disabled', 'hidden']):
+def test_server_side_validation(shared_screen: SharedScreen, attribute: Literal['disabled', 'hidden']):
     @ui.page('/')
     def page():
         b = ui.button('Button', on_click=lambda: ui.label('Button clicked'))
@@ -192,26 +192,26 @@ def test_server_side_validation(screen: Screen, attribute: Literal['disabled', '
         '''))  # pylint: disable=protected-access
         ui.button('Allowed', on_click=lambda: n.set_value(42))
 
-    screen.open('/')
-    screen.click('Forbidden')
-    screen.wait(0.5)
-    screen.should_not_contain('Button clicked')  # triggering the click event through JavaScript does not work
+    shared_screen.open('/')
+    shared_screen.click('Forbidden')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Button clicked')  # triggering the click event through JavaScript does not work
 
-    screen.click('Allowed')
-    screen.should_contain('Number changed')  # triggering the change event through Python works
+    shared_screen.click('Allowed')
+    shared_screen.should_contain('Number changed')  # triggering the change event through Python works
 
 
-def test_js_handler(screen: Screen) -> None:
+def test_js_handler(shared_screen: SharedScreen) -> None:
     @ui.page('/')
     def page():
         ui.button('Button').on('click', js_handler='() => document.body.appendChild(document.createTextNode("Click!"))')
 
-    screen.open('/')
-    screen.click('Button')
-    screen.should_contain('Click!')
+    shared_screen.open('/')
+    shared_screen.click('Button')
+    shared_screen.should_contain('Click!')
 
 
-def test_delegated_event_with_argument_filtering(screen: Screen) -> None:
+def test_delegated_event_with_argument_filtering(shared_screen: SharedScreen) -> None:
     ids = []
 
     @ui.page('/')
@@ -222,32 +222,32 @@ def test_delegated_event_with_argument_filtering(screen: Screen) -> None:
             <p data-id="C">Item C</p>
         ''', sanitize=False).on('click', lambda e: ids.append(e.args), js_handler='(e) => emit(e.target.dataset.id)')
 
-    screen.open('/')
-    screen.click('Item A')
-    screen.click('Item B')
-    screen.click('Item C')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.click('Item A')
+    shared_screen.click('Item B')
+    shared_screen.click('Item C')
+    shared_screen.wait(0.5)
     assert ids == ['A', 'B', 'C']
 
 
-def test_value_change_event_arguments(screen: Screen):
+def test_value_change_event_arguments(shared_screen: SharedScreen):
     events = []
 
     @ui.page('/')
     def page():
         ui.checkbox('Checkbox', on_change=lambda e: events.append((e.value, e.previous_value)))
 
-    screen.open('/')
-    screen.click('Checkbox')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.click('Checkbox')
+    shared_screen.wait(0.5)
     assert events == [(True, False)]
 
-    screen.click('Checkbox')
-    screen.wait(0.5)
+    shared_screen.click('Checkbox')
+    shared_screen.wait(0.5)
     assert events == [(True, False), (False, True)]
 
 
-async def test_late_event_registration(screen: Screen):
+async def test_late_event_registration(shared_screen: SharedScreen):
     events = []
 
     @ui.page('/')
@@ -258,10 +258,10 @@ async def test_late_event_registration(screen: Screen):
         name.on('keydown.b', lambda: events.append('B'))
         ui.label('Ready')
 
-    screen.open('/')
-    screen.should_contain('Ready')
-    screen.selenium.find_element(By.XPATH, '//*[@aria-label="Name"]').send_keys('ab')
+    shared_screen.open('/')
+    shared_screen.should_contain('Ready')
+    shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Name"]').send_keys('ab')
     assert events == ['A', 'B']
-    assert 'Event listeners changed after initial definition. Re-rendering affected elements.' in screen.render_js_logs()
-    screen.assert_py_logger('WARNING',
+    assert 'Event listeners changed after initial definition. Re-rendering affected elements.' in shared_screen.render_js_logs()
+    shared_screen.assert_py_logger('WARNING',
                             'Event listeners changed after initial definition. Re-rendering affected elements.')

--- a/tests/test_expansion.py
+++ b/tests/test_expansion.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_open_close_expansion(screen: Screen):
+def test_open_close_expansion(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.expansion('Expansion') as e:
@@ -10,38 +10,38 @@ def test_open_close_expansion(screen: Screen):
         ui.button('Open', on_click=e.open)
         ui.button('Close', on_click=e.close)
 
-    screen.open('/')
-    screen.should_contain('Expansion')
-    screen.should_not_contain('Content')
+    shared_screen.open('/')
+    shared_screen.should_contain('Expansion')
+    shared_screen.should_not_contain('Content')
 
-    screen.click('Open')
-    screen.wait(0.5)
-    screen.should_contain('Content')
+    shared_screen.click('Open')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Content')
 
-    screen.click('Close')
-    screen.wait(0.5)
-    screen.should_not_contain('Content')
+    shared_screen.click('Close')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Content')
 
 
-def test_caption(screen: Screen):
+def test_caption(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.expansion('Expansion', caption='Caption'):
             ui.label('Content')
 
-    screen.open('/')
-    screen.should_contain('Expansion')
-    screen.should_contain('Caption')
-    screen.should_not_contain('Content')
+    shared_screen.open('/')
+    shared_screen.should_contain('Expansion')
+    shared_screen.should_contain('Caption')
+    shared_screen.should_not_contain('Content')
 
-    screen.click('Expansion')
-    screen.wait(0.5)
-    screen.should_contain('Expansion')
-    screen.should_contain('Caption')
-    screen.should_contain('Content')
+    shared_screen.click('Expansion')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Expansion')
+    shared_screen.should_contain('Caption')
+    shared_screen.should_contain('Content')
 
 
-def test_group(screen: Screen):
+def test_group(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.expansion('Expansion A', group='group'):
@@ -51,28 +51,28 @@ def test_group(screen: Screen):
         with ui.expansion('Expansion C', group='group'):
             ui.label('Content C')
 
-    screen.open('/')
-    screen.should_contain('Expansion A')
-    screen.should_contain('Expansion B')
-    screen.should_contain('Expansion C')
-    screen.should_not_contain('Content A')
-    screen.should_not_contain('Content B')
-    screen.should_not_contain('Content C')
+    shared_screen.open('/')
+    shared_screen.should_contain('Expansion A')
+    shared_screen.should_contain('Expansion B')
+    shared_screen.should_contain('Expansion C')
+    shared_screen.should_not_contain('Content A')
+    shared_screen.should_not_contain('Content B')
+    shared_screen.should_not_contain('Content C')
 
-    screen.click('Expansion A')
-    screen.wait(0.5)
-    screen.should_contain('Content A')
-    screen.should_not_contain('Content B')
-    screen.should_not_contain('Content C')
+    shared_screen.click('Expansion A')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Content A')
+    shared_screen.should_not_contain('Content B')
+    shared_screen.should_not_contain('Content C')
 
-    screen.click('Expansion B')
-    screen.wait(0.5)
-    screen.should_not_contain('Content A')
-    screen.should_contain('Content B')
-    screen.should_not_contain('Content C')
+    shared_screen.click('Expansion B')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Content A')
+    shared_screen.should_contain('Content B')
+    shared_screen.should_not_contain('Content C')
 
-    screen.click('Expansion C')
-    screen.wait(0.5)
-    screen.should_not_contain('Content A')
-    screen.should_not_contain('Content B')
-    screen.should_contain('Content C')
+    shared_screen.click('Expansion C')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Content A')
+    shared_screen.should_not_contain('Content B')
+    shared_screen.should_contain('Content C')

--- a/tests/test_fab.py
+++ b/tests/test_fab.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_fab(screen: Screen):
+def test_fab(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.fab('menu', label='FAB') as fab:
@@ -14,25 +14,25 @@ def test_fab(screen: Screen):
         ui.button('Toggle FAB', on_click=fab.toggle)
         ui.label().bind_text_from(fab, 'value', lambda v: 'FAB is open' if v else 'FAB is closed')
 
-    screen.open('/')
-    screen.click('FAB')
-    screen.click('Action 1')
-    screen.should_contain('Action 1 clicked')
-    screen.should_contain('FAB is closed')
+    shared_screen.open('/')
+    shared_screen.click('FAB')
+    shared_screen.click('Action 1')
+    shared_screen.should_contain('Action 1 clicked')
+    shared_screen.should_contain('FAB is closed')
 
-    screen.click('FAB')
-    screen.click('Action 2')
-    screen.should_contain('Action 2 clicked')
-    screen.should_contain('FAB is open')
+    shared_screen.click('FAB')
+    shared_screen.click('Action 2')
+    shared_screen.should_contain('Action 2 clicked')
+    shared_screen.should_contain('FAB is open')
 
-    screen.click('Close FAB')
-    screen.should_contain('FAB is closed')
+    shared_screen.click('Close FAB')
+    shared_screen.should_contain('FAB is closed')
 
-    screen.click('Open FAB')
-    screen.should_contain('FAB is open')
+    shared_screen.click('Open FAB')
+    shared_screen.should_contain('FAB is open')
 
-    screen.click('Toggle FAB')
-    screen.should_contain('FAB is closed')
+    shared_screen.click('Toggle FAB')
+    shared_screen.should_contain('FAB is closed')
 
-    screen.click('Toggle FAB')
-    screen.should_contain('FAB is open')
+    shared_screen.click('Toggle FAB')
+    shared_screen.should_contain('FAB is open')

--- a/tests/test_fullscreen.py
+++ b/tests/test_fullscreen.py
@@ -3,21 +3,21 @@ from unittest.mock import patch
 import pytest
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
 @pytest.mark.parametrize('require_escape_hold', [True, False])
-def test_fullscreen_creation(screen: Screen, require_escape_hold: bool):
+def test_fullscreen_creation(shared_screen: SharedScreen, require_escape_hold: bool):
     @ui.page('/')
     def page():
         fullscreen = ui.fullscreen(require_escape_hold=require_escape_hold)
         assert not fullscreen.value
         assert fullscreen.require_escape_hold == require_escape_hold
 
-    screen.open('/')
+    shared_screen.open('/')
 
 
-def test_fullscreen_methods(screen: Screen):
+def test_fullscreen_methods(shared_screen: SharedScreen):
     values = []
     fullscreen = None
 
@@ -26,7 +26,7 @@ def test_fullscreen_methods(screen: Screen):
         nonlocal fullscreen
         fullscreen = ui.fullscreen(on_value_change=lambda e: values.append(e.value))
 
-    screen.open('/')
+    shared_screen.open('/')
 
     with patch.object(fullscreen, 'run_method') as mock_run:
         fullscreen.enter()
@@ -52,7 +52,7 @@ def test_fullscreen_methods(screen: Screen):
     assert values == [True, False, True, False, True]
 
 
-def test_fullscreen_button_click(screen: Screen):
+def test_fullscreen_button_click(shared_screen: SharedScreen):
     """Test that clicking a button to enter fullscreen creates the correct JavaScript call.
 
     Note: We cannot test actual fullscreen behavior as it requires user interaction,
@@ -66,11 +66,11 @@ def test_fullscreen_button_click(screen: Screen):
         ui.button('Enter Fullscreen', on_click=fullscreen.enter)
         ui.button('Exit Fullscreen', on_click=fullscreen.exit)
 
-    screen.open('/')
-    screen.click('Enter Fullscreen')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.click('Enter Fullscreen')
+    shared_screen.wait(0.5)
     assert values == [True]
 
-    screen.click('Exit Fullscreen')
-    screen.wait(0.5)
+    shared_screen.click('Exit Fullscreen')
+    shared_screen.wait(0.5)
     assert values == [True, False]

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,11 +1,11 @@
 import pytest
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
 @pytest.mark.parametrize('add_scroll_padding', [True, False])
-def test_no_scroll_padding(screen: Screen, add_scroll_padding: bool):
+def test_no_scroll_padding(shared_screen: SharedScreen, add_scroll_padding: bool):
     @ui.page('/')
     def page():
         ui.header(add_scroll_padding=add_scroll_padding).classes('h-[50px]')
@@ -13,12 +13,12 @@ def test_no_scroll_padding(screen: Screen, add_scroll_padding: bool):
             with ui.link_target(f'line{i}'):
                 ui.link(f'Line {i}', f'#line{i}')
 
-    screen.open('/')
-    screen.should_contain('Line 0')
+    shared_screen.open('/')
+    shared_screen.should_contain('Line 0')
 
-    screen.click('Line 10')
-    screen.wait(0.5)
-    line_y = screen.selenium.execute_script("return arguments[0].getBoundingClientRect()['y'];", screen.find('Line 10'))
+    shared_screen.click('Line 10')
+    shared_screen.wait(0.5)
+    line_y = shared_screen.selenium.execute_script("return arguments[0].getBoundingClientRect()['y'];", shared_screen.find('Line 10'))
     if add_scroll_padding:
         assert line_y > 50
     else:

--- a/tests/test_highchart.py
+++ b/tests/test_highchart.py
@@ -1,10 +1,10 @@
 from selenium.webdriver.common.by import By
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_change_chart_series(screen: Screen):
+def test_change_chart_series(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         chart = ui.highchart({
@@ -18,19 +18,19 @@ def test_change_chart_series(screen: Screen):
         ui.button('Update', on_click=lambda: chart.options['series'][0].update(data=[1, 1]))
 
     def get_series_0():
-        return screen.selenium.find_elements(By.CSS_SELECTOR, '.highcharts-series-0 .highcharts-point')
+        return shared_screen.selenium.find_elements(By.CSS_SELECTOR, '.highcharts-series-0 .highcharts-point')
 
-    screen.open('/')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
     before = [bar.size['width'] for bar in get_series_0()]  # pylint: disable=disallowed-name
-    screen.click('Update')
-    screen.wait(0.5)
+    shared_screen.click('Update')
+    shared_screen.wait(0.5)
     after = [bar.size['width'] for bar in get_series_0()]  # pylint: disable=disallowed-name
     assert before[0] < after[0]
     assert before[1] < after[1]
 
 
-def test_adding_chart_series(screen: Screen):
+def test_adding_chart_series(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         chart = ui.highchart({
@@ -40,13 +40,13 @@ def test_adding_chart_series(screen: Screen):
         }).classes('w-full h-64')
         ui.button('Add', on_click=lambda: chart.options['series'].append({'name': 'X', 'data': [0.1, 0.2]}))
 
-    screen.open('/')
-    screen.click('Add')
-    screen.wait(0.5)
-    assert len(screen.selenium.find_elements(By.CSS_SELECTOR, '.highcharts-point')) == 3
+    shared_screen.open('/')
+    shared_screen.click('Add')
+    shared_screen.wait(0.5)
+    assert len(shared_screen.selenium.find_elements(By.CSS_SELECTOR, '.highcharts-point')) == 3
 
 
-def test_removing_chart_series(screen: Screen):
+def test_removing_chart_series(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         chart = ui.highchart({
@@ -59,41 +59,41 @@ def test_removing_chart_series(screen: Screen):
         }).classes('w-full h-64')
         ui.button('Remove', on_click=chart.options['series'].pop)
 
-    screen.open('/')
-    screen.click('Remove')
-    screen.wait(0.5)
-    assert len(screen.selenium.find_elements(By.CSS_SELECTOR, '.highcharts-point')) == 3
+    shared_screen.open('/')
+    shared_screen.click('Remove')
+    shared_screen.wait(0.5)
+    assert len(shared_screen.selenium.find_elements(By.CSS_SELECTOR, '.highcharts-point')) == 3
 
 
-def test_missing_extra(screen: Screen):
+def test_missing_extra(shared_screen: SharedScreen):
     # NOTE: This test does not work after test_extra() has been run, because conftest won't reset libraries correctly.
     @ui.page('/')
     def page():
         ui.highchart({'chart': {'type': 'solidgauge'}, 'series': {'data': [1.0]}})
 
-    screen.open('/')
-    assert not screen.selenium.find_elements(By.CSS_SELECTOR, '.highcharts-pane')
+    shared_screen.open('/')
+    assert not shared_screen.selenium.find_elements(By.CSS_SELECTOR, '.highcharts-pane')
 
 
-def test_extra(screen: Screen):
+def test_extra(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.highchart({'chart': {'type': 'solidgauge'}, 'series': {'data': [1.0]}}, extras=['solid-gauge'])
 
-    screen.open('/')
-    assert screen.selenium.find_elements(By.CSS_SELECTOR, '.highcharts-pane')
+    shared_screen.open('/')
+    assert shared_screen.selenium.find_elements(By.CSS_SELECTOR, '.highcharts-pane')
 
 
-def test_stock_chart(screen: Screen):
+def test_stock_chart(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.highchart({'series': {'data': [1.0]}}, type='stockChart', extras=['stock'])
 
-    screen.open('/')
-    assert screen.selenium.find_elements(By.CSS_SELECTOR, '.highcharts-range-selector-buttons')
+    shared_screen.open('/')
+    assert shared_screen.selenium.find_elements(By.CSS_SELECTOR, '.highcharts-range-selector-buttons')
 
 
-def test_replace_chart(screen: Screen):
+def test_replace_chart(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.row() as container:
@@ -104,14 +104,14 @@ def test_replace_chart(screen: Screen):
                 ui.highchart({'series': [{'name': 'B'}]})
         ui.button('Replace', on_click=replace)
 
-    screen.open('/')
-    screen.should_contain('A')
-    screen.click('Replace')
-    screen.should_contain('B')
-    screen.should_not_contain('A')
+    shared_screen.open('/')
+    shared_screen.should_contain('A')
+    shared_screen.click('Replace')
+    shared_screen.should_contain('B')
+    shared_screen.should_not_contain('A')
 
 
-def test_updating_stock_chart(screen: Screen):
+def test_updating_stock_chart(shared_screen: SharedScreen):
     """https://github.com/zauberzeug/nicegui/discussions/948"""
     @ui.page('/')
     def page():
@@ -119,22 +119,22 @@ def test_updating_stock_chart(screen: Screen):
         ui.button('update', on_click=lambda: chart.options['series'].extend([{'name': 'alice'}, {'name': 'bob'}]))
         ui.button('clear', on_click=chart.options['series'].clear)
 
-    screen.open('/')
-    screen.click('update')
-    screen.should_contain('alice')
-    screen.should_contain('bob')
+    shared_screen.open('/')
+    shared_screen.click('update')
+    shared_screen.should_contain('alice')
+    shared_screen.should_contain('bob')
 
-    screen.click('clear')
-    screen.wait(0.5)
-    screen.should_not_contain('alice')
-    screen.should_not_contain('bob')
+    shared_screen.click('clear')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('alice')
+    shared_screen.should_not_contain('bob')
 
 
-def test_create_dynamically(screen: Screen):
+def test_create_dynamically(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('Create', on_click=lambda: ui.highchart({'series': {'data': [1.0]}}))
 
-    screen.open('/')
-    screen.click('Create')
-    screen.should_contain('Chart title')
+    shared_screen.open('/')
+    shared_screen.click('Create')
+    shared_screen.should_contain('Chart title')

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,29 +1,29 @@
 from html_sanitizer import Sanitizer
 
 from nicegui import html, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_html_element(screen: Screen):
+def test_html_element(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.html('This is strong.', sanitize=False, tag='strong')
 
-    screen.open('/')
-    assert screen.find_by_tag('strong').text == 'This is strong.'
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('strong').text == 'This is strong.'
 
 
-def test_html_button(screen: Screen):
+def test_html_button(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         html.button('Click me').on('click', lambda: ui.notify('Hi!'))
 
-    screen.open('/')
-    screen.click('Click me')
-    screen.should_contain('Hi!')
+    shared_screen.open('/')
+    shared_screen.click('Click me')
+    shared_screen.should_contain('Hi!')
 
 
-def test_sanitize(screen: Screen):
+def test_sanitize(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.html('<img src=x onerror=Quasar.Notify.create({message:"A"})>', sanitize=False)
@@ -31,19 +31,19 @@ def test_sanitize(screen: Screen):
         ui.html('<img src=x onerror=Quasar.Notify.create({message:"C"})>', sanitize=lambda x: x.replace('C', 'C!'))
         ui.html('<img src=x onerror=Quasar.Notify.create({message:"D"})>', sanitize=Sanitizer().sanitize)
 
-    screen.allowed_js_errors.append('/x - Failed to load resource')
-    screen.open('/')
-    screen.should_contain('A')
-    screen.should_contain('B')
-    screen.should_contain('C!')
-    screen.should_not_contain('D')
+    shared_screen.allowed_js_errors.append('/x - Failed to load resource')
+    shared_screen.open('/')
+    shared_screen.should_contain('A')
+    shared_screen.should_contain('B')
+    shared_screen.should_contain('C!')
+    shared_screen.should_not_contain('D')
 
 
-def test_xss_sanitization(screen: Screen):
+def test_xss_sanitization(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.html('<img src=x onerror="alert(\'XSS\')">')
 
-    screen.allowed_js_errors.append('/x - Failed to load resource')
-    screen.open('/')
-    assert screen.find_by_tag('img').get_attribute('onerror') is None
+    shared_screen.allowed_js_errors.append('/x - Failed to load resource')
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('img').get_attribute('onerror') is None

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from PIL import Image
 
 from nicegui import app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 example_file = Path(__file__).parent / '../examples/slideshow/slides/slide1.jpg'
 example_data = ('data:image/png;base64,'
@@ -28,69 +28,69 @@ example_data = ('data:image/png;base64,'
                 'cHLlz0gP6T8lepD+xTQjvKnT/mXKlCmzAX8Dl7JCqRHaepQAAAAASUVORK5CYII=')
 
 
-def test_base64_image(screen: Screen):
+def test_base64_image(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.image(example_data).style('width: 50px;')
 
-    screen.open('/')
-    screen.wait(0.2)
-    image = screen.find_by_class('q-img__image')
+    shared_screen.open('/')
+    shared_screen.wait(0.2)
+    image = shared_screen.find_by_class('q-img__image')
     assert 'data:image/png;base64,iVB' in image.get_attribute('src')
 
 
-def test_setting_local_file(screen: Screen):
+def test_setting_local_file(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.image(example_file)
 
-    screen.open('/')
-    image = screen.find_by_class('q-img__image')
-    screen.should_load_image(image)
+    shared_screen.open('/')
+    image = shared_screen.find_by_class('q-img__image')
+    shared_screen.should_load_image(image)
 
 
-def test_binding_local_file(screen: Screen):
+def test_binding_local_file(shared_screen: SharedScreen):
     images = {'one': example_file}
 
     @ui.page('/')
     def page():
         ui.image().bind_source_from(images, 'one')
 
-    screen.open('/')
-    image = screen.find_by_class('q-img__image')
-    screen.should_load_image(image)
+    shared_screen.open('/')
+    image = shared_screen.find_by_class('q-img__image')
+    shared_screen.should_load_image(image)
 
 
-def test_set_source_with_local_file(screen: Screen):
+def test_set_source_with_local_file(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.image().set_source(example_file)
 
-    screen.open('/')
-    image = screen.find_by_class('q-img__image')
-    screen.should_load_image(image)
+    shared_screen.open('/')
+    image = shared_screen.find_by_class('q-img__image')
+    shared_screen.should_load_image(image)
 
 
-def test_removal_of_generated_routes(screen: Screen):
+def test_removal_of_generated_routes(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         img = ui.image(example_file)
         ui.button('Slide 2', on_click=lambda: img.set_source(str(example_file).replace('slide1', 'slide2')))
         ui.button('Slide 3', on_click=lambda: img.set_source(str(example_file).replace('slide1', 'slide3')))
 
-    screen.open('/')
+    shared_screen.open('/')
     number_of_routes = len(app.routes)
 
-    screen.click('Slide 2')
-    screen.wait(0.5)
+    shared_screen.click('Slide 2')
+    shared_screen.wait(0.5)
     assert len(app.routes) == number_of_routes
 
-    screen.click('Slide 3')
-    screen.wait(0.5)
+    shared_screen.click('Slide 3')
+    shared_screen.wait(0.5)
     assert len(app.routes) == number_of_routes
 
 
-def test_force_reload(screen: Screen):
+def test_force_reload(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         img1 = ui.image(example_file)
@@ -99,21 +99,21 @@ def test_force_reload(screen: Screen):
         ui.button('Reload 1', on_click=img1.force_reload)
         ui.button('Reload 2', on_click=img2.force_reload)
 
-    screen.open('/')
-    images = screen.find_all_by_class('q-img__image')
-    screen.should_load_image(images[0])
-    screen.should_load_image(images[1])
+    shared_screen.open('/')
+    images = shared_screen.find_all_by_class('q-img__image')
+    shared_screen.should_load_image(images[0])
+    shared_screen.should_load_image(images[1])
 
-    screen.click('Reload 1')
-    screen.wait(0.5)
-    assert not screen.caplog.records
+    shared_screen.click('Reload 1')
+    shared_screen.wait(0.5)
+    assert not shared_screen.caplog.records
 
-    screen.click('Reload 2')
-    screen.wait(0.5)
-    screen.assert_py_logger('WARNING', 'ui.image: force_reload() only works with network sources (not data URIs)')
+    shared_screen.click('Reload 2')
+    shared_screen.wait(0.5)
+    shared_screen.assert_py_logger('WARNING', 'ui.image: force_reload() only works with network sources (not data URIs)')
 
 
-def test_pil_image_cleanup(screen: Screen):
+def test_pil_image_cleanup(shared_screen: SharedScreen):
     temp_path_str = ''
 
     @ui.page('/')
@@ -125,9 +125,9 @@ def test_pil_image_cleanup(screen: Screen):
         assert Path(temp_path_str).exists()
         ui.button('Delete', on_click=image.delete)
 
-    screen.open('/')
-    image = screen.find_by_class('q-img__image')
-    screen.should_load_image(image)
+    shared_screen.open('/')
+    image = shared_screen.find_by_class('q-img__image')
+    shared_screen.should_load_image(image)
 
-    screen.click('Delete')
-    screen.wait_for(lambda: not Path(temp_path_str).exists())
+    shared_screen.click('Delete')
+    shared_screen.wait_for(lambda: not Path(temp_path_str).exists())

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -6,17 +6,17 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_input(screen: Screen):
+def test_input(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.input('Your name', value='John Doe')
 
-    screen.open('/')
-    screen.should_contain('Your name')
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Your name"]')
+    shared_screen.open('/')
+    shared_screen.should_contain('Your name')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Your name"]')
     assert element.get_attribute('type') == 'text'
     assert element.get_attribute('value') == 'John Doe'
 
@@ -24,47 +24,47 @@ def test_input(screen: Screen):
     assert element.get_attribute('value') == 'John Doe Jr.'
 
 
-def test_password(screen: Screen):
+def test_password(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.input('Your password', value='123456', password=True)
 
-    screen.open('/')
-    screen.should_contain('Your password')
+    shared_screen.open('/')
+    shared_screen.should_contain('Your password')
 
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Your password"]')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Your password"]')
     assert element.get_attribute('type') == 'password'
     assert element.get_attribute('value') == '123456'
 
     element.send_keys('789')
-    screen.wait(0.5)
+    shared_screen.wait(0.5)
     assert element.get_attribute('value') == '123456789'
 
 
-def test_toggle_button(screen: Screen):
+def test_toggle_button(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.input('Your password', value='123456', password=True, password_toggle_button=True)
 
-    screen.open('/')
-    screen.should_contain('Your password')
-    screen.should_contain('visibility_off')
+    shared_screen.open('/')
+    shared_screen.should_contain('Your password')
+    shared_screen.should_contain('visibility_off')
 
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Your password"]')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Your password"]')
     assert element.get_attribute('type') == 'password'
     assert element.get_attribute('value') == '123456'
 
-    screen.click('visibility_off')
-    screen.wait(0.5)
+    shared_screen.click('visibility_off')
+    shared_screen.wait(0.5)
     assert element.get_attribute('type') == 'text'
 
-    screen.click('visibility')
-    screen.wait(0.5)
+    shared_screen.click('visibility')
+    shared_screen.wait(0.5)
     assert element.get_attribute('type') == 'password'
 
 
 @pytest.mark.parametrize('method', ['dict', 'sync', 'async'])
-def test_input_validation(method: Literal['dict', 'sync', 'async'], screen: Screen):
+def test_input_validation(method: Literal['dict', 'sync', 'async'], shared_screen: SharedScreen):
     input_ = None
 
     @ui.page('/')
@@ -90,42 +90,42 @@ def test_input_validation(method: Literal['dict', 'sync', 'async'], screen: Scre
         else:
             assert input_.validate() == expected
 
-    screen.open('/')
-    screen.should_contain('Name')
+    shared_screen.open('/')
+    shared_screen.should_contain('Name')
 
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Name"]')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Name"]')
     element.send_keys('Jo')
-    screen.should_contain('Short')
+    shared_screen.should_contain('Short')
     assert input_.error == 'Short'
     assert_validation(False)
 
     element.send_keys('hn')
-    screen.should_contain('Still short')
+    shared_screen.should_contain('Still short')
     assert input_.error == 'Still short'
     assert_validation(False)
 
     element.send_keys(' Doe')
-    screen.wait(1.0)
-    screen.should_not_contain('Short')
-    screen.should_not_contain('Still short')
+    shared_screen.wait(1.0)
+    shared_screen.should_not_contain('Short')
+    shared_screen.should_not_contain('Still short')
     assert input_.error is None
     assert_validation(True)
 
 
-def test_input_with_multi_word_error_message(screen: Screen):
+def test_input_with_multi_word_error_message(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         input_ = ui.input(label='some input')
         ui.button('set error', on_click=lambda: input_.props('error error-message="Some multi word error message"'))
 
-    screen.open('/')
-    screen.should_not_contain('Some multi word error message')
+    shared_screen.open('/')
+    shared_screen.should_not_contain('Some multi word error message')
 
-    screen.click('set error')
-    screen.should_contain('Some multi word error message')
+    shared_screen.click('set error')
+    shared_screen.should_contain('Some multi word error message')
 
 
-def test_autocompletion(screen: Screen):
+def test_autocompletion(shared_screen: SharedScreen):
     input_ = None
 
     @ui.page('/')
@@ -133,20 +133,20 @@ def test_autocompletion(screen: Screen):
         nonlocal input_
         input_ = ui.input('Input', autocomplete=['foo', 'bar', 'baz'])
 
-    screen.open('/')
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
+    shared_screen.open('/')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
     element.send_keys('f')
-    screen.should_contain('oo')
+    shared_screen.should_contain('oo')
 
     element.send_keys('l')
-    screen.wait(0.5)
-    screen.should_not_contain('oo')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('oo')
 
     element.send_keys(Keys.BACKSPACE)
-    screen.should_contain('oo')
+    shared_screen.should_contain('oo')
 
     element.send_keys(Keys.TAB)
-    screen.wait(0.2)
+    shared_screen.wait(0.2)
     assert element.get_attribute('value') == 'foo'
     assert input_.value == 'foo'
 
@@ -154,31 +154,31 @@ def test_autocompletion(screen: Screen):
     element.send_keys(Keys.BACKSPACE)
     element.send_keys('x')
     element.send_keys(Keys.TAB)
-    screen.wait(0.5)
+    shared_screen.wait(0.5)
     assert element.get_attribute('value') == 'fx'
     assert input_.value == 'fx'
 
     input_.set_autocomplete(['once', 'twice'])
-    screen.wait(0.2)
+    shared_screen.wait(0.2)
     element.send_keys(Keys.BACKSPACE)
     element.send_keys(Keys.BACKSPACE)
     element.send_keys('o')
-    screen.should_contain('nce')
+    shared_screen.should_contain('nce')
 
 
-def test_clearable_input(screen: Screen):
+def test_clearable_input(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         input_ = ui.input(value='foo').props('clearable')
         ui.label().bind_text_from(input_, 'value', lambda value: f'value: {value}')
 
-    screen.open('/')
-    screen.should_contain('value: foo')
-    screen.click('cancel')
-    screen.should_contain('value: None')
+    shared_screen.open('/')
+    shared_screen.should_contain('value: foo')
+    shared_screen.click('cancel')
+    shared_screen.should_contain('value: None')
 
 
-def test_update_input(screen: Screen):
+def test_update_input(shared_screen: SharedScreen):
     input_ = None
 
     @ui.page('/')
@@ -186,20 +186,20 @@ def test_update_input(screen: Screen):
         nonlocal input_
         input_ = ui.input('Name', value='Pete')
 
-    screen.open('/')
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Name"]')
+    shared_screen.open('/')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Name"]')
     assert element.get_attribute('value') == 'Pete'
 
     element.send_keys('r')
-    screen.wait(0.5)
+    shared_screen.wait(0.5)
     assert element.get_attribute('value') == 'Peter'
 
     input_.value = 'Pete'
-    screen.wait(0.5)
+    shared_screen.wait(0.5)
     assert element.get_attribute('value') == 'Pete'
 
 
-def test_switching_focus(screen: Screen):
+def test_switching_focus(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         input1 = ui.input()
@@ -207,18 +207,18 @@ def test_switching_focus(screen: Screen):
         ui.button('focus 1', on_click=lambda: input1.run_method('focus'))
         ui.button('focus 2', on_click=lambda: input2.run_method('focus'))
 
-    screen.open('/')
-    elements = screen.selenium.find_elements(By.XPATH, '//input')
+    shared_screen.open('/')
+    elements = shared_screen.selenium.find_elements(By.XPATH, '//input')
     assert len(elements) == 2
-    screen.click('focus 1')
-    screen.wait(0.3)
-    assert elements[0] == screen.selenium.switch_to.active_element
-    screen.click('focus 2')
-    screen.wait(0.3)
-    assert elements[1] == screen.selenium.switch_to.active_element
+    shared_screen.click('focus 1')
+    shared_screen.wait(0.3)
+    assert elements[0] == shared_screen.selenium.switch_to.active_element
+    shared_screen.click('focus 2')
+    shared_screen.wait(0.3)
+    assert elements[1] == shared_screen.selenium.switch_to.active_element
 
 
-def test_prefix_and_suffix(screen: Screen):
+def test_prefix_and_suffix(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         n = ui.input(prefix='MyPrefix', suffix='MySuffix')
@@ -229,10 +229,10 @@ def test_prefix_and_suffix(screen: Screen):
 
         ui.button('Change', on_click=change_prefix_suffix)
 
-    screen.open('/')
-    screen.should_contain('MyPrefix')
-    screen.should_contain('MySuffix')
+    shared_screen.open('/')
+    shared_screen.should_contain('MyPrefix')
+    shared_screen.should_contain('MySuffix')
 
-    screen.click('Change')
-    screen.should_contain('NewPrefix')
-    screen.should_contain('NewSuffix')
+    shared_screen.click('Change')
+    shared_screen.should_contain('NewPrefix')
+    shared_screen.should_contain('NewSuffix')

--- a/tests/test_input_chips.py
+++ b/tests/test_input_chips.py
@@ -2,47 +2,47 @@ import pytest
 from selenium.webdriver import Keys
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
 @pytest.mark.parametrize('new_value_mode', ['add', 'add-unique', 'toggle'])
-def test_add_new_values(screen: Screen, new_value_mode: str):
+def test_add_new_values(shared_screen: SharedScreen, new_value_mode: str):
     @ui.page('/')
     def page():
         chips = ui.input_chips(new_value_mode=new_value_mode)
         ui.label().bind_text_from(chips, 'value', lambda v: f'value = {v}')
 
-    screen.open('/')
-    screen.should_contain('value = []')
+    shared_screen.open('/')
+    shared_screen.should_contain('value = []')
 
-    screen.find_by_tag('input').send_keys('x' + Keys.ENTER)
-    screen.wait(0.5)
+    shared_screen.find_by_tag('input').send_keys('x' + Keys.ENTER)
+    shared_screen.wait(0.5)
 
     for _ in range(2):
-        screen.find_by_tag('input').send_keys('y' + Keys.ENTER)
-        screen.wait(0.5)
+        shared_screen.find_by_tag('input').send_keys('y' + Keys.ENTER)
+        shared_screen.wait(0.5)
 
     if new_value_mode == 'add':
-        screen.should_contain("value = ['x', 'y', 'y']")
+        shared_screen.should_contain("value = ['x', 'y', 'y']")
     elif new_value_mode == 'add-unique':
-        screen.should_contain("value = ['x', 'y']")
+        shared_screen.should_contain("value = ['x', 'y']")
     elif new_value_mode == 'toggle':
-        screen.should_contain("value = ['x']")
+        shared_screen.should_contain("value = ['x']")
 
 
 @pytest.mark.parametrize('auto_validation', [True, False])
-def test_input_chips_validation(auto_validation: bool, screen: Screen):
+def test_input_chips_validation(auto_validation: bool, shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         input_chips = ui.input_chips(value=['A', 'BC'], validation={'Too many': lambda v: len(v) < 3})
         if not auto_validation:
             input_chips.without_auto_validation()
 
-    screen.open('/')
-    screen.find_by_tag('input').send_keys('DEF' + Keys.ENTER)
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.find_by_tag('input').send_keys('DEF' + Keys.ENTER)
+    shared_screen.wait(0.5)
 
     if auto_validation:
-        screen.should_contain('Too many')
+        shared_screen.should_contain('Too many')
     else:
-        screen.should_not_contain('Too many')
+        shared_screen.should_not_contain('Too many')

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -1,52 +1,52 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_run_javascript_on_button_press(screen: Screen):
+def test_run_javascript_on_button_press(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('change title', on_click=lambda: ui.run_javascript('document.title = "A New Title"'))
 
-    screen.open('/')
-    assert screen.selenium.title == 'NiceGUI'
-    screen.click('change title')
-    screen.wait(0.5)
-    screen.should_contain('A New Title')
+    shared_screen.open('/')
+    assert shared_screen.selenium.title == 'NiceGUI'
+    shared_screen.click('change title')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('A New Title')
 
 
-def test_run_javascript_on_value_change(screen: Screen):
+def test_run_javascript_on_value_change(shared_screen: SharedScreen):
     @ui.page('/')
     async def page():
         ui.radio(['A', 'B'], on_change=lambda e: ui.run_javascript(f'document.title = "Page {e.value}"'))
         await ui.context.client.connected()
         ui.run_javascript('document.title = "Initial Title"')
 
-    screen.open('/')
-    screen.wait(0.5)
-    screen.should_contain('Initial Title')
-    screen.click('A')
-    screen.wait(0.5)
-    screen.should_contain('Page A')
-    screen.click('B')
-    screen.wait(0.5)
-    screen.should_contain('Page B')
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Initial Title')
+    shared_screen.click('A')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Page A')
+    shared_screen.click('B')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Page B')
 
 
-def test_run_javascript_before_client_connected(screen: Screen):
+def test_run_javascript_before_client_connected(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label('before js')
         ui.run_javascript('document.title = "New Title"')
         ui.label('after js')
 
-    screen.open('/')
-    screen.should_contain('before js')
-    screen.should_contain('after js')
-    screen.wait(0.5)
-    screen.should_contain('New Title')
+    shared_screen.open('/')
+    shared_screen.should_contain('before js')
+    shared_screen.should_contain('after js')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('New Title')
 
 
-def test_response_from_javascript(screen: Screen):
+def test_response_from_javascript(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         async def compute() -> None:
@@ -55,12 +55,12 @@ def test_response_from_javascript(screen: Screen):
 
         ui.button('compute', on_click=compute)
 
-    screen.open('/')
-    screen.click('compute')
-    screen.should_contain('42')
+    shared_screen.open('/')
+    shared_screen.click('compute')
+    shared_screen.should_contain('42')
 
 
-def test_async_javascript(screen: Screen):
+def test_async_javascript(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         async def run():
@@ -69,12 +69,12 @@ def test_async_javascript(screen: Screen):
 
         ui.button('run', on_click=run)
 
-    screen.open('/')
-    screen.click('run')
-    screen.should_contain('42')
+    shared_screen.open('/')
+    shared_screen.click('run')
+    shared_screen.should_contain('42')
 
 
-def test_simultaneous_async_javascript(screen: Screen):
+def test_simultaneous_async_javascript(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         async def runA():
@@ -88,8 +88,8 @@ def test_simultaneous_async_javascript(screen: Screen):
         ui.button('runA', on_click=runA)
         ui.button('runB', on_click=runB)
 
-    screen.open('/')
-    screen.click('runA')
-    screen.click('runB')
-    screen.should_contain('A: 1')
-    screen.should_contain('B: 2')
+    shared_screen.open('/')
+    shared_screen.click('runA')
+    shared_screen.click('runB')
+    shared_screen.should_contain('A: 1')
+    shared_screen.should_contain('B: 2')

--- a/tests/test_joystick.py
+++ b/tests/test_joystick.py
@@ -1,10 +1,10 @@
 from selenium.webdriver.common.action_chains import ActionChains
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_joystick(screen: Screen):
+def test_joystick(shared_screen: SharedScreen):
     j = None
 
     @ui.page('/')
@@ -14,28 +14,28 @@ def test_joystick(screen: Screen):
                         on_end=lambda _: coordinates.set_text('end 0, 0'))
         coordinates = ui.label('start 0, 0')
 
-    screen.open('/')
-    joystick = screen.find_element(j)
+    shared_screen.open('/')
+    joystick = shared_screen.find_element(j)
     assert joystick
-    screen.should_contain('start 0, 0')
+    shared_screen.should_contain('start 0, 0')
 
-    ActionChains(screen.selenium) \
+    ActionChains(shared_screen.selenium) \
         .move_to_element_with_offset(joystick, 25, 25) \
         .click_and_hold() \
         .pause(1) \
         .move_by_offset(20, 20) \
         .pause(1) \
         .perform()
-    screen.should_contain('move 0.400, -0.400')
+    shared_screen.should_contain('move 0.400, -0.400')
 
-    ActionChains(screen.selenium) \
+    ActionChains(shared_screen.selenium) \
         .move_to_element_with_offset(joystick, 25, 25) \
         .click() \
         .perform()
-    screen.should_contain('end 0, 0')
+    shared_screen.should_contain('end 0, 0')
 
 
-def test_styling_joystick(screen: Screen):
+def test_styling_joystick(shared_screen: SharedScreen):
     j = None
 
     @ui.page('/')
@@ -43,7 +43,7 @@ def test_styling_joystick(screen: Screen):
         nonlocal j
         j = ui.joystick().style('background-color: gray;').classes('shadow-lg')
 
-    screen.open('/')
-    joystick = screen.find_element(j)
+    shared_screen.open('/')
+    joystick = shared_screen.find_element(j)
     assert 'background-color: gray;' in joystick.get_attribute('style')
     assert 'shadow-lg' in joystick.get_attribute('class')

--- a/tests/test_json_editor.py
+++ b/tests/test_json_editor.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_json_editor_methods(screen: Screen):
+def test_json_editor_methods(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         editor = ui.json_editor({'content': {'json': {'a': 1, 'b': 2}}})
@@ -12,26 +12,26 @@ def test_json_editor_methods(screen: Screen):
             ui.label(f'Data: {data}')
         ui.button('Get Data', on_click=get_data)
 
-    screen.open('/')
-    screen.should_contain('text')
-    screen.should_contain('tree')
-    screen.should_contain('table')
+    shared_screen.open('/')
+    shared_screen.should_contain('text')
+    shared_screen.should_contain('tree')
+    shared_screen.should_contain('table')
 
-    screen.click('Get Data')
-    screen.should_contain("Data: {'json': {'a': 1, 'b': 2}}")
+    shared_screen.click('Get Data')
+    shared_screen.should_contain("Data: {'json': {'a': 1, 'b': 2}}")
 
 
-def test_json_editor_validation(screen: Screen):
+def test_json_editor_validation(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.json_editor({'content': {'json': {'x': 0}}},
                        schema={'type': 'object', 'properties': {'x': {'type': 'string'}}})
 
-    screen.open('/')
-    screen.should_contain('must be string')
+    shared_screen.open('/')
+    shared_screen.should_contain('must be string')
 
 
-def test_json_editor_validate_uuid(screen: Screen):
+def test_json_editor_validate_uuid(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         editor = ui.json_editor({
@@ -45,10 +45,10 @@ def test_json_editor_validate_uuid(screen: Screen):
         })
         ui.button('Replace ID', on_click=lambda: editor.properties['content']['json'].update(id='invalid-id'))
 
-    screen.open('/')
-    screen.should_contain('00000000-0000-0000-0000-000000000000')
-    screen.should_not_contain('must match format')
+    shared_screen.open('/')
+    shared_screen.should_contain('00000000-0000-0000-0000-000000000000')
+    shared_screen.should_not_contain('must match format')
 
-    screen.click('Replace ID')
-    screen.should_contain('invalid-id')
-    screen.should_contain('must match format')
+    shared_screen.click('Replace ID')
+    shared_screen.should_contain('invalid-id')
+    shared_screen.should_contain('must match format')

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -1,14 +1,14 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_keyboard(screen: Screen):
+def test_keyboard(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         result = ui.label()
         ui.keyboard(on_key=lambda e: result.set_text(f'{e.key, e.action}'))
 
-    screen.open('/')
-    screen.wait(1.0)
-    screen.type('t')
-    screen.should_contain('t, KeyboardAction(keydown=False, keyup=True, repeat=False)')
+    shared_screen.open('/')
+    shared_screen.wait(1.0)
+    shared_screen.type('t')
+    shared_screen.should_contain('t, KeyboardAction(keydown=False, keyup=True, repeat=False)')

--- a/tests/test_knob.py
+++ b/tests/test_knob.py
@@ -1,14 +1,14 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_knob(screen: Screen):
+def test_knob(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         knob = ui.knob(0.3, show_value=True)
         ui.button('turn up', on_click=lambda: knob.set_value(0.8))
 
-    screen.open('/')
-    screen.should_contain('0.3')
-    screen.click('turn up')
-    screen.should_contain('0.8')
+    shared_screen.open('/')
+    shared_screen.should_contain('0.3')
+    shared_screen.click('turn up')
+    shared_screen.should_contain('0.8')

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -1,20 +1,20 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_hello_world(screen: Screen):
+def test_hello_world(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label('Hello, world')
 
-    screen.open('/')
-    screen.should_contain('Hello, world')
+    shared_screen.open('/')
+    shared_screen.should_contain('Hello, world')
 
 
-def test_text_0(screen: Screen):
+def test_text_0(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label(0)
 
-    screen.open('/')
-    screen.should_contain('0')
+    shared_screen.open('/')
+    shared_screen.should_contain('0')

--- a/tests/test_leaflet.py
+++ b/tests/test_leaflet.py
@@ -4,10 +4,10 @@ import time
 from fastapi import Response
 
 from nicegui import app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_leaflet(screen: Screen):
+def test_leaflet(shared_screen: SharedScreen):
     m = None
 
     @ui.page('/')
@@ -23,30 +23,30 @@ def test_leaflet(screen: Screen):
         ui.button('Berlin', on_click=lambda: m.set_center((52.520, 13.405)))
         ui.button('London', on_click=lambda: m.set_center((51.505, -0.090)))
 
-    screen.open('/')
-    assert screen.find_all_by_class('leaflet-pane')
-    assert screen.find_all_by_class('leaflet-control-container')
+    shared_screen.open('/')
+    assert shared_screen.find_all_by_class('leaflet-pane')
+    assert shared_screen.find_all_by_class('leaflet-control-container')
 
     deadline = time.time() + 3
     while not m.is_initialized and time.time() < deadline:
-        screen.wait(0.1)
-    screen.should_contain('Center: 51.505, -0.090')
-    screen.should_contain('Zoom: 13')
+        shared_screen.wait(0.1)
+    shared_screen.should_contain('Center: 51.505, -0.090')
+    shared_screen.should_contain('Zoom: 13')
 
-    screen.click('Zoom in')
-    screen.should_contain('Zoom: 14')
+    shared_screen.click('Zoom in')
+    shared_screen.should_contain('Zoom: 14')
 
-    screen.click('Zoom out')
-    screen.should_contain('Zoom: 13')
+    shared_screen.click('Zoom out')
+    shared_screen.should_contain('Zoom: 13')
 
-    screen.click('Berlin')
-    screen.should_contain('Center: 52.520, 13.405')
+    shared_screen.click('Berlin')
+    shared_screen.should_contain('Center: 52.520, 13.405')
 
-    screen.click('London')
-    screen.should_contain('Center: 51.505, -0.090')
+    shared_screen.click('London')
+    shared_screen.should_contain('Center: 51.505, -0.090')
 
 
-def test_leaflet_unhide(screen: Screen):
+def test_leaflet_unhide(shared_screen: SharedScreen):
     requested_tiles = set()
 
     @app.get('/mock_tile/{z}/{x}/{y}')
@@ -61,7 +61,7 @@ def test_leaflet_unhide(screen: Screen):
             card.visible = False
         ui.button('Show map card', on_click=lambda: card.set_visibility(True))
 
-    screen.open('/')
-    screen.click('Show map card')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.click('Show map card')
+    shared_screen.wait(0.5)
     assert len(requested_tiles) == 8

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_local_target_linking_on_sub_pages(screen: Screen):
+def test_local_target_linking_on_sub_pages(shared_screen: SharedScreen):
     """The issue arose when using <base> tag for reverse-proxy path handling. See https://github.com/zauberzeug/nicegui/pull/188#issuecomment-1336313925"""
     @ui.page('/sub')
     def main():
@@ -14,13 +14,13 @@ def test_local_target_linking_on_sub_pages(screen: Screen):
     def page():
         ui.label('main page')
 
-    screen.open('/sub')
-    screen.click('goto target')
-    screen.should_contain('the target')
-    screen.should_not_contain('main page')
+    shared_screen.open('/sub')
+    shared_screen.click('goto target')
+    shared_screen.should_contain('the target')
+    shared_screen.should_not_contain('main page')
 
 
-def test_opening_link_in_new_tab(screen: Screen):
+def test_opening_link_in_new_tab(shared_screen: SharedScreen):
     @ui.page('/sub')
     def subpage():
         ui.label('the sub-page')
@@ -29,17 +29,17 @@ def test_opening_link_in_new_tab(screen: Screen):
     def page():
         ui.link('open sub-page in new tab', '/sub', new_tab=True)
 
-    screen.open('/')
-    screen.click('open sub-page')
-    screen.switch_to(1)
-    screen.should_contain('the sub-page')
-    screen.should_not_contain('open sub-page')
-    screen.switch_to(0)
-    screen.should_not_contain('the sub-page')
-    screen.should_contain('open sub-page')
+    shared_screen.open('/')
+    shared_screen.click('open sub-page')
+    shared_screen.switch_to(1)
+    shared_screen.should_contain('the sub-page')
+    shared_screen.should_not_contain('open sub-page')
+    shared_screen.switch_to(0)
+    shared_screen.should_not_contain('the sub-page')
+    shared_screen.should_contain('open sub-page')
 
 
-def test_replace_link(screen: Screen):
+def test_replace_link(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.row() as container:
@@ -50,14 +50,14 @@ def test_replace_link(screen: Screen):
                 ui.link('zauberzeug', 'https://zauberzeug.com/')
         ui.button('Replace', on_click=replace)
 
-    screen.open('/')
-    assert screen.find('nicegui.io').get_attribute('href') == 'https://nicegui.io/'
+    shared_screen.open('/')
+    assert shared_screen.find('nicegui.io').get_attribute('href') == 'https://nicegui.io/'
 
-    screen.click('Replace')
-    assert screen.find('zauberzeug').get_attribute('href') == 'https://zauberzeug.com/'
+    shared_screen.click('Replace')
+    assert shared_screen.find('zauberzeug').get_attribute('href') == 'https://zauberzeug.com/'
 
 
-def test_updating_href_prop(screen: Screen):
+def test_updating_href_prop(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         link = ui.link('nicegui.io', 'https://nicegui.io')
@@ -66,15 +66,15 @@ def test_updating_href_prop(screen: Screen):
             ui.notify('href changed'),
         ))
 
-    screen.open('/')
-    assert screen.find('nicegui.io').get_attribute('href') == 'https://nicegui.io/'
+    shared_screen.open('/')
+    assert shared_screen.find('nicegui.io').get_attribute('href') == 'https://nicegui.io/'
 
-    screen.click('change href')
-    screen.should_contain('href changed')
-    assert screen.find('nicegui.io').get_attribute('href') == 'https://github.com/zauberzeug/nicegui'
+    shared_screen.click('change href')
+    shared_screen.should_contain('href changed')
+    assert shared_screen.find('nicegui.io').get_attribute('href') == 'https://github.com/zauberzeug/nicegui'
 
 
-def test_link_to_elements(screen: Screen):
+def test_link_to_elements(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         navigation = ui.row()
@@ -84,13 +84,13 @@ def test_link_to_elements(screen: Screen):
         with navigation:
             ui.link('goto bottom', link)
 
-    screen.open('/')
-    assert screen.selenium.execute_script('return window.scrollY') == 0
+    shared_screen.open('/')
+    assert shared_screen.selenium.execute_script('return window.scrollY') == 0
 
-    screen.click('goto bottom')
-    screen.wait(0.5)
-    assert screen.selenium.execute_script('return window.scrollY') > 100
+    shared_screen.click('goto bottom')
+    shared_screen.wait(0.5)
+    assert shared_screen.selenium.execute_script('return window.scrollY') > 100
 
-    screen.click('goto top')
-    screen.wait(0.5)
-    assert screen.selenium.execute_script('return window.scrollY') < 100
+    shared_screen.click('goto top')
+    shared_screen.wait(0.5)
+    assert shared_screen.selenium.execute_script('return window.scrollY') < 100

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_clicking_items(screen: Screen):
+def test_clicking_items(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.list():
@@ -11,12 +11,12 @@ def test_clicking_items(screen: Screen):
                 with ui.item_section():
                     ui.button('Button').on('click.stop', lambda: ui.notify('Clicked button!'))
 
-    screen.open('/')
-    screen.click('Item 1')
-    screen.should_contain('Clicked item 1')
+    shared_screen.open('/')
+    shared_screen.click('Item 1')
+    shared_screen.should_contain('Clicked item 1')
 
-    screen.click('Item 2')
-    screen.should_contain('Clicked item 2')
+    shared_screen.click('Item 2')
+    shared_screen.should_contain('Clicked item 2')
 
-    screen.click('Button')
-    screen.should_contain('Clicked button!')
+    shared_screen.click('Button')
+    shared_screen.should_contain('Clicked button!')

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_log(screen: Screen):
+def test_log(shared_screen: SharedScreen):
     log = None
 
     @ui.page('/')
@@ -14,15 +14,15 @@ def test_log(screen: Screen):
         log.push('C')
         log.push('D')
 
-    screen.open('/')
-    assert screen.find_element(log).text == 'B\nC\nD'
+    shared_screen.open('/')
+    assert shared_screen.find_element(log).text == 'B\nC\nD'
 
     log.clear()
-    screen.wait(0.5)
-    assert screen.find_element(log).text == ''
+    shared_screen.wait(0.5)
+    assert shared_screen.find_element(log).text == ''
 
 
-def test_log_with_newlines(screen: Screen):
+def test_log_with_newlines(shared_screen: SharedScreen):
     log = None
 
     @ui.page('/')
@@ -33,11 +33,11 @@ def test_log_with_newlines(screen: Screen):
         log.push('B')
         log.push('C\nD')
 
-    screen.open('/')
-    assert screen.find_element(log).text == 'B\nC\nD'
+    shared_screen.open('/')
+    assert shared_screen.find_element(log).text == 'B\nC\nD'
 
 
-def test_replace_log(screen: Screen):
+def test_replace_log(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.row().classes('w-full') as container:
@@ -48,29 +48,29 @@ def test_replace_log(screen: Screen):
                 ui.log().push('B')
         ui.button('Replace', on_click=replace)
 
-    screen.open('/')
-    screen.should_contain('A')
+    shared_screen.open('/')
+    shared_screen.should_contain('A')
 
-    screen.click('Replace')
-    screen.should_contain('B')
-    screen.should_not_contain('A')
+    shared_screen.click('Replace')
+    shared_screen.should_contain('B')
+    shared_screen.should_not_contain('A')
 
 
-def test_special_characters(screen: Screen):
+def test_special_characters(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         log = ui.log()
         log.push('50%')
         ui.button('push', on_click=lambda: log.push('100%'))
 
-    screen.open('/')
-    screen.should_contain('50%')
+    shared_screen.open('/')
+    shared_screen.should_contain('50%')
 
-    screen.click('push')
-    screen.should_contain('100%')
+    shared_screen.click('push')
+    shared_screen.should_contain('100%')
 
 
-def test_log_against_defaults(screen: Screen):
+def test_log_against_defaults(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label.default_classes('text-red')
@@ -80,8 +80,8 @@ def test_log_against_defaults(screen: Screen):
         log = ui.log()
         log.push('Log line', classes='text-green', style='margin: 2rem', props='my-prop=B')
 
-    screen.open('/')
-    line = screen.find('Log line')
+    shared_screen.open('/')
+    line = shared_screen.find('Log line')
     assert line.get_attribute('my-prop') == 'B'
     assert line.get_attribute('class') == 'text-green'
     assert line.get_attribute('style') == 'margin: 2rem;'

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,27 +1,27 @@
 from selenium.webdriver.common.by import By
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_markdown(screen: Screen):
+def test_markdown(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         m = ui.markdown('This is **Markdown**')
         ui.button('Set new content', on_click=lambda: m.set_content('New **content**'))
 
-    screen.open('/')
-    element = screen.find('This is')
+    shared_screen.open('/')
+    element = shared_screen.find('This is')
     assert element.text == 'This is Markdown'
     assert element.get_attribute('innerHTML') == 'This is <strong>Markdown</strong>'
 
-    screen.click('Set new content')
-    element = screen.find('New')
+    shared_screen.click('Set new content')
+    element = shared_screen.find('New')
     assert element.text == 'New content'
     assert element.get_attribute('innerHTML') == 'New <strong>content</strong>'
 
 
-def test_markdown_with_mermaid(screen: Screen):
+def test_markdown_with_mermaid(shared_screen: SharedScreen):
     m = None
 
     @ui.page('/')
@@ -44,19 +44,19 @@ def test_markdown_with_mermaid(screen: Screen):
             ```
         '''))
 
-    screen.open('/')
-    screen.wait(1.0)  # wait for Mermaid to render
-    screen.should_contain('Mermaid')
-    assert screen.find_by_tag('svg').get_attribute('id') == f'{m.html_id}_mermaid_0'
-    assert screen.selenium.find_element(By.XPATH, '//span[p[contains(text(), "Node_A")]]').is_displayed()
+    shared_screen.open('/')
+    shared_screen.wait(1.0)  # wait for Mermaid to render
+    shared_screen.should_contain('Mermaid')
+    assert shared_screen.find_by_tag('svg').get_attribute('id') == f'{m.html_id}_mermaid_0'
+    assert shared_screen.selenium.find_element(By.XPATH, '//span[p[contains(text(), "Node_A")]]').is_displayed()
 
-    screen.click('Set new content')
-    screen.should_contain('New')
-    assert screen.selenium.find_element(By.XPATH, '//span[p[contains(text(), "Node_C")]]').is_displayed()
-    screen.should_not_contain('Node_A')
+    shared_screen.click('Set new content')
+    shared_screen.should_contain('New')
+    assert shared_screen.selenium.find_element(By.XPATH, '//span[p[contains(text(), "Node_C")]]').is_displayed()
+    shared_screen.should_not_contain('Node_A')
 
 
-def test_markdown_with_mermaid_on_demand(screen: Screen):
+def test_markdown_with_mermaid_on_demand(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('Create Mermaid', on_click=lambda: ui.markdown('''
@@ -66,25 +66,25 @@ def test_markdown_with_mermaid_on_demand(screen: Screen):
             ```
         ''', extras=['mermaid', 'fenced-code-blocks']))
 
-    screen.open('/')
-    screen.click('Create Mermaid')
-    assert screen.selenium.find_element(By.XPATH, '//span[p[contains(text(), "Node_A")]]').is_displayed()
-    assert screen.selenium.find_element(By.XPATH, '//span[p[contains(text(), "Node_B")]]').is_displayed()
+    shared_screen.open('/')
+    shared_screen.click('Create Mermaid')
+    assert shared_screen.selenium.find_element(By.XPATH, '//span[p[contains(text(), "Node_A")]]').is_displayed()
+    assert shared_screen.selenium.find_element(By.XPATH, '//span[p[contains(text(), "Node_B")]]').is_displayed()
 
 
-def test_strip_indentation(screen: Screen):
+def test_strip_indentation(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.markdown('''
             **This is Markdown.**
         ''')
 
-    screen.open('/')
-    screen.should_contain('This is Markdown.')
-    screen.should_not_contain('**This is Markdown.**')  # NOTE: '**' are translated to formatting and not visible
+    shared_screen.open('/')
+    shared_screen.should_contain('This is Markdown.')
+    shared_screen.should_not_contain('**This is Markdown.**')  # NOTE: '**' are translated to formatting and not visible
 
 
-def test_replace_markdown(screen: Screen):
+def test_replace_markdown(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.row() as container:
@@ -95,19 +95,19 @@ def test_replace_markdown(screen: Screen):
                 ui.markdown('B')
         ui.button('Replace', on_click=replace)
 
-    screen.open('/')
-    screen.should_contain('A')
+    shared_screen.open('/')
+    shared_screen.should_contain('A')
 
-    screen.click('Replace')
-    screen.should_contain('B')
-    screen.should_not_contain('A')
+    shared_screen.click('Replace')
+    shared_screen.should_contain('B')
+    shared_screen.should_not_contain('A')
 
 
-def test_xss_sanitization(screen: Screen):
+def test_xss_sanitization(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.markdown('<img src=x onerror="alert(\'XSS\')">')
 
-    screen.allowed_js_errors.append('/x - Failed to load resource')
-    screen.open('/')
-    assert screen.find_by_tag('img').get_attribute('onerror') is None
+    shared_screen.allowed_js_errors.append('/x - Failed to load resource')
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('img').get_attribute('onerror') is None

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_menu(screen: Screen):
+def test_menu(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.button('Menu'):
@@ -11,6 +11,6 @@ def test_menu(screen: Screen):
                 ui.menu_item('Item 2')
                 ui.menu_item('Item 3')
 
-    screen.open('/')
-    screen.click('Menu')
-    screen.should_contain('Item 1')
+    shared_screen.open('/')
+    shared_screen.click('Menu')
+    shared_screen.should_contain('Item 1')

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -2,10 +2,10 @@ import pytest
 from selenium.webdriver.common.by import By
 
 from nicegui import events, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_mermaid(screen: Screen):
+def test_mermaid(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         m = ui.mermaid('''
@@ -17,17 +17,17 @@ def test_mermaid(screen: Screen):
                 Node_C --> Node_D;
         '''))
 
-    screen.open('/')
-    node_a = screen.selenium.find_element(By.XPATH, '//span[p[contains(text(), "Node_A")]]')
+    shared_screen.open('/')
+    node_a = shared_screen.selenium.find_element(By.XPATH, '//span[p[contains(text(), "Node_A")]]')
     assert node_a.get_attribute('class') == 'nodeLabel'
 
-    screen.click('Set new content')
-    node_c = screen.selenium.find_element(By.XPATH, '//span[p[contains(text(), "Node_C")]]')
+    shared_screen.click('Set new content')
+    node_c = shared_screen.selenium.find_element(By.XPATH, '//span[p[contains(text(), "Node_C")]]')
     assert node_c.get_attribute('class') == 'nodeLabel'
-    screen.should_not_contain('Node_A')
+    shared_screen.should_not_contain('Node_A')
 
 
-def test_mermaid_with_line_breaks(screen: Screen):
+def test_mermaid_with_line_breaks(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.mermaid('''
@@ -41,15 +41,15 @@ def test_mermaid_with_line_breaks(screen: Screen):
             }
         ''')
 
-    screen.open('/')
-    screen.should_contain('<<Requirement>>')
-    screen.should_contain('ID: 1')
-    screen.should_contain('Text: some test text')
-    screen.should_contain('Risk: High')
-    screen.should_contain('Verification: Test')
+    shared_screen.open('/')
+    shared_screen.should_contain('<<Requirement>>')
+    shared_screen.should_contain('ID: 1')
+    shared_screen.should_contain('Text: some test text')
+    shared_screen.should_contain('Risk: High')
+    shared_screen.should_contain('Verification: Test')
 
 
-def test_replace_mermaid(screen: Screen):
+def test_replace_mermaid(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.row() as container:
@@ -60,26 +60,26 @@ def test_replace_mermaid(screen: Screen):
                 ui.mermaid('graph LR; Node_B')
         ui.button('Replace', on_click=replace)
 
-    screen.open('/')
-    screen.should_contain('Node_A')
+    shared_screen.open('/')
+    shared_screen.should_contain('Node_A')
 
-    screen.click('Replace')
-    screen.wait(0.5)
-    screen.should_contain('Node_B')
-    screen.should_not_contain('Node_A')
+    shared_screen.click('Replace')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Node_B')
+    shared_screen.should_not_contain('Node_A')
 
 
-def test_create_dynamically(screen: Screen):
+def test_create_dynamically(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('Create', on_click=lambda: ui.mermaid('graph LR; Node'))
 
-    screen.open('/')
-    screen.click('Create')
-    screen.should_contain('Node')
+    shared_screen.open('/')
+    shared_screen.click('Create')
+    shared_screen.should_contain('Node')
 
 
-def test_error(screen: Screen):
+def test_error(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.mermaid('''
@@ -88,13 +88,13 @@ def test_error(screen: Screen):
                 A -> C;
         ''').on('error', lambda e: ui.label(e.args['message']))
 
-    screen.allowed_js_errors.append(':18 Object')
-    screen.open('/')
-    screen.should_contain('Syntax error in text')
-    screen.should_contain('Parse error on line 3')
+    shared_screen.allowed_js_errors.append(':18 Object')
+    shared_screen.open('/')
+    shared_screen.should_contain('Syntax error in text')
+    shared_screen.should_contain('Parse error on line 3')
 
 
-def test_error_source_accurate(screen: Screen):
+def test_error_source_accurate(shared_screen: SharedScreen):
     errors: list[events.GenericEventArguments] = []
 
     @ui.page('/')
@@ -102,13 +102,13 @@ def test_error_source_accurate(screen: Screen):
         ui.mermaid('graph TD; A --> B').on('error', errors.append)
         ui.mermaid('BAD SYNTAX')
 
-    screen.allowed_js_errors.append(':18 Object')
-    screen.open('/')
+    shared_screen.allowed_js_errors.append(':18 Object')
+    shared_screen.open('/')
     assert not errors, 'No errors should be collected because the invalid diagram has no error handler'
 
 
 @pytest.mark.parametrize('security_level', ['loose', 'strict'])
-def test_click_mermaid_node(security_level: str, screen: Screen):
+def test_click_mermaid_node(security_level: str, shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.mermaid('''
@@ -129,18 +129,18 @@ def test_click_mermaid_node(security_level: str, screen: Screen):
                 click Z call document.write("Clicked Z")
         ''', config={'securityLevel': security_level})
 
-    screen.open('/')
-    screen.click('Y')
-    screen.wait(0.5)
-    screen.should_not_contain('Clicked X')
-    screen.should_not_contain('Clicked Z')
+    shared_screen.open('/')
+    shared_screen.click('Y')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Clicked X')
+    shared_screen.should_not_contain('Clicked Z')
     if security_level == 'loose':
-        screen.should_contain('Clicked Y')
+        shared_screen.should_contain('Clicked Y')
     else:
-        screen.should_not_contain('Clicked Y')
+        shared_screen.should_not_contain('Clicked Y')
 
 
-def test_node_click_handler(screen: Screen):
+def test_node_click_handler(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.mermaid('''
@@ -150,12 +150,12 @@ def test_node_click_handler(screen: Screen):
                 Node-With-Hyphen[Node With Hyphen];
         ''', on_node_click=lambda e: ui.notify(f'{e.node_id} clicked'))
 
-    screen.open('/')
-    screen.click('Node A')
-    screen.should_contain('A clicked')
+    shared_screen.open('/')
+    shared_screen.click('Node A')
+    shared_screen.should_contain('A clicked')
 
-    screen.click('Node B')
-    screen.should_contain('B clicked')
+    shared_screen.click('Node B')
+    shared_screen.should_contain('B clicked')
 
-    screen.click('Node With Hyphen')
-    screen.should_contain('Node-With-Hyphen clicked')  # make sure our ID extraction works even with hyphens
+    shared_screen.click('Node With Hyphen')
+    shared_screen.should_contain('Node-With-Hyphen clicked')  # make sure our ID extraction works even with hyphens

--- a/tests/test_navigate.py
+++ b/tests/test_navigate.py
@@ -1,11 +1,11 @@
 import pytest
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
 @pytest.mark.parametrize('new_tab', [False, True])
-def test_navigate_to(screen: Screen, new_tab: bool):
+def test_navigate_to(shared_screen: SharedScreen, new_tab: bool):
     @ui.page('/test_page')
     def test_page():
         ui.label('Test page')
@@ -16,34 +16,34 @@ def test_navigate_to(screen: Screen, new_tab: bool):
         ui.button('Open test page', on_click=lambda: ui.navigate.to('/test_page', new_tab=new_tab))
         ui.button('Forward', on_click=ui.navigate.forward)
 
-    screen.open('/')
-    screen.click('Open test page')
-    screen.wait(0.5)
-    screen.switch_to(1 if new_tab else 0)
-    screen.should_contain('Test page')
+    shared_screen.open('/')
+    shared_screen.click('Open test page')
+    shared_screen.wait(0.5)
+    shared_screen.switch_to(1 if new_tab else 0)
+    shared_screen.should_contain('Test page')
 
     if not new_tab:
-        screen.click('Back')
-        screen.should_contain('Open test page')
+        shared_screen.click('Back')
+        shared_screen.should_contain('Open test page')
 
-        screen.click('Forward')
-        screen.should_contain('Test page')
+        shared_screen.click('Forward')
+        shared_screen.should_contain('Test page')
 
 
-def test_navigate_to_absolute_url(screen: Screen):
+def test_navigate_to_absolute_url(shared_screen: SharedScreen):
     external_url = 'https://www.google.com/'
 
     @ui.page('/')
     def page():
         ui.button('Go external', on_click=lambda: ui.navigate.to(external_url))
 
-    screen.open('/')
-    screen.click('Go external')
-    screen.wait(1.0)
-    assert external_url in screen.selenium.current_url
+    shared_screen.open('/')
+    shared_screen.click('Go external')
+    shared_screen.wait(1.0)
+    assert external_url in shared_screen.selenium.current_url
 
 
-def test_navigate_to_relative_url(screen: Screen):
+def test_navigate_to_relative_url(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label('Index page')
@@ -54,37 +54,37 @@ def test_navigate_to_relative_url(screen: Screen):
         ui.label('Test page')
         ui.button('Back', on_click=ui.navigate.back)
 
-    screen.open('/')
-    screen.click('Go test page')
-    screen.should_contain('Test page')
+    shared_screen.open('/')
+    shared_screen.click('Go test page')
+    shared_screen.should_contain('Test page')
 
-    screen.click('Back')
-    screen.should_contain('Index page')
+    shared_screen.click('Back')
+    shared_screen.should_contain('Index page')
 
 
 @pytest.mark.parametrize('sub_pages', [False, True])
-def test_navigate_to_mailto_url(screen: Screen, sub_pages: bool):
+def test_navigate_to_mailto_url(shared_screen: SharedScreen, sub_pages: bool):
     @ui.page('/')
     def page():
         ui.button('Send mail', on_click=lambda: ui.navigate.to('mailto:test@example.com'))
         if sub_pages:
             ui.sub_pages({'/': lambda: ui.label('sub page')})
 
-    screen.open('/')
+    shared_screen.open('/')
     # Override window.open to capture calls instead of triggering the system mail client
-    screen.selenium.execute_script('window.__open_calls = [];'
+    shared_screen.selenium.execute_script('window.__open_calls = [];'
                                    'window.open = (url, target) => window.__open_calls.push([url, target]);')
-    screen.click('Send mail')
-    screen.wait(0.5)
-    assert screen.selenium.execute_script('return window.__open_calls') == [['mailto:test@example.com', '_self']]
+    shared_screen.click('Send mail')
+    shared_screen.wait(0.5)
+    assert shared_screen.selenium.execute_script('return window.__open_calls') == [['mailto:test@example.com', '_self']]
 
 
-def test_xss_via_history_push(screen: Screen):
+def test_xss_via_history_push(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('Push', on_click=lambda: ui.navigate.history.push('/");console.log("XSS");//'))
 
-    screen.open('/')
-    screen.click('Push')
-    screen.wait(1)
-    assert 'XSS' not in screen.render_js_logs()
+    shared_screen.open('/')
+    shared_screen.click('Push')
+    shared_screen.wait(1)
+    assert 'XSS' not in shared_screen.render_js_logs()

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,18 +1,18 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_notification(screen: Screen):
+def test_notification(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('Notify', on_click=lambda: ui.notification('Hi!'))
 
-    screen.open('/')
-    screen.click('Notify')
-    screen.should_contain('Hi!')
+    shared_screen.open('/')
+    shared_screen.click('Notify')
+    shared_screen.should_contain('Hi!')
 
 
-def test_close_button(screen: Screen):
+def test_close_button(shared_screen: SharedScreen):
     b = None
 
     @ui.page('/')
@@ -20,19 +20,19 @@ def test_close_button(screen: Screen):
         nonlocal b
         b = ui.button('Notify', on_click=lambda: ui.notification('Hi!', timeout=None, close_button=True))
 
-    screen.open('/')
-    screen.click('Notify')
-    screen.should_contain('Hi!')
+    shared_screen.open('/')
+    shared_screen.click('Notify')
+    shared_screen.should_contain('Hi!')
     assert len(b.client.layout.default_slot.children) == 2
-    screen.wait_for('Close')
-    screen.wait(0.1)  # NOTE: wait for button to become clickable
-    screen.click('Close')
-    screen.wait(1.5)
-    screen.should_not_contain('Hi!')
+    shared_screen.wait_for('Close')
+    shared_screen.wait(0.1)  # NOTE: wait for button to become clickable
+    shared_screen.click('Close')
+    shared_screen.wait(1.5)
+    shared_screen.should_not_contain('Hi!')
     assert len(b.client.layout.default_slot.children) == 1
 
 
-def test_dismiss(screen: Screen):
+def test_dismiss(shared_screen: SharedScreen):
     n = None
     b = None
 
@@ -42,17 +42,17 @@ def test_dismiss(screen: Screen):
         n = ui.notification('Hi!', timeout=None)
         b = ui.button('Dismiss', on_click=n.dismiss)
 
-    screen.open('/')
-    screen.should_contain('Hi!')
+    shared_screen.open('/')
+    shared_screen.should_contain('Hi!')
     assert len(b.client.layout.default_slot.children) == 2
-    screen.wait(1)
-    screen.click('Dismiss')
-    screen.wait(1.5)
-    screen.should_not_contain('Hi!')
+    shared_screen.wait(1)
+    shared_screen.click('Dismiss')
+    shared_screen.wait(1.5)
+    shared_screen.should_not_contain('Hi!')
     assert len(b.client.layout.default_slot.children) == 1
 
 
-def test_no_reset_by_other_notifications(screen: Screen):
+def test_no_reset_by_other_notifications(shared_screen: SharedScreen):
     # see #4373
     @ui.page('/')
     def page():
@@ -61,13 +61,13 @@ def test_no_reset_by_other_notifications(screen: Screen):
         ui.button('Button C', on_click=lambda: ui.notification('Notification C', timeout=1.0))
         ui.button('Button D', on_click=lambda: ui.notification('Notification D', timeout=1.0))
 
-    screen.open('/')
-    screen.click('Button A')
-    screen.wait(1)
-    screen.click('Button B')
-    screen.wait(1)
-    screen.click('Button C')
-    screen.wait(1)
-    screen.click('Button D')
-    screen.should_contain('Notification D')
-    screen.should_not_contain('Notification A')
+    shared_screen.open('/')
+    shared_screen.click('Button A')
+    shared_screen.wait(1)
+    shared_screen.click('Button B')
+    shared_screen.wait(1)
+    shared_screen.click('Button C')
+    shared_screen.wait(1)
+    shared_screen.click('Button D')
+    shared_screen.should_contain('Notification D')
+    shared_screen.should_not_contain('Notification A')

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -3,74 +3,74 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_number_input(screen: Screen):
+def test_number_input(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.number('Number', value=42)
         ui.button('Button')
 
-    screen.open('/')
-    screen.should_contain_input('42')
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
+    shared_screen.open('/')
+    shared_screen.should_contain_input('42')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
     element.send_keys('00')
-    screen.click('Button')
-    screen.should_contain_input('4200')
+    shared_screen.click('Button')
+    shared_screen.should_contain_input('4200')
 
 
-def test_apply_format_on_blur(screen: Screen):
+def test_apply_format_on_blur(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.number('Number', format='%.4f', value=3.14159)
         ui.button('Button')
 
-    screen.open('/')
-    screen.should_contain_input('3.1416')
+    shared_screen.open('/')
+    shared_screen.should_contain_input('3.1416')
 
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
     element.send_keys('789')
-    screen.click('Button')
-    screen.should_contain_input('3.1417')
+    shared_screen.click('Button')
+    shared_screen.should_contain_input('3.1417')
 
     element.click()
     element.send_keys(Keys.BACKSPACE * 10 + '2')
-    screen.click('Button')
-    screen.should_contain_input('2.0000')
+    shared_screen.click('Button')
+    shared_screen.should_contain_input('2.0000')
 
 
-def test_max_value(screen: Screen):
+def test_max_value(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.number('Number', min=0, max=10, value=5)
         ui.button('Button')
 
-    screen.open('/')
-    screen.should_contain_input('5')
+    shared_screen.open('/')
+    shared_screen.should_contain_input('5')
 
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
     element.send_keys('6')
-    screen.click('Button')
-    screen.should_contain_input('10')
+    shared_screen.click('Button')
+    shared_screen.should_contain_input('10')
 
 
-def test_clearable_number(screen: Screen):
+def test_clearable_number(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         number = ui.number(value=42).props('clearable')
         ui.label().bind_text_from(number, 'value', lambda value: f'value: {value}')
 
-    screen.open('/')
-    screen.should_contain('value: 42')
-    screen.click('cancel')
-    screen.should_contain('value: None')
-    screen.click('value: None')  # loose focus
-    screen.wait(0.5)
-    screen.should_contain('value: None')
+    shared_screen.open('/')
+    shared_screen.should_contain('value: 42')
+    shared_screen.click('cancel')
+    shared_screen.should_contain('value: None')
+    shared_screen.click('value: None')  # loose focus
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('value: None')
 
 
-def test_out_of_limits(screen: Screen):
+def test_out_of_limits(shared_screen: SharedScreen):
     number = None
 
     @ui.page('/')
@@ -79,106 +79,106 @@ def test_out_of_limits(screen: Screen):
         number = ui.number('Number', min=0, max=10, value=5)
         ui.label().bind_text_from(number, 'out_of_limits', lambda value: f'out_of_limits: {value}')
 
-    screen.open('/')
-    screen.should_contain('out_of_limits: False')
+    shared_screen.open('/')
+    shared_screen.should_contain('out_of_limits: False')
 
     number.value = 11
-    screen.should_contain('out_of_limits: True')
+    shared_screen.should_contain('out_of_limits: True')
 
     number.max = 15
-    screen.should_contain('out_of_limits: False')
+    shared_screen.should_contain('out_of_limits: False')
 
 
 @pytest.mark.parametrize('precision', [None, 1, -1])
-def test_rounding(precision: int, screen: Screen):
+def test_rounding(precision: int, shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         number = ui.number('Number', value=12, precision=precision)
         ui.label().bind_text_from(number, 'value', lambda value: f'number=_{value}_')
 
-    screen.open('/')
-    screen.should_contain('number=_12_')
+    shared_screen.open('/')
+    shared_screen.should_contain('number=_12_')
 
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
     element.send_keys('.345')
-    screen.click('number=')  # blur the number input
+    shared_screen.click('number=')  # blur the number input
     if precision is None:
-        screen.should_contain('number=_12.345_')
+        shared_screen.should_contain('number=_12.345_')
     elif precision == 1:
-        screen.should_contain('number=_12.3_')
+        shared_screen.should_contain('number=_12.3_')
     elif precision == -1:
-        screen.should_contain('number=_10.0_')
+        shared_screen.should_contain('number=_10.0_')
 
 
-def test_int_float_conversion_on_error1(screen: Screen):
+def test_int_float_conversion_on_error1(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.number('Number', validation={'Error': lambda value: value == 1}, value=1)
 
-    screen.open('/')
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
+    shared_screen.open('/')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
     element.send_keys('2')
-    screen.should_contain('Error')
+    shared_screen.should_contain('Error')
     assert element.get_attribute('value') == '12'
 
 
-def test_int_float_conversion_on_error2(screen: Screen):
+def test_int_float_conversion_on_error2(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.number('Number', validation={'Error': lambda value: value == 1.02}, value=1.02)
 
-    screen.open('/')
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
+    shared_screen.open('/')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
     element.send_keys(Keys.BACKSPACE)
-    screen.should_contain('Error')
+    shared_screen.should_contain('Error')
     assert element.get_attribute('value') == '1.0'
 
 
-def test_changing_limits(screen: Screen):
+def test_changing_limits(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         number = ui.number('Number', max=0, value=0)
         ui.button('Raise max', on_click=lambda: setattr(number, 'max', 1))
         ui.button('Step up', on_click=lambda: number.run_method('(e) => e.getNativeElement().stepUp()'))
 
-    screen.open('/')
-    screen.should_contain_input('0')
+    shared_screen.open('/')
+    shared_screen.should_contain_input('0')
 
-    screen.click('Step up')
-    screen.should_contain_input('0')
+    shared_screen.click('Step up')
+    shared_screen.should_contain_input('0')
 
-    screen.click('Raise max')
-    screen.should_contain_input('0')
+    shared_screen.click('Raise max')
+    shared_screen.should_contain_input('0')
 
-    screen.click('Step up')
-    screen.should_contain_input('1')
+    shared_screen.click('Step up')
+    shared_screen.should_contain_input('1')
 
 
-def test_none_values(screen: Screen):
+def test_none_values(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         n = ui.number('Number', on_change=lambda e: ui.label(f'event: {e.value}'))
         ui.label().bind_text_from(n, 'value', lambda value: f'model: {value}')
 
-    screen.open('/')
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
+    shared_screen.open('/')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Number"]')
     element.send_keys('0')
-    screen.should_contain_input('0')
-    screen.should_contain('model: 0')
-    screen.should_contain('event: 0')
+    shared_screen.should_contain_input('0')
+    shared_screen.should_contain('model: 0')
+    shared_screen.should_contain('event: 0')
 
     element.send_keys(Keys.BACKSPACE)
-    screen.should_contain_input('')
-    screen.should_contain('model: None')
-    screen.should_contain('event: None')
+    shared_screen.should_contain_input('')
+    shared_screen.should_contain('model: None')
+    shared_screen.should_contain('event: None')
 
     element.send_keys('1')
-    screen.should_contain_input('1')
-    screen.should_contain('model: 1')
-    screen.should_contain('event: 1')
+    shared_screen.should_contain_input('1')
+    shared_screen.should_contain('model: 1')
+    shared_screen.should_contain('event: 1')
 
 
-def test_prefix_and_suffix(screen: Screen):
+def test_prefix_and_suffix(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         n = ui.number(prefix='MyPrefix', suffix='MySuffix')
@@ -189,10 +189,10 @@ def test_prefix_and_suffix(screen: Screen):
 
         ui.button('Change', on_click=change_prefix_suffix)
 
-    screen.open('/')
-    screen.should_contain('MyPrefix')
-    screen.should_contain('MySuffix')
+    shared_screen.open('/')
+    shared_screen.should_contain('MyPrefix')
+    shared_screen.should_contain('MySuffix')
 
-    screen.click('Change')
-    screen.should_contain('NewPrefix')
-    screen.should_contain('NewSuffix')
+    shared_screen.click('Change')
+    shared_screen.should_contain('NewPrefix')
+    shared_screen.should_contain('NewSuffix')

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -3,7 +3,7 @@ import copy
 
 from nicegui import ui
 from nicegui.observables import ObservableDict, ObservableList, ObservableSet
-from nicegui.testing import Screen, User
+from nicegui.testing import SharedScreen, User
 
 # pylint: disable=global-statement
 count = 0
@@ -130,7 +130,7 @@ def test_nested_observables():
     assert count == 6
 
 
-def test_async_handler(screen: Screen):
+def test_async_handler(shared_screen: SharedScreen):
     reset_counter()
     data = ObservableList(on_change=increment_counter_slowly)
 
@@ -138,11 +138,11 @@ def test_async_handler(screen: Screen):
     def page():
         ui.button('Append 42', on_click=lambda: data.append(42))
 
-    screen.open('/')
+    shared_screen.open('/')
     assert count == 0
 
-    screen.click('Append 42')
-    screen.wait(0.5)
+    shared_screen.click('Append 42')
+    shared_screen.wait(0.5)
     assert count == 1
 
 

--- a/tests/test_outbox.py
+++ b/tests/test_outbox.py
@@ -1,10 +1,10 @@
 import asyncio
 
 from nicegui import app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_removing_outbox_loops(screen: Screen):
+def test_removing_outbox_loops(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label('Index page')
@@ -17,12 +17,12 @@ def test_removing_outbox_loops(screen: Screen):
     app.timer(0.1, lambda: state.update(count=len([t for t in asyncio.all_tasks()
                                                    if t.get_name().startswith('outbox loop')])))
 
-    screen.open('/subpage')
-    screen.click('Click me')
-    screen.should_contain('Hello world!')
+    shared_screen.open('/subpage')
+    shared_screen.click('Click me')
+    shared_screen.should_contain('Hello world!')
     assert state['count'] == 1
 
-    screen.open('/')
-    screen.should_contain('Index page')
-    screen.wait(0.5)  # wait for the outbox loop to finish
+    shared_screen.open('/')
+    shared_screen.should_contain('Index page')
+    shared_screen.wait(0.5)  # wait for the outbox loop to finish
     assert state['count'] == 1

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -7,39 +7,39 @@ from fastapi.responses import PlainTextResponse
 from selenium.webdriver.common.by import By
 
 from nicegui import app, background_tasks, ui
-from nicegui.testing import Screen
+from nicegui.testing import Screen, SharedScreen
 
 
-def test_page(screen: Screen):
+def test_page(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label('Hello, world!')
 
-    screen.open('/')
-    screen.should_contain('NiceGUI')
-    screen.should_contain('Hello, world!')
+    shared_screen.open('/')
+    shared_screen.should_contain('NiceGUI')
+    shared_screen.should_contain('Hello, world!')
 
 
-def test_custom_title(screen: Screen):
+def test_custom_title(shared_screen: SharedScreen):
     @ui.page('/', title='My Custom Title')
     def page():
         ui.label('Hello, world!')
 
-    screen.open('/')
-    screen.should_contain('My Custom Title')
-    screen.should_contain('Hello, world!')
+    shared_screen.open('/')
+    shared_screen.should_contain('My Custom Title')
+    shared_screen.should_contain('Hello, world!')
 
 
-def test_route_with_custom_path(screen: Screen):
+def test_route_with_custom_path(shared_screen: SharedScreen):
     @ui.page('/test_route')
     def page():
         ui.label('page with custom path')
 
-    screen.open('/test_route')
-    screen.should_contain('page with custom path')
+    shared_screen.open('/test_route')
+    shared_screen.should_contain('page with custom path')
 
 
-def test_link_to_page_by_passing_function(screen: Screen):
+def test_link_to_page_by_passing_function(shared_screen: SharedScreen):
     @ui.page('/subpage')
     def subpage():
         ui.label('the subpage')
@@ -48,23 +48,23 @@ def test_link_to_page_by_passing_function(screen: Screen):
     def page():
         ui.link('link to subpage', subpage)
 
-    screen.open('/')
-    screen.click('link to subpage')
-    screen.should_contain('the subpage')
+    shared_screen.open('/')
+    shared_screen.click('link to subpage')
+    shared_screen.should_contain('the subpage')
 
 
-def test_creating_new_page_after_startup(screen: Screen):
-    screen.start_server()
+def test_creating_new_page_after_startup(shared_screen: SharedScreen):
+    shared_screen.start_server()
 
     @ui.page('/late_page')
     def page():
         ui.label('page created after startup')
 
-    screen.open('/late_page')
-    screen.should_contain('page created after startup')
+    shared_screen.open('/late_page')
+    shared_screen.should_contain('page created after startup')
 
 
-def test_wait_for_connected(screen: Screen):
+def test_wait_for_connected(shared_screen: SharedScreen):
     label: ui.label | None = None
 
     async def load() -> None:
@@ -85,11 +85,11 @@ def test_wait_for_connected(screen: Screen):
         await ui.context.client.connected()
         await load()
 
-    screen.open('/')
-    screen.should_contain('delayed data has been loaded')
+    shared_screen.open('/')
+    shared_screen.should_contain('delayed data has been loaded')
 
 
-def test_wait_for_disconnect(screen: Screen):
+def test_wait_for_disconnect(shared_screen: SharedScreen):
     events = []
 
     @ui.page('/', reconnect_timeout=0)
@@ -99,14 +99,14 @@ def test_wait_for_disconnect(screen: Screen):
         await ui.context.client.disconnected()
         events.append('disconnected')
 
-    screen.open('/')
-    screen.wait(0.5)
-    screen.open('/')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
     assert events == ['connected', 'disconnected', 'connected']
 
 
-def test_wait_for_disconnect_without_awaiting_connected(screen: Screen):
+def test_wait_for_disconnect_without_awaiting_connected(shared_screen: SharedScreen):
     events = []
 
     @ui.page('/', reconnect_timeout=0)
@@ -114,26 +114,26 @@ def test_wait_for_disconnect_without_awaiting_connected(screen: Screen):
         await ui.context.client.disconnected()
         events.append('disconnected')
 
-    screen.open('/')
-    screen.wait(0.5)
-    screen.open('/')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
     assert events == ['disconnected']
 
 
-def test_adding_elements_after_connected(screen: Screen):
+def test_adding_elements_after_connected(shared_screen: SharedScreen):
     @ui.page('/')
     async def page():
         ui.label('before')
         await ui.context.client.connected()
         ui.label('after')
 
-    screen.open('/')
-    screen.should_contain('before')
-    screen.should_contain('after')
+    shared_screen.open('/')
+    shared_screen.should_contain('before')
+    shared_screen.should_contain('after')
 
 
-def test_exception(screen: Screen):
+def test_exception(shared_screen: SharedScreen):
     exceptions = []
 
     @ui.page('/')
@@ -141,15 +141,15 @@ def test_exception(screen: Screen):
         ui.on_exception(exceptions.append)
         raise RuntimeError('some exception')
 
-    screen.allowed_js_errors.append('/ - Failed to load resource')
-    screen.open('/')
-    screen.should_contain('500')
-    screen.should_contain('Server error')
-    screen.assert_py_logger('ERROR', 'some exception')
+    shared_screen.allowed_js_errors.append('/ - Failed to load resource')
+    shared_screen.open('/')
+    shared_screen.should_contain('500')
+    shared_screen.should_contain('Server error')
+    shared_screen.assert_py_logger('ERROR', 'some exception')
     assert not exceptions, 'ui.on_exception is for in-page exceptions (after page sent to browser)'
 
 
-def test_exception_after_connected(screen: Screen):
+def test_exception_after_connected(shared_screen: SharedScreen):
     exceptions = []
 
     @ui.page('/')
@@ -159,42 +159,43 @@ def test_exception_after_connected(screen: Screen):
         ui.label('this is shown')
         raise RuntimeError('some exception')
 
-    screen.open('/')
-    screen.should_contain('this is shown')
-    screen.assert_py_logger('ERROR', 'some exception')
+    shared_screen.open('/')
+    shared_screen.should_contain('this is shown')
+    shared_screen.assert_py_logger('ERROR', 'some exception')
     assert exceptions, 'in-page exception should be caught by ui.on_exception'
 
 
-def test_api_exception(screen: Screen):
+def test_api_exception(shared_screen: SharedScreen):
     @app.get('/')
     def api_exception():
         raise RuntimeError('some exception in a GET endpoint')
 
-    screen.allowed_js_errors.append('/ - Failed to load resource')
-    screen.open('/')
-    screen.should_contain('Internal Server Error')
+    shared_screen.allowed_js_errors.append('/ - Failed to load resource')
+    shared_screen.allowed_js_errors.append('/favicon.ico - Failed to load resource')
+    shared_screen.open('/')
+    shared_screen.should_contain('Internal Server Error')
 
 
-def test_page_with_args(screen: Screen):
+def test_page_with_args(shared_screen: SharedScreen):
     @ui.page('/page/{id_}')
     def page(id_: int):
         ui.label(f'Page {id_}')
 
-    screen.open('/page/42')
-    screen.should_contain('Page 42')
+    shared_screen.open('/page/42')
+    shared_screen.should_contain('Page 42')
 
 
-def test_adding_elements_during_onconnect(screen: Screen):
+def test_adding_elements_during_onconnect(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label('Label 1')
         ui.context.client.on_connect(lambda: ui.label('Label 2'))
 
-    screen.open('/')
-    screen.should_contain('Label 2')
+    shared_screen.open('/')
+    shared_screen.should_contain('Label 2')
 
 
-def test_async_connect_handler(screen: Screen):
+def test_async_connect_handler(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         async def run_js():
@@ -202,8 +203,8 @@ def test_async_connect_handler(screen: Screen):
         result = ui.label()
         ui.context.client.on_connect(run_js)
 
-    screen.open('/')
-    screen.should_contain('42')
+    shared_screen.open('/')
+    shared_screen.should_contain('42')
 
 
 @pytest.mark.parametrize('unocss', [None, 'mini', 'wind3', 'wind4'])
@@ -240,7 +241,7 @@ def test_dark_mode(screen: Screen, unocss: Literal['mini', 'wind3', 'wind4'] | N
     assert screen.find_by_tag('body').value_of_css_property('background-color') == black
 
 
-def test_returning_custom_response(screen: Screen):
+def test_returning_custom_response(shared_screen: SharedScreen):
     @ui.page('/')
     def page(plain: bool = False):
         if plain:
@@ -248,15 +249,16 @@ def test_returning_custom_response(screen: Screen):
         else:
             ui.label('normal NiceGUI page')
 
-    screen.open('/')
-    screen.should_contain('normal NiceGUI page')
-    screen.should_not_contain('custom response')
-    screen.open('/?plain=true')
-    screen.should_contain('custom response')
-    screen.should_not_contain('normal NiceGUI page')
+    shared_screen.allowed_js_errors.append('/favicon.ico - Failed to load resource')
+    shared_screen.open('/')
+    shared_screen.should_contain('normal NiceGUI page')
+    shared_screen.should_not_contain('custom response')
+    shared_screen.open('/?plain=true')
+    shared_screen.should_contain('custom response')
+    shared_screen.should_not_contain('normal NiceGUI page')
 
 
-def test_returning_custom_response_async(screen: Screen):
+def test_returning_custom_response_async(shared_screen: SharedScreen):
     @ui.page('/')
     async def page(plain: bool = False):
         await asyncio.sleep(0.01)  # simulates a db request or similar
@@ -265,50 +267,51 @@ def test_returning_custom_response_async(screen: Screen):
         else:
             ui.label('normal NiceGUI page')
 
-    screen.open('/')
-    screen.should_contain('normal NiceGUI page')
-    screen.should_not_contain('custom response')
-    screen.open('/?plain=true')
-    screen.should_contain('custom response')
-    screen.should_not_contain('normal NiceGUI page')
+    shared_screen.allowed_js_errors.append('/favicon.ico - Failed to load resource')
+    shared_screen.open('/')
+    shared_screen.should_contain('normal NiceGUI page')
+    shared_screen.should_not_contain('custom response')
+    shared_screen.open('/?plain=true')
+    shared_screen.should_contain('custom response')
+    shared_screen.should_not_contain('normal NiceGUI page')
 
 
-def test_warning_about_to_late_responses(screen: Screen):
+def test_warning_about_to_late_responses(shared_screen: SharedScreen):
     @ui.page('/')
     async def page():
         await ui.context.client.connected()
         ui.label('NiceGUI page')
         return PlainTextResponse('custom response')
 
-    screen.open('/')
-    screen.should_contain('NiceGUI page')
-    screen.assert_py_logger('ERROR', re.compile('it was returned after the HTML had been delivered to the client'))
+    shared_screen.open('/')
+    shared_screen.should_contain('NiceGUI page')
+    shared_screen.assert_py_logger('ERROR', re.compile('it was returned after the HTML had been delivered to the client'))
 
 
-def test_reconnecting_without_page_reload(screen: Screen):
+def test_reconnecting_without_page_reload(shared_screen: SharedScreen):
     @ui.page('/', reconnect_timeout=3.0)
     def page():
         ui.input('Input').props('autofocus')
         ui.button('drop connection', on_click=lambda: ui.run_javascript('socket.io.engine.close()'))
 
-    screen.open('/')
-    screen.type('hello')
-    screen.click('drop connection')
-    screen.wait(2.0)
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
+    shared_screen.open('/')
+    shared_screen.type('hello')
+    shared_screen.click('drop connection')
+    shared_screen.wait(2.0)
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
     assert element.get_attribute('value') == 'hello', 'input should be preserved after reconnect (i.e. no page reload)'
 
 
-def test_ip(screen: Screen):
+def test_ip(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label(ui.context.client.ip or 'unknown')
 
-    screen.open('/')
-    screen.should_contain('127.0.0.1')
+    shared_screen.open('/')
+    shared_screen.should_contain('127.0.0.1')
 
 
-def test_multicast(screen: Screen):
+def test_multicast(shared_screen: SharedScreen):
     def update():
         for client in app.clients('/'):
             with client:
@@ -318,21 +321,21 @@ def test_multicast(screen: Screen):
     def page():
         ui.button('add label', on_click=update)
 
-    screen.open('/')
-    screen.switch_to(1)
-    screen.open('/')
-    screen.click('add label')
-    screen.should_contain('added')
-    screen.switch_to(0)
-    screen.should_contain('added')
+    shared_screen.open('/')
+    shared_screen.switch_to(1)
+    shared_screen.open('/')
+    shared_screen.click('add label')
+    shared_screen.should_contain('added')
+    shared_screen.switch_to(0)
+    shared_screen.should_contain('added')
 
 
-def test_warning_if_response_takes_too_long(screen: Screen):
+def test_warning_if_response_takes_too_long(shared_screen: SharedScreen):
     @ui.page('/', response_timeout=0.5)
     async def page():
         await asyncio.sleep(1)
         ui.label('all done')
 
-    screen.allowed_js_errors.append('/ - Failed to load resource')
-    screen.open('/')
-    screen.assert_py_logger('WARNING', re.compile('Response for / not ready after 0.5 seconds'))
+    shared_screen.allowed_js_errors.append('/ - Failed to load resource')
+    shared_screen.open('/')
+    shared_screen.assert_py_logger('WARNING', re.compile('Response for / not ready after 0.5 seconds'))

--- a/tests/test_page_title.py
+++ b/tests/test_page_title.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_page_title(screen: Screen):
+def test_page_title(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.page_title('Initial title')
@@ -12,14 +12,14 @@ def test_page_title(screen: Screen):
     def page_with_title(title: str):
         ui.page_title(f'Title: {title}')
 
-    screen.open('/')
-    screen.wait(0.5)
-    screen.should_contain('Initial title')
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Initial title')
 
-    screen.click('Change title')
-    screen.wait(0.5)
-    screen.should_contain('"New title"')
+    shared_screen.click('Change title')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('"New title"')
 
-    screen.open('/test')
-    screen.wait(0.5)
-    screen.should_contain('Title: test')
+    shared_screen.open('/test')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Title: test')

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,21 +1,21 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_pagination(screen: Screen):
+def test_pagination(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         p = ui.pagination(1, 10, direction_links=True)
         ui.label().bind_text_from(p, 'value', lambda v: f'Page {v}')
 
-    screen.open('/')
-    screen.should_contain('Page 1')
+    shared_screen.open('/')
+    shared_screen.should_contain('Page 1')
 
-    screen.click('7')
-    screen.should_contain('Page 7')
+    shared_screen.click('7')
+    shared_screen.should_contain('Page 7')
 
-    screen.click('keyboard_arrow_left')
-    screen.should_contain('Page 6')
+    shared_screen.click('keyboard_arrow_left')
+    shared_screen.should_contain('Page 6')
 
-    screen.click('keyboard_arrow_right')
-    screen.should_contain('Page 7')
+    shared_screen.click('keyboard_arrow_right')
+    shared_screen.should_contain('Page 7')

--- a/tests/test_plotly.py
+++ b/tests/test_plotly.py
@@ -2,10 +2,10 @@ import numpy as np
 import plotly.graph_objects as go
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_plotly(screen: Screen):
+def test_plotly(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         fig = go.Figure(go.Scatter(x=[1, 2, 3], y=[1, 2, 3], name='Trace 1'))
@@ -18,15 +18,15 @@ def test_plotly(screen: Screen):
             plot.update()
         ))
 
-    screen.open('/')
-    screen.should_contain('Test Figure')
+    shared_screen.open('/')
+    shared_screen.should_contain('Test Figure')
 
-    screen.click('Add trace')
-    screen.should_contain('Trace 1')
-    screen.should_contain('Trace 2')
+    shared_screen.click('Add trace')
+    shared_screen.should_contain('Trace 1')
+    shared_screen.should_contain('Trace 2')
 
 
-def test_replace_plotly(screen: Screen):
+def test_replace_plotly(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.row() as container:
@@ -37,19 +37,19 @@ def test_replace_plotly(screen: Screen):
                 ui.plotly(go.Figure(go.Scatter(x=[1], y=[1], text=['B'], mode='text')))
         ui.button('Replace', on_click=replace)
 
-    screen.open('/')
-    assert screen.find_by_tag('text').text == 'A'
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('text').text == 'A'
 
-    screen.click('Replace')
-    screen.wait(0.5)
-    assert screen.find_by_tag('text').text == 'B'
+    shared_screen.click('Replace')
+    shared_screen.wait(0.5)
+    assert shared_screen.find_by_tag('text').text == 'B'
 
 
-def test_create_dynamically(screen: Screen):
+def test_create_dynamically(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('Create', on_click=lambda: ui.plotly(go.Figure(go.Scatter(x=[], y=[]))))
 
-    screen.open('/')
-    screen.click('Create')
-    assert screen.find_by_tag('svg')
+    shared_screen.open('/')
+    shared_screen.click('Create')
+    assert shared_screen.find_by_tag('svg')

--- a/tests/test_quasar_tailwind_interplay.py
+++ b/tests/test_quasar_tailwind_interplay.py
@@ -4,16 +4,16 @@ import numpy as np
 from PIL import Image
 
 from nicegui import ui
-from nicegui.testing.screen import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_rotate(screen: Screen, tmp_path: Path) -> None:
+def test_rotate(shared_screen: SharedScreen, tmp_path: Path) -> None:
     @ui.page('/')
     def main():
         ui.icon('sym_o_wifi_1_bar').classes('rotate-90')
 
-    screen.open('/')
-    screen.find_by_tag('i').screenshot(str(tmp_path / 'icon.png'))
+    shared_screen.open('/')
+    shared_screen.find_by_tag('i').screenshot(str(tmp_path / 'icon.png'))
     img = np.array(Image.open(tmp_path / 'icon.png').convert('L'))
     left_black = (img[:, :img.shape[1] // 2] < 128).sum()
     right_black = (img[:, img.shape[1] // 2:] < 128).sum()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_query_body(screen: Screen):
+def test_query_body(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label('Hello')
@@ -15,56 +15,56 @@ def test_query_body(screen: Screen):
         ui.button('Data X = 2', on_click=lambda: ui.query('body').props('data-x=2'))
 
     def get_bg_classes() -> list[str]:
-        return [c for c in (screen.find_by_tag('body').get_attribute('class') or '').split() if c.startswith('bg-')]
+        return [c for c in (shared_screen.find_by_tag('body').get_attribute('class') or '').split() if c.startswith('bg-')]
 
-    screen.open('/')
-    screen.should_contain('Hello')
+    shared_screen.open('/')
+    shared_screen.should_contain('Hello')
     assert get_bg_classes() == ['bg-orange-100']
 
-    screen.click('Red background')
-    screen.wait(0.5)
+    shared_screen.click('Red background')
+    shared_screen.wait(0.5)
     assert get_bg_classes() == ['bg-red-100']
 
-    screen.click('Blue background')
-    screen.wait(0.5)
+    shared_screen.click('Blue background')
+    shared_screen.wait(0.5)
     assert get_bg_classes() == ['bg-blue-100']
 
-    screen.click('Small padding')
-    screen.wait(0.5)
-    assert screen.find_by_tag('body').value_of_css_property('padding') == '1px'
+    shared_screen.click('Small padding')
+    shared_screen.wait(0.5)
+    assert shared_screen.find_by_tag('body').value_of_css_property('padding') == '1px'
 
-    screen.click('Large padding')
-    screen.wait(0.5)
-    assert screen.find_by_tag('body').value_of_css_property('padding') == '10px'
+    shared_screen.click('Large padding')
+    shared_screen.wait(0.5)
+    assert shared_screen.find_by_tag('body').value_of_css_property('padding') == '10px'
 
-    screen.click('Data X = 1')
-    screen.wait(0.5)
-    assert screen.find_by_tag('body').get_attribute('data-x') == '1'
+    shared_screen.click('Data X = 1')
+    shared_screen.wait(0.5)
+    assert shared_screen.find_by_tag('body').get_attribute('data-x') == '1'
 
-    screen.click('Data X = 2')
-    screen.wait(0.5)
-    assert screen.find_by_tag('body').get_attribute('data-x') == '2'
+    shared_screen.click('Data X = 2')
+    shared_screen.wait(0.5)
+    assert shared_screen.find_by_tag('body').get_attribute('data-x') == '2'
 
 
-def test_query_multiple_divs(screen: Screen):
+def test_query_multiple_divs(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label('A')
         ui.label('B')
         ui.button('Add border', on_click=lambda: ui.query('div').style('border: 1px solid black'))
 
-    screen.open('/')
-    screen.click('Add border')
-    screen.wait(0.5)
-    assert screen.find('A').value_of_css_property('border') == '1px solid rgb(0, 0, 0)'
-    assert screen.find('B').value_of_css_property('border') == '1px solid rgb(0, 0, 0)'
+    shared_screen.open('/')
+    shared_screen.click('Add border')
+    shared_screen.wait(0.5)
+    assert shared_screen.find('A').value_of_css_property('border') == '1px solid rgb(0, 0, 0)'
+    assert shared_screen.find('B').value_of_css_property('border') == '1px solid rgb(0, 0, 0)'
 
 
-def test_query_with_css_variables(screen: Screen):
+def test_query_with_css_variables(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.add_body_html('<div id="element">Test</div>')
         ui.query('#element').style('--color: red; color: var(--color)')
 
-    screen.open('/')
-    assert screen.find('Test').value_of_css_property('color') == 'rgba(255, 0, 0, 1)'
+    shared_screen.open('/')
+    assert shared_screen.find('Test').value_of_css_property('color') == 'rgba(255, 0, 0, 1)'

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1,25 +1,25 @@
 from nicegui import ui
-from nicegui.testing import Screen, User
+from nicegui.testing import SharedScreen, User
 
 
-def test_radio_click(screen: Screen):
+def test_radio_click(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         radio = ui.radio(['A', 'B', 'C'])
         ui.label().bind_text_from(radio, 'value', lambda x: f'Value: {x}')
 
-    screen.open('/')
-    screen.click('A')
-    screen.should_contain('Value: A')
-    screen.click('B')
-    screen.should_contain('Value: B')
+    shared_screen.open('/')
+    shared_screen.click('A')
+    shared_screen.should_contain('Value: A')
+    shared_screen.click('B')
+    shared_screen.should_contain('Value: B')
 
-    screen.click('B')  # already selected, should not change
-    screen.wait(0.5)
-    screen.should_contain('Value: B')
+    shared_screen.click('B')  # already selected, should not change
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('Value: B')
 
 
-def test_radio_set_value(screen: Screen):
+def test_radio_set_value(shared_screen: SharedScreen):
     radio = None
 
     @ui.page('/')
@@ -28,12 +28,12 @@ def test_radio_set_value(screen: Screen):
         radio = ui.radio(['A', 'B', 'C'])
         ui.label().bind_text_from(radio, 'value', lambda x: f'Value: {x}')
 
-    screen.open('/')
+    shared_screen.open('/')
     radio.set_value('B')
-    screen.should_contain('Value: B')
+    shared_screen.should_contain('Value: B')
 
 
-def test_radio_set_options(screen: Screen):
+def test_radio_set_options(shared_screen: SharedScreen):
     radio = None
 
     @ui.page('/')
@@ -45,29 +45,29 @@ def test_radio_set_options(screen: Screen):
         ui.button('reverse', on_click=lambda: (radio.options.reverse(), radio.update()))  # type: ignore
         ui.button('clear', on_click=lambda: (radio.options.clear(), radio.update()))  # type: ignore
 
-    screen.open('/')
+    shared_screen.open('/')
     radio.set_options(['C', 'D', 'E'])
-    screen.should_contain('D')
-    screen.should_contain('E')
-    screen.should_contain('Value: C')
+    shared_screen.should_contain('D')
+    shared_screen.should_contain('E')
+    shared_screen.should_contain('Value: C')
 
     radio.set_options(['X', 'Y', 'Z'])
-    screen.should_contain('X')
-    screen.should_contain('Y')
-    screen.should_contain('Z')
-    screen.should_contain('Value: None')
-    screen.should_contain('Event: None')
+    shared_screen.should_contain('X')
+    shared_screen.should_contain('Y')
+    shared_screen.should_contain('Z')
+    shared_screen.should_contain('Value: None')
+    shared_screen.should_contain('Event: None')
 
     radio.set_options(['1', '2', '3'], value='3')
-    screen.should_contain('Value: 3')
-    screen.should_contain('Event: 3')
+    shared_screen.should_contain('Value: 3')
+    shared_screen.should_contain('Event: 3')
 
-    screen.click('reverse')
-    screen.should_contain('Value: 3')
-    screen.should_contain('Event: 3')
+    shared_screen.click('reverse')
+    shared_screen.should_contain('Value: 3')
+    shared_screen.should_contain('Event: 3')
 
-    screen.click('clear')
-    screen.should_contain('Value: None')
+    shared_screen.click('clear')
+    shared_screen.should_contain('Value: None')
 
 
 async def test_radio_click_with_user(user: User):

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -1,22 +1,22 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_range(screen: Screen):
+def test_range(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         r = ui.range(min=0, max=100, value={'min': 20, 'max': 80})
         ui.label().bind_text_from(r, 'value', backward=lambda v: f'min: {v["min"]}, max: {v["max"]}')
 
-    screen.open('/')
-    screen.should_contain('min: 20, max: 80')
+    shared_screen.open('/')
+    shared_screen.should_contain('min: 20, max: 80')
 
 
-def test_range_no_value(screen: Screen):
+def test_range_no_value(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         r = ui.range(min=0, max=100)
         ui.label().bind_text_from(r, 'value', backward=lambda v: f'min: {v["min"]}, max: {v["max"]}')
 
-    screen.open('/')
-    screen.should_contain('min: 0, max: 100')
+    shared_screen.open('/')
+    shared_screen.should_contain('min: 0, max: 100')

--- a/tests/test_rating.py
+++ b/tests/test_rating.py
@@ -1,20 +1,20 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_rating_click(screen: Screen):
+def test_rating_click(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         rating = ui.rating(value=2)
         ui.label().bind_text_from(rating, 'value', lambda x: f'Value: {x}')
 
-    screen.open('/')
-    rating_icons = screen.find_all_by_class('q-rating__icon-container')
+    shared_screen.open('/')
+    rating_icons = shared_screen.find_all_by_class('q-rating__icon-container')
     rating_icons[0].click()
-    screen.should_contain('Value: 1')
+    shared_screen.should_contain('Value: 1')
 
     rating_icons[3].click()
-    screen.should_contain('Value: 4')
+    shared_screen.should_contain('Value: 4')
 
     rating_icons[3].click()  # already selected, should unselect
-    screen.should_contain('Value: 0')
+    shared_screen.should_contain('Value: 0')

--- a/tests/test_refreshable.py
+++ b/tests/test_refreshable.py
@@ -1,10 +1,10 @@
 import asyncio
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_refreshable(screen: Screen) -> None:
+def test_refreshable(shared_screen: SharedScreen) -> None:
     numbers = []
 
     @ui.refreshable
@@ -16,23 +16,23 @@ def test_refreshable(screen: Screen) -> None:
         number_ui()
         ui.button('Refresh', on_click=number_ui.refresh)
 
-    screen.open('/')
-    screen.should_contain('[]')
+    shared_screen.open('/')
+    shared_screen.should_contain('[]')
 
     numbers.append(1)
-    screen.click('Refresh')
-    screen.should_contain('[1]')
+    shared_screen.click('Refresh')
+    shared_screen.should_contain('[1]')
 
     numbers.append(2)
-    screen.click('Refresh')
-    screen.should_contain('[1, 2]')
+    shared_screen.click('Refresh')
+    shared_screen.should_contain('[1, 2]')
 
     numbers.clear()
-    screen.click('Refresh')
-    screen.should_contain('[]')
+    shared_screen.click('Refresh')
+    shared_screen.should_contain('[]')
 
 
-def test_async_refreshable(screen: Screen) -> None:
+def test_async_refreshable(shared_screen: SharedScreen) -> None:
     numbers = []
 
     @ui.refreshable
@@ -46,25 +46,25 @@ def test_async_refreshable(screen: Screen) -> None:
             await number_ui()
         ui.button('Refresh', on_click=number_ui.refresh)
 
-    screen.open('/')
-    screen.should_contain('[]')
+    shared_screen.open('/')
+    shared_screen.should_contain('[]')
 
     numbers.append(1)
-    screen.click('Refresh')
-    screen.should_contain('[1]')
-    screen.should_not_contain('[]')  # ensure bug #863 is fixed
+    shared_screen.click('Refresh')
+    shared_screen.should_contain('[1]')
+    shared_screen.should_not_contain('[]')  # ensure bug #863 is fixed
 
     numbers.append(2)
-    screen.click('Refresh')
-    screen.should_contain('[1, 2]')
-    screen.should_not_contain('[]')
+    shared_screen.click('Refresh')
+    shared_screen.should_contain('[1, 2]')
+    shared_screen.should_not_contain('[]')
 
     numbers.clear()
-    screen.click('Refresh')
-    screen.should_contain('[]')
+    shared_screen.click('Refresh')
+    shared_screen.should_contain('[]')
 
 
-def test_multiple_targets(screen: Screen) -> None:
+def test_multiple_targets(shared_screen: SharedScreen) -> None:
     count = 0
 
     class MyClass:
@@ -92,20 +92,20 @@ def test_multiple_targets(screen: Screen) -> None:
         b = MyClass('B')
         b.create_ui()
 
-    screen.open('/')
-    screen.should_contain('A = 1 (1)')
-    screen.should_contain('B = 1 (2)')
+    shared_screen.open('/')
+    shared_screen.should_contain('A = 1 (1)')
+    shared_screen.should_contain('B = 1 (2)')
 
-    screen.click('increment A')
-    screen.should_contain('A = 2 (3)')
-    screen.should_contain('B = 1 (2)')
+    shared_screen.click('increment A')
+    shared_screen.should_contain('A = 2 (3)')
+    shared_screen.should_contain('B = 1 (2)')
 
-    screen.click('increment B')
-    screen.should_contain('A = 2 (3)')
-    screen.should_contain('B = 2 (4)')
+    shared_screen.click('increment B')
+    shared_screen.should_contain('A = 2 (3)')
+    shared_screen.should_contain('B = 2 (4)')
 
 
-def test_refresh_with_arguments(screen: Screen):
+def test_refresh_with_arguments(shared_screen: SharedScreen):
     count = 0
 
     @ui.refreshable
@@ -123,28 +123,28 @@ def test_refresh_with_arguments(screen: Screen):
         ui.button('refresh(2)', on_click=lambda: some_ui.refresh(2))
         ui.button('refresh(value=3)', on_click=lambda: some_ui.refresh(value=3))
 
-    screen.open('/')
-    screen.should_contain('count=1, value=0')
+    shared_screen.open('/')
+    shared_screen.should_contain('count=1, value=0')
 
-    screen.click('refresh')
-    screen.should_contain('count=2, value=0')
+    shared_screen.click('refresh')
+    shared_screen.should_contain('count=2, value=0')
 
-    screen.click('refresh()')
-    screen.should_contain('count=3, value=0')
+    shared_screen.click('refresh()')
+    shared_screen.should_contain('count=3, value=0')
 
-    screen.click('refresh(1)')
-    screen.should_contain('count=4, value=1')
+    shared_screen.click('refresh(1)')
+    shared_screen.should_contain('count=4, value=1')
 
-    screen.click('refresh(2)')
-    screen.should_contain('count=5, value=2')
+    shared_screen.click('refresh(2)')
+    shared_screen.should_contain('count=5, value=2')
 
-    screen.click('refresh(value=3)')
-    screen.wait(0.5)
-    screen.assert_py_logger(
+    shared_screen.click('refresh(value=3)')
+    shared_screen.wait(0.5)
+    shared_screen.assert_py_logger(
         'ERROR', "'value' needs to be consistently passed to some_ui() either as positional or as keyword argument")
 
 
-def test_refresh_deleted_element(screen: Screen):
+def test_refresh_deleted_element(shared_screen: SharedScreen):
     @ui.refreshable
     def some_ui():
         ui.label('some text')
@@ -159,14 +159,14 @@ def test_refresh_deleted_element(screen: Screen):
 
         some_ui()
 
-    screen.open('/')
-    screen.should_contain('some text')
+    shared_screen.open('/')
+    shared_screen.should_contain('some text')
 
-    screen.click('Clear')
-    screen.click('Refresh')
+    shared_screen.click('Clear')
+    shared_screen.click('Refresh')
 
 
-def test_refresh_with_function_reference(screen: Screen):
+def test_refresh_with_function_reference(shared_screen: SharedScreen):
     # https://github.com/zauberzeug/nicegui/issues/1283
     class Test:
 
@@ -186,16 +186,16 @@ def test_refresh_with_function_reference(screen: Screen):
         Test('A')
         Test('B')
 
-    screen.open('/')
-    screen.should_contain('Refreshing A (0)')
-    screen.should_contain('Refreshing B (0)')
-    screen.click('A')
-    screen.should_contain('Refreshing A (1)')
-    screen.click('B')
-    screen.should_contain('Refreshing B (1)')
+    shared_screen.open('/')
+    shared_screen.should_contain('Refreshing A (0)')
+    shared_screen.should_contain('Refreshing B (0)')
+    shared_screen.click('A')
+    shared_screen.should_contain('Refreshing A (1)')
+    shared_screen.click('B')
+    shared_screen.should_contain('Refreshing B (1)')
 
 
-def test_refreshable_with_state(screen: Screen):
+def test_refreshable_with_state(shared_screen: SharedScreen):
     @ui.refreshable
     def counter(title: str):
         count, set_count = ui.state(0)
@@ -207,22 +207,22 @@ def test_refreshable_with_state(screen: Screen):
         counter('A')
         counter('B')
 
-    screen.open('/')
-    screen.should_contain('A: 0')
-    screen.should_contain('B: 0')
+    shared_screen.open('/')
+    shared_screen.should_contain('A: 0')
+    shared_screen.should_contain('B: 0')
 
-    screen.click('Increment A')
-    screen.wait(0.5)
-    screen.should_contain('A: 1')
-    screen.should_contain('B: 0')
+    shared_screen.click('Increment A')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('A: 1')
+    shared_screen.should_contain('B: 0')
 
-    screen.click('Increment B')
-    screen.wait(0.5)
-    screen.should_contain('A: 1')
-    screen.should_contain('B: 1')
+    shared_screen.click('Increment B')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('A: 1')
+    shared_screen.should_contain('B: 1')
 
 
-def test_refreshable_with_return_value(screen: Screen):
+def test_refreshable_with_return_value(shared_screen: SharedScreen):
     @ui.refreshable
     def number_ui() -> int:
         ui.label('42')
@@ -233,11 +233,11 @@ def test_refreshable_with_return_value(screen: Screen):
         answer = number_ui()
         assert answer == 42
 
-    screen.open('/')
-    screen.should_contain('42')
+    shared_screen.open('/')
+    shared_screen.should_contain('42')
 
 
-def test_awaitable_refresh(screen: Screen):
+def test_awaitable_refresh(shared_screen: SharedScreen):
     events = []
 
     @ui.refreshable
@@ -262,16 +262,16 @@ def test_awaitable_refresh(screen: Screen):
         ui.button('Try 2', on_click=lambda: update(2))
         ui.button('Try 0', on_click=lambda: update(0))
 
-    screen.open('/')
-    screen.should_contain('1 / 1 = 1.0')
+    shared_screen.open('/')
+    shared_screen.should_contain('1 / 1 = 1.0')
     assert events == ['refresh started', 'refresh finished']
 
     events.clear()
-    screen.click('Try 2')
-    screen.should_contain('1 / 2 = 0.5')
+    shared_screen.click('Try 2')
+    shared_screen.should_contain('1 / 2 = 0.5')
     assert events == ['update started', 'refresh started', 'refresh finished', 'update finished']
 
     events.clear()
-    screen.click('Try 0')
-    screen.should_contain('error handled')
+    shared_screen.click('Try 0')
+    shared_screen.should_contain('error handled')
     assert events == ['update started', 'refresh started', 'refresh failed', 'update finished']

--- a/tests/test_restructured_text.py
+++ b/tests/test_restructured_text.py
@@ -1,19 +1,19 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_restructured_text(screen: Screen):
+def test_restructured_text(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         rst = ui.restructured_text('This is **reStructuredText**')
         ui.button('Set new content', on_click=lambda: rst.set_content('New **content**'))
 
-    screen.open('/')
-    element = screen.find('This is')
+    shared_screen.open('/')
+    element = shared_screen.find('This is')
     assert element.text == 'This is reStructuredText'
     assert element.get_attribute('innerHTML') == 'This is <strong>reStructuredText</strong>'
 
-    screen.click('Set new content')
-    element = screen.find('New')
+    shared_screen.click('Set new content')
+    element = shared_screen.find('New')
     assert element.text == 'New content'
     assert element.get_attribute('innerHTML') == 'New <strong>content</strong>'

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -5,12 +5,12 @@ from selenium.common.exceptions import JavascriptException
 
 from nicegui import app, ui
 from nicegui.elements.scene import Object3D
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 from .test_helpers import TEST_DIR
 
 
-def test_moving_sphere_with_timer(screen: Screen):
+def test_moving_sphere_with_timer(shared_screen: SharedScreen):
     scene = None
 
     @ui.page('/')
@@ -20,25 +20,25 @@ def test_moving_sphere_with_timer(screen: Screen):
             sphere = scene.sphere().with_name('sphere')
             ui.timer(0.1, lambda: sphere.move(0, 0, sphere.z + 0.01))
 
-    screen.open('/')
+    shared_screen.open('/')
 
     def position() -> float:
         for _ in range(3):
             try:
-                pos = screen.selenium.execute_script(
+                pos = shared_screen.selenium.execute_script(
                     f'return scene_{scene.html_id}.getObjectByName("sphere").position.z')
                 if pos is not None:
                     return pos
             except JavascriptException as e:
                 print(e.msg, flush=True)
-            screen.wait(1.0)
+            shared_screen.wait(1.0)
         raise RuntimeError('Could not get position')
 
-    screen.wait(0.2)
+    shared_screen.wait(0.2)
     assert position() > 0
 
 
-def test_no_object_duplication_on_index_client(screen: Screen):
+def test_no_object_duplication_on_index_client(shared_screen: SharedScreen):
     scene = None
 
     @ui.page('/')
@@ -48,16 +48,16 @@ def test_no_object_duplication_on_index_client(screen: Screen):
             sphere = scene.sphere().move(0, -4, 0)
             ui.timer(0.1, lambda: sphere.move(0, sphere.y + 0.5, 0))
 
-    screen.open('/')
-    screen.wait(0.4)
-    screen.switch_to(1)
-    screen.open('/')
-    screen.switch_to(0)
-    screen.wait(0.2)
-    assert screen.selenium.execute_script(f'return scene_{scene.html_id}.children.length') == 5
+    shared_screen.open('/')
+    shared_screen.wait(0.4)
+    shared_screen.switch_to(1)
+    shared_screen.open('/')
+    shared_screen.switch_to(0)
+    shared_screen.wait(0.2)
+    assert shared_screen.selenium.execute_script(f'return scene_{scene.html_id}.children.length') == 5
 
 
-def test_no_object_duplication_with_page_builder(screen: Screen):
+def test_no_object_duplication_with_page_builder(shared_screen: SharedScreen):
     scene_html_ids: list[int] = []
 
     @ui.page('/')
@@ -67,19 +67,19 @@ def test_no_object_duplication_with_page_builder(screen: Screen):
             ui.timer(0.1, lambda: sphere.move(0, sphere.y + 0.5, 0))
         scene_html_ids.append(scene.html_id)
 
-    screen.open('/')
-    screen.wait(0.4)
-    screen.switch_to(1)
-    screen.open('/')
-    screen.switch_to(0)
-    screen.wait(0.2)
-    assert screen.selenium.execute_script(f'return scene_{scene_html_ids[0]}.children.length') == 5
-    screen.switch_to(1)
-    screen.wait(0.2)
-    assert screen.selenium.execute_script(f'return scene_{scene_html_ids[1]}.children.length') == 5
+    shared_screen.open('/')
+    shared_screen.wait(0.4)
+    shared_screen.switch_to(1)
+    shared_screen.open('/')
+    shared_screen.switch_to(0)
+    shared_screen.wait(0.2)
+    assert shared_screen.selenium.execute_script(f'return scene_{scene_html_ids[0]}.children.length') == 5
+    shared_screen.switch_to(1)
+    shared_screen.wait(0.2)
+    assert shared_screen.selenium.execute_script(f'return scene_{scene_html_ids[1]}.children.length') == 5
 
 
-def test_deleting_group(screen: Screen):
+def test_deleting_group(shared_screen: SharedScreen):
     scene = None
 
     @ui.page('/')
@@ -90,15 +90,15 @@ def test_deleting_group(screen: Screen):
                 scene.sphere()
         ui.button('Delete group', on_click=group.delete)
 
-    screen.open('/')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
     assert len(scene.objects) == 2
-    screen.click('Delete group')
-    screen.wait(0.5)
+    shared_screen.click('Delete group')
+    shared_screen.wait(0.5)
     assert len(scene.objects) == 0
 
 
-def test_replace_scene(screen: Screen):
+def test_replace_scene(shared_screen: SharedScreen):
     scene = None
 
     @ui.page('/')
@@ -115,23 +115,23 @@ def test_replace_scene(screen: Screen):
                     scene.box().with_name('box')
         ui.button('Replace scene', on_click=replace)
 
-    screen.open('/')
-    screen.wait(0.5)
-    assert screen.selenium.execute_script(f'return scene_{scene.html_id}.children[4].name') == 'sphere'
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
+    assert shared_screen.selenium.execute_script(f'return scene_{scene.html_id}.children[4].name') == 'sphere'
 
-    screen.click('Replace scene')
-    screen.wait(0.5)
-    assert screen.selenium.execute_script(f'return scene_{scene.html_id}.children[4].name') == 'box'
+    shared_screen.click('Replace scene')
+    shared_screen.wait(0.5)
+    assert shared_screen.selenium.execute_script(f'return scene_{scene.html_id}.children[4].name') == 'box'
 
 
-def test_create_dynamically(screen: Screen):
+def test_create_dynamically(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.button('Create', on_click=ui.scene)
 
-    screen.open('/')
-    screen.click('Create')
-    assert screen.find_by_tag('canvas')
+    shared_screen.open('/')
+    shared_screen.click('Create')
+    assert shared_screen.find_by_tag('canvas')
 
 
 def test_rotation_matrix_from_euler():
@@ -143,7 +143,7 @@ def test_rotation_matrix_from_euler():
     assert np.allclose(Object3D.rotation_matrix_from_euler(omega, phi, kappa), R)
 
 
-def test_object_creation_via_context(screen: Screen):
+def test_object_creation_via_context(shared_screen: SharedScreen):
     scene = None
 
     @ui.page('/')
@@ -152,12 +152,12 @@ def test_object_creation_via_context(screen: Screen):
         with ui.scene() as scene:
             scene.box().with_name('box')
 
-    screen.open('/')
-    screen.wait(0.5)
-    assert screen.selenium.execute_script(f'return scene_{scene.html_id}.children[4].name') == 'box'
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
+    assert shared_screen.selenium.execute_script(f'return scene_{scene.html_id}.children[4].name') == 'box'
 
 
-def test_object_creation_via_attribute(screen: Screen):
+def test_object_creation_via_attribute(shared_screen: SharedScreen):
     scene = None
 
     @ui.page('/')
@@ -166,12 +166,12 @@ def test_object_creation_via_attribute(screen: Screen):
         scene = ui.scene()
         scene.box().with_name('box')
 
-    screen.open('/')
-    screen.wait(0.5)
-    assert screen.selenium.execute_script(f'return scene_{scene.html_id}.children[4].name') == 'box'
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
+    assert shared_screen.selenium.execute_script(f'return scene_{scene.html_id}.children[4].name') == 'box'
 
 
-def test_clearing_scene(screen: Screen):
+def test_clearing_scene(shared_screen: SharedScreen):
     scene = None
 
     @ui.page('/')
@@ -183,15 +183,15 @@ def test_clearing_scene(screen: Screen):
                 scene.box().with_name('box2')
         ui.button('Clear', on_click=scene.clear)
 
-    screen.open('/')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.wait(0.5)
     assert len(scene.objects) == 3
-    screen.click('Clear')
-    screen.wait(0.5)
+    shared_screen.click('Clear')
+    shared_screen.wait(0.5)
     assert len(scene.objects) == 0
 
 
-def test_gltf(screen: Screen):
+def test_gltf(shared_screen: SharedScreen):
     scene = None
 
     @ui.page('/')
@@ -201,12 +201,12 @@ def test_gltf(screen: Screen):
         with ui.scene() as scene:
             scene.gltf('/box.glb')
 
-    screen.open('/')
-    screen.wait(1.0)
-    assert screen.selenium.execute_script(f'return scene_{scene.html_id}.children.length') == 5
+    shared_screen.open('/')
+    shared_screen.wait(1.0)
+    assert shared_screen.selenium.execute_script(f'return scene_{scene.html_id}.children.length') == 5
 
 
-def test_no_cyclic_references(screen: Screen):
+def test_no_cyclic_references(shared_screen: SharedScreen):
     objects: weakref.WeakSet = weakref.WeakSet()
     scene = None
 
@@ -219,6 +219,6 @@ def test_no_cyclic_references(screen: Screen):
 
         ui.button('Clear', on_click=scene.clear)
 
-    screen.open('/')
-    screen.click('Clear')
+    shared_screen.open('/')
+    shared_screen.click('Clear')
     assert len(objects) == 0

--- a/tests/test_scene_view.py
+++ b/tests/test_scene_view.py
@@ -1,10 +1,10 @@
 import numpy as np
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_create_dynamically(screen: Screen):
+def test_create_dynamically(shared_screen: SharedScreen):
     scene = scene_view = None
 
     @ui.page('/')
@@ -17,14 +17,14 @@ def test_create_dynamically(screen: Screen):
             scene_view = ui.scene_view(scene)
         ui.button('Create', on_click=create)
 
-    screen.open('/')
-    screen.click('Create')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.click('Create')
+    shared_screen.wait(0.5)
     assert scene_view is not None
-    assert screen.selenium.execute_script(f'return getElement({scene_view.id}).scene == getElement({scene.id}).scene')
+    assert shared_screen.selenium.execute_script(f'return getElement({scene_view.id}).scene == getElement({scene.id}).scene')
 
 
-def test_object_creation_via_context(screen: Screen):
+def test_object_creation_via_context(shared_screen: SharedScreen):
     scene = scene_view = None
 
     @ui.page('/')
@@ -35,12 +35,12 @@ def test_object_creation_via_context(screen: Screen):
 
         scene_view = ui.scene_view(scene)
 
-    screen.open('/')
-    screen.wait(1)
-    assert screen.selenium.execute_script(f'return getElement({scene_view.id}).scene == getElement({scene.id}).scene')
+    shared_screen.open('/')
+    shared_screen.wait(1)
+    assert shared_screen.selenium.execute_script(f'return getElement({scene_view.id}).scene == getElement({scene.id}).scene')
 
 
-def test_camera_move(screen: Screen):
+def test_camera_move(shared_screen: SharedScreen):
     scene = scene_view = None
 
     @ui.page('/')
@@ -51,11 +51,11 @@ def test_camera_move(screen: Screen):
 
         scene_view = ui.scene_view(scene)
 
-    screen.open('/')
+    shared_screen.open('/')
 
-    screen.wait(0.5)
+    shared_screen.wait(0.5)
     scene_view.move_camera(x=1, y=2, z=3, look_at_x=4, look_at_y=5, look_at_z=6, up_x=7, up_y=8, up_z=9, duration=0.0)
 
-    screen.wait(1)
-    position = screen.selenium.execute_script(f'return getElement({scene_view.id}).camera_tween._object')
+    shared_screen.wait(1)
+    position = shared_screen.selenium.execute_script(f'return getElement({scene_view.id}).camera_tween._object')
     assert np.allclose(position, [1, 2, 3, 7, 8, 9, 4, 5, 6])

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -2,48 +2,48 @@ import pytest
 from selenium.webdriver import Keys
 
 from nicegui import ui
-from nicegui.testing import Screen, User
+from nicegui.testing import SharedScreen, User
 
 
-def test_select(screen: Screen):
+def test_select(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.select(['A', 'B', 'C'], value='A')
 
-    screen.open('/')
-    screen.should_contain('A')
-    screen.should_not_contain('B')
-    screen.should_not_contain('C')
+    shared_screen.open('/')
+    shared_screen.should_contain('A')
+    shared_screen.should_not_contain('B')
+    shared_screen.should_not_contain('C')
 
-    screen.click('A')  # open the dropdown
-    screen.click('B')  # close the dropdown
-    screen.wait(0.5)
-    screen.should_not_contain('A')
-    screen.should_contain('B')
-    screen.should_not_contain('C')
+    shared_screen.click('A')  # open the dropdown
+    shared_screen.click('B')  # close the dropdown
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('A')
+    shared_screen.should_contain('B')
+    shared_screen.should_not_contain('C')
 
 
-def test_select_with_input(screen: Screen):
+def test_select_with_input(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.select(['A', 'AB', 'XYZ'], with_input=True)
 
-    screen.open('/')
-    screen.find_by_tag('input').click()
-    screen.should_contain('XYZ')
+    shared_screen.open('/')
+    shared_screen.find_by_tag('input').click()
+    shared_screen.should_contain('XYZ')
 
-    screen.find_by_tag('input').send_keys('A')
-    screen.wait(0.5)
-    screen.should_contain('A')
-    screen.should_contain('AB')
-    screen.should_not_contain('XYZ')
+    shared_screen.find_by_tag('input').send_keys('A')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('A')
+    shared_screen.should_contain('AB')
+    shared_screen.should_not_contain('XYZ')
 
-    screen.find_by_tag('input').send_keys('ABC' + Keys.ENTER)
-    screen.find_by_tag('input').click()
-    screen.should_not_contain('ABC')
+    shared_screen.find_by_tag('input').send_keys('ABC' + Keys.ENTER)
+    shared_screen.find_by_tag('input').click()
+    shared_screen.should_not_contain('ABC')
 
 
-def test_replace_select(screen: Screen):
+def test_replace_select(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.row() as container:
@@ -54,31 +54,31 @@ def test_replace_select(screen: Screen):
                 ui.select(['B'], value='B')
         ui.button('Replace', on_click=replace)
 
-    screen.open('/')
-    screen.should_contain('A')
+    shared_screen.open('/')
+    shared_screen.should_contain('A')
 
-    screen.click('Replace')
-    screen.should_contain('B')
-    screen.should_not_contain('A')
+    shared_screen.click('Replace')
+    shared_screen.should_contain('B')
+    shared_screen.should_not_contain('A')
 
 
-def test_multi_select(screen: Screen):
+def test_multi_select(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         s = ui.select(['Alice', 'Bob', 'Carol'], value='Alice', multiple=True).props('use-chips')
         ui.label().bind_text_from(s, 'value', backward=str)
 
-    screen.open('/')
-    screen.should_contain("['Alice']")
-    screen.click('Alice')
-    screen.click('Bob')
-    screen.should_contain("['Alice', 'Bob']")
+    shared_screen.open('/')
+    shared_screen.should_contain("['Alice']")
+    shared_screen.click('Alice')
+    shared_screen.click('Bob')
+    shared_screen.should_contain("['Alice', 'Bob']")
 
-    screen.click('cancel')  # remove icon
-    screen.should_contain("['Bob']")
+    shared_screen.click('cancel')  # remove icon
+    shared_screen.should_contain("['Bob']")
 
 
-def test_changing_options(screen: Screen):
+def test_changing_options(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         s = ui.select([10, 20, 30], value=10)
@@ -86,30 +86,30 @@ def test_changing_options(screen: Screen):
         ui.button('reverse', on_click=lambda: (s.options.reverse(), s.update()))
         ui.button('clear', on_click=lambda: (s.options.clear(), s.update()))
 
-    screen.open('/')
-    screen.click('reverse')
-    screen.should_contain('value = 10')
-    screen.click('clear')
-    screen.should_contain('value = None')
+    shared_screen.open('/')
+    shared_screen.click('reverse')
+    shared_screen.should_contain('value = 10')
+    shared_screen.click('clear')
+    shared_screen.should_contain('value = None')
 
 
-def test_set_options(screen:  Screen):
+def test_set_options(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         s = ui.select([1, 2, 3], value=1)
         ui.button('Set new options', on_click=lambda: s.set_options([4, 5, 6], value=4))
 
-    screen.open('/')
-    screen.click('Set new options')
-    screen.click('4')
-    screen.should_contain('5')
-    screen.should_contain('6')
+    shared_screen.open('/')
+    shared_screen.click('Set new options')
+    shared_screen.click('4')
+    shared_screen.should_contain('5')
+    shared_screen.should_contain('6')
 
 
 @pytest.mark.parametrize('option_dict', [False, True])
 @pytest.mark.parametrize('multiple', [False, True])
 @pytest.mark.parametrize('new_value_mode', ['add', 'add-unique', 'toggle', None])
-def test_add_new_values(screen:  Screen, option_dict: bool, multiple: bool, new_value_mode: str | None):
+def test_add_new_values(shared_screen: SharedScreen, option_dict: bool, multiple: bool, new_value_mode: str | None):
     @ui.page('/')
     def page():
         options = {'a': 'A', 'b': 'B', 'c': 'C'} if option_dict else ['a', 'b', 'c']
@@ -117,118 +117,118 @@ def test_add_new_values(screen:  Screen, option_dict: bool, multiple: bool, new_
         ui.label().bind_text_from(s, 'value', lambda v: f'value = {v}')
         ui.label().bind_text_from(s, 'options', lambda v: f'options = {v}')
 
-    screen.open('/')
+    shared_screen.open('/')
     if option_dict and new_value_mode == 'add':
-        screen.allowed_js_errors.append('500 (Internal Server Error)')
-        screen.assert_py_logger('ERROR', 'new_value_mode "add" is not supported for dict options without key_generator')
+        shared_screen.allowed_js_errors.append('500 (Internal Server Error)')
+        shared_screen.assert_py_logger('ERROR', 'new_value_mode "add" is not supported for dict options without key_generator')
         return
 
-    screen.should_contain('value = []' if multiple else 'value = None')
-    screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C'}" if option_dict else "options = ['a', 'b', 'c']")
+    shared_screen.should_contain('value = []' if multiple else 'value = None')
+    shared_screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C'}" if option_dict else "options = ['a', 'b', 'c']")
 
-    screen.find_by_class('q-select').click()
-    screen.wait(0.5)
-    screen.find_all('A' if option_dict else 'a')[-1].click()
-    screen.should_contain("value = ['a']" if multiple else 'value = a')
+    shared_screen.find_by_class('q-select').click()
+    shared_screen.wait(0.5)
+    shared_screen.find_all('A' if option_dict else 'a')[-1].click()
+    shared_screen.should_contain("value = ['a']" if multiple else 'value = a')
 
     if new_value_mode:
         for _ in range(2):
-            screen.find_by_tag('input').send_keys(Keys.BACKSPACE + 'd')
-            screen.wait(0.5)
-            screen.find_by_tag('input').click()
-            screen.wait(0.5)
-            screen.find_by_tag('input').send_keys(Keys.ENTER)
-            screen.wait(0.5)
+            shared_screen.find_by_tag('input').send_keys(Keys.BACKSPACE + 'd')
+            shared_screen.wait(0.5)
+            shared_screen.find_by_tag('input').click()
+            shared_screen.wait(0.5)
+            shared_screen.find_by_tag('input').send_keys(Keys.ENTER)
+            shared_screen.wait(0.5)
         if new_value_mode == 'add':
-            screen.should_contain("value = ['a', 'd', 'd']" if multiple else 'value = d')
-            screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd'}" if option_dict else
+            shared_screen.should_contain("value = ['a', 'd', 'd']" if multiple else 'value = d')
+            shared_screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd', 'd': 'd'}" if option_dict else
                                   "options = ['a', 'b', 'c', 'd', 'd']")
         elif new_value_mode == 'add-unique':
-            screen.should_contain("value = ['a', 'd']" if multiple else 'value = d')
-            screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd'}" if option_dict else
+            shared_screen.should_contain("value = ['a', 'd']" if multiple else 'value = d')
+            shared_screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 'd': 'd'}" if option_dict else
                                   "options = ['a', 'b', 'c', 'd']")
         elif new_value_mode == 'toggle':
-            screen.should_contain("value = ['a']" if multiple else 'value = None')
-            screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C'}" if option_dict else
+            shared_screen.should_contain("value = ['a']" if multiple else 'value = None')
+            shared_screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C'}" if option_dict else
                                   "options = ['a', 'b', 'c']")
 
 
-def test_id_generator(screen: Screen):
+def test_id_generator(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         options = {'a': 'A', 'b': 'B', 'c': 'C'}
         select = ui.select(options, value='b', new_value_mode='add', key_generator=lambda _: len(options))
         ui.label().bind_text_from(select, 'options', lambda v: f'options = {v}')
 
-    screen.open('/')
-    screen.find_by_tag('input').send_keys(Keys.BACKSPACE + 'd')
-    screen.wait(0.5)
-    screen.find_by_tag('input').send_keys(Keys.ENTER)
-    screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 3: 'd'}")
+    shared_screen.open('/')
+    shared_screen.find_by_tag('input').send_keys(Keys.BACKSPACE + 'd')
+    shared_screen.wait(0.5)
+    shared_screen.find_by_tag('input').send_keys(Keys.ENTER)
+    shared_screen.should_contain("options = {'a': 'A', 'b': 'B', 'c': 'C', 3: 'd'}")
 
 
 @pytest.mark.parametrize('multiple', [False, True])
-def test_keep_filtered_options(multiple: bool, screen: Screen):
+def test_keep_filtered_options(multiple: bool, shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.select(options=['A1', 'A2', 'B1', 'B2'], with_input=True, multiple=multiple)
 
-    screen.open('/')
-    screen.find_by_tag('input').click()
-    screen.should_contain('A1')
-    screen.should_contain('A2')
-    screen.should_contain('B1')
-    screen.should_contain('B2')
+    shared_screen.open('/')
+    shared_screen.find_by_tag('input').click()
+    shared_screen.should_contain('A1')
+    shared_screen.should_contain('A2')
+    shared_screen.should_contain('B1')
+    shared_screen.should_contain('B2')
 
-    screen.find_by_tag('input').send_keys('A')
-    screen.wait(0.5)
-    screen.should_contain('A1')
-    screen.should_contain('A2')
-    screen.should_not_contain('B1')
-    screen.should_not_contain('B2')
+    shared_screen.find_by_tag('input').send_keys('A')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('A1')
+    shared_screen.should_contain('A2')
+    shared_screen.should_not_contain('B1')
+    shared_screen.should_not_contain('B2')
 
-    screen.click('A1')
-    screen.wait(0.5)
-    screen.find_by_tag('input').click()
-    screen.should_contain('A1')
-    screen.should_contain('A2')
+    shared_screen.click('A1')
+    shared_screen.wait(0.5)
+    shared_screen.find_by_tag('input').click()
+    shared_screen.should_contain('A1')
+    shared_screen.should_contain('A2')
     if multiple:
-        screen.should_not_contain('B1')
-        screen.should_not_contain('B2')
+        shared_screen.should_not_contain('B1')
+        shared_screen.should_not_contain('B2')
     else:
-        screen.should_contain('B1')
-        screen.should_contain('B2')
+        shared_screen.should_contain('B1')
+        shared_screen.should_contain('B2')
 
 
 @pytest.mark.parametrize('auto_validation', [True, False])
-def test_select_validation(auto_validation: bool, screen: Screen):
+def test_select_validation(auto_validation: bool, shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         select = ui.select(['A', 'BC', 'DEF'], value='A', validation={'Too long': lambda v: len(v) < 3})
         if not auto_validation:
             select.without_auto_validation()
 
-    screen.open('/')
-    screen.click('A')
-    screen.click('DEF')
-    screen.wait(0.5)
+    shared_screen.open('/')
+    shared_screen.click('A')
+    shared_screen.click('DEF')
+    shared_screen.wait(0.5)
     if auto_validation:
-        screen.should_contain('Too long')
+        shared_screen.should_contain('Too long')
     else:
-        screen.should_not_contain('Too long')
+        shared_screen.should_not_contain('Too long')
 
 
-def test_invalid_value(screen: Screen):
+def test_invalid_value(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with pytest.raises(ValueError, match='Invalid value: X'):
             ui.select(['A', 'B', 'C'], value='X')
 
-    screen.open('/')
+    shared_screen.open('/')
 
 
 @pytest.mark.parametrize('multiple', [False, True])
-def test_opening_and_closing_popup_with_screen(multiple: bool, screen: Screen):
+def test_opening_and_closing_popup_with_screen(multiple: bool, shared_screen: SharedScreen):
     select = None
 
     @ui.page('/')
@@ -238,26 +238,26 @@ def test_opening_and_closing_popup_with_screen(multiple: bool, screen: Screen):
         ui.label().bind_text_from(select, 'is_showing_popup', lambda v: 'open' if v else 'closed')
         ui.label().bind_text_from(select, 'value', lambda v: f'value = {v}')
 
-    screen.open('/')
-    fruits = screen.find_element(select)
-    screen.should_contain('closed')
+    shared_screen.open('/')
+    fruits = shared_screen.find_element(select)
+    shared_screen.should_contain('closed')
 
     fruits.click()
-    screen.should_contain('open')
+    shared_screen.should_contain('open')
     fruits.click()
-    screen.should_contain('closed')
+    shared_screen.should_contain('closed')
 
     fruits.click()
-    screen.click('Apple')
+    shared_screen.click('Apple')
     if multiple:
-        screen.click('Banana')
-        screen.should_contain("value = ['Apple', 'Banana']")
-        screen.should_contain('open')
+        shared_screen.click('Banana')
+        shared_screen.should_contain("value = ['Apple', 'Banana']")
+        shared_screen.should_contain('open')
     else:
         fruits.click()
-        screen.click('Banana')
-        screen.should_contain('value = Banana')
-        screen.should_contain('closed')
+        shared_screen.click('Banana')
+        shared_screen.should_contain('value = Banana')
+        shared_screen.should_contain('closed')
 
 
 @pytest.mark.parametrize('multiple', [False, True])
@@ -290,7 +290,7 @@ async def test_opening_and_closing_popup_with_user(multiple: bool, user: User):
         await user.should_see('closed')
 
 
-def test_popup_scroll_behavior(screen: Screen):
+def test_popup_scroll_behavior(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.add_css('html { scroll-behavior: smooth }')
@@ -298,14 +298,14 @@ def test_popup_scroll_behavior(screen: Screen):
         ui.link_target('bottom').classes('mt-[2000px]')
         ui.select(['apple', 'banana', 'cherry'], value='apple').props('behavior=dialog')
 
-    screen.open('/')
-    screen.click('Go to bottom')
-    screen.wait(1)
-    position = screen.selenium.execute_script('return window.scrollY')
+    shared_screen.open('/')
+    shared_screen.click('Go to bottom')
+    shared_screen.wait(1)
+    position = shared_screen.selenium.execute_script('return window.scrollY')
     assert position > 1000
 
-    screen.click('apple')
-    screen.wait(0.5)
-    screen.type(Keys.ESCAPE)
-    screen.wait(0.2)
-    assert screen.selenium.execute_script('return window.scrollY') == position
+    shared_screen.click('apple')
+    shared_screen.wait(0.5)
+    shared_screen.type(Keys.ESCAPE)
+    shared_screen.wait(0.2)
+    assert shared_screen.selenium.execute_script('return window.scrollY') == position

--- a/tests/test_serving_files.py
+++ b/tests/test_serving_files.py
@@ -5,7 +5,7 @@ import httpx
 import pytest
 
 from nicegui import __version__, app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 from .test_helpers import TEST_DIR
 
@@ -26,7 +26,7 @@ def secret_file():
 def assert_video_file_streaming(path: str) -> None:
     with httpx.Client() as http_client:
         r = http_client.get(
-            path if 'http' in path else f'http://localhost:{Screen.PORT}{path}',
+            path if 'http' in path else f'http://localhost:{SharedScreen.PORT}{path}',
             headers={'Range': 'bytes=0-1000'},
         )
         assert r.status_code == 206
@@ -36,152 +36,152 @@ def assert_video_file_streaming(path: str) -> None:
         assert r.headers['Content-Type'] == 'video/mp4'
 
 
-def test_media_files_can_be_streamed(screen: Screen):
+def test_media_files_can_be_streamed(shared_screen: SharedScreen):
     app.add_media_files('/media', Path(TEST_DIR) / 'media')
 
     @ui.page('/')
     def page():
         ui.label('Hello, world!')
 
-    screen.open('/')
+    shared_screen.open('/')
     assert_video_file_streaming('/media/test.mp4')
 
 
-def test_media_files_against_path_traversal(screen: Screen, secret_file):
+def test_media_files_against_path_traversal(shared_screen: SharedScreen, secret_file):
     app.add_media_files('/media', Path(TEST_DIR) / 'media')
 
     @ui.page('/')
     def page():
         ui.label('Hello, world!')
 
-    screen.open('/')
+    shared_screen.open('/')
 
     with httpx.Client() as http_client:
-        r = http_client.get(f'http://localhost:{Screen.PORT}/media/%2e%2e/.env')
+        r = http_client.get(f'http://localhost:{SharedScreen.PORT}/media/%2e%2e/.env')
         assert 'TOP SECRET DATA' not in r.text
         assert r.status_code == 404
 
 
-def test_adding_single_media_file(screen: Screen):
+def test_adding_single_media_file(shared_screen: SharedScreen):
     url_path = app.add_media_file(local_file=VIDEO_FILE)
 
     @ui.page('/')
     def page():
         ui.label('Hello, world!')
 
-    screen.open('/')
+    shared_screen.open('/')
     assert_video_file_streaming(url_path)
 
 
 @pytest.mark.parametrize('url_path', ['/static', '/static/'])
-def test_get_from_static_files_dir(url_path: str, screen: Screen):
+def test_get_from_static_files_dir(url_path: str, shared_screen: SharedScreen):
     app.add_static_files(url_path, Path(TEST_DIR).parent, max_cache_age=3456)
 
     @ui.page('/')
     def page():
         ui.label('Hello, world!')
 
-    screen.open('/')
+    shared_screen.open('/')
     with httpx.Client() as http_client:
-        r = http_client.get(f'http://localhost:{Screen.PORT}/static/examples/slideshow/slides/slide1.jpg')
+        r = http_client.get(f'http://localhost:{SharedScreen.PORT}/static/examples/slideshow/slides/slide1.jpg')
         assert r.status_code == 200
         assert 'max-age=3456' in r.headers['Cache-Control']
 
 
-def test_404_for_non_existing_static_file(screen: Screen):
+def test_404_for_non_existing_static_file(shared_screen: SharedScreen):
     app.add_static_files('/static', Path(TEST_DIR))
 
     @ui.page('/')
     def page():
         ui.label('Hello, world!')
 
-    screen.open('/')
+    shared_screen.open('/')
     with httpx.Client() as http_client:
-        r = http_client.get(f'http://localhost:{Screen.PORT}/static/does_not_exist.jpg')
-        screen.assert_py_logger('WARNING', re.compile('.*does_not_exist.jpg not found'))
+        r = http_client.get(f'http://localhost:{SharedScreen.PORT}/static/does_not_exist.jpg')
+        shared_screen.assert_py_logger('WARNING', re.compile('.*does_not_exist.jpg not found'))
         assert r.status_code == 404
         assert 'static/_nicegui' not in r.text, 'should use root_path, see https://github.com/zauberzeug/nicegui/issues/2570'
 
 
-def test_adding_single_static_file(screen: Screen):
+def test_adding_single_static_file(shared_screen: SharedScreen):
     url_path = app.add_static_file(local_file=IMAGE_FILE, max_cache_age=3456)
 
     @ui.page('/')
     def page():
         ui.label('Hello, world!')
 
-    screen.open('/')
+    shared_screen.open('/')
     with httpx.Client() as http_client:
-        r = http_client.get(f'http://localhost:{Screen.PORT}{url_path}')
+        r = http_client.get(f'http://localhost:{SharedScreen.PORT}{url_path}')
         assert r.status_code == 200
         assert 'max-age=3456' in r.headers['Cache-Control']
 
 
-def test_auto_serving_file_from_image_source(screen: Screen):
+def test_auto_serving_file_from_image_source(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.image(IMAGE_FILE)
 
-    screen.open('/')
-    img = screen.find_by_tag('img')
+    shared_screen.open('/')
+    img = shared_screen.find_by_tag('img')
     assert '/_nicegui/auto/static/' in img.get_attribute('src')
-    screen.wait(0.5)
-    assert screen.selenium.execute_script('''
+    shared_screen.wait(0.5)
+    assert shared_screen.selenium.execute_script('''
     return arguments[0].complete &&
         typeof arguments[0].naturalWidth != "undefined" &&
         arguments[0].naturalWidth > 0
     ''', img), 'image should load successfully'
 
 
-def test_auto_serving_file_from_video_source(screen: Screen):
+def test_auto_serving_file_from_video_source(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.video(VIDEO_FILE)
 
-    screen.open('/')
-    video = screen.find_by_tag('video')
+    shared_screen.open('/')
+    video = shared_screen.find_by_tag('video')
     assert '/_nicegui/auto/media/' in video.get_attribute('src')
     assert_video_file_streaming(video.get_attribute('src'))
 
 
-def test_mimetypes_of_static_files(screen: Screen):
+def test_mimetypes_of_static_files(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.label('Hello, world!')
 
-    screen.open('/')
+    shared_screen.open('/')
 
-    response = httpx.get(f'http://localhost:{Screen.PORT}/_nicegui/{__version__}/static/vue.esm-browser.js', timeout=5)
+    response = httpx.get(f'http://localhost:{SharedScreen.PORT}/_nicegui/{__version__}/static/vue.esm-browser.js', timeout=5)
     assert response.status_code == 200
     assert response.headers['Content-Type'].startswith('text/javascript')
 
-    response = httpx.get(f'http://localhost:{Screen.PORT}/_nicegui/{__version__}/static/dompurify.mjs', timeout=5)
+    response = httpx.get(f'http://localhost:{SharedScreen.PORT}/_nicegui/{__version__}/static/dompurify.mjs', timeout=5)
     assert response.status_code == 200
     assert response.headers['Content-Type'].startswith('text/javascript')
 
-    response = httpx.get(f'http://localhost:{Screen.PORT}/_nicegui/{__version__}/static/nicegui.css', timeout=5)
+    response = httpx.get(f'http://localhost:{SharedScreen.PORT}/_nicegui/{__version__}/static/nicegui.css', timeout=5)
     assert response.status_code == 200
     assert response.headers['Content-Type'].startswith('text/css')
 
 
-def test_cache_control_header_of_static_files(screen: Screen):
+def test_cache_control_header_of_static_files(shared_screen: SharedScreen):
     app.add_static_files('/static', Path(TEST_DIR).parent)
 
     @ui.page('/')
     def page():
         ui.markdown()
 
-    screen.open('/')
+    shared_screen.open('/')
 
     # resources are served with cache-control headers from `ui.run`
-    response1 = httpx.get(f'http://localhost:{Screen.PORT}/_nicegui/{__version__}/static/nicegui.css', timeout=5)
+    response1 = httpx.get(f'http://localhost:{SharedScreen.PORT}/_nicegui/{__version__}/static/nicegui.css', timeout=5)
     assert 'immutable' in response1.headers.get('Cache-Control', '')
 
     # dynamic resources are _not_ served with cache-control headers from `ui.run`
     response2 = httpx.get(
-        f'http://localhost:{Screen.PORT}/_nicegui/{__version__}/dynamic_resources/codehilite.css', timeout=5)
+        f'http://localhost:{SharedScreen.PORT}/_nicegui/{__version__}/dynamic_resources/codehilite.css', timeout=5)
     assert 'immutable' not in response2.headers.get('Cache-Control', '')
 
     # static resources are _not_ served with cache-control headers from `ui.run`
-    response3 = httpx.get(f'http://localhost:{Screen.PORT}/static/examples/slideshow/slides/slide1.jpg', timeout=5)
+    response3 = httpx.get(f'http://localhost:{SharedScreen.PORT}/static/examples/slideshow/slides/slide1.jpg', timeout=5)
     assert 'immutable' not in response3.headers.get('Cache-Control', '')

--- a/tests/test_slide_item.py
+++ b/tests/test_slide_item.py
@@ -1,10 +1,10 @@
 from selenium.webdriver.common.action_chains import ActionChains
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_slide_item(screen: Screen):
+def test_slide_item(shared_screen: SharedScreen):
     slide_item = None
 
     @ui.page('/')
@@ -14,22 +14,22 @@ def test_slide_item(screen: Screen):
         with ui.slide_item('slide item', on_slide=lambda e: label.set_text(f'Event: {e.side}')) as slide_item:
             slide_item.left()
 
-    screen.open('/')
-    screen.should_contain('slide item')
-    screen.should_contain('None')
+    shared_screen.open('/')
+    shared_screen.should_contain('slide item')
+    shared_screen.should_contain('None')
 
-    ActionChains(screen.selenium) \
-        .move_to_element_with_offset(screen.find_element(slide_item), -20, 0) \
+    ActionChains(shared_screen.selenium) \
+        .move_to_element_with_offset(shared_screen.find_element(slide_item), -20, 0) \
         .click_and_hold() \
         .pause(0.5) \
         .move_by_offset(60, 0) \
         .pause(0.5) \
         .release() \
         .perform()
-    screen.should_contain('Event: left')
+    shared_screen.should_contain('Event: left')
 
 
-def test_slide_side(screen: Screen):
+def test_slide_side(shared_screen: SharedScreen):
     slide_item = None
 
     @ui.page('/')
@@ -40,28 +40,28 @@ def test_slide_side(screen: Screen):
             slide_item.left(on_slide=lambda e: label.set_text(f'Event: {e.side}'))
             slide_item.right(on_slide=lambda e: label.set_text(f'Event: {e.side}'))
 
-    screen.open('/')
-    screen.should_contain('None')
+    shared_screen.open('/')
+    shared_screen.should_contain('None')
 
-    ActionChains(screen.selenium) \
-        .move_to_element_with_offset(screen.find_element(slide_item), -20, 0) \
+    ActionChains(shared_screen.selenium) \
+        .move_to_element_with_offset(shared_screen.find_element(slide_item), -20, 0) \
         .click_and_hold() \
         .pause(0.5) \
         .move_by_offset(60, 0) \
         .pause(0.5) \
         .release() \
         .perform()
-    screen.should_contain('Event: left')
+    shared_screen.should_contain('Event: left')
 
     slide_item.reset()
-    screen.should_contain('slide item')
+    shared_screen.should_contain('slide item')
 
-    ActionChains(screen.selenium) \
-        .move_to_element_with_offset(screen.find_element(slide_item), 20, 0) \
+    ActionChains(shared_screen.selenium) \
+        .move_to_element_with_offset(shared_screen.find_element(slide_item), 20, 0) \
         .click_and_hold() \
         .pause(0.5) \
         .move_by_offset(-60, 0) \
         .pause(0.5) \
         .release() \
         .perform()
-    screen.should_contain('Event: right')
+    shared_screen.should_contain('Event: right')

--- a/tests/test_socketio_too_long.py
+++ b/tests/test_socketio_too_long.py
@@ -4,11 +4,11 @@ import pytest
 from selenium.webdriver.common.keys import Keys
 
 from nicegui import core, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
 @pytest.mark.parametrize('transport', ['websocket', 'polling'])
-def test_socketio_too_long(screen: Screen, transport: Literal['websocket', 'polling']):
+def test_socketio_too_long(shared_screen: SharedScreen, transport: Literal['websocket', 'polling']):
     events: list[str] = []
     core.app.config.socket_io_js_transports = [transport]
 
@@ -16,13 +16,13 @@ def test_socketio_too_long(screen: Screen, transport: Literal['websocket', 'poll
     def page():
         ui.textarea(value='x' * (1_000_000 - 242), on_change=lambda: events.append('changed'))
 
-    screen.open('/')
-    screen.type(Keys.TAB)
+    shared_screen.open('/')
+    shared_screen.type(Keys.TAB)
     for _ in range(5):
-        screen.type('y')
+        shared_screen.type('y')
 
     assert events == ['changed'] * 2, 'two more characters are ok'
-    assert len([log for log in screen.selenium.get_log('browser') if 'Payload size' in log['message']]) == 3
-    screen.assert_py_logger('ERROR', 'Payload size 999901 exceeds the maximum allowed limit.')
-    screen.assert_py_logger('ERROR', 'Payload size 999902 exceeds the maximum allowed limit.')
-    screen.assert_py_logger('ERROR', 'Payload size 999903 exceeds the maximum allowed limit.')
+    assert len([log for log in shared_screen.selenium.get_log('browser') if 'Payload size' in log['message']]) == 3
+    shared_screen.assert_py_logger('ERROR', 'Payload size 999901 exceeds the maximum allowed limit.')
+    shared_screen.assert_py_logger('ERROR', 'Payload size 999902 exceeds the maximum allowed limit.')
+    shared_screen.assert_py_logger('ERROR', 'Payload size 999903 exceeds the maximum allowed limit.')

--- a/tests/test_speculative_loading.py
+++ b/tests/test_speculative_loading.py
@@ -6,10 +6,10 @@ import json
 import pytest
 
 from nicegui import Client, app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_prerender_with_run_javascript(screen: Screen, event_log: EventLog) -> None:
+def test_prerender_with_run_javascript(shared_screen: SharedScreen, event_log: EventLog) -> None:
     app.on_connect(lambda client: event_log.append(f'connect: {client.page.path}'))
 
     @ui.page('/')
@@ -21,13 +21,13 @@ def test_prerender_with_run_javascript(screen: Screen, event_log: EventLog) -> N
         result = await ui.run_javascript('1 + 41')
         event_log.append(f'answer: {result}')
 
-    screen.open('/')
+    shared_screen.open('/')
     event_log.wait_for('connect: /')
     event_log.wait_for('connect: /answer')
     event_log.wait_for('answer: 42')
 
 
-def test_prerender_with_client_connected(screen: Screen, event_log: EventLog) -> None:
+def test_prerender_with_client_connected(shared_screen: SharedScreen, event_log: EventLog) -> None:
     app.on_connect(lambda client: event_log.append(f'connect: {client.page.path}'))
 
     @ui.page('/')
@@ -39,13 +39,13 @@ def test_prerender_with_client_connected(screen: Screen, event_log: EventLog) ->
         await ui.context.client.connected()
         event_log.append('subpage: connected')
 
-    screen.open('/')
+    shared_screen.open('/')
     event_log.wait_for('connect: /')
     event_log.wait_for('connect: /subpage')
     event_log.wait_for('subpage: connected')
 
 
-def test_prerender_with_timer(screen: Screen, event_log: EventLog) -> None:
+def test_prerender_with_timer(shared_screen: SharedScreen, event_log: EventLog) -> None:
     app.on_connect(lambda client: event_log.append(f'connect: {client.page.path}'))
 
     @ui.page('/')
@@ -57,13 +57,13 @@ def test_prerender_with_timer(screen: Screen, event_log: EventLog) -> None:
         await ui.context.client.connected()
         ui.timer(0.1, lambda: event_log.append('timer: running'), once=True)
 
-    screen.open('/')
+    shared_screen.open('/')
     event_log.wait_for('connect: /')
     event_log.wait_for('connect: /timer')
     event_log.wait_for('timer: running')
 
 
-def test_prerender_with_long_page_build(screen: Screen, event_log: EventLog) -> None:
+def test_prerender_with_long_page_build(shared_screen: SharedScreen, event_log: EventLog) -> None:
     app.on_connect(lambda client: event_log.append(f'connect: {client.page.path}'))
 
     @ui.page('/')
@@ -75,14 +75,14 @@ def test_prerender_with_long_page_build(screen: Screen, event_log: EventLog) -> 
         await asyncio.sleep(2)
         event_log.append('longbuild: done')
 
-    screen.open('/')
+    shared_screen.open('/')
     event_log.wait_for('connect: /')
     event_log.wait_for('longbuild: done')
     event_log.wait_for('connect: /longbuild')
     assert event_log.items.index('longbuild: done') < event_log.items.index('connect: /longbuild')
 
 
-def test_prefetch_connects_after_navigation(screen: Screen, event_log: EventLog) -> None:
+def test_prefetch_connects_after_navigation(shared_screen: SharedScreen, event_log: EventLog) -> None:
     app.on_connect(lambda client: event_log.append(f'connect: {client.page.path}'))
 
     @ui.page('/')
@@ -97,29 +97,29 @@ def test_prefetch_connects_after_navigation(screen: Screen, event_log: EventLog)
         event_log.append(f'answer: {result}')
         ui.label('all done')
 
-    screen.open('/')
+    shared_screen.open('/')
     event_log.wait_for('connect: /')
-    screen.wait(1)
+    shared_screen.wait(1)
     assert event_log.items == ['answer: called', 'connect: /']
 
-    screen.click('answer')
+    shared_screen.click('answer')
     event_log.wait_for('answer: 42')
     assert event_log.items == ['answer: called', 'connect: /', 'connect: /answer', 'answer: 42'], \
         'answer() should not re-evaluate despite small run_javascript timeout because in prefetch the page response timeout is used'
-    screen.should_contain('all done')
+    shared_screen.should_contain('all done')
     event_log.items.clear()
 
-    screen.open('/')
+    shared_screen.open('/')
     event_log.wait_for('answer: called')
     Client.prune_instances(client_age_threshold=0)
     assert event_log.items == ['answer: called', 'connect: /']
 
-    screen.click('answer')
+    shared_screen.click('answer')
     event_log.wait_for('connect: /answer')
     event_log.wait_for('answer: 42')
     assert event_log.items == ['answer: called', 'connect: /', 'answer: called', 'connect: /answer', 'answer: 42'], \
         'answer() should re-evaluate after prefetch client was pruned'
-    screen.should_contain('all done')
+    shared_screen.should_contain('all done')
 
 
 def add_speculation_rule(url: str, *, kind: str = 'prerender') -> None:
@@ -129,20 +129,20 @@ def add_speculation_rule(url: str, *, kind: str = 'prerender') -> None:
 
 
 class EventLog:
-    def __init__(self, screen: Screen) -> None:
+    def __init__(self, shared_screen: SharedScreen) -> None:
         self.items: list[str] = []
-        self._screen = screen
+        self._shared_screen = shared_screen
 
     def append(self, entry: str) -> None:
         self.items.append(entry)
 
     def wait_for(self, entry: str) -> None:
         try:
-            self._screen.wait_for(lambda: entry in self.items)
+            self._shared_screen.wait_for(lambda: entry in self.items)
         except AssertionError as e:
             raise AssertionError(f'{entry} not found in {self.items}') from e
 
 
 @pytest.fixture(name='event_log')
-def _event_log(screen: Screen) -> EventLog:
-    return EventLog(screen)
+def _event_log(shared_screen: SharedScreen) -> EventLog:
+    return EventLog(shared_screen)

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -1,16 +1,16 @@
 from selenium.webdriver.common.by import By
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_spinner(screen: Screen):
+def test_spinner(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.spinner(size='3em', thickness=10)
 
-    screen.open('/')
-    element = screen.find_by_tag('svg')
+    shared_screen.open('/')
+    element = shared_screen.find_by_tag('svg')
     assert element.get_attribute('width') == '3em'
     assert element.get_attribute('height') == '3em'
     assert element.find_element(By.TAG_NAME, 'circle').get_attribute('stroke-width') == '10'

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_splitter(screen: Screen):
+def test_splitter(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.splitter() as splitter:
@@ -12,8 +12,8 @@ def test_splitter(screen: Screen):
                 ui.label('Right hand side.')
         ui.label().bind_text_from(splitter, 'value')
 
-    screen.open('/')
-    screen.should_contain('Left hand side.')
-    screen.should_contain('Right hand side.')
-    screen.should_contain('50')
+    shared_screen.open('/')
+    shared_screen.should_contain('Left hand side.')
+    shared_screen.should_contain('Right hand side.')
+    shared_screen.should_contain('50')
     # TODO: programmatically move splitter

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_stepper(screen: Screen):
+def test_stepper(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.stepper() as stepper:
@@ -17,14 +17,14 @@ def test_stepper(screen: Screen):
                     ui.button('Next', on_click=stepper.next)
                     ui.button('Back', on_click=stepper.previous)
 
-    screen.open('/')
-    screen.should_contain('First step')
-    screen.should_not_contain('Second step')
+    shared_screen.open('/')
+    shared_screen.should_contain('First step')
+    shared_screen.should_not_contain('Second step')
 
-    screen.click('Next')
-    screen.should_contain('Second step')
-    screen.should_not_contain('First step')
+    shared_screen.click('Next')
+    shared_screen.should_contain('Second step')
+    shared_screen.should_not_contain('First step')
 
-    screen.click('Back')
-    screen.should_contain('First step')
-    screen.should_not_contain('Second step')
+    shared_screen.click('Back')
+    shared_screen.should_contain('First step')
+    shared_screen.should_not_contain('Second step')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -6,7 +6,7 @@ import pytest
 from selenium.webdriver.common.by import By
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
 def columns() -> list:
@@ -24,78 +24,78 @@ def rows() -> list:
     ]
 
 
-def test_table(screen: Screen):
+def test_table(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.table(title='My Team', columns=columns(), rows=rows())
 
-    screen.open('/')
-    screen.should_contain('My Team')
-    screen.should_contain('Name')
-    screen.should_contain('Alice')
-    screen.should_contain('Bob')
-    screen.should_contain('Lionel')
+    shared_screen.open('/')
+    shared_screen.should_contain('My Team')
+    shared_screen.should_contain('Name')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('Bob')
+    shared_screen.should_contain('Lionel')
 
 
-def test_pagination_int(screen: Screen):
+def test_pagination_int(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.table(columns=columns(), rows=rows(), pagination=2)
 
-    screen.open('/')
-    screen.should_contain('Alice')
-    screen.should_contain('Bob')
-    screen.should_not_contain('Lionel')
-    screen.should_contain('1-2 of 3')
+    shared_screen.open('/')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('Bob')
+    shared_screen.should_not_contain('Lionel')
+    shared_screen.should_contain('1-2 of 3')
 
 
-def test_pagination_dict(screen: Screen):
+def test_pagination_dict(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.table(columns=columns(), rows=rows(), pagination={'rowsPerPage': 2})
 
-    screen.open('/')
-    screen.should_contain('Alice')
-    screen.should_contain('Bob')
-    screen.should_not_contain('Lionel')
-    screen.should_contain('1-2 of 3')
+    shared_screen.open('/')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('Bob')
+    shared_screen.should_not_contain('Lionel')
+    shared_screen.should_contain('1-2 of 3')
 
 
-def test_filter(screen: Screen):
+def test_filter(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         table = ui.table(columns=columns(), rows=rows())
         ui.input('Search by name').bind_value(table, 'filter')
 
-    screen.open('/')
-    screen.should_contain('Alice')
-    screen.should_contain('Bob')
-    screen.should_contain('Lionel')
+    shared_screen.open('/')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('Bob')
+    shared_screen.should_contain('Lionel')
 
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Search by name"]')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Search by name"]')
     element.send_keys('e')
-    screen.should_contain('Alice')
-    screen.should_not_contain('Bob')
-    screen.should_contain('Lionel')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_not_contain('Bob')
+    shared_screen.should_contain('Lionel')
 
 
-def test_add_remove(screen: Screen):
+def test_add_remove(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         table = ui.table(columns=columns(), rows=rows())
         ui.button('Add', on_click=lambda: table.add_row({'id': 3, 'name': 'Carol', 'age': 32}))
         ui.button('Remove', on_click=lambda: table.remove_row(table.rows[0]))
 
-    screen.open('/')
-    screen.click('Add')
-    screen.should_contain('Carol')
+    shared_screen.open('/')
+    shared_screen.click('Add')
+    shared_screen.should_contain('Carol')
 
-    screen.click('Remove')
-    screen.wait(0.5)
-    screen.should_not_contain('Alice')
+    shared_screen.click('Remove')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Alice')
 
 
-def test_slots(screen: Screen):
+def test_slots(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.table(columns=columns(), rows=rows()) as table:
@@ -113,14 +113,14 @@ def test_slots(screen: Screen):
                 </q-tr>
             ''')
 
-    screen.open('/')
-    screen.should_contain('This is the top slot.')
-    screen.should_not_contain('Alice')
-    screen.should_contain('overridden')
-    screen.should_contain('21')
+    shared_screen.open('/')
+    shared_screen.should_contain('This is the top slot.')
+    shared_screen.should_not_contain('Alice')
+    shared_screen.should_contain('overridden')
+    shared_screen.should_contain('21')
 
 
-def test_selection(screen: Screen):
+def test_selection(shared_screen: SharedScreen):
     table = None
 
     @ui.page('/')
@@ -130,56 +130,56 @@ def test_selection(screen: Screen):
         ui.radio({None: 'none', 'single': 'single', 'multiple': 'multiple'},
                  on_change=lambda e: table.set_selection(e.value))
 
-    screen.open('/')
-    screen.find('Alice').find_element(By.XPATH, 'preceding-sibling::td').click()
-    screen.wait(0.5)
-    screen.should_contain('1 record selected.')
+    shared_screen.open('/')
+    shared_screen.find('Alice').find_element(By.XPATH, 'preceding-sibling::td').click()
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('1 record selected.')
 
-    screen.find('Bob').find_element(By.XPATH, 'preceding-sibling::td').click()
-    screen.wait(0.5)
-    screen.should_contain('1 record selected.')
+    shared_screen.find('Bob').find_element(By.XPATH, 'preceding-sibling::td').click()
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('1 record selected.')
 
-    screen.click('multiple')
-    screen.wait(0.5)
+    shared_screen.click('multiple')
+    shared_screen.wait(0.5)
 
-    screen.find('Lionel').find_element(By.XPATH, 'preceding-sibling::td').click()
-    screen.wait(0.5)
-    screen.should_contain('2 records selected.')
+    shared_screen.find('Lionel').find_element(By.XPATH, 'preceding-sibling::td').click()
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('2 records selected.')
     assert table.selection == 'multiple'
 
-    screen.click('none')
-    screen.wait(0.5)
-    screen.should_not_contain('1 record selected.')
+    shared_screen.click('none')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('1 record selected.')
     assert table.selection is None
 
 
-def test_dynamic_column_attributes(screen: Screen):
+def test_dynamic_column_attributes(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.table(columns=[{'name': 'age', 'label': 'Age', 'field': 'age', ':format': 'value => value + " years"'}],
                  rows=[{'name': 'Alice', 'age': 18}])
 
-    screen.open('/')
-    screen.should_contain('18 years')
+    shared_screen.open('/')
+    shared_screen.should_contain('18 years')
 
 
-def test_remove_selection(screen: Screen):
+def test_remove_selection(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         t = ui.table(columns=columns(), rows=rows(), selection='single')
         ui.button('Remove first row', on_click=lambda: t.remove_row(t.rows[0]))
 
-    screen.open('/')
-    screen.find('Alice').find_element(By.XPATH, 'preceding-sibling::td').click()
-    screen.should_contain('1 record selected.')
+    shared_screen.open('/')
+    shared_screen.find('Alice').find_element(By.XPATH, 'preceding-sibling::td').click()
+    shared_screen.should_contain('1 record selected.')
 
-    screen.click('Remove first row')
-    screen.wait(0.5)
-    screen.should_not_contain('Alice')
-    screen.should_not_contain('1 record selected.')
+    shared_screen.click('Remove first row')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Alice')
+    shared_screen.should_not_contain('1 record selected.')
 
 
-def test_replace_rows(screen: Screen):
+def test_replace_rows(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         t = ui.table(columns=columns(), rows=rows())
@@ -193,26 +193,26 @@ def test_replace_rows(screen: Screen):
         ui.button('Replace rows with C.', on_click=replace_rows_with_carol)
         ui.button('Replace rows with D.', on_click=replace_rows_with_daniel)
 
-    screen.open('/')
-    screen.should_contain('Alice')
-    screen.should_contain('Bob')
-    screen.should_contain('Lionel')
+    shared_screen.open('/')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('Bob')
+    shared_screen.should_contain('Lionel')
 
-    screen.click('Replace rows with C.')
-    screen.wait(0.5)
-    screen.should_not_contain('Alice')
-    screen.should_not_contain('Bob')
-    screen.should_not_contain('Lionel')
-    screen.should_contain('Carol')
+    shared_screen.click('Replace rows with C.')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Alice')
+    shared_screen.should_not_contain('Bob')
+    shared_screen.should_not_contain('Lionel')
+    shared_screen.should_contain('Carol')
 
-    screen.click('Replace rows with D.')
-    screen.wait(0.5)
-    screen.should_not_contain('Carol')
-    screen.should_contain('Daniel')
+    shared_screen.click('Replace rows with D.')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('Carol')
+    shared_screen.should_contain('Daniel')
 
 
 @pytest.mark.parametrize('df_type', ['pandas', 'polars'])
-def test_create_and_update_from_df(screen: Screen, df_type: str):
+def test_create_and_update_from_df(shared_screen: SharedScreen, df_type: str):
     @ui.page('/')
     def page():
         if df_type == 'pandas':
@@ -228,19 +228,19 @@ def test_create_and_update_from_df(screen: Screen, df_type: str):
 
         ui.button('Update', on_click=lambda: update_from_df(DataFrame({'name': ['Lionel'], 'age': [19]})))
 
-    screen.open('/')
-    screen.should_contain('Alice')
-    screen.should_contain('Bob')
-    screen.should_contain('18')
-    screen.should_contain('21')
+    shared_screen.open('/')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('Bob')
+    shared_screen.should_contain('18')
+    shared_screen.should_contain('21')
 
-    screen.click('Update')
-    screen.should_contain('Lionel')
-    screen.should_contain('19')
+    shared_screen.click('Update')
+    shared_screen.should_contain('Lionel')
+    shared_screen.should_contain('19')
 
 
 @pytest.mark.parametrize('df_type', ['pandas', 'polars'])
-def test_problematic_datatypes(screen: Screen, df_type: str):
+def test_problematic_datatypes(shared_screen: SharedScreen, df_type: str):
     @ui.page('/')
     def page():
         if df_type == 'pandas':
@@ -259,21 +259,21 @@ def test_problematic_datatypes(screen: Screen, df_type: str):
             })
             ui.table.from_polars(df)
 
-    screen.open('/')
-    screen.should_contain('Datetime_col')
-    screen.should_contain('2020-01-01')
-    screen.should_contain('Datetime_col_tz')
-    screen.should_contain('2020-01-02')
+    shared_screen.open('/')
+    shared_screen.should_contain('Datetime_col')
+    shared_screen.should_contain('2020-01-01')
+    shared_screen.should_contain('Datetime_col_tz')
+    shared_screen.should_contain('2020-01-02')
     if df_type == 'pandas':
-        screen.should_contain('Timedelta_col')
-        screen.should_contain('5 days')
-        screen.should_contain('Complex_col')
-        screen.should_contain('(1+2j)')
-        screen.should_contain('Period_col')
-        screen.should_contain('2021-01')
+        shared_screen.should_contain('Timedelta_col')
+        shared_screen.should_contain('5 days')
+        shared_screen.should_contain('Complex_col')
+        shared_screen.should_contain('(1+2j)')
+        shared_screen.should_contain('Period_col')
+        shared_screen.should_contain('2021-01')
 
 
-def test_table_computed_props(screen: Screen):
+def test_table_computed_props(shared_screen: SharedScreen):
     all_rows = rows()
     filtered_rows = [row for row in all_rows if 'e' in row['name']]
     filtered_sorted_rows = sorted(filtered_rows, key=lambda row: row['age'], reverse=True)
@@ -293,13 +293,13 @@ def test_table_computed_props(screen: Screen):
         assert filtered_sorted_rows[:1] == await table.get_computed_rows()
         assert len(filtered_sorted_rows) == await table.get_computed_rows_number()
 
-    screen.open('/')
-    screen.should_contain('Lionel')
-    screen.should_not_contain('Alice')
-    screen.should_not_contain('Bob')
+    shared_screen.open('/')
+    shared_screen.should_contain('Lionel')
+    shared_screen.should_not_contain('Alice')
+    shared_screen.should_not_contain('Bob')
 
 
-def test_infer_columns(screen: Screen):
+def test_infer_columns(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.table(rows=[
@@ -307,16 +307,16 @@ def test_infer_columns(screen: Screen):
             {'name': 'Bob', 'age': 21},
         ])
 
-    screen.open('/')
-    screen.should_contain('NAME')
-    screen.should_contain('AGE')
-    screen.should_contain('Alice')
-    screen.should_contain('Bob')
-    screen.should_contain('18')
-    screen.should_contain('21')
+    shared_screen.open('/')
+    shared_screen.should_contain('NAME')
+    shared_screen.should_contain('AGE')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('Bob')
+    shared_screen.should_contain('18')
+    shared_screen.should_contain('21')
 
 
-def test_default_column_parameters(screen: Screen):
+def test_default_column_parameters(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.table(rows=[
@@ -328,20 +328,20 @@ def test_default_column_parameters(screen: Screen):
             {'name': 'city', 'label': 'City', 'field': 'city', 'sortable': False},
         ], column_defaults={'sortable': True})
 
-    screen.open('/')
-    screen.should_contain('Name')
-    screen.should_contain('Age')
-    screen.should_contain('Alice')
-    screen.should_contain('Bob')
-    screen.should_contain('18')
-    screen.should_contain('21')
-    screen.should_contain('London')
-    screen.should_contain('Paris')
-    assert len(screen.find_all_by_class('sortable')) == 2
+    shared_screen.open('/')
+    shared_screen.should_contain('Name')
+    shared_screen.should_contain('Age')
+    shared_screen.should_contain('Alice')
+    shared_screen.should_contain('Bob')
+    shared_screen.should_contain('18')
+    shared_screen.should_contain('21')
+    shared_screen.should_contain('London')
+    shared_screen.should_contain('Paris')
+    assert len(shared_screen.find_all_by_class('sortable')) == 2
 
 
 @pytest.mark.parametrize('df_type', ['pandas', 'polars'])
-def test_columns_from_df(screen: Screen, df_type: str):
+def test_columns_from_df(shared_screen: SharedScreen, df_type: str):
     @ui.page('/')
     def page():
         if df_type == 'pandas':
@@ -374,31 +374,31 @@ def test_columns_from_df(screen: Screen, df_type: str):
                                                        columns=[{'name': 'make', 'label': 'make', 'field': 'make'},
                                                                 {'name': 'model', 'label': 'model', 'field': 'model'}]))
 
-    screen.open('/')
-    screen.should_contain('name')
-    screen.should_contain('age')
-    screen.should_contain('make')
-    screen.should_not_contain('model')
+    shared_screen.open('/')
+    shared_screen.should_contain('name')
+    shared_screen.should_contain('age')
+    shared_screen.should_contain('make')
+    shared_screen.should_not_contain('model')
 
-    screen.click('Update persons without columns')  # infer columns (like during instantiation)
-    screen.should_contain('Dan')
-    screen.should_contain('5')
-    screen.should_contain('male')
+    shared_screen.click('Update persons without columns')  # infer columns (like during instantiation)
+    shared_screen.should_contain('Dan')
+    shared_screen.should_contain('5')
+    shared_screen.should_contain('male')
 
-    screen.click('Update persons with columns')  # updated columns via parameter
-    screen.should_contain('Stephen')
-    screen.should_not_contain('32')
+    shared_screen.click('Update persons with columns')  # updated columns via parameter
+    shared_screen.should_contain('Stephen')
+    shared_screen.should_not_contain('32')
 
-    screen.click('Update cars without columns')  # don't change columns
-    screen.should_contain('Honda')
-    screen.should_not_contain('Civic')
+    shared_screen.click('Update cars without columns')  # don't change columns
+    shared_screen.should_contain('Honda')
+    shared_screen.should_not_contain('Civic')
 
-    screen.click('Update cars with columns')  # updated columns via parameter
-    screen.should_contain('Hyundai')
-    screen.should_contain('i30')
+    shared_screen.click('Update cars with columns')  # updated columns via parameter
+    shared_screen.should_contain('Hyundai')
+    shared_screen.should_contain('i30')
 
 
-def test_new_slots(screen: Screen):
+def test_new_slots(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         table = ui.table(rows=[{'name': 'Alice'}, {'name': 'Bob'}, {'name': 'Carol'}])
@@ -407,8 +407,8 @@ def test_new_slots(screen: Screen):
                 ui.button().props(':label="props.value"') \
                     .on('click', js_handler='() => emit(props.value)', handler=lambda e: ui.notify(f'Clicked {e.args}'))
 
-    screen.open('/')
-    screen.should_contain('Alice')
+    shared_screen.open('/')
+    shared_screen.should_contain('Alice')
 
-    screen.click('Alice')
-    screen.should_contain('Clicked Alice')
+    shared_screen.click('Alice')
+    shared_screen.should_contain('Clicked Alice')

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_with_strings(screen: Screen):
+def test_with_strings(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.tabs() as tabs:
@@ -15,13 +15,13 @@ def test_with_strings(screen: Screen):
             with ui.tab_panel('Two'):
                 ui.label('Second tab')
 
-    screen.open('/')
-    screen.should_contain('First tab')
-    screen.click('Two')
-    screen.should_contain('Second tab')
+    shared_screen.open('/')
+    shared_screen.should_contain('First tab')
+    shared_screen.click('Two')
+    shared_screen.should_contain('Second tab')
 
 
-def test_with_tab_objects(screen: Screen):
+def test_with_tab_objects(shared_screen: SharedScreen):
     tab_events = []
     tab_panel_events = []
 
@@ -39,25 +39,25 @@ def test_with_tab_objects(screen: Screen):
 
         ui.button('Switch to Two', on_click=lambda: tab_panels.set_value(tab2))
 
-    screen.open('/')
-    screen.should_contain('One')
-    screen.should_contain('Two')
-    screen.should_contain('Second tab')
+    shared_screen.open('/')
+    shared_screen.should_contain('One')
+    shared_screen.should_contain('Two')
+    shared_screen.should_contain('Second tab')
     assert tab_events == ['Two']
     assert tab_panel_events == []
 
-    screen.click('One')
-    screen.should_contain('First tab')
+    shared_screen.click('One')
+    shared_screen.should_contain('First tab')
     assert tab_events == ['Two', 'One']
     assert tab_panel_events == ['One']
 
-    screen.click('Switch to Two')
-    screen.should_contain('Second tab')
+    shared_screen.click('Switch to Two')
+    shared_screen.should_contain('Second tab')
     assert tab_events == ['Two', 'One', 'Two']
     assert tab_panel_events == ['One', 'Two']
 
 
-def test_updating_offscreen_elements_with_update_method(screen: Screen):
+def test_updating_offscreen_elements_with_update_method(shared_screen: SharedScreen):
     @ui.page('/')
     def main_page():
         with ui.tabs() as tabs:
@@ -70,5 +70,5 @@ def test_updating_offscreen_elements_with_update_method(screen: Screen):
             with ui.tab_panel('Two'):
                 editor = ui.json_editor({})
 
-    screen.open('/')
-    screen.click('Update')
+    shared_screen.open('/')
+    shared_screen.click('Update')

--- a/tests/test_teleport.py
+++ b/tests/test_teleport.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_teleport(screen: Screen):
+def test_teleport(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.card().classes('card')
@@ -13,12 +13,12 @@ def test_teleport(screen: Screen):
 
         ui.button('create', on_click=create_teleport)
 
-    screen.open('/')
-    screen.click('create')
-    assert screen.find_by_css('.card > div').text == 'Hello'
+    shared_screen.open('/')
+    shared_screen.click('create')
+    assert shared_screen.find_by_css('.card > div').text == 'Hello'
 
 
-def test_teleport_with_element(screen: Screen):
+def test_teleport_with_element(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         card = ui.card().classes('card')
@@ -29,12 +29,12 @@ def test_teleport_with_element(screen: Screen):
 
         ui.button('create', on_click=create_teleport)
 
-    screen.open('/')
-    screen.click('create')
-    assert screen.find_by_css('.card > div').text == 'Hello'
+    shared_screen.open('/')
+    shared_screen.click('create')
+    assert shared_screen.find_by_css('.card > div').text == 'Hello'
 
 
-def test_update(screen: Screen):
+def test_update(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         teleport: ui.teleport | None = None
@@ -57,9 +57,9 @@ def test_update(screen: Screen):
 
         ui.button('rebuild card', on_click=rebuild_card)
 
-    screen.open('/')
-    screen.click('create')
-    screen.should_contain('Hello')
-    screen.click('rebuild card')
-    screen.should_contain('Card rebuilt')
-    assert screen.find_by_css('.card > div').text == 'Hello'
+    shared_screen.open('/')
+    shared_screen.click('create')
+    shared_screen.should_contain('Hello')
+    shared_screen.click('rebuild card')
+    shared_screen.should_contain('Card rebuilt')
+    assert shared_screen.find_by_css('.card > div').text == 'Hello'

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,21 +1,21 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_time(screen: Screen):
+def test_time(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         t = ui.time(value='01:23')
         ui.label().bind_text_from(t, 'value')
 
-    screen.open('/')
-    screen.should_contain('01:23')
-    screen.wait(0.2)
-    screen.click('8')
-    screen.should_contain('08:23')
-    screen.wait(0.2)
-    screen.click('45')
-    screen.should_contain('08:45')
-    screen.wait(0.2)
-    screen.click('PM')
-    screen.should_contain('20:45')
+    shared_screen.open('/')
+    shared_screen.should_contain('01:23')
+    shared_screen.wait(0.2)
+    shared_screen.click('8')
+    shared_screen.should_contain('08:23')
+    shared_screen.wait(0.2)
+    shared_screen.click('45')
+    shared_screen.should_contain('08:45')
+    shared_screen.wait(0.2)
+    shared_screen.click('PM')
+    shared_screen.should_contain('20:45')

--- a/tests/test_time_input.py
+++ b/tests/test_time_input.py
@@ -1,21 +1,21 @@
 from selenium.webdriver.common.by import By
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_time_input(screen: Screen):
+def test_time_input(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         time_input = ui.time_input('Time')
         ui.label().bind_text_from(time_input, 'value', lambda value: f'time: {value}')
 
-    screen.open('/')
-    screen.should_contain('Time')
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Time"]')
+    shared_screen.open('/')
+    shared_screen.should_contain('Time')
+    element = shared_screen.selenium.find_element(By.XPATH, '//*[@aria-label="Time"]')
     element.send_keys('12:00')
-    screen.should_contain('time: 12:00')
+    shared_screen.should_contain('time: 12:00')
 
-    screen.click('schedule')
-    screen.should_contain('AM')
-    screen.should_contain('PM')
+    shared_screen.click('schedule')
+    shared_screen.should_contain('AM')
+    shared_screen.should_contain('PM')

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_timeline(screen: Screen):
+def test_timeline(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.timeline():
@@ -10,8 +10,8 @@ def test_timeline(screen: Screen):
             with ui.timeline():
                 ui.label('Entry 2')
 
-    screen.open('/')
-    screen.should_contain('Entry 1')
-    screen.should_contain('Title 1')
-    screen.should_contain('Subtitle 1')
-    screen.should_contain('Entry 2')
+    shared_screen.open('/')
+    shared_screen.should_contain('Entry 1')
+    shared_screen.should_contain('Title 1')
+    shared_screen.should_contain('Subtitle 1')
+    shared_screen.should_contain('Entry 2')

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_adding_toggle_options(screen: Screen):
+def test_adding_toggle_options(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         label = ui.label()
@@ -14,19 +14,19 @@ def test_adding_toggle_options(screen: Screen):
 
         ui.button('Add option', on_click=add_option)
 
-    screen.open('/')
-    screen.click('A')
-    screen.should_contain('Choice: A')
-    screen.should_not_contain('D')
+    shared_screen.open('/')
+    shared_screen.click('A')
+    shared_screen.should_contain('Choice: A')
+    shared_screen.should_not_contain('D')
 
-    screen.click('Add option')
-    screen.should_contain('D')
+    shared_screen.click('Add option')
+    shared_screen.should_contain('D')
 
-    screen.click('D')
-    screen.should_contain('Choice: D')
+    shared_screen.click('D')
+    shared_screen.should_contain('Choice: D')
 
 
-def test_changing_options(screen: Screen):
+def test_changing_options(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         t = ui.toggle([10, 20, 30], value=10)
@@ -34,23 +34,23 @@ def test_changing_options(screen: Screen):
         ui.button('reverse', on_click=lambda: (t.options.reverse(), t.update()))
         ui.button('clear', on_click=lambda: (t.options.clear(), t.update()))
 
-    screen.open('/')
-    screen.click('reverse')
-    screen.should_contain('value = 10')
+    shared_screen.open('/')
+    shared_screen.click('reverse')
+    shared_screen.should_contain('value = 10')
 
-    screen.click('clear')
-    screen.should_contain('value = None')
+    shared_screen.click('clear')
+    shared_screen.should_contain('value = None')
 
 
-def test_clearable_toggle(screen: Screen):
+def test_clearable_toggle(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         t = ui.toggle(['A', 'B', 'C'], clearable=True)
         ui.label().bind_text_from(t, 'value', lambda v: f'value = {v}')
 
-    screen.open('/')
-    screen.click('A')
-    screen.should_contain('value = A')
+    shared_screen.open('/')
+    shared_screen.click('A')
+    shared_screen.should_contain('value = A')
 
-    screen.click('A')
-    screen.should_contain('value = None')
+    shared_screen.click('A')
+    shared_screen.should_contain('value = None')

--- a/tests/test_tooltip.py
+++ b/tests/test_tooltip.py
@@ -2,15 +2,15 @@ import pytest
 from selenium.webdriver import ActionChains
 
 from nicegui import ui
-from nicegui.testing.screen import Screen
+from nicegui.testing import SharedScreen
 
 
 @pytest.mark.parametrize('element', [ui.label, ui.button, ui.markdown])
-def test_tooltip_method(screen: Screen, element: type[ui.element]):
+def test_tooltip_method(shared_screen: SharedScreen, element: type[ui.element]):
     @ui.page('/')
     def page():
         element('Hover').tooltip('OK')
 
-    screen.open('/')
-    ActionChains(screen.selenium).move_to_element(screen.find('Hover')).perform()
-    screen.should_contain('OK')
+    shared_screen.open('/')
+    ActionChains(shared_screen.selenium).move_to_element(shared_screen.find('Hover')).perform()
+    shared_screen.should_contain('OK')

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,8 +1,8 @@
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_tree(screen: Screen):
+def test_tree(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.tree([
@@ -10,21 +10,21 @@ def test_tree(screen: Screen):
             {'id': 'letters', 'children': [{'id': 'A'}, {'id': 'B'}]},
         ], label_key='id')
 
-    screen.open('/')
-    screen.should_contain('numbers')
-    screen.should_contain('letters')
-    screen.should_not_contain('1')
-    screen.should_not_contain('2')
-    screen.should_not_contain('A')
-    screen.should_not_contain('B')
+    shared_screen.open('/')
+    shared_screen.should_contain('numbers')
+    shared_screen.should_contain('letters')
+    shared_screen.should_not_contain('1')
+    shared_screen.should_not_contain('2')
+    shared_screen.should_not_contain('A')
+    shared_screen.should_not_contain('B')
 
-    screen.find_by_class('q-icon').click()
-    screen.wait(0.5)
-    screen.should_contain('1')
-    screen.should_contain('2')
+    shared_screen.find_by_class('q-icon').click()
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('1')
+    shared_screen.should_contain('2')
 
 
-def test_expand_and_collapse_nodes(screen: Screen):
+def test_expand_and_collapse_nodes(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         tree = ui.tree([
@@ -37,38 +37,38 @@ def test_expand_and_collapse_nodes(screen: Screen):
         ui.button('Expand numbers', on_click=lambda: tree.expand(['numbers']))
         ui.button('Collapse numbers', on_click=lambda: tree.collapse(['numbers']))
 
-    screen.open('/')
-    screen.click('Expand all')
-    screen.wait(0.5)
-    screen.should_contain('1')
-    screen.should_contain('2')
-    screen.should_contain('A')
-    screen.should_contain('B')
+    shared_screen.open('/')
+    shared_screen.click('Expand all')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('1')
+    shared_screen.should_contain('2')
+    shared_screen.should_contain('A')
+    shared_screen.should_contain('B')
 
-    screen.click('Collapse all')
-    screen.wait(0.5)
-    screen.should_not_contain('1')
-    screen.should_not_contain('2')
-    screen.should_not_contain('A')
-    screen.should_not_contain('B')
+    shared_screen.click('Collapse all')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('1')
+    shared_screen.should_not_contain('2')
+    shared_screen.should_not_contain('A')
+    shared_screen.should_not_contain('B')
 
-    screen.click('Expand numbers')
-    screen.wait(0.5)
-    screen.should_contain('1')
-    screen.should_contain('2')
-    screen.should_not_contain('A')
-    screen.should_not_contain('B')
+    shared_screen.click('Expand numbers')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('1')
+    shared_screen.should_contain('2')
+    shared_screen.should_not_contain('A')
+    shared_screen.should_not_contain('B')
 
-    screen.click('Expand all')
-    screen.click('Collapse numbers')
-    screen.wait(0.5)
-    screen.should_not_contain('1')
-    screen.should_not_contain('2')
-    screen.should_contain('A')
-    screen.should_contain('B')
+    shared_screen.click('Expand all')
+    shared_screen.click('Collapse numbers')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain('1')
+    shared_screen.should_not_contain('2')
+    shared_screen.should_contain('A')
+    shared_screen.should_contain('B')
 
 
-def test_select_deselect_node(screen: Screen):
+def test_select_deselect_node(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         tree = ui.tree([
@@ -80,15 +80,15 @@ def test_select_deselect_node(screen: Screen):
         ui.button('Deselect', on_click=tree.deselect)
         ui.label().bind_text_from(tree.props, 'selected', lambda x: f'Selected: {x}')
 
-    screen.open('/')
-    screen.click('Select')
-    screen.should_contain('Selected: 2')
+    shared_screen.open('/')
+    shared_screen.click('Select')
+    shared_screen.should_contain('Selected: 2')
 
-    screen.click('Deselect')
-    screen.should_contain('Selected: None')
+    shared_screen.click('Deselect')
+    shared_screen.should_contain('Selected: None')
 
 
-def test_tick_untick_node_or_nodes(screen: Screen):
+def test_tick_untick_node_or_nodes(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         tree = ui.tree([
@@ -102,23 +102,23 @@ def test_tick_untick_node_or_nodes(screen: Screen):
         ui.button('Untick all', on_click=tree.untick)
         ui.label().bind_text_from(tree.props, 'ticked', lambda x: f'Ticked: {sorted(x)}')
 
-    screen.open('/')
-    screen.should_contain('Ticked: []')
+    shared_screen.open('/')
+    shared_screen.should_contain('Ticked: []')
 
-    screen.click('Tick some')
-    screen.should_contain("Ticked: ['1', '2', 'B']")
+    shared_screen.click('Tick some')
+    shared_screen.should_contain("Ticked: ['1', '2', 'B']")
 
-    screen.click('Untick some')
-    screen.should_contain("Ticked: ['2']")
+    shared_screen.click('Untick some')
+    shared_screen.should_contain("Ticked: ['2']")
 
-    screen.click('Tick all')
-    screen.should_contain("Ticked: ['1', '2', 'A', 'B', 'letters', 'numbers']")
+    shared_screen.click('Tick all')
+    shared_screen.should_contain("Ticked: ['1', '2', 'A', 'B', 'letters', 'numbers']")
 
-    screen.click('Untick all')
-    screen.should_contain('Ticked: []')
+    shared_screen.click('Untick all')
+    shared_screen.should_contain('Ticked: []')
 
 
-def test_filter(screen: Screen):
+def test_filter(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         t = ui.tree([
@@ -126,12 +126,12 @@ def test_filter(screen: Screen):
         ], label_key='id', tick_strategy='leaf-filtered').expand()
         ui.button('Filter', on_click=lambda: t.set_filter('a'))
 
-    screen.open('/')
-    screen.should_contain('Apple')
-    screen.should_contain('Banana')
-    screen.should_contain('Cherry')
+    shared_screen.open('/')
+    shared_screen.should_contain('Apple')
+    shared_screen.should_contain('Banana')
+    shared_screen.should_contain('Cherry')
 
-    screen.click('Filter')
-    screen.should_contain('Apple')
-    screen.should_contain('Banana')
-    screen.should_not_contain('Cherry')
+    shared_screen.click('Filter')
+    shared_screen.should_contain('Apple')
+    shared_screen.should_contain('Banana')
+    shared_screen.should_not_contain('Cherry')

--- a/tests/test_unocss.py
+++ b/tests/test_unocss.py
@@ -3,11 +3,11 @@ from typing import Literal
 import pytest
 
 from nicegui import app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
 @pytest.mark.parametrize('unocss', [None, 'mini', 'wind3', 'wind4'])
-def test_dynamic_classes(screen: Screen, unocss: Literal['mini', 'wind3', 'wind4'] | None):
+def test_dynamic_classes(shared_screen: SharedScreen, unocss: Literal['mini', 'wind3', 'wind4'] | None):
     app.config.unocss = unocss
 
     @ui.page('/')
@@ -19,14 +19,14 @@ def test_dynamic_classes(screen: Screen, unocss: Literal['mini', 'wind3', 'wind4
         ui.button('Make yellow', on_click=lambda: label.classes('text-yellow-500'))
         ui.button('Create blue', on_click=lambda: ui.label('Blue Label').classes('text-blue-500'))
 
-    screen.open('/')
-    screen.wait_for(lambda: screen.find('Red slot').value_of_css_property('color') == 'oklch(0.637 0.237 25.331)')
+    shared_screen.open('/')
+    shared_screen.wait_for(lambda: shared_screen.find('Red slot').value_of_css_property('color') == 'oklch(0.637 0.237 25.331)')
 
-    screen.click('Make green')
-    screen.wait_for(lambda: screen.find('Label').value_of_css_property('color') == 'oklch(0.723 0.219 149.579)')
+    shared_screen.click('Make green')
+    shared_screen.wait_for(lambda: shared_screen.find('Label').value_of_css_property('color') == 'oklch(0.723 0.219 149.579)')
 
-    screen.click('Make yellow')
-    screen.wait_for(lambda: screen.find('Label').value_of_css_property('color') == 'oklch(0.795 0.184 86.047)')
+    shared_screen.click('Make yellow')
+    shared_screen.wait_for(lambda: shared_screen.find('Label').value_of_css_property('color') == 'oklch(0.795 0.184 86.047)')
 
-    screen.click('Create blue')
-    screen.wait_for(lambda: screen.find('Blue Label').value_of_css_property('color') == 'oklch(0.623 0.214 259.815)')
+    shared_screen.click('Create blue')
+    shared_screen.wait_for(lambda: shared_screen.find('Blue Label').value_of_css_property('color') == 'oklch(0.623 0.214 259.815)')

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -3,32 +3,32 @@ from pathlib import Path
 import pytest
 
 from nicegui import events, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 test_path1 = Path('tests/test_upload.py').resolve()
 test_path2 = Path('tests/test_scene.py').resolve()
 
 
-async def test_uploading_text_file(screen: Screen):
+async def test_uploading_text_file(shared_screen: SharedScreen):
     results: list[events.UploadEventArguments] = []
 
     @ui.page('/')
     def page():
         ui.upload(on_upload=results.append, label='Test Title')
 
-    screen.open('/')
-    screen.should_contain('Test Title')
-    screen.find_by_class('q-uploader__input').send_keys(str(test_path1))
-    screen.wait(0.1)
-    screen.click('cloud_upload')
-    screen.wait(0.1)
+    shared_screen.open('/')
+    shared_screen.should_contain('Test Title')
+    shared_screen.find_by_class('q-uploader__input').send_keys(str(test_path1))
+    shared_screen.wait(0.1)
+    shared_screen.click('cloud_upload')
+    shared_screen.wait(0.1)
     assert len(results) == 1
     assert results[0].file.name == test_path1.name
     assert results[0].file.content_type in {'text/x-python', 'text/x-python-script'}
     assert await results[0].file.read() == test_path1.read_bytes()
 
 
-def test_two_upload_elements(screen: Screen):
+def test_two_upload_elements(shared_screen: SharedScreen):
     results: list[events.UploadEventArguments] = []
 
     @ui.page('/')
@@ -36,43 +36,43 @@ def test_two_upload_elements(screen: Screen):
         ui.upload(on_upload=results.append, auto_upload=True, label='Test Title 1')
         ui.upload(on_upload=results.append, auto_upload=True, label='Test Title 2')
 
-    screen.open('/')
-    screen.should_contain('Test Title 1')
-    screen.should_contain('Test Title 2')
-    screen.find_all_by_class('q-uploader__input')[0].send_keys(str(test_path1))
-    screen.find_all_by_class('q-uploader__input')[1].send_keys(str(test_path2))
-    screen.wait(0.1)
+    shared_screen.open('/')
+    shared_screen.should_contain('Test Title 1')
+    shared_screen.should_contain('Test Title 2')
+    shared_screen.find_all_by_class('q-uploader__input')[0].send_keys(str(test_path1))
+    shared_screen.find_all_by_class('q-uploader__input')[1].send_keys(str(test_path2))
+    shared_screen.wait(0.1)
     assert len(results) == 2
     assert results[0].file.name == test_path1.name
     assert results[1].file.name == test_path2.name
 
 
-def test_uploading_from_two_tabs(screen: Screen):
+def test_uploading_from_two_tabs(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         ui.upload(on_upload=lambda e: ui.label(f'uploaded {e.file.name}'), auto_upload=True)
 
-    screen.open('/')
-    screen.switch_to(1)
-    screen.open('/')
-    screen.should_not_contain(test_path1.name)
-    screen.find_by_class('q-uploader__input').send_keys(str(test_path1))
-    screen.should_contain(f'uploaded {test_path1.name}')
-    screen.switch_to(0)
-    screen.should_not_contain(f'uploaded {test_path1.name}')
+    shared_screen.open('/')
+    shared_screen.switch_to(1)
+    shared_screen.open('/')
+    shared_screen.should_not_contain(test_path1.name)
+    shared_screen.find_by_class('q-uploader__input').send_keys(str(test_path1))
+    shared_screen.should_contain(f'uploaded {test_path1.name}')
+    shared_screen.switch_to(0)
+    shared_screen.should_not_contain(f'uploaded {test_path1.name}')
 
 
-def test_upload_with_header_slot(screen: Screen):
+def test_upload_with_header_slot(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.upload().add_slot('header'):
             ui.label('Header')
 
-    screen.open('/')
-    screen.should_contain('Header')
+    shared_screen.open('/')
+    shared_screen.should_contain('Header')
 
 
-def test_replace_upload(screen: Screen):
+def test_replace_upload(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         with ui.row() as container:
@@ -83,41 +83,41 @@ def test_replace_upload(screen: Screen):
                 ui.upload(label='B')
         ui.button('Replace', on_click=replace)
 
-    screen.open('/')
-    screen.should_contain('A')
+    shared_screen.open('/')
+    shared_screen.should_contain('A')
 
-    screen.click('Replace')
-    screen.wait(0.5)
-    screen.should_contain('B')
-    screen.should_not_contain('A')
+    shared_screen.click('Replace')
+    shared_screen.wait(0.5)
+    shared_screen.should_contain('B')
+    shared_screen.should_not_contain('A')
 
 
-def test_reset_upload(screen: Screen):
+def test_reset_upload(shared_screen: SharedScreen):
     @ui.page('/')
     def page():
         upload = ui.upload()
         ui.button('Reset', on_click=upload.reset)
 
-    screen.open('/')
-    screen.find_by_class('q-uploader__input').send_keys(str(test_path1))
-    screen.should_contain(test_path1.name)
-    screen.click('Reset')
-    screen.wait(0.5)
-    screen.should_not_contain(test_path1.name)
+    shared_screen.open('/')
+    shared_screen.find_by_class('q-uploader__input').send_keys(str(test_path1))
+    shared_screen.should_contain(test_path1.name)
+    shared_screen.click('Reset')
+    shared_screen.wait(0.5)
+    shared_screen.should_not_contain(test_path1.name)
 
 
-async def test_multi_upload_event(screen: Screen):
+async def test_multi_upload_event(shared_screen: SharedScreen):
     results: list[events.MultiUploadEventArguments] = []
 
     @ui.page('/')
     def page():
         ui.upload(on_multi_upload=results.append, multiple=True)
 
-    screen.open('/')
-    screen.find_by_class('q-uploader__input').send_keys(f'{test_path1}\n{test_path2}')
-    screen.wait(0.1)
-    screen.click('cloud_upload')
-    screen.wait(0.1)
+    shared_screen.open('/')
+    shared_screen.find_by_class('q-uploader__input').send_keys(f'{test_path1}\n{test_path2}')
+    shared_screen.wait(0.1)
+    shared_screen.click('cloud_upload')
+    shared_screen.wait(0.1)
 
     assert len(results) == 1
     assert len(results[0].files) == 2
@@ -127,7 +127,7 @@ async def test_multi_upload_event(screen: Screen):
     assert await results[0].files[1].read() == test_path2.read_bytes()
 
 
-async def test_two_handlers_can_read_file(screen: Screen):
+async def test_two_handlers_can_read_file(shared_screen: SharedScreen):
     reads: list[events.UploadEventArguments] = []
 
     @ui.page('/')
@@ -136,9 +136,9 @@ async def test_two_handlers_can_read_file(screen: Screen):
         upload.on_upload(reads.append)
         upload.on_upload(reads.append)
 
-    screen.open('/')
-    screen.find_by_class('q-uploader__input').send_keys(str(test_path1))
-    screen.wait(0.1)
+    shared_screen.open('/')
+    shared_screen.find_by_class('q-uploader__input').send_keys(str(test_path1))
+    shared_screen.wait(0.1)
 
     assert len(reads) == 2
     upload_1 = await reads[0].file.text()
@@ -147,7 +147,7 @@ async def test_two_handlers_can_read_file(screen: Screen):
 
 
 @pytest.mark.parametrize('size', [500, 5_000_000])
-async def test_different_file_sizes(screen: Screen, size: int, tmp_path: Path):
+async def test_different_file_sizes(shared_screen: SharedScreen, size: int, tmp_path: Path):
     tmp_file = tmp_path / 'test.txt'
     reads: list[events.UploadEventArguments] = []
 
@@ -158,8 +158,8 @@ async def test_different_file_sizes(screen: Screen, size: int, tmp_path: Path):
 
     tmp_file.write_text('x' * size)
 
-    screen.open('/')
-    screen.find_by_class('q-uploader__input').send_keys(str(tmp_file))
-    screen.wait(0.1)
+    shared_screen.open('/')
+    shared_screen.find_by_class('q-uploader__input').send_keys(str(tmp_file))
+    shared_screen.wait(0.1)
     assert reads[0].file.size() == size
     assert await reads[0].file.text() == tmp_file.read_text()

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,5 +1,5 @@
 from nicegui import app, ui
-from nicegui.testing import Screen
+from nicegui.testing import SharedScreen
 
 
 def _serve_empty_file(path: str):
@@ -8,7 +8,7 @@ def _serve_empty_file(path: str):
         return b''
 
 
-def test_replace_video(screen: Screen):
+def test_replace_video(shared_screen: SharedScreen):
     _serve_empty_file(VIDEO1 := '/video1.mp4')
     _serve_empty_file(VIDEO2 := '/video2.mp4')
 
@@ -22,15 +22,15 @@ def test_replace_video(screen: Screen):
                 ui.video(VIDEO2)
         ui.button('Replace', on_click=replace)
 
-    screen.open('/')
-    assert screen.find_by_tag('video').get_attribute('src').endswith(VIDEO1)
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('video').get_attribute('src').endswith(VIDEO1)
 
-    screen.click('Replace')
-    screen.wait(0.5)
-    assert screen.find_by_tag('video').get_attribute('src').endswith(VIDEO2)
+    shared_screen.click('Replace')
+    shared_screen.wait(0.5)
+    assert shared_screen.find_by_tag('video').get_attribute('src').endswith(VIDEO2)
 
 
-def test_change_source(screen: Screen):
+def test_change_source(shared_screen: SharedScreen):
     _serve_empty_file(VIDEO1 := '/video1.mp4')
     _serve_empty_file(VIDEO2 := '/video2.mp4')
 
@@ -39,9 +39,9 @@ def test_change_source(screen: Screen):
         video = ui.video(VIDEO1)
         ui.button('Change source', on_click=lambda: video.set_source(VIDEO2))
 
-    screen.open('/')
-    assert screen.find_by_tag('video').get_attribute('src').endswith(VIDEO1)
+    shared_screen.open('/')
+    assert shared_screen.find_by_tag('video').get_attribute('src').endswith(VIDEO1)
 
-    screen.click('Change source')
-    screen.wait(0.5)
-    assert screen.find_by_tag('video').get_attribute('src').endswith(VIDEO2)
+    shared_screen.click('Change source')
+    shared_screen.wait(0.5)
+    assert shared_screen.find_by_tag('video').get_attribute('src').endswith(VIDEO2)

--- a/tests/test_vue_component.py
+++ b/tests/test_vue_component.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
 from nicegui import ui
-from nicegui.testing.screen import Screen
+from nicegui.testing import SharedScreen
 
 
-def test_vue_element(screen: Screen, tmp_path: Path):
+def test_vue_element(shared_screen: SharedScreen, tmp_path: Path):
     vue_component_path = tmp_path / 'component.vue'
     vue_component_path.write_text('''
         <template>
@@ -39,7 +39,7 @@ def test_vue_element(screen: Screen, tmp_path: Path):
         MyVueElement()
         ui.label('This is not red')
 
-    screen.open('/')
-    assert screen.find('Template shows up').value_of_css_property('color') == 'rgba(255, 0, 0, 1)'
-    assert screen.find('JavaScript runs').value_of_css_property('color') == 'rgba(255, 0, 0, 1)'
-    assert screen.find('This is not red').value_of_css_property('color') == 'rgba(0, 0, 0, 1)'
+    shared_screen.open('/')
+    assert shared_screen.find('Template shows up').value_of_css_property('color') == 'rgba(255, 0, 0, 1)'
+    assert shared_screen.find('JavaScript runs').value_of_css_property('color') == 'rgba(255, 0, 0, 1)'
+    assert shared_screen.find('This is not red').value_of_css_property('color') == 'rgba(0, 0, 0, 1)'


### PR DESCRIPTION
### Motivation

Besides sharing the Chromedriver in #5729, significant timesavings may be had, if we share the screen fixture as well. 

### Implementation

Right now this branch is a mess because the diff is always big and messy straight off Claude, but for some reason the actions at my branch is not running automatically! https://github.com/evnchn/nicegui/actions/workflows/ci-gate.yml

To use the CI to see the tests without flakiness on local, I have no choice but to open a draft PR. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] The implementation is complete.
- [ ] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).
