### PR TITLE
Add AI co-authorship attribution guidance to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -409,16 +409,16 @@ This helps maintainers understand the origin of changes and smooths the review p
 
 Some agents add a `Co-authored-by` trailer automatically, but others do not.
 Some even silently **remove** existing co-authorship lines when amending or rebasing commits.
-If you find it missing, please include the appropriate line in your commit message:
+If you find it missing, please include the appropriate line for your agent in your commit message (pick one):
 
 ```
 Co-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
 Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
-Co-Authored-By: opencode <noreply@opencode.ai>
+Co-authored-by: opencode <noreply@opencode.ai>
 ```
 
 > [!TIP]
-> Edits are welcome to add new co-authorship lines for other coding agents not yet listed here.
+> PRs are welcome to add co-authorship lines for other coding agents not yet listed here.
 
 ## YouTube
 


### PR DESCRIPTION
### Motivation

AI coding agents (Copilot, Claude Code, OpenCode, etc.) are increasingly used to author PRs.
Some agents add `Co-authored-by` trailers automatically, but others silently omit or even **remove** them when amending or rebasing.
Clear guidance in CONTRIBUTING.md helps contributors properly attribute AI-generated code, which smooths the review process for maintainers.

### Implementation

Adds a new **AI Co-Authorship** subsection under "Pull Requests" in CONTRIBUTING.md that:
- Explains why co-authorship attribution matters
- Warns that some agents drop existing trailers
- Provides ready-to-copy `Co-authored-by` lines for common agents
- Invites edits to add lines for agents not yet listed

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)