### PR TITLE
Fix jumpy table fullscreen with smooth scrolling

### DIFF
--- a/nicegui/elements/table.js
+++ b/nicegui/elements/table.js
@@ -2,7 +2,7 @@ import { convertDynamicProperties } from "../../static/utils/dynamic_properties.
 
 export default {
   template: `
-    <q-table ref="qRef" :columns="convertedColumns">
+    <q-table ref="qRef" :columns="convertedColumns" @fullscreen="setFullscreenClass">
       <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
         <slot :name="slot" v-bind="slotProps || {}" />
       </template>
@@ -16,5 +16,20 @@ export default {
       this.columns.forEach((column) => convertDynamicProperties(column, false));
       return this.columns;
     },
+  },
+  methods: {
+    setFullscreenClass(isFullscreen) {
+      // NOTE: prevent the page from smooth-scrolling when the table exits fullscreen;
+      // Quasar uses setTimeout(() => el.scrollIntoView()) in exitFullscreen,
+      // so we need a setTimeout to remove the class after that scroll completes.
+      if (isFullscreen) {
+        document.documentElement.classList.add("nicegui-table-fullscreen");
+      } else {
+        setTimeout(() => document.documentElement.classList.remove("nicegui-table-fullscreen"));
+      }
+    },
+  },
+  unmounted() {
+    this.setFullscreenClass(false);
   },
 };

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -31,7 +31,8 @@
           display: inline-flex;  /* HACK: re-apply Quasar's inline styles to override Tailwind */
         }
         .nicegui-dialog-open,
-        .nicegui-select-popup-open {
+        .nicegui-select-popup-open,
+        .nicegui-table-fullscreen {
           scroll-behavior: auto !important; /* HACK: avoid smooth-scrolling when dialogs or select popups close */
         }
       }

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -414,3 +414,26 @@ def test_new_slots(screen: Screen):
 
     screen.click('Alice')
     screen.should_contain('Clicked Alice')
+
+
+def test_fullscreen_scroll_behavior(screen: Screen):
+    @ui.page('/')
+    def page():
+        ui.add_css('html { scroll-behavior: smooth }')
+        ui.link('Go to bottom', '#bottom')
+        ui.link_target('bottom').classes('mt-[2000px]')
+        table = ui.table(rows=[{'name': 'Alice'}])
+        with table.add_slot('bottom'):
+            ui.button('Toggle fullscreen', on_click=table.toggle_fullscreen).props('flat')
+
+    screen.open('/')
+    screen.click('Go to bottom')
+    screen.wait(1)
+    position = screen.selenium.execute_script('return window.scrollY')
+    assert position > 1000
+
+    screen.click('Toggle fullscreen')
+    screen.wait(0.5)
+    screen.click('Toggle fullscreen')
+    screen.wait(0.5)
+    assert screen.selenium.execute_script('return window.scrollY') == position


### PR DESCRIPTION
### Motivation

Closing a fullscreen `ui.table` triggers a scroll animation if `html { scroll-behavior: smooth; }` is set. This is the same class of issue fixed for `ui.dialog` and `ui.select` in PR #5050.

MRE:
```py
ui.add_css('html { scroll-behavior: smooth }')
ui.link('Go to bottom', '#bottom')
ui.link_target('bottom').classes('mt-[2000px]')
table = ui.table(rows=[{'name': 'Alice'}])
with table.add_slot('bottom'):
    ui.button('Toggle fullscreen', on_click=table.toggle_fullscreen).props('flat')
```

### Implementation

Applies the same pattern as PR #5050: temporarily override `scroll-behavior` to `auto` on the `<html>` element while the table is in fullscreen mode.

One difference from the dialog/select fix: Quasar's fullscreen mixin uses `setTimeout(() => el.scrollIntoView())` to restore the scroll position after exiting fullscreen. Because the `@fullscreen` event fires before that macrotask, we also use `setTimeout` to defer removing the class, ensuring `scroll-behavior: auto` is still in effect when `scrollIntoView()` executes.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This is not a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
