### PR TITLE
Fix flaky page test

### DIFF
--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -337,5 +337,5 @@ def test_warning_if_response_takes_too_long(screen: Screen):
     screen.start_server()
     # NOTE: using httpx instead of screen.open to avoid Selenium script timeout on incomplete page responses
     httpx.get(f'http://localhost:{Screen.PORT}/', timeout=5)
-    screen.wait(1.0)
+    screen.wait(1)
     screen.assert_py_logger('WARNING', re.compile('Response for / not ready after 0.5 seconds'))


### PR DESCRIPTION
### Motivation

The test `test_warning_if_response_takes_too_long` is flaky in CI. When the page's `response_timeout` fires and the client is deleted, the resulting incomplete page response causes Selenium's `get()` to hang until its internal script timeout (~30s), throwing a `TimeoutException` before the test's log assertion is ever reached. This has been observed failing on Python 3.10 and 3.14 in CI ([example run](https://github.com/zauberzeug/nicegui/actions/runs/22177922207/job/64131335858)).

### Implementation

Replace `screen.open('/')` with a plain `httpx.get()` request. The test only verifies that a server-side warning is logged — it doesn't need a fully loaded browser page. Using `httpx` avoids Selenium entirely, eliminating the script timeout issue while keeping the same assertion.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This is not a security issue.
- [x] Pytests have been updated.
- [x] Documentation is not necessary.
