### PR TITLE
Fix prune_user_storage crash with request-less clients

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -264,7 +264,8 @@ async def prune_tab_storage(*, force: bool = False) -> None:
 
 async def prune_user_storage(*, force: bool = False) -> None:
     """Remove user storage objects without a client session."""
-    client_session_ids = {client.request.session['id'] for client in Client.instances.values()}
+    client_session_ids = {client.request.session['id'] for client in Client.instances.values()
+                          if client._request is not None}  # pylint: disable=protected-access
     storages_to_close: list[PersistentDict] = []
     now = time.time()
     user_storages = core.app.storage._users  # pylint: disable=protected-access


### PR DESCRIPTION
### Motivation

Fixes #5480

`prune_user_storage` crashes with `RuntimeError: Request is not set` when a client exists in `Client.instances` without a request. This happens when UI elements (e.g. `ui.button()`) are created at module scope before `ui.run_with()`, which triggers a pseudo-client via `Context.slot_stack` with `_request=None`.

Reproduction from https://github.com/zauberzeug/nicegui/issues/5480#issuecomment-3862254308:
a plugin calling `ui.button()` in `__init__`, loaded via `importlib` before `ui.run_with(fastapi_app, storage_secret=...)`.

### Implementation

Skip clients where `_request is None` in the set comprehension at `nicegui.py:267`. These clients never created a session, so they have no session ID to contribute.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).