### PR TITLE
Fix echart zoom reset on data update by using `getOption()` API

### DIFF
--- a/nicegui/elements/echart/echart.js
+++ b/nicegui/elements/echart/echart.js
@@ -95,7 +95,7 @@ export default {
       }
       convertDynamicProperties(this.options, true);
       this.chart.setOption(this.options, {
-        notMerge: this.chart.options?.series?.length != this.options.series?.length,
+        notMerge: this.chart.getOption()?.series?.length != this.options.series?.length,
       });
     },
     run_chart_method(name, ...args) {


### PR DESCRIPTION
### Motivation

Fixes #5819.

Updating echart data (e.g. appending points via a timer) always resets interactive state like dataZoom slider positions. This is because `this.chart.options` is not a valid ECharts API — it's always `undefined` — so the `notMerge` flag evaluates to `true` on every update, causing a full replacement of chart state instead of a merge.

MRE:

```py
chart = ui.echart({
    'xAxis': {},
    'yAxis': {},
    'dataZoom': [{'type': 'slider', 'yAxisIndex': 0}],
    'series': [{'type': 'line', 'data': []}],
})

ui.timer(1, lambda: chart.options['series'][0]['data'].append(len(chart.options['series'][0]['data'])))
```

### Implementation

Replace `this.chart.options?.series?.length` with `this.chart.getOption()?.series?.length` in `echart.js`. [`getOption()`](https://echarts.apache.org/en/api.html#echartsInstance.getOption) is the correct ECharts API to retrieve the current chart configuration. This way `notMerge` is only `true` when the number of series actually changes (requiring a clean replacement), and `false` for normal data updates (preserving zoom, slider positions, and other interactive state).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This is not a security issue.
- [x] Pytests are not necessary (would be pretty hard).
- [x] Documentation is not necessary.
