### PR TITLE
Make first demo always load immediately (lazy=False)

### DIFF
--- a/website/documentation/rendering.py
+++ b/website/documentation/rendering.py
@@ -13,6 +13,7 @@ def render_page(documentation: DocumentationPage) -> None:
     ui.page_title('NiceGUI' if not title else title if title.split()[0] == 'NiceGUI' else f'{title} | NiceGUI')
 
     def render_content():
+        first_demo_seen = False
         section_heading(documentation.subtitle or '', documentation.heading)
         for part in documentation.parts:
             if part.title:
@@ -32,7 +33,8 @@ def render_page(documentation: DocumentationPage) -> None:
             if part.ui:
                 part.ui()
             if part.demo:
-                demo(part.demo.function, lazy=part.demo.lazy, tab=part.demo.tab)
+                demo(part.demo.function, lazy=part.demo.lazy and first_demo_seen, tab=part.demo.tab)
+                first_demo_seen = True
             if part.reference:
                 generate_class_doc(part.reference, part.title)
             if part.link:


### PR DESCRIPTION
### Motivation

Supersedes #5793 with the simplified implementation suggested in [review](https://github.com/zauberzeug/nicegui/pull/5793#pullrequestreview-3812353324).

<img height="300" alt="image" src="https://github.com/user-attachments/assets/5aa42b6e-f45d-47e3-ac1e-47f761d37799" />

While may not have been relevant before the AI boom, I highly suspect Google uses VLM on the screenshot for SEO purposes. Otherwise the screenshot preview wouldn't be necessary in the first place.

As such, having the demo show a spinner when the screenshot happens is a dealbreaker.

### Implementation

Instead of introducing new abstractions (as in #5793), this PR takes the minimal approach suggested by @falkoschindler:

1. Track `first_demo_seen = False` in `render_content`.
2. Override `lazy` with `part.demo.lazy and first_demo_seen` — the first demo always gets `lazy=False`, subsequent demos respect their configured `lazy` value.

This is a 3-line change in `website/documentation/rendering.py` with no new types, constants, or API surface.

> PR opened by Claude Code on behalf of @evnchn, using the code originally written by GitHub Copilot in https://github.com/evnchn/nicegui/pull/84.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).