### PR TITLE
Fix vnode cache invalidation for loopback=False elements and event listener changes

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -304,6 +304,7 @@ function renderRecursively(elements, id, propsContext) {
       throttle(delayed_emitter, event.throttle, event.leading_events, event.trailing_events, event.listener_id);
       if (element.props["loopback"] === False && event.type == "update:modelValue") {
         element.props["model-value"] = args;
+        invalidateVnodeCache(elements, [id]);
       }
     };
 
@@ -518,8 +519,8 @@ function createApp(elements, options) {
             if (!(id in this.elements)) continue;
             const oldListenerIds = new Set((this.elements[id]?.events || []).map((ev) => ev.listener_id));
             if (element.events?.some((e) => !oldListenerIds.has(e.listener_id))) {
+              invalidateVnodeCache(this.elements, [Number(id)]);
               delete this.elements[id];
-              vnodeCache.delete(Number(id));
               eventListenersChanged = true;
             }
           }


### PR DESCRIPTION
## Summary
- Fix vnode cache not being invalidated when loopback=False elements mutate model-value directly
- Fix ancestor cache invalidation for event listener change detection (unmount/remount cycle)

These two gaps caused 13 test failures in the vnode-cache branch.

## Test plan
- [x] All 13 previously failing tests should now pass:
  - test_entering_color, test_date_input, test_time_input
  - test_number_input, test_apply_format_on_blur, test_max_value, test_clearable_number
  - test_rounding[None], test_rounding[1], test_rounding[-1]
  - test_int_float_conversion_on_error1, test_int_float_conversion_on_error2
  - test_late_event_registration
- [x] Existing passing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)