### PR TITLE
fix(reaktiv example): assign Effects to variables to prevent garbage collection

### DIFF
--- a/examples/reaktiv/main.py
+++ b/examples/reaktiv/main.py
@@ -23,9 +23,10 @@ with ui.row():
         tax_label = ui.label()
         total_label = ui.label().classes('text-bold')
 
-        Effect(lambda: subtotal_label.set_text(f'Subtotal: ${subtotal():.2f}'))
-        Effect(lambda: tax_label.set_text(f'Tax: ${tax():.2f}'))
-        Effect(lambda: total_label.set_text(f'Total: ${total():.2f}'))
+        # NOTE: Effects must be assigned to variables to prevent garbage collection
+        subtotal_effect = Effect(lambda: subtotal_label.set_text(f'Subtotal: ${subtotal():.2f}'))
+        tax_effect = Effect(lambda: tax_label.set_text(f'Tax: ${tax():.2f}'))
+        total_effect = Effect(lambda: total_label.set_text(f'Total: ${total():.2f}'))
 
     with ui.card().classes('w-72 items-stretch'):
         ui.markdown('### Bindable dataclass')


### PR DESCRIPTION
### Motivation

Effects in reaktiv must be assigned to variables, otherwise they get garbage collected and stop working. The previous example only worked due to a bug in reaktiv that has since been fixed. Updated the example to properly store Effect instances.

This API behavior is documented in the reaktiv docs.

References: #5783, #4758

### Implementation

We need just to assign Effects to variables.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
