### PR TITLE
Use Web Worker heartbeat to keep connection alive during blocking dialogs

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -210,6 +210,7 @@ class Client:
                 'socket_io_js_query_params': socket_io_js_query_params,
                 'socket_io_js_extra_headers': core.app.config.socket_io_js_extra_headers,
                 'socket_io_js_transports': core.app.config.socket_io_js_transports,
+                'reconnect_timeout': self.page.resolve_reconnect_timeout(),
             },
             status_code=status_code,
             headers={'Cache-Control': 'no-store', 'X-NiceGUI-Content': 'page'},
@@ -351,6 +352,11 @@ class Client:
                 self.delete()
         self._delete_tasks[document_id] = \
             background_tasks.create(delete_content(), name=f'delete content {document_id}')
+
+    def _handle_heartbeat(self) -> None:
+        """Cancel pending delete tasks to keep the client alive during blocking browser dialogs."""
+        for document_id in list(self._delete_tasks):
+            self._cancel_delete_task(document_id)
 
     def _cancel_delete_task(self, document_id: str) -> None:
         if document_id in self._delete_tasks:

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -79,6 +79,7 @@ class Client:
         self.on_air = False
         self._num_connections: defaultdict[str, int] = defaultdict(int)
         self._delete_tasks: dict[str, asyncio.Task] = {}
+        self._pending_tab_ids: dict[str, str | None] = {}
         self._deleted = False
         self._socket_to_document_id: dict[str, str] = {}
         self.tab_id: str | None = None
@@ -335,7 +336,7 @@ class Client:
         document_id = self._socket_to_document_id.pop(socket_id)
         self._cancel_delete_task(document_id)
         self._num_connections[document_id] -= 1
-        tab_id_to_close = self.tab_id
+        self._pending_tab_ids[document_id] = self.tab_id
         self.tab_id = None
 
         for t in self.disconnect_handlers:
@@ -343,20 +344,33 @@ class Client:
         for t in core.app._disconnect_handlers:  # pylint: disable=protected-access
             self.safe_invoke(t)
 
+        self._create_delete_task(document_id)
+
+    def _create_delete_task(self, document_id: str) -> None:
+        """Schedule deletion of client content after reconnect timeout."""
         async def delete_content() -> None:
             await asyncio.sleep(self.page.resolve_reconnect_timeout())
             if self._num_connections[document_id] == 0:
-                self._num_connections.pop(document_id)
-                self._delete_tasks.pop(document_id)
-                await core.app.storage.close_tab(tab_id_to_close)
+                self._num_connections.pop(document_id, None)
+                self._delete_tasks.pop(document_id, None)
+                tab_id = self._pending_tab_ids.pop(document_id, None)
+                if tab_id is not None:
+                    await core.app.storage.close_tab(tab_id)
                 self.delete()
         self._delete_tasks[document_id] = \
             background_tasks.create(delete_content(), name=f'delete content {document_id}')
 
     def _handle_heartbeat(self) -> None:
-        """Cancel pending delete tasks to keep the client alive during blocking browser dialogs."""
+        """Reset pending delete tasks to keep the client alive during blocking browser dialogs."""
         for document_id in list(self._delete_tasks):
-            self._cancel_delete_task(document_id)
+            self._reschedule_delete_task(document_id)
+
+    def _reschedule_delete_task(self, document_id: str) -> None:
+        """Cancel the current delete task and create a new one with a fresh timeout."""
+        if document_id not in self._delete_tasks:
+            return
+        self._delete_tasks.pop(document_id).cancel()
+        self._create_delete_task(document_id)
 
     def _cancel_delete_task(self, document_id: str) -> None:
         if document_id in self._delete_tasks:

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -195,6 +195,14 @@ async def _exception_handler_500(request: Request, exception: Exception) -> Resp
     return client.build_response(request, 500)
 
 
+@app.post('/_nicegui/heartbeat')
+async def _heartbeat(request: Request) -> Response:
+    data = await request.json()
+    if client := Client.instances.get(data['client_id']):
+        client._handle_heartbeat()  # pylint: disable=protected-access
+    return Response(status_code=200)
+
+
 @sio.on('connect')
 async def _on_connect(sid: str, data: dict[str, Any], _=None) -> None:
     query = {k: v[0] for k, v in urllib.parse.parse_qs(data.get('QUERY_STRING', '')).items()}

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -197,8 +197,11 @@ async def _exception_handler_500(request: Request, exception: Exception) -> Resp
 
 @app.post('/_nicegui/heartbeat')
 async def _heartbeat(request: Request) -> Response:
-    data = await request.json()
-    if client := Client.instances.get(data['client_id']):
+    try:
+        client_id = (await request.json()).get('client_id')
+    except ValueError:
+        return Response(status_code=400)
+    if client_id and (client := Client.instances.get(client_id)):
         client._handle_heartbeat()  # pylint: disable=protected-access
     return Response(status_code=200)
 

--- a/nicegui/static/nicegui-heartbeat.js
+++ b/nicegui/static/nicegui-heartbeat.js
@@ -1,0 +1,18 @@
+let intervalId = null;
+
+self.onmessage = function (e) {
+  if (e.data.type === "start") {
+    const { url, clientId, interval } = e.data;
+    if (intervalId) clearInterval(intervalId);
+    intervalId = setInterval(() => {
+      fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_id: clientId }),
+      }).catch(() => {});
+    }, interval);
+  } else if (e.data.type === "stop") {
+    if (intervalId) clearInterval(intervalId);
+    intervalId = null;
+  }
+};

--- a/nicegui/static/nicegui-heartbeat.js
+++ b/nicegui/static/nicegui-heartbeat.js
@@ -9,7 +9,7 @@ self.onmessage = function (e) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ client_id: clientId }),
-      }).catch(() => {});
+      }).catch((err) => console.debug("heartbeat failed:", err));
     }, interval);
   } else if (e.data.type === "stop") {
     if (intervalId) clearInterval(intervalId);

--- a/nicegui/static/nicegui-heartbeat.js
+++ b/nicegui/static/nicegui-heartbeat.js
@@ -1,26 +1,28 @@
-let intervalId = null;
-let inFlight = false;
+let timeoutId = null;
+
+function scheduleNext(url, clientId, interval) {
+  // jitter ±25% so synchronously-loaded clients don't stampede the server
+  const jittered = interval * (0.75 + Math.random() * 0.5);
+  timeoutId = setTimeout(() => {
+    fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ client_id: clientId }),
+    })
+      .catch((err) => console.debug("heartbeat failed:", err))
+      .finally(() => {
+        if (timeoutId !== null) scheduleNext(url, clientId, interval);
+      });
+  }, jittered);
+}
 
 self.onmessage = function (e) {
   if (e.data.type === "start") {
     const { url, clientId, interval } = e.data;
-    if (intervalId) clearInterval(intervalId);
-    intervalId = setInterval(() => {
-      if (inFlight) return; // skip while a previous heartbeat is still pending
-      inFlight = true;
-      fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ client_id: clientId }),
-      })
-        .catch((err) => console.debug("heartbeat failed:", err))
-        .finally(() => {
-          inFlight = false;
-        });
-    }, interval);
+    if (timeoutId !== null) clearTimeout(timeoutId);
+    scheduleNext(url, clientId, interval);
   } else if (e.data.type === "stop") {
-    if (intervalId) clearInterval(intervalId);
-    intervalId = null;
-    inFlight = false;
+    if (timeoutId !== null) clearTimeout(timeoutId);
+    timeoutId = null;
   }
 };

--- a/nicegui/static/nicegui-heartbeat.js
+++ b/nicegui/static/nicegui-heartbeat.js
@@ -1,18 +1,26 @@
 let intervalId = null;
+let inFlight = false;
 
 self.onmessage = function (e) {
   if (e.data.type === "start") {
     const { url, clientId, interval } = e.data;
     if (intervalId) clearInterval(intervalId);
     intervalId = setInterval(() => {
+      if (inFlight) return; // skip while a previous heartbeat is still pending
+      inFlight = true;
       fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ client_id: clientId }),
-      }).catch((err) => console.debug("heartbeat failed:", err));
+      })
+        .catch((err) => console.debug("heartbeat failed:", err))
+        .finally(() => {
+          inFlight = false;
+        });
     }, interval);
   } else if (e.data.type === "stop") {
     if (intervalId) clearInterval(intervalId);
     intervalId = null;
+    inFlight = false;
   }
 };

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -422,6 +422,18 @@ function createApp(elements, options) {
         // keep the otherwise-frozen reconnect query in sync to avoid triggering a reload (see #6019)
         options.query.next_message_id = window.nextMessageId;
       });
+      if (window.Worker) {
+        window.heartbeatWorker = new Worker(
+          `${options.prefix}/_nicegui/${options.version}/static/nicegui-heartbeat.js`,
+        );
+        window.heartbeatWorker.postMessage({
+          type: "start",
+          url: `${window.location.origin}${options.prefix}/_nicegui/heartbeat`,
+          clientId: window.clientId,
+          interval: Math.max(options.reconnect_timeout * 0.5, 0.5) * 1000,
+        });
+      }
+
       window.did_handshake = false;
       const messageHandlers = {
         connect: () => {
@@ -477,6 +489,7 @@ function createApp(elements, options) {
         },
         disconnect: () => {
           document.getElementById("popup").ariaHidden = false;
+          options.query.next_message_id = window.nextMessageId;
         },
         load_js_components: async (msg) => {
           const urls = msg.components.map((c) => `${options.prefix}/_nicegui/${options.version}/components/${c.key}`);

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -423,16 +423,14 @@ function createApp(elements, options) {
         options.query.next_message_id = window.nextMessageId;
       });
       if (window.Worker) {
-        window.heartbeatWorker = new Worker(
+        const heartbeatWorker = new Worker(
           `${options.prefix}/_nicegui/${options.version}/static/nicegui-heartbeat.js`,
         );
         window.addEventListener("pagehide", () => {
-          if (window.heartbeatWorker) {
-            window.heartbeatWorker.postMessage({ type: "stop" });
-            window.heartbeatWorker.terminate();
-          }
+          heartbeatWorker.postMessage({ type: "stop" });
+          heartbeatWorker.terminate();
         });
-        window.heartbeatWorker.postMessage({
+        heartbeatWorker.postMessage({
           type: "start",
           url: `${options.prefix}/_nicegui/heartbeat`,
           clientId: window.clientId,

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -426,11 +426,17 @@ function createApp(elements, options) {
         window.heartbeatWorker = new Worker(
           `${options.prefix}/_nicegui/${options.version}/static/nicegui-heartbeat.js`,
         );
+        window.addEventListener("pagehide", () => {
+          if (window.heartbeatWorker) {
+            window.heartbeatWorker.postMessage({ type: "stop" });
+            window.heartbeatWorker.terminate();
+          }
+        });
         window.heartbeatWorker.postMessage({
           type: "start",
-          url: `${window.location.origin}${options.prefix}/_nicegui/heartbeat`,
+          url: `${options.prefix}/_nicegui/heartbeat`,
           clientId: window.clientId,
-          interval: Math.max(options.reconnect_timeout * 0.5, 0.5) * 1000,
+          interval: Math.max(options.reconnect_timeout * 0.5, 2) * 1000,
         });
       }
 

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -151,6 +151,7 @@
         query: {{ socket_io_js_query_params | safe }},
         extraHeaders: {{ socket_io_js_extra_headers | safe }},
         transports: {{ socket_io_js_transports | safe }},
+        reconnect_timeout: {{ reconnect_timeout }},
       });
       const dark = {{ dark }};
       const language = "{{ language }}";

--- a/tests/test_endpoint_docs.py
+++ b/tests/test_endpoint_docs.py
@@ -48,6 +48,7 @@ def test_endpoint_documentation_internal_only(screen: Screen):
         f'/_nicegui/{__version__}/resources/{{key}}/{{path}}',
         f'/_nicegui/{__version__}/dynamic_resources/{{name}}',
         f'/_nicegui/{__version__}/esm/{{key}}/{{path}}',
+        '/_nicegui/heartbeat',
     }
 
 
@@ -66,4 +67,5 @@ def test_endpoint_documentation_all(screen: Screen):
         f'/_nicegui/{__version__}/resources/{{key}}/{{path}}',
         f'/_nicegui/{__version__}/dynamic_resources/{{name}}',
         f'/_nicegui/{__version__}/esm/{{key}}/{{path}}',
+        '/_nicegui/heartbeat',
     }

--- a/tests/test_heartbeat_worker.py
+++ b/tests/test_heartbeat_worker.py
@@ -1,0 +1,102 @@
+import time
+
+from selenium.webdriver.common.by import By
+
+from nicegui import Client, ui
+from nicegui.testing import Screen
+
+
+def test_connection_survives_alert_dialog(screen: Screen):
+    """Test that a blocking alert() dialog does not kill the connection."""
+    @ui.page('/', reconnect_timeout=3.0)
+    def page():
+        ui.input('Input').props('autofocus')
+
+    screen.open('/')
+    screen.type('hello')
+
+    client_id = screen.selenium.execute_script('return window.clientId')
+
+    # Open a blocking alert dialog (freezes the main JS thread)
+    screen.selenium.execute_script('setTimeout(() => alert("blocking"), 100)')
+    time.sleep(0.5)
+    # Main JS thread is now frozen — Socket.IO cannot respond to pings
+
+    # Wait longer than reconnect_timeout while the dialog is open
+    time.sleep(5.0)
+
+    # Client must still exist thanks to heartbeat worker
+    assert client_id in Client.instances, 'client should survive blocking dialog thanks to heartbeat'
+
+    # Dismiss the alert — main thread resumes, Socket.IO auto-reconnects
+    screen.selenium.switch_to.alert.accept()
+    screen.wait(2.0)
+
+    # Input value should be preserved (no page reload happened)
+    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
+    assert element.get_attribute('value') == 'hello', 'input should be preserved after reconnect'
+
+
+def test_connection_survives_alert_with_high_reconnect_timeout(screen: Screen):
+    """Test with reconnect_timeout=10 (like main.py) after many messages have been sent."""
+    counter = {'value': 0}
+
+    @ui.page('/', reconnect_timeout=10.0)
+    def page():
+        label = ui.label('0')
+        ui.input('Input').props('autofocus')
+        ui.timer(0.05, lambda: label.set_text(str(counter.__setitem__('value', counter['value'] + 1) or counter['value'])))
+
+    screen.open('/')
+    screen.type('hello')
+
+    # Let the timer generate many messages so the early message history gets pruned
+    screen.wait(3.0)
+
+    client_id = screen.selenium.execute_script('return window.clientId')
+    next_msg_id = screen.selenium.execute_script('return window.nextMessageId')
+    assert next_msg_id > 10, f'expected many messages, got {next_msg_id}'
+
+    # Block the main thread with alert
+    screen.selenium.execute_script('setTimeout(() => alert("blocking"), 100)')
+    time.sleep(0.5)
+    time.sleep(15.0)  # longer than ping_interval(8) + ping_timeout(4) = 12s
+
+    assert client_id in Client.instances, 'client should survive thanks to heartbeat'
+
+    # Dismiss alert — Socket.IO reconnects with current next_message_id (not stale one)
+    screen.selenium.switch_to.alert.accept()
+    screen.wait(3.0)
+
+    # Input value should be preserved (no page reload)
+    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
+    assert element.get_attribute('value') == 'hello', 'input should be preserved (no reload)'
+
+
+def test_heartbeat_worker_is_started(screen: Screen):
+    """Test that the heartbeat worker is created on page load."""
+    @ui.page('/')
+    def page():
+        ui.label('Hello')
+
+    screen.open('/')
+    has_worker = screen.selenium.execute_script('return window.heartbeatWorker !== undefined')
+    assert has_worker, 'heartbeat worker should be created'
+
+
+def test_client_deleted_when_heartbeat_stops(screen: Screen):
+    """Test that the client is eventually deleted when browser navigates away (worker stops)."""
+    @ui.page('/', reconnect_timeout=1.0)
+    def page():
+        ui.label('Hello')
+
+    screen.open('/')
+    client_id = screen.selenium.execute_script('return window.clientId')
+    assert client_id in Client.instances
+
+    # Navigate away (this stops the worker and socket)
+    screen.selenium.get('about:blank')
+    screen.wait(3.0)
+
+    # Client should be deleted since no heartbeat is being sent
+    assert client_id not in Client.instances, 'client should be deleted after navigation away'

--- a/tests/test_heartbeat_worker.py
+++ b/tests/test_heartbeat_worker.py
@@ -38,14 +38,18 @@ def test_connection_survives_alert_dialog(screen: Screen):
 
 
 def test_connection_survives_alert_with_high_reconnect_timeout(screen: Screen):
-    """Test with reconnect_timeout=10 (like main.py) after many messages have been sent."""
-    counter = {'value': 0}
+    """Test with lower reconnect_timeout after many messages have been sent."""
+    counter = [0]
 
-    @ui.page('/', reconnect_timeout=10.0)
+    def increment():
+        counter[0] += 1
+        return counter[0]
+
+    @ui.page('/', reconnect_timeout=3.0)
     def page():
         label = ui.label('0')
         ui.input('Input').props('autofocus')
-        ui.timer(0.05, lambda: label.set_text(str(counter.__setitem__('value', counter['value'] + 1) or counter['value'])))
+        ui.timer(0.05, lambda: label.set_text(str(increment())))
 
     screen.open('/')
     screen.type('hello')
@@ -60,7 +64,7 @@ def test_connection_survives_alert_with_high_reconnect_timeout(screen: Screen):
     # Block the main thread with alert
     screen.selenium.execute_script('setTimeout(() => alert("blocking"), 100)')
     time.sleep(0.5)
-    time.sleep(15.0)  # longer than ping_interval(8) + ping_timeout(4) = 12s
+    time.sleep(5.0)  # longer than reconnect_timeout(3)
 
     assert client_id in Client.instances, 'client should survive thanks to heartbeat'
 

--- a/tests/test_heartbeat_worker.py
+++ b/tests/test_heartbeat_worker.py
@@ -6,6 +6,18 @@ from nicegui import Client, ui
 from nicegui.testing import Screen
 
 
+def _wait_for_disconnect_to_register(client_id: str, timeout: float = 10) -> None:
+    # ping_interval + ping_timeout (>= 6s by default) must elapse before socket.io reports the
+    # disconnect server-side; only then does _delete_tasks populate and the heartbeat have work to do.
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        client = Client.instances.get(client_id)
+        if client and client._delete_tasks:  # pylint: disable=protected-access
+            return
+        time.sleep(0.2)
+    raise AssertionError('disconnect was never registered server-side')
+
+
 def test_connection_survives_alert_dialog(screen: Screen):
     @ui.page('/', reconnect_timeout=3.0)
     def page():
@@ -17,7 +29,8 @@ def test_connection_survives_alert_dialog(screen: Screen):
     client_id = screen.selenium.execute_script('return window.clientId')
 
     screen.selenium.execute_script('setTimeout(() => alert("blocking"), 100)')
-    time.sleep(3.5)
+    _wait_for_disconnect_to_register(client_id)
+    time.sleep(4.0)  # past reconnect_timeout — without the heartbeat the client would be deleted by now
 
     assert client_id in Client.instances
 
@@ -50,7 +63,8 @@ def test_connection_survives_alert_after_many_messages(screen: Screen):
     assert next_msg_id > 10
 
     screen.selenium.execute_script('setTimeout(() => alert("blocking"), 100)')
-    time.sleep(3.5)
+    _wait_for_disconnect_to_register(client_id)
+    time.sleep(4.0)
 
     assert client_id in Client.instances
 
@@ -71,6 +85,6 @@ def test_client_deleted_when_heartbeat_stops(screen: Screen):
     assert client_id in Client.instances
 
     screen.selenium.get('about:blank')
-    screen.wait(3.0)
+    screen.wait(8.0)  # > ping_interval + ping_timeout + reconnect_timeout
 
     assert client_id not in Client.instances

--- a/tests/test_heartbeat_worker.py
+++ b/tests/test_heartbeat_worker.py
@@ -17,13 +17,12 @@ def test_connection_survives_alert_dialog(screen: Screen):
 
     client_id = screen.selenium.execute_script('return window.clientId')
 
-    # Open a blocking alert dialog (freezes the main JS thread)
+    # Open a blocking alert dialog (freezes the main JS thread, so Socket.IO cannot respond to pings).
+    # Wait longer than reconnect_timeout (3s) but rely on the heartbeat worker (interval=2s) to refresh
+    # the delete task at least once during the alert. 3.5s = past the timeout, with 1.5s safety after the
+    # 2s heartbeat resets the deadline.
     screen.selenium.execute_script('setTimeout(() => alert("blocking"), 100)')
-    time.sleep(0.5)
-    # Main JS thread is now frozen — Socket.IO cannot respond to pings
-
-    # Wait longer than reconnect_timeout while the dialog is open
-    time.sleep(5.0)
+    time.sleep(3.5)
 
     # Client must still exist thanks to heartbeat worker
     assert client_id in Client.instances, 'client should survive blocking dialog thanks to heartbeat'
@@ -49,28 +48,27 @@ def test_connection_survives_alert_with_high_reconnect_timeout(screen: Screen):
     def page():
         label = ui.label('0')
         ui.input('Input').props('autofocus')
-        ui.timer(0.05, lambda: label.set_text(str(increment())))
+        ui.timer(0.02, lambda: label.set_text(str(increment())))
 
     screen.open('/')
     screen.type('hello')
 
     # Let the timer generate many messages so the early message history gets pruned
-    screen.wait(3.0)
+    screen.wait(1.5)
 
     client_id = screen.selenium.execute_script('return window.clientId')
     next_msg_id = screen.selenium.execute_script('return window.nextMessageId')
     assert next_msg_id > 10, f'expected many messages, got {next_msg_id}'
 
-    # Block the main thread with alert
+    # Block the main thread; same 3.5s window as above (past reconnect_timeout, heartbeat keeps it alive)
     screen.selenium.execute_script('setTimeout(() => alert("blocking"), 100)')
-    time.sleep(0.5)
-    time.sleep(5.0)  # longer than reconnect_timeout(3)
+    time.sleep(3.5)
 
     assert client_id in Client.instances, 'client should survive thanks to heartbeat'
 
     # Dismiss alert — Socket.IO reconnects with current next_message_id (not stale one)
     screen.selenium.switch_to.alert.accept()
-    screen.wait(3.0)
+    screen.wait(2.0)
 
     # Input value should be preserved (no page reload)
     element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')

--- a/tests/test_heartbeat_worker.py
+++ b/tests/test_heartbeat_worker.py
@@ -7,7 +7,6 @@ from nicegui.testing import Screen
 
 
 def test_connection_survives_alert_dialog(screen: Screen):
-    """Test that a blocking alert() dialog does not kill the connection."""
     @ui.page('/', reconnect_timeout=3.0)
     def page():
         ui.input('Input').props('autofocus')
@@ -17,27 +16,19 @@ def test_connection_survives_alert_dialog(screen: Screen):
 
     client_id = screen.selenium.execute_script('return window.clientId')
 
-    # Open a blocking alert dialog (freezes the main JS thread, so Socket.IO cannot respond to pings).
-    # Wait longer than reconnect_timeout (3s) but rely on the heartbeat worker (interval=2s) to refresh
-    # the delete task at least once during the alert. 3.5s = past the timeout, with 1.5s safety after the
-    # 2s heartbeat resets the deadline.
     screen.selenium.execute_script('setTimeout(() => alert("blocking"), 100)')
     time.sleep(3.5)
 
-    # Client must still exist thanks to heartbeat worker
-    assert client_id in Client.instances, 'client should survive blocking dialog thanks to heartbeat'
+    assert client_id in Client.instances
 
-    # Dismiss the alert — main thread resumes, Socket.IO auto-reconnects
     screen.selenium.switch_to.alert.accept()
     screen.wait(2.0)
 
-    # Input value should be preserved (no page reload happened)
     element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
-    assert element.get_attribute('value') == 'hello', 'input should be preserved after reconnect'
+    assert element.get_attribute('value') == 'hello'
 
 
-def test_connection_survives_alert_with_high_reconnect_timeout(screen: Screen):
-    """Test with lower reconnect_timeout after many messages have been sent."""
+def test_connection_survives_alert_after_many_messages(screen: Screen):
     counter = [0]
 
     def increment():
@@ -52,31 +43,25 @@ def test_connection_survives_alert_with_high_reconnect_timeout(screen: Screen):
 
     screen.open('/')
     screen.type('hello')
-
-    # Let the timer generate many messages so the early message history gets pruned
     screen.wait(1.5)
 
     client_id = screen.selenium.execute_script('return window.clientId')
     next_msg_id = screen.selenium.execute_script('return window.nextMessageId')
-    assert next_msg_id > 10, f'expected many messages, got {next_msg_id}'
+    assert next_msg_id > 10
 
-    # Block the main thread; same 3.5s window as above (past reconnect_timeout, heartbeat keeps it alive)
     screen.selenium.execute_script('setTimeout(() => alert("blocking"), 100)')
     time.sleep(3.5)
 
-    assert client_id in Client.instances, 'client should survive thanks to heartbeat'
+    assert client_id in Client.instances
 
-    # Dismiss alert — Socket.IO reconnects with current next_message_id (not stale one)
     screen.selenium.switch_to.alert.accept()
     screen.wait(2.0)
 
-    # Input value should be preserved (no page reload)
     element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
-    assert element.get_attribute('value') == 'hello', 'input should be preserved (no reload)'
+    assert element.get_attribute('value') == 'hello'
 
 
 def test_client_deleted_when_heartbeat_stops(screen: Screen):
-    """Test that the client is eventually deleted when browser navigates away (worker stops)."""
     @ui.page('/', reconnect_timeout=1.0)
     def page():
         ui.label('Hello')
@@ -85,9 +70,7 @@ def test_client_deleted_when_heartbeat_stops(screen: Screen):
     client_id = screen.selenium.execute_script('return window.clientId')
     assert client_id in Client.instances
 
-    # Navigate away (this stops the worker and socket)
     screen.selenium.get('about:blank')
     screen.wait(3.0)
 
-    # Client should be deleted since no heartbeat is being sent
-    assert client_id not in Client.instances, 'client should be deleted after navigation away'
+    assert client_id not in Client.instances

--- a/tests/test_heartbeat_worker.py
+++ b/tests/test_heartbeat_worker.py
@@ -77,17 +77,6 @@ def test_connection_survives_alert_with_high_reconnect_timeout(screen: Screen):
     assert element.get_attribute('value') == 'hello', 'input should be preserved (no reload)'
 
 
-def test_heartbeat_worker_is_started(screen: Screen):
-    """Test that the heartbeat worker is created on page load."""
-    @ui.page('/')
-    def page():
-        ui.label('Hello')
-
-    screen.open('/')
-    has_worker = screen.selenium.execute_script('return window.heartbeatWorker !== undefined')
-    assert has_worker, 'heartbeat worker should be created'
-
-
 def test_client_deleted_when_heartbeat_stops(screen: Screen):
     """Test that the client is eventually deleted when browser navigates away (worker stops)."""
     @ui.page('/', reconnect_timeout=1.0)


### PR DESCRIPTION
### Motivation

When blocking browser dialogs (`alert()`, `confirm()`, `print()`) freeze the main JavaScript thread, Socket.IO cannot respond to server pings. This causes the server to consider the client disconnected, eventually deleting the client and forcing a full page reload — losing all user state.

Addresses https://github.com/zauberzeug/nicegui/discussions/2410

### Implementation

- **Web Worker heartbeat** (`nicegui-heartbeat.js`): A lightweight Web Worker runs on a separate thread, sending periodic HTTP POST requests to a new `/_nicegui/heartbeat` endpoint. Since Web Workers are unaffected by main thread blocking, heartbeats continue even during blocking dialogs.
- **Server-side heartbeat handler** (`nicegui.py`): Receives heartbeat POSTs and calls `client._handle_heartbeat()`, which reschedules (cancels and recreates) any pending delete task so the client stays alive while the worker keeps reporting in. If heartbeats stop, the rescheduled delete task still fires after `reconnect_timeout` and cleanup happens normally.
- **Stale `next_message_id` fix** (was in `nicegui.js`): superseded by main's `reconnect_attempt` handler from #6019 — only the heartbeat-related JS remains in this PR after rebase.
- **`reconnect_timeout` passed to client JS** (`client.py`, `index.html`): The heartbeat interval is derived from `reconnect_timeout * 0.5` with a 2 s floor so the worker adapts to the configured timeout without being too aggressive.

### How to test manually

1. Run any NiceGUI app with a default `reconnect_timeout`.
2. Open the page, open DevTools → Console, enable **Preserve log**, and type something into a focused input.
3. Run `alert("blocking")` in the console.
4. Walk away for at least `reconnect_timeout` seconds (default 3 s — try 30 s for confidence).
5. Return and click **OK** to dismiss the alert.
6. Expected: the page does **not** reload; the input value is preserved; reconnect happens silently.
7. Without this PR (i.e. on `main`), the same recipe forces a full page reload after the timeout.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
