### PR TITLE
Fix sponsor button border styling with dark mode support

### DIFF
--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -143,7 +143,8 @@ tiles = [
 def create_tiles():
     with ui.row().classes('items-center content-between'):
         ui.label('If you like NiceGUI, go and become a')
-        ui.html('<iframe src="https://github.com/sponsors/zauberzeug/button" title="Sponsor zauberzeug" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>', sanitize=False)
+        ui.html('<iframe src="https://github.com/sponsors/zauberzeug/button" title="Sponsor zauberzeug" height="32" width="114"'
+                ' class="border-0 outline-[1px] outline-offset-[-1px] outline-[#d1d9e0] dark:outline-[#3d444d] rounded"></iframe>', sanitize=False)
     for documentation, description in tiles:
         page = doc.get_page(documentation)
         with ui.link(target=f'/documentation/{page.name}') \


### PR DESCRIPTION
### Motivation

Quick win: the original `border-radius: 6px` inline style on the GitHub Sponsors iframe is broken, as the original content is not rounded. 

This replaces the inline styles with Tailwind utility classes and adds proper dark mode support.

### Implementation

- Replaced `style="border: 0; border-radius: 6px;"` with Tailwind classes
- `border-0` to suppress the default iframe border
- `outline-[1px]` with `outline-offset-[-1px]` for a subtle border that matches GitHub's Primer design tokens (`#d1d9e0` light / `#3d444d` dark)
- `rounded` for border radius

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).