### PR TITLE
Skip redundant innerHTML updates in ui.html to preserve client-side DOM modifications

### DIFF
--- a/nicegui/elements/html.js
+++ b/nicegui/elements/html.js
@@ -1,5 +1,8 @@
 export default {
   template: `<component :is="tag"></component>`,
+  data() {
+    return { previousInnerHTML: null };
+  },
   mounted() {
     this.renderContent();
   },
@@ -8,11 +11,13 @@ export default {
   },
   methods: {
     renderContent() {
+      if (this.innerHTML === this.previousInnerHTML) return;
       if (this.sanitize) {
         this.$el.setHTML(this.innerHTML);
       } else {
         this.$el.innerHTML = this.innerHTML;
       }
+      this.previousInnerHTML = this.innerHTML;
     },
   },
   props: {


### PR DESCRIPTION
### Motivation

Fixes #5749

In NiceGUI 3.7.x, server-side updates (e.g. toggling visibility of an unrelated element) cause `ui.html` to re-assign `innerHTML` even when the content hasn't changed. This destroys any client-side DOM modifications (such as JavaScript-injected styled spans) that were applied after the initial render. This worked correctly in 3.6.1.

### Implementation

Added a `previousInnerHTML` data property to the html component. The `renderContent()` method now compares the current `innerHTML` prop against the cached value and returns early if unchanged, avoiding unnecessary DOM rewrites that would wipe client-side modifications.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)