### PR TITLE
fix WebSocket URL missing host on HTTPS

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -399,7 +399,7 @@ function createApp(elements, options) {
       mounted_app = this;
       window.documentId = createRandomUUID();
       window.clientId = options.query.client_id;
-      const url = window.location.protocol === "https:" ? "wss://" : "ws://" + window.location.host;
+      const url = (window.location.protocol === "https:" ? "wss://" : "ws://") + window.location.host;
       window.path_prefix = options.prefix;
       window.nextMessageId = options.query.next_message_id;
       window.ackedMessageId = -1;


### PR DESCRIPTION
### Motivation

JavaScript operator precedence causes the WebSocket URL to lose its host on HTTPS pages. The `+` operator binds tighter than the ternary `? :`, so:

```js
const url = window.location.protocol === "https:" ? "wss://" : "ws://" + window.location.host;
```

evaluates as:

```js
const url = (protocol === "https:") ? "wss://" : ("ws://" + window.location.host);
```

On https://nicegui.io, this produces just `"wss://"` with no host at all:

```
> const url = window.location.protocol === "https:" ? "wss://" : "ws://" + window.location.host;
> console.log(url);
wss://
```

### Implementation

Add parentheses around the ternary so the host is always appended:

```js
const url = (window.location.protocol === "https:" ? "wss://" : "ws://") + window.location.host;
```

such that:

```
> const url = (window.location.protocol === "https:" ? "wss://" : "ws://") + window.location.host;
> console.log(url)
wss://nicegui.io
```

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] HTTPS out of Pytests scope.
- [x] Documentation is not necessary for a bugfix.


