### PR TITLE
Use IntersectionObserver for side tree in documentation

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,11 +70,11 @@ def _main_page() -> None:
         tree.visible = False
         spinner = ui.image('/static/loading.gif').classes('w-8 h-8 m-auto').props('no-spinner no-transition')
 
+        @intersection_observer
         def update_tree() -> None:
             tree.props['nodes'] = documentation.tree.nodes
             tree.visible = True
             spinner.delete()
-        intersection_observer(on_intersection=update_tree)
     menu_button = header.add_header(menu)
 
     window_state = {'is_desktop': None}

--- a/website/documentation/demo.py
+++ b/website/documentation/demo.py
@@ -22,6 +22,7 @@ def demo(f: Callable, *, lazy: bool = True, tab: str | Callable | None = None) -
             if lazy:
                 spinner = ui.image('/static/loading.gif').classes('w-8 h-8').props('no-spinner no-transition')
 
+                @intersection_observer
                 async def handle_intersection():
                     window.remove(spinner)
                     if helpers.is_coroutine_function(f):
@@ -33,7 +34,6 @@ def demo(f: Callable, *, lazy: bool = True, tab: str | Callable | None = None) -
                             await result()
                         else:
                             result()
-                intersection_observer(on_intersection=handle_intersection)
             else:
                 result = f()
                 if callable(result):

--- a/website/documentation/intersection_observer.js
+++ b/website/documentation/intersection_observer.js
@@ -1,16 +1,18 @@
 export default {
   template: '<div style="position: absolute"></div>',
   mounted() {
-    this.interval = setInterval(() => {
-      const rect = this.$el.getBoundingClientRect();
-      if (rect.x >= 0 && rect.bottom > -window.innerHeight && rect.top < 2 * window.innerHeight) {
-        this.$emit("intersection");
-      }
-    }, 100);
+    this.observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          this.observer.disconnect();
+          this.$emit("intersection");
+        }
+      },
+      { rootMargin: "100% 0px 100% 0px" },
+    );
+    this.observer.observe(this.$el);
   },
-  methods: {
-    stop() {
-      clearInterval(this.interval);
-    },
+  unmounted() {
+    this.observer.disconnect();
   },
 };

--- a/website/documentation/intersection_observer.py
+++ b/website/documentation/intersection_observer.py
@@ -1,19 +1,10 @@
 from collections.abc import Callable
 
-from nicegui.element import Element
-from nicegui.events import UiEventArguments, handle_event
+from nicegui import ui
 
 
-class IntersectionObserver(Element, component='intersection_observer.js'):
+class IntersectionObserver(ui.element, component='intersection_observer.js'):
 
-    def __init__(self, *, on_intersection: Callable) -> None:
+    def __init__(self, on_intersection: Callable) -> None:
         super().__init__()
-        self.on_intersection = on_intersection
-        self.active = True
-        self.on('intersection', self.handle_intersection, [])
-
-    def handle_intersection(self, _) -> None:
-        self.run_method('stop')
-        if self.active:
-            handle_event(self.on_intersection, UiEventArguments(sender=self, client=self.client))
-            self.active = False
+        self.on('intersection', on_intersection)


### PR DESCRIPTION
### Motivation

After benchmarking, my evaluation is that **quite a bit of the render time** on NiceGUI is being used to render the sidebar's tree. 

Mind you, it's hidden (1) if not on documentation, and (2) if not manually expanded on Mobile. 

### Implementation

There is already a `IntersectionObserver` lying around for the demo. I expanded it to detect left-offscreen elements, and used it for the `ui.tree`. 

I used my `spinner.gif` for an efficient spinner which [does not involve style recals](https://github.com/zauberzeug/nicegui/pull/4822)

I also hide the tree using `set_visibility(False)` because it would show "No nodes available" otherwise. 

### Performance comparison

Evaluation page: `http://127.0.0.1:8080/documentation/section_testing` (chosen for no demos). 

Evaluation environment: Low-tier mobile (16.3x on my machine), no network throttling nor caching

Page size: 

- Before PR: 27.6kB
- After PR: 18.3kB

LCP:

- Before PR: 2.53s
- After PR: 2.07s

**Note:** Would have more improvement in LCP in real life considering it less time to download the page after the PR. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
