### PR TITLE
Add copilot-setup-steps.yml for Copilot coding agent environment

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,22 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-
       - name: Install Python
         run: uv python install 3.10
-
       - name: Install dependencies
         run: uv sync
-
       - name: Install pre-commit hooks
         run: uv run pre-commit install


### PR DESCRIPTION
### Motivation

Add a `copilot-setup-steps.yml` workflow so that the [GitHub Copilot coding agent](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment#preinstalling-tools-or-dependencies-in-copilots-environment) has Python, uv, project dependencies, and pre-commit hooks pre-installed in its ephemeral environment. This reduces exploration time and avoids build failures when Copilot works on issues or PRs.

### Implementation

The workflow follows the canonical schema from the official GitHub documentation:
- **Job name**: `copilot-setup-steps` (required for Copilot to recognize it)
- **Triggers**: `workflow_dispatch`, `push`, and `pull_request` (path-filtered to itself for validation)
- **Permissions**: Minimal `contents: read`
- **Setup steps**: Mirrors the existing CI setup in `_check.yml` — checkout, setup-uv with caching, install Python 3.10, `uv sync`, and `uv run pre-commit install`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).