### PR TITLE
Add "Client-Side Secrets" section to security documentation

### DIFF
--- a/website/documentation/content/section_security.py
+++ b/website/documentation/content/section_security.py
@@ -161,6 +161,21 @@ doc.text('', '''
 ''')
 
 
+doc.text('Client-Side Secrets', '''
+    NiceGUI assigns each client session a unique `client_id` (a random UUID).
+    This ID is used to route Socket.IO messages between the browser and the server.
+    A client session is considered **compromised** if either the `client_id` or client-side cookies are exposed to an attacker.
+
+    **To protect client sessions:**
+
+    - **Serve pages over HTTPS** in production to prevent traffic sniffing.
+    - **Do not serve untrusted content** from the same origin
+      (e.g. serving user-uploaded HTML files could leak secrets via JavaScript).
+    - **Do not expose `client_id`** in logs, URLs, or API responses visible to other users.
+    - **Treat `client_id` like a session token**: anyone who knows it can send events on behalf of that client.
+''')
+
+
 doc.text('Additional Resources', '''
     **Security Advisories:**
 


### PR DESCRIPTION
### Motivation

In a private conversation, @oxqnd and @evnchn noticed that `client_id` is security-sensitive but was not documented as such. This documents the security assumptions around `client_id` so developers understand its role as a session-equivalent secret.

### Implementation

Adds a "Client-Side Secrets" section to the Security Best Practices documentation page, explaining that `client_id` and client-side cookies must be protected, and providing actionable guidance (use HTTPS, don't serve untrusted content from the same origin, don't expose `client_id` in logs).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This PR has been coordinated via the security advisory process.
- [x] Pytests are not necessary.
- [x] Documentation has been added.
