### PR TITLE
Add support for typing numbers in UserInteraction

### DIFF
--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -65,7 +65,8 @@ class UserInteraction(Generic[T]):
                 if isinstance(element, DisableableElement) and not element.enabled:
                     continue
                 if isinstance(element, ui.number):
-                    element.value = float(text)
+                    current = element._value_to_model_value(element.value) or ''  # pylint: disable=protected-access
+                    element.value = float(current + text)
                 elif isinstance(element, (ui.input, ui.editor, ui.codemirror)):
                     element.value = (element.value or '') + text
                 else:

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -234,19 +234,23 @@ async def test_input(user: User, kind: type) -> None:
 async def test_type_number(user: User) -> None:
     @ui.page('/')
     def page():
-        number = ui.number(on_change=lambda e: ui.notify(f'Changed: {e.value}'))
+        number = ui.number()
         ui.label().bind_text_from(number, 'value', lambda v: f'Value: {v}')
 
     await user.open('/')
 
-    user.find(ui.number).type('42')
+    user.find(ui.number).type('4')
+    await user.should_see('Value: 4.0')
+
+    user.find(ui.number).type('2')
     await user.should_see('Value: 42.0')
-    await user.should_see('Changed: 42.0')
 
     user.find(ui.number).clear()
     user.find(ui.number).type('7')
     await user.should_see('Value: 7.0')
-    await user.should_see('Changed: 7.0')
+
+    user.find(ui.number).type('.5')
+    await user.should_see('Value: 7.5')
 
 
 async def test_name_property(user: User) -> None:


### PR DESCRIPTION
### Motivation

See discussion #5771: Calling `user.find(ui.number).type('42')` in user simulation tests raises an `AssertionError` because `type()` only supports `ui.input`, `ui.editor`, and `ui.codemirror`. There's no reason `ui.number` shouldn't work too.

### Implementation

- Added `ui.number` as a supported element in `UserInteraction.type()`
- For `ui.number`, the typed text is converted to `float` and set directly (no string concatenation, since that doesn't apply to numeric values)
- Replaced the bare `assert` with an explicit `TypeError` for unsupported element types, giving a clear error message
- Added `test_type_number` to verify typing and clearing on `ui.number` elements

### Limitation

~~Unlike text inputs, `type()` on `ui.number` does not simulate character-by-character typing. It converts the full text to a float in one step. Simulating intermediate keystroke states (e.g., `type('7.')` → NaN → `type('0')` → 7.0) would require modeling browser-level input behavior, which is out of scope for this change.~~

Each `type()` call must produce a valid float. Intermediate states that aren't valid floats (like `"."` or `"1e"`) can't be represented, and trailing dots get lost (e.g., `type("7.")` + `type("5")` yields `75.0` instead of `7.5` because `"7."` is parsed as `7`).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This is not a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
