### PR TITLE
Fix prune_user_storage crash when UI elements created before ui.run_with()

### DIFF
--- a/nicegui/ui_run_with.py
+++ b/nicegui/ui_run_with.py
@@ -12,6 +12,7 @@ from starlette.types import ASGIApp
 from . import core, helpers, storage
 from .air import Air
 from .language import Language
+from .logging import log
 from .middlewares import RedirectWithPrefixMiddleware, SetCacheControlMiddleware
 from .nicegui import _shutdown, _startup
 from .server import Server
@@ -62,6 +63,17 @@ def run_with(
     :param session_middleware_kwargs: additional keyword arguments passed to SessionMiddleware that creates the session cookies used for browser-based storage
     :param show_welcome_message: whether to show the welcome message (default: `True`)
     """
+    if core.script_mode:
+        log.warning(
+            'NiceGUI elements were created outside of a page context before ui.run_with() was called.\n'
+            'This is not supported and the elements will be discarded.\n'
+            'Move UI element creation into a @ui.page function or an app.on_startup handler.'
+        )
+        if core.script_client is not None:
+            core.script_client.delete()
+            core.script_client = None
+        core.script_mode = False
+
     core.app.config.add_run_config(
         reload=False,
         title=title,


### PR DESCRIPTION
### Motivation

Fixes #5480

When UI elements (e.g. `ui.button()`) are created at module level before `ui.run_with()`, NiceGUI's `Context.slot_stack` creates a pseudo "script client" with `_request=None`. This client is designed for `ui.run()` script mode, which properly handles it. However, `run_with()` never handled this case — leaving an orphaned request-less client in `Client.instances`. When `prune_user_storage()` runs every 10 seconds, it crashes accessing `client.request.session['id']` on this client.

Supersedes #5742, which was closed because it only silenced the crash without addressing the root cause.

### Implementation

Detect `core.script_mode` at the start of `run_with()`. If UI elements were created outside a page context:
1. Log a clear, actionable warning telling the user what happened and how to fix it
2. Delete the orphaned script client (removing it from `Client.instances`)
3. Reset `core.script_mode` to `False`

This mirrors how `ui.run()` handles `core.script_mode` in `ui_run.py`, adapted for `run_with()` where module-level UI creation is not a valid pattern.

### Reproduction

From https://github.com/zauberzeug/nicegui/issues/5480#issuecomment-3862254308:

```python
# myplugin.py
from nicegui import ui

class MyPlugin:
    def __init__(self) -> None:
        self.my_button = ui.button()
```

```python
# main.py
import importlib
from fastapi import FastAPI
from nicegui import ui

fastapi_app = FastAPI()
module = importlib.import_module('myplugin')
plugin_instance = module.MyPlugin()
ui.run_with(fastapi_app, storage_secret='secret')
```

**Before**: `RuntimeError: Request is not set` every 10 seconds.
**After**: Clear warning at startup, no crash.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).