### PR TITLE
use static URL for sponsor images instead of local path

### DIFF
--- a/website/main_page.py
+++ b/website/main_page.py
@@ -173,11 +173,11 @@ def create() -> None:
                             with ui.link(target=SPONSORS['special'][sponsor]):
                                 img_path = Path(__file__).parent / 'static' / 'sponsors' / f'{sponsor}.webp'
                                 if img_path.exists():
-                                    ui.interactive_image(img_path).classes('h-12')
+                                    ui.interactive_image(f'/static/sponsors/{sponsor}.webp').classes('h-12')
                                 else:
-                                    ui.interactive_image(img_path.with_suffix('.light.webp')) \
+                                    ui.interactive_image(f'/static/sponsors/{sponsor}.light.webp') \
                                         .classes('h-12 block dark:!hidden')
-                                    ui.interactive_image(img_path.with_suffix('.dark.webp')) \
+                                    ui.interactive_image(f'/static/sponsors/{sponsor}.dark.webp') \
                                         .classes('h-12 hidden dark:!block')
                         for sponsor in SPONSORS['top']:
                             with ui.link(target=f'https://github.com/{sponsor}').classes('row items-center gap-2'):


### PR DESCRIPTION
### Motivation

Sponsor images on the main page were passed as local file `Path` objects to `ui.interactive_image()`, causing
NiceGUI to serve them via auto-generated paths like `/_nicegui/auto/static/<hash>/lechler-gmbh.webp`. This had two
  problems:

1. **Broken images across server instances:** The hash in the auto path is instance-specific. Since nicegui.io
runs multiple server instances, a client could receive HTML from one instance but have the image request routed to
  another instance where that hash doesn't exist, causing the image to fail to load.

2. **Poor caching / Lighthouse score:** The auto path bypasses the `DocsSetCacheControlMiddleware` that sets cache
  headers for `/static/` paths. Using the static URL ensures sponsor images are strongly cached.

### Implementation

Use the URL path `/static/sponsors/...` (served by `app.add_static_files`) instead of local file `Path` objects.
The local path is still used for the `exists()` check to decide between single vs light/dark image variants.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security
advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).