### PR TITLE
Remove nanasess/setup-chromedriver from CI — use runner's preinstalled Chrome

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -32,7 +32,6 @@ jobs:
         run: uv python install ${{ matrix.python }}
       - name: Install dependencies
         run: uv sync
-      - uses: nanasess/setup-chromedriver@v2.3.0
       - name: ${{ matrix.python }} / ${{ matrix.scope }}
         if: matrix.scope == 'pytest'
         run: uv run pytest


### PR DESCRIPTION
### Motivation

The `ubuntu-latest` runner image already ships with matched Chrome and ChromeDriver versions ([runner-images manifest](https://github.com/actions/runner-images/blob/ubuntu24/20260201.15/images/ubuntu/Ubuntu2404-Readme.md)). The third-party `nanasess/setup-chromedriver@v2.3.0` action is redundant and introduces a point of fragility: when Chrome auto-updates on the runner image, the action may install a mismatched or conflicting ChromeDriver version, causing test failures unrelated to any code change.

This issue materialized on Feb 8, 2026, when Chrome auto-updated from `144.0.7559.96` to `144.0.7559.109` on the runner image. The update caused 4 test failures and 1 error across multiple unrelated PRs:

| Test | Error |
|------|-------|
| `test_page::test_exception` | `AssertionError: Could not find "500"` |
| `test_select::test_add_new_values[add-False-True]` | `IndexError: pop from empty list` |
| `test_select::test_add_new_values[add-True-True]` | `IndexError: pop from empty list` |
| `test_storage::test_missing_storage_secret` | `IndexError: pop from empty list` |
| `test_page::test_exception_after_connected` | JS `RangeError: Maximum call stack size exceeded` |

These failures appeared identically on two completely unrelated PRs ([evnchn#68](https://github.com/evnchn/nicegui/pull/68), [evnchn#71](https://github.com/evnchn/nicegui/pull/71)), confirming they are environment-caused, not code-caused. Upstream last ran CI on Feb 5 with Chrome `.96` (passing); the next CI run will encounter the same failures.

### Implementation

Remove the `nanasess/setup-chromedriver@v2.3.0` step from `.github/workflows/_test.yml`. The runner image's preinstalled Chrome and ChromeDriver are used instead.

This is the most maintainable approach because:
- The runner image always ships a matched Chrome + ChromeDriver pair
- If the preinstalled Chrome breaks, it affects the entire GitHub Actions ecosystem, guaranteeing rapid upstream fixes from GitHub/Microsoft
- No third-party action to maintain, audit, or pin versions for
- One fewer network fetch during CI (the action downloads ChromeDriver on every run)

### Alternatives explored

Five approaches were tested on [evnchn/nicegui](https://github.com/evnchn/nicegui) to triangulate the root cause and find the best fix:

| PR | Approach | Result | Trade-off |
|----|----------|--------|-----------|
| [#72](https://github.com/evnchn/nicegui/pull/72) | Pin Chrome+ChromeDriver to `.96` via `browser-actions/setup-chrome@v2` | **All 769 tests pass** | Requires manual version bumps; masks Chrome regressions |
| [#73](https://github.com/evnchn/nicegui/pull/73) | Pin ChromeDriver only to `.96` via `nanasess` with `chromedriver-version` | **All 769 tests pass** | Same pinning burden; still depends on third-party action |
| [#74](https://github.com/evnchn/nicegui/pull/74) | ARM64 runner (`ubuntu-24.04-arm`) + Chromium via apt | **3 failures**, 769 passed | 8% slower pytest (24m06s vs 22m18s), +93s Chromium install overhead, new platform-specific test failures (`test_upload` file path bug, `test_xterm` terminal size mismatch) |
| [#75](https://github.com/evnchn/nicegui/pull/75) | Remove `nanasess`, use preinstalled Chrome | **All 769 tests pass** | **This approach** — zero maintenance, zero overhead |

### Timing comparison (PR #75 vs PR #74)

| | PR #75 x86_64 (this approach) | PR #74 ARM64 |
|---|---|---|
| Chrome install | 0s (preinstalled) | 93s (apt-get) |
| pytest duration | 22m 18s | 24m 06s |
| Total job wall-clock | 22m 30s | 25m 56s |
| Test result | **769 passed** | 3 failed, 769 passed |

### Root cause analysis

- Chrome auto-updated from `144.0.7559.96` to `144.0.7559.109` between Feb 6 and Feb 8 on the `ubuntu-latest` runner image
- All Python dependencies are identical across passing and failing runs (`selenium==4.40.0`, `cpython-3.10.19`)
- Chromium commit log between `.97` and `.110` contains only Chrome-internal changes (contextual tasks UI, i18n, Android GPU, sandbox policy, translation, PDF, PKI metadata) — no V8, CSS, WebDriver, or networking changes
- The behavioral regression in `.109` is likely in a rolled dependency (via DEPS) rather than a direct Chromium commit
- Removing `nanasess` resolves the issue because the runner image's preinstalled Chrome `.109` and its matched ChromeDriver work correctly together — the problem was the version mismatch introduced by the action

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).