### PR TITLE
Fix Googlebot homepage screenshot: unbounded `h-screen`

### DIFF
--- a/website/main_page.py
+++ b/website/main_page.py
@@ -12,7 +12,7 @@ SPONSORS = json.loads((Path(__file__).parent / 'sponsors.json').read_text(encodi
 
 def create() -> None:
     """Create the content of the main page."""
-    with ui.row().classes('w-full h-screen items-center gap-8 pr-4 no-wrap into-section'):
+    with ui.row().classes('w-full h-screen max-h-[200vw] items-center gap-8 pr-4 no-wrap into-section'):
         svg.face(half=True).classes('stroke-black dark:stroke-white w-[200px] md:w-[230px] lg:w-[300px]')
         with ui.column().classes('gap-4 md:gap-8 pt-32'):
             title('Meet the *NiceGUI*.')


### PR DESCRIPTION
### Motivation

Live test screenshot of https://nicegui.io looks like:

<img height="300" alt="image" src="https://github.com/user-attachments/assets/2c182de6-8c90-40e4-8188-8d4fa288fdad" />

while the rest of the pages are all normal.

### Implementation

The implementation details of `Google Inspection Tool smartphone` remains intentionally sparse by Google, but it is likely that it simulates a really long screen to facilitate taking a long screenshot without scrolling-and-stitching. 

Assuming this is true, I set a `max-h-[200vw]` to limit the first chunk in our documentation to a 1:2 aspect ratio. 

As no mainstream phone broke the 2:1 aspect ratio bound, 99% users should not notice a difference. 

For the 1% (Foldable phone users on external screen), you will have a blue bar at the bottom, but I'd argue the visual balance is better after this fix anyways 🤷 

<img height="300" alt="image" src="https://github.com/user-attachments/assets/2c2ec512-9fe6-41cd-b8fe-b97d747fa9c1" />


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
