### PR TITLE
Fix `ui.log` background color being tinted by inner element

### DIFF
--- a/nicegui/static/nicegui.css
+++ b/nicegui/static/nicegui.css
@@ -212,11 +212,11 @@
 }
 .nicegui-log {
   outline: 1px solid rgba(127, 159, 191, 0.15);
+  background-color: rgba(127, 159, 191, 0.05);
 }
 .nicegui-log .q-scrollarea__container {
   scroll-padding-bottom: 0.5rem;
   scroll-snap-type: y proximity;
-  background-color: rgba(127, 159, 191, 0.05);
 }
 .nicegui-log .q-scrollarea__content {
   white-space: pre;


### PR DESCRIPTION
### Motivation

Fixes #5828. Applying Tailwind `bg-*` classes to `ui.log` results in "dirty" colors (e.g. `bg-white` shows as #F8FAFC instead of pure white) because a semi-transparent `background-color: rgba(127, 159, 191, 0.05)` on the inner `.q-scrollarea__container` blends on top of the user-specified background.

### Implementation

Move the default `background-color` from `.nicegui-log .q-scrollarea__container` to `.nicegui-log` itself. This way, user-applied `bg-*` classes on the log element win via CSS specificity, cleanly overriding the default tint instead of being layered underneath it.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This is not a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.