### PR TITLE
Upgrade SQL example to tortoise 1.0.0

### DIFF
--- a/examples/sqlite_database/main.py
+++ b/examples/sqlite_database/main.py
@@ -1,20 +1,10 @@
 #!/usr/bin/env python3
 import models
-from tortoise import Tortoise
+from tortoise.contrib.fastapi import register_tortoise
 
 from nicegui import app, ui
 
-
-async def init_db() -> None:
-    await Tortoise.init(db_url='sqlite://db.sqlite3', modules={'models': ['models']})
-    await Tortoise.generate_schemas()
-
-
-async def close_db() -> None:
-    await Tortoise.close_connections()
-
-app.on_startup(init_db)
-app.on_shutdown(close_db)
+register_tortoise(app, db_url='sqlite://db.sqlite3', modules={'models': ['models']}, generate_schemas=True)
 
 
 @ui.refreshable

--- a/examples/sqlite_database/requirements.txt
+++ b/examples/sqlite_database/requirements.txt
@@ -1,3 +1,2 @@
 nicegui>=3.0
-tortoise-orm
-aiosqlite==0.21.0  # until https://github.com/tortoise/tortoise-orm/issues/2037 is fixed
+tortoise-orm>=1.0.0

--- a/test_startup.sh
+++ b/test_startup.sh
@@ -44,11 +44,6 @@ do
         continue # until https://github.com/pygobject/pycairo/issues/387 is fixed
     fi
 
-    # Skip examples/sqlite_database for Python 3.11 and 3.12
-    if [[ $(uv run python3 --version | cut -d' ' -f2 | cut -d'.' -f1,2) =~ ^3.1[12]$ ]] && [[ $path == "examples/sqlite_database" ]]; then
-        continue # until https://github.com/omnilib/aiosqlite/issues/241 is fixed
-    fi
-
     # Skip examples/ai_interface for Python 3.14
     if [[ $(uv run python3 --version | cut -d' ' -f2 | cut -d'.' -f1,2) =~ ^3.14$ ]] && [[ $path == "examples/ai_interface" ]]; then
         continue # It still uses Pydantic V1, which breaks horribly with Python 3.14


### PR DESCRIPTION
### Motivation

The `sqlite_database` example breaks with Tortoise ORM 1.0:

```
RuntimeError: No TortoiseContext is currently active.
Use 'async with TortoiseContext() as ctx:' to create one, or call Tortoise.init() for global state.
```

Tortoise ORM 1.0 replaced global state with a `ContextVar`-based architecture. Since NiceGUI runs async `on_startup` handlers as background tasks (via `safe_invoke` / `background_tasks.create`), the `ContextVar` set by `Tortoise.init()` in the startup task never propagates to request handler tasks.

Additionally, `aiosqlite` was pinned to 0.21.0 to work around [tortoise/tortoise-orm#2037](https://github.com/tortoise/tortoise-orm/issues/2037), and the example was skipped in CI for Python 3.11/3.12 due to [omnilib/aiosqlite#241](https://github.com/omnilib/aiosqlite/issues/241). Both issues are resolved in Tortoise ORM 1.0.

### Implementation

Replace the manual `Tortoise.init()` / `close_connections()` / `on_startup` / `on_shutdown` boilerplate with `register_tortoise()` from `tortoise.contrib.fastapi`. Since NiceGUI's `app` is a FastAPI subclass, this hooks directly into the app's lifespan and uses `_enable_global_fallback=True` internally, making the Tortoise context available across all async tasks.

This also removes the `aiosqlite` pin and the CI skip for Python 3.11/3.12.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This is not a security issue.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
