### PR TITLE
Reset `_page_exception_handler` in `App.reset()` for test isolation

### DIFF
--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -374,6 +374,7 @@ class App(FastAPI):
         self._disconnect_handlers.clear()
         self._delete_handlers.clear()
         self._exception_handlers[:] = [log.exception]
+        self._page_exception_handler = None
         self.config = AppConfig()
         self.colors()  # reset colors to default
 


### PR DESCRIPTION
### Motivation

Website imports trigger demo code that registers a custom exception handler via `app.on_page_exception`. Without resetting it in `App.reset()`, this handler leaks between tests, blocking reliable pytesting of documentation features.

Split out from #5767 per review feedback to isolate concerns.

### Implementation

- Add `self._page_exception_handler = None` to `App.reset()`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)