### PR TITLE
Fix `ui.log` scroll to bottom on Firefox 140esr

### DIFF
--- a/nicegui/elements/log.js
+++ b/nicegui/elements/log.js
@@ -8,7 +8,9 @@ export default {
   },
   updated() {
     if (this.shouldScroll) {
-      this.$nextTick(() => this.$refs.qRef.setScrollPosition("vertical", Number.MAX_SAFE_INTEGER));
+      this.$nextTick(() =>
+        this.$refs.qRef.setScrollPosition("vertical", this.$refs.qRef.getScrollTarget().scrollHeight),
+      );
     }
   },
   methods: {


### PR DESCRIPTION
### Motivation

#5788 showed that `ui.log` does not scroll to bottom on the current esr version of Firefox (140).

### Implementation

This is fixed by avoiding usage of `Number.MAX_SAFE_INTEGER`: https://github.com/zauberzeug/nicegui/issues/5788#issuecomment-3915867650

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
