### PR TITLE
Enhance Googlebot homepage screenshot: show first demo

### DIFF
--- a/website/documentation/content/doc/api.py
+++ b/website/documentation/content/doc/api.py
@@ -21,6 +21,8 @@ from .part import Demo, DocumentationPart
 registry: dict[str, DocumentationPage] = {}
 redirects: dict[str, str] = {}
 
+TRUE_EXCEPT_FIRST_DEMO = True
+
 
 @contextmanager
 def dummy_client() -> Generator[Client]:
@@ -74,7 +76,7 @@ def text(title_: str, description: str) -> None:
 def demo(title_: str,
          description: str, /, *,
          tab: str | Callable | None = None,
-         lazy: bool = True,
+         lazy: bool = TRUE_EXCEPT_FIRST_DEMO,
          ) -> Callable[[Callable], Callable]:
     ...
 
@@ -82,7 +84,7 @@ def demo(title_: str,
 @overload
 def demo(element: type, /,
          tab: str | Callable | None = None,
-         lazy: bool = True,
+         lazy: bool = TRUE_EXCEPT_FIRST_DEMO,
          ) -> Callable[[Callable], Callable]:
     ...
 
@@ -90,13 +92,15 @@ def demo(element: type, /,
 @overload
 def demo(function: Callable | Navigate, /,
          tab: str | Callable | None = None,
-         lazy: bool = True,
+         lazy: bool = TRUE_EXCEPT_FIRST_DEMO,
          ) -> Callable[[Callable], Callable]:
     ...
 
 
 def demo(*args, **kwargs) -> Callable[[Callable], Callable]:
-    """Add a demo section to the current documentation page."""
+    """Add a demo section to the current documentation page.
+
+    NOTE: For SEO and UX, ``lazy=False`` is the default for the first demo."""
     if len(args) == 2:
         element = None
         title_, description = args
@@ -126,8 +130,9 @@ def demo(*args, **kwargs) -> Callable[[Callable], Callable]:
             title=title_,
             description=description,
             description_format='md' if is_markdown else 'rst',
-            demo=Demo(function=function, lazy=kwargs.get('lazy', True), tab=kwargs.get('tab')),
+            demo=Demo(function=function, lazy=kwargs.get('lazy', page.has_demo), tab=kwargs.get('tab')),
         ))
+        page.has_demo = True
         return function
     return decorator
 

--- a/website/documentation/content/doc/page.py
+++ b/website/documentation/content/doc/page.py
@@ -14,6 +14,7 @@ class DocumentationPage:
     back_link: str | None = None
     parts: list[DocumentationPart] = field(default_factory=list)
     extra_column: Callable | None = None
+    has_demo: bool = False
 
     @property
     def heading(self) -> str:


### PR DESCRIPTION
### Motivation

<img height="300" alt="image" src="https://github.com/user-attachments/assets/5aa42b6e-f45d-47e3-ac1e-47f761d37799" />

While may not relevant before the AI boom, I highly suspect Google uses VLM on the screenshot for SEO purposes. Otherwise the screenshot preview wouldn't be necessary in the first place. 

As such, having the demo a spinner when the screenshot happens is a dealbreaker. 

### Implementation

Introduce `has_demo` to `DocumentationPage`, such that each `@doc.demo` call can check in O(1) time whether there is already a demo, and fallback to `False` instead of `True` if not passed. 

Introduction of constant `TRUE_EXCEPT_FIRST_DEMO` is intentional to get the messaging across:

<img width="417" height="166" alt="image" src="https://github.com/user-attachments/assets/ab6b4619-2e5b-445a-93d8-333c808e878c" />


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
