### PR TITLE
Select search text when reopening search dialog

### DIFF
--- a/website/search.py
+++ b/website/search.py
@@ -85,5 +85,5 @@ class Search:
         background_tasks.create_lazy(handle_input(), name='handle_search_input')
 
     def open_dialog(self) -> None:
-        ui.run_javascript(f'{self.input.html_id}.select()')
+        self.input.run_method('select')
         self.dialog.open()


### PR DESCRIPTION
### Motivation

When reopening the search dialog on nicegui.io, the previously entered text remains, requiring users to manually delete it before starting a new search. As suggested in https://github.com/zauberzeug/nicegui/discussions/5744#discussioncomment-15803209, selecting the existing text (instead of clearing it) provides the best of both worlds: users can immediately type to replace the old query, or use arrow keys to navigate and edit it.

### Implementation

- Store a reference to the search `ui.input` element as `self.input`
- Add an `open_dialog()` method that selects the input text via `ui.run_javascript` before opening the dialog
- Route both the keyboard shortcut handler and the search button through `open_dialog()` instead of `self.dialog.open()` directly

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)