### PR TITLE
Sort menu alphabetically, open external links in new tabs

### DIFF
--- a/website/documentation/tree.py
+++ b/website/documentation/tree.py
@@ -7,7 +7,10 @@ nodes: list[dict[str, Any]] = []
 
 
 def build_tree() -> None:
-    """Build tree by recursively collecting documentation pages and parts."""
+    """Build tree by recursively collecting documentation pages and parts.
+
+    NOTE: Also sorts intro parts in-place so both the tree and page rendering use alphabetical order.
+    """
     nodes.clear()
     for module, _ in tiles:
         page = registry[module.__name__.rsplit('.', 1)[-1]]

--- a/website/header.py
+++ b/website/header.py
@@ -16,11 +16,11 @@ def add_head_html() -> None:
     ui.add_head_html(HEADER_HTML + f'<style>{STYLE_CSS}</style>')
     ui.add_head_html('''
         <script>
-            document.addEventListener('click', function(e) {
-                const link = e.target.closest('a[href]');
+            document.addEventListener("click", function(e) {
+                const link = e.target.closest("a[href]");
                 if (link && link.hostname && link.hostname !== location.hostname) {
-                    link.target = '_blank';
-                    link.rel = 'noopener';
+                    link.target = "_blank";
+                    link.rel = "noopener";
                 }
             });
         </script>


### PR DESCRIPTION
## Summary
- Sort documentation menu items alphabetically by title across all sections
- Open external links in new browser tabs

Addresses https://github.com/zauberzeug/nicegui/discussions/5744.

## Changes

**Alphabetical menu** (`tree.py`): `_sort_intro_parts()` sorts contiguous groups of intro parts in-place during `build_tree()`.
This avoids touching individual section files — the sort applies to all sections automatically.

**External links in new tabs** (`header.py`): JS click-event delegation detects external links (different hostname) and sets `target="_blank"` with `rel="noopener"`.

### Why JS over Python-side?

A Python-side approach was also prototyped (passing a regex post-processor as `sanitize=` to `ui.markdown`).
It was discarded because:
- Passing a callable to `sanitize=` **disables client-side sanitization** (DOMPurify), a subtle behavioral change
- Incomplete coverage: only catches the `rendering.py` pipeline, misses overview, demos, RST content
- Fragile regex assuming `href` is the first attribute

The JS approach covers everything globally with a single delegated listener and no side-effects.

## Test plan
- [x] `ruff check` / pre-commit hooks pass
- [x] Verified Controls menu is alphabetically sorted via Python-level check
- [x] Verified sanitize function correctness (external links get `target="_blank"`, internal links untouched)
- [ ] Manual: visit `/documentation/section_controls` and confirm alphabetical order in left nav
- [ ] Manual: click an external link (e.g. Quasar link on Styling page) and confirm it opens in a new tab
