### PR TITLE
Cut header and tree visual effects for mobile

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ def _main_page() -> None:
             .style('height: calc(100% + 20px) !important') as menu:
         tree = ui.tree(documentation.tree.nodes, label_key='title',
                        on_select=lambda e: ui.navigate.to(f'/documentation/{e.value}')) \
-            .classes('w-full').props('accordion no-connectors no-selection-unset')
+            .classes('w-full nav-tree').props('accordion no-connectors no-selection-unset')
     menu_button = header.add_header(menu)
 
     window_state = {'is_desktop': None}

--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ def _main_page() -> None:
             .style('height: calc(100% + 20px) !important') as menu:
         tree = ui.tree(documentation.tree.nodes, label_key='title',
                        on_select=lambda e: ui.navigate.to(f'/documentation/{e.value}')) \
-            .classes('w-full nav-tree').props('accordion no-connectors no-selection-unset')
+            .classes('w-full nav-tree').props('accordion no-connectors no-selection-unset :no-transition="Quasar.Screen.lt.md"')
     menu_button = header.add_header(menu)
 
     window_state = {'is_desktop': None}

--- a/website/header.py
+++ b/website/header.py
@@ -39,7 +39,7 @@ def add_header(menu: ui.left_drawer) -> ui.button:
         }});
     '''))
     with ui.header() \
-            .classes('items-center duration-200 p-0 px-4 no-wrap') \
+            .classes('items-center duration-200 max-[1023px]:transition-colors p-0 px-4 no-wrap') \
             .style('box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1)'):
         menu_button = ui.button(on_click=menu.toggle, icon='menu').props('flat color=white round').classes('lg:hidden')
         with ui.link(target='/').classes('row gap-4 items-center no-wrap mr-auto'):

--- a/website/search.py
+++ b/website/search.py
@@ -34,7 +34,7 @@ class Search:
             }
             </script>
         ''')
-        with ui.dialog() as self.dialog, ui.card().tight().classes('w-[800px] h-[600px]'):
+        with ui.dialog().props(''':transition-show="Quasar.Screen.lt.md ? 'fade' : undefined" :transition-hide="Quasar.Screen.lt.md ? 'fade' : undefined"''') as self.dialog, ui.card().tight().classes('w-[800px] h-[600px]'):
             with ui.row().classes('w-full items-center px-4'):
                 ui.icon('search', size='2em')
                 self.input = ui.input(placeholder='Search documentation', on_change=self.handle_input) \

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -148,11 +148,6 @@ dl.docinfo p {
   margin: 0;
 }
 
-@media (max-width: 1023px) {
-  .nav-tree .q-tree__node-collapsible {
-    transition: none !important;
-  }
-}
 
 .dark-box {
   background-color: #5898d4;

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -72,6 +72,20 @@ a:active:not(.browser-window *) {
   background-color: #3e6a94d0;
 }
 
+@media (max-width: 1023px) {
+  .q-header {
+    padding-top: 20px;
+    transform: translateY(-20px);
+  }
+  .q-header.fade {
+    background-color: #77aadb;
+    backdrop-filter: none;
+  }
+  .body--dark .q-header.fade {
+    background-color: #365a7c;
+  }
+}
+
 .scroll-indicator:after {
   content: "";
   display: block;
@@ -132,6 +146,12 @@ dl.docinfo dd {
 dl.field-list p,
 dl.docinfo p {
   margin: 0;
+}
+
+@media (max-width: 1023px) {
+  .nav-tree .q-tree__node-collapsible {
+    transition: none !important;
+  }
 }
 
 .dark-box {


### PR DESCRIPTION
### Motivation

While good INP is strongly desired for SEO purposes, the approach at #5801 is hacky, to say the least. 

Are there any lower-hanging fruits before we go the nuclear option?

### Implementation

I spotted 4 places for optimization:

- Mobile devices lack room. They would benefit from the shrunk header almost always. Removing dynamic header grow-shrink logic cuts layout recomputations for frames in a 200ms window. 
- CSS blur effects have a high computational cost, and it honestly doesn't matter on mobile, so I substituted the colors with what they would be assuming empty background to minimize felt change. 
- While likely broken just because https://github.com/zauberzeug/nicegui/pull/5732 is not merged yet, the docs tree is supposed to collapse-on-click for mobile. As such, remove the animation which is not readily seen by the user but would have been rendered anyways. 
- The search dialog now uses a conditional `fade` transition on mobile (via `Quasar.Screen.lt.md`) instead of the default scale animation, reducing compositing work.


While the network bottleneck is still there, we do everything in our power to ensure the CPU load is relieved as much as possible. 

As we need only to shave 11ms for `https://nicegui.io/documentation/section_*` we might just have a win for that. For the others 39ms is needed, and I am not super hopeful on that. 

<img width="731" height="115" alt="image" src="https://github.com/user-attachments/assets/b2da09b7-8c0c-4b78-85db-d0e05a1762bc" />


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
