### PR TITLE
Add opt-in diagnostics endpoint and ui.diagnostics_view element

### DIFF
--- a/nicegui/app/app_config.py
+++ b/nicegui/app/app_config.py
@@ -42,6 +42,7 @@ class AppConfig:
     unocss: Literal['mini', 'wind3', 'wind4'] | None = field(init=False)
     prod_js: bool = field(init=False)
     show_welcome_message: bool = field(init=False)
+    diagnostics: bool = field(init=False)
     _has_run_config: bool = False
 
     def add_run_config(self,
@@ -60,6 +61,7 @@ class AppConfig:
                        unocss: Literal['mini', 'wind3', 'wind4'] | None,
                        prod_js: bool,
                        show_welcome_message: bool,
+                       diagnostics: bool = False,
                        ) -> None:
         """Add the run config to the app config."""
         self.reload = reload
@@ -76,6 +78,7 @@ class AppConfig:
         self.unocss = unocss
         self.prod_js = prod_js
         self.show_welcome_message = show_welcome_message
+        self.diagnostics = diagnostics
         self._has_run_config = True
 
     @property

--- a/nicegui/diagnostics.py
+++ b/nicegui/diagnostics.py
@@ -1,0 +1,141 @@
+"""Runtime diagnostics for NiceGUI applications."""
+import asyncio
+import collections
+import contextlib
+import datetime
+import sys
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from . import background_tasks, core
+from .client import Client
+
+# NOTE: resource module is POSIX-only; gracefully degrade on other platforms
+try:
+    import resource
+except ImportError:
+    resource = None  # type: ignore[assignment]
+
+
+def _collect_task_summary() -> dict[str, Any]:
+    """Collect asyncio task summary grouped by coroutine name."""
+    tasks = asyncio.all_tasks()
+    counter: collections.Counter[str] = collections.Counter()
+    names_by_group: dict[str, list[str]] = {}
+    for task in tasks:
+        qualname = getattr(task.get_coro(), '__qualname__', '')
+        # NOTE: extract last two dotted segments for readable grouping
+        key = '.'.join(qualname.rsplit('.', 2)[-2:])
+        counter[key] += 1
+        names_by_group.setdefault(key, []).append(task.get_name())
+    by_coroutine = {
+        key: {'count': count, 'names': names_by_group[key]}
+        for key, count in counter.most_common()
+    }
+    return {
+        'total': len(tasks),
+        'by_coroutine': by_coroutine,
+    }
+
+
+def _collect_memory() -> dict[str, Any]:
+    """Collect memory usage metrics with source labels."""
+    if resource is not None:
+        peak_rss_raw = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        # NOTE: on Linux, ru_maxrss is in KB; on macOS it is in bytes
+        peak_rss_bytes = peak_rss_raw * 1024 if sys.platform == 'linux' else peak_rss_raw
+        peak_rss_source = 'resource.getrusage(RUSAGE_SELF).ru_maxrss'
+    else:
+        peak_rss_bytes = None
+        peak_rss_source = 'resource module not available (non-POSIX platform)'
+
+    current_rss_bytes = None
+    current_rss_source = '/proc/self/status not available (non-Linux platform)'
+    with contextlib.suppress(OSError):
+        with open('/proc/self/status', encoding='utf-8') as f:
+            for line in f:
+                if line.startswith('VmRSS:'):
+                    # NOTE: VmRSS line format is "VmRSS:    <number> kB"
+                    current_rss_bytes = int(line.split()[1]) * 1024
+                    current_rss_source = '/proc/self/status VmRSS'
+                    break
+
+    return {
+        'peak_rss_bytes': peak_rss_bytes,
+        'peak_rss_source': peak_rss_source,
+        'current_rss_bytes': current_rss_bytes,
+        'current_rss_source': current_rss_source,
+    }
+
+
+def _collect_client_detail(client_id: str) -> dict[str, Any]:
+    """Collect detail for a specific client."""
+    client = Client.instances.get(client_id)
+    if client is None:
+        return {'client': None, 'client_error': 'not found'}
+    return {
+        'client': {
+            'id': client_id,
+            'elements': len(client.elements),
+            'outbox_pending_updates': len(client.outbox.updates),
+            'outbox_pending_messages': len(client.outbox.messages),
+            'has_socket_connection': client.has_socket_connection,
+        },
+    }
+
+
+def _collect_config() -> dict[str, Any]:
+    """Collect server configuration relevant to event handling and debugging."""
+    # NOTE: core.sio.eio is a third-party internal; guard against attribute changes
+    eio = getattr(core.sio, 'eio', None)
+    config: dict[str, Any] = {
+        'async_handlers': getattr(core.sio, 'async_handlers', None),
+        'transports': getattr(eio, 'transports', []) if eio is not None else [],
+        'reconnect_timeout': getattr(core.app.config, 'reconnect_timeout', None),
+        'binding_refresh_interval': getattr(core.app.config, 'binding_refresh_interval', None),
+    }
+    return config
+
+
+def collect_snapshot(*, client_id: str | None = None, verbose: bool = False) -> dict[str, Any]:
+    """Collect a diagnostics snapshot of the running NiceGUI application."""
+    result: dict[str, Any] = {
+        'timestamp': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        'server': {
+            'asyncio_tasks': _collect_task_summary(),
+            'background_tasks': len(background_tasks.running_tasks),
+            'memory': _collect_memory(),
+            'config': _collect_config(),
+            'clients_total': len(Client.instances),
+            'clients_connected': sum(1 for c in Client.instances.values() if c.has_socket_connection),
+        },
+        'client': None,
+    }
+
+    if client_id is not None:
+        result.update(_collect_client_detail(client_id))
+
+    if verbose:
+        result['clients_detail'] = [
+            {
+                'id': cid,
+                'elements': len(c.elements),
+                'has_socket_connection': c.has_socket_connection,
+            }
+            for cid, c in Client.instances.items()
+        ]
+
+    return result
+
+
+async def get_diagnostics(request: Request) -> JSONResponse:
+    """Return a JSON response with current diagnostics data.
+
+    NOTE: must be async so Starlette runs it in the event loop, not a threadpool;
+    collect_snapshot() calls asyncio.all_tasks() which requires a running loop.
+    """
+    client_id = request.query_params.get('client_id')
+    verbose = request.query_params.get('verbose', '').lower() in ('true', '1', 'yes')
+    return JSONResponse(collect_snapshot(client_id=client_id, verbose=verbose))

--- a/nicegui/elements/diagnostics_view.py
+++ b/nicegui/elements/diagnostics_view.py
@@ -1,0 +1,60 @@
+from typing import Literal
+
+from .. import diagnostics
+from ..element import Element
+from .button import Button as button
+from .log import Log
+from .timer import Timer as timer
+
+
+class DiagnosticsView(Element):
+
+    def __init__(self, *,
+                 scope: Literal['client', 'global'] = 'client',
+                 mode: Literal['append', 'replace'] = 'append',
+                 interval: float | None = None,
+                 ) -> None:
+        """Diagnostics View
+
+        Display a live diagnostics snapshot of the running NiceGUI application.
+
+        :param scope: ``'client'`` shows per-client detail, ``'global'`` shows server-wide summary (default: ``'client'``)
+        :param mode: ``'append'`` preserves history, ``'replace'`` clears before each refresh (default: ``'append'``)
+        :param interval: auto-refresh interval in seconds; ``None`` disables auto-refresh (default: ``None``)
+        """
+        super().__init__()
+        self._scope = scope
+        self._mode = mode
+
+        with self:
+            self._log = Log().classes('w-full')
+            button('Refresh', on_click=self.refresh)
+            if interval is not None:
+                timer(interval, self.refresh)
+
+    def refresh(self) -> None:
+        """Fetch and display a diagnostics snapshot."""
+        snapshot = diagnostics.collect_snapshot(
+            client_id=self.client.id if self._scope == 'client' else None,
+        )
+
+        if self._mode == 'replace':
+            self._log.clear()
+
+        server = snapshot['server']
+        tasks = server['asyncio_tasks']
+        memory = server['memory']
+
+        self._log.push(f'--- {snapshot["timestamp"]} ---')
+        self._log.push(f'Tasks: {tasks["total"]}')
+
+        if self._scope == 'client' and snapshot.get('client'):
+            client_info = snapshot['client']
+            self._log.push(f'Elements: {client_info["elements"]}')  # pylint: disable=unsubscriptable-object
+            self._log.push(f'Connected: {client_info["has_socket_connection"]}')  # pylint: disable=unsubscriptable-object
+        elif self._scope == 'global':
+            self._log.push(f'Clients: {server["clients_total"]} ({server["clients_connected"]} connected)')
+
+        if memory.get('current_rss_bytes') is not None:
+            mb = memory['current_rss_bytes'] / (1024 * 1024)
+            self._log.push(f'Memory: {mb:.1f} MB')

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -138,6 +138,9 @@ async def _startup() -> None:
             app.add_route('/favicon.ico', lambda _: favicon.get_favicon_response())
     else:
         app.add_route('/favicon.ico', lambda _: FileResponse(Path(__file__).parent / 'static' / 'favicon.ico'))
+    if core.app.config.diagnostics:
+        from . import diagnostics  # pylint: disable=import-outside-toplevel
+        app.add_route('/_nicegui/diagnostics', diagnostics.get_diagnostics)
     core.loop = asyncio.get_running_loop()
     run.setup()
     app.start()

--- a/nicegui/testing/general.py
+++ b/nicegui/testing/general.py
@@ -36,6 +36,7 @@ def nicegui_reset_globals():
             not route.path.startswith('/_nicegui/')
             or route.path.startswith('/_nicegui/auto/static')
             or route.path.startswith('/_nicegui/client/')
+            or route.path == '/_nicegui/diagnostics'
         ):
             app.remove_route(route.path)
 

--- a/nicegui/testing/user_simulation.py
+++ b/nicegui/testing/user_simulation.py
@@ -3,6 +3,7 @@ import runpy
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -16,7 +17,7 @@ from .user import User
 
 @asynccontextmanager
 async def user_simulation(
-    root: Callable | None = None, *, main_file: str | os.PathLike | None = None,
+    root: Callable | None = None, *, main_file: str | os.PathLike | None = None, **run_kwargs: Any,
 ) -> AsyncGenerator[User]:
     """Context manager for test user simulation.
 
@@ -24,9 +25,13 @@ async def user_simulation(
 
     :param root: root function which is passed directly to ``ui.run``; mutually exclusive with ``main_file`` argument.
     :param main_file: path to a NiceGUI main file executed via ``runpy.run_path``; mutually exclusive with ``root`` argument.
+    :param run_kwargs: additional keyword arguments forwarded to ``ui.run``; mutually exclusive with ``main_file``.
     """
     if main_file is not None and root is not None:
         raise ValueError('Cannot specify both `main_file` and `root` function simultaneously.')
+    if main_file is not None and run_kwargs:
+        raise ValueError(
+            'Cannot specify both `main_file` and `run_kwargs`; kwargs are ignored when `main_file` is provided.')
 
     with nicegui_reset_globals():
         os.environ['NICEGUI_USER_SIMULATION'] = 'true'
@@ -37,7 +42,7 @@ async def user_simulation(
                 runpy.run_path(str(main_file), run_name='__main__')
             else:
                 prepare_simulation()
-                ui.run(root, storage_secret='simulated secret')
+                ui.run(root, storage_secret='simulated secret', **run_kwargs)
 
             async with core.app.router.lifespan_context(core.app):
                 async with httpx.AsyncClient(transport=httpx.ASGITransport(core.app), base_url='http://test') as client:

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -33,6 +33,7 @@ __all__ = [
     'dark_mode',
     'date',
     'date_input',
+    'diagnostics_view',
     'dialog',
     'download',
     'drawer',
@@ -167,6 +168,7 @@ from .elements.context_menu import ContextMenu as context_menu
 from .elements.dark_mode import DarkMode as dark_mode
 from .elements.date import Date as date
 from .elements.date_input import DateInput as date_input
+from .elements.diagnostics_view import DiagnosticsView as diagnostics_view
 from .elements.dialog import Dialog as dialog
 from .elements.drawer import Drawer as drawer
 from .elements.drawer import LeftDrawer as left_drawer

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -79,6 +79,7 @@ def run(root: Callable | None = None, *,
         storage_secret: str | None = None,
         session_middleware_kwargs: dict[str, Any] | None = None,
         show_welcome_message: bool = True,
+        diagnostics: bool = False,
         **kwargs: Any,
         ) -> None:
     """ui.run
@@ -118,6 +119,7 @@ def run(root: Callable | None = None, *,
     :param storage_secret: secret key for browser-based storage (default: `None`, a value is required to enable ui.storage.individual and ui.storage.browser)
     :param session_middleware_kwargs: additional keyword arguments passed to SessionMiddleware that creates the session cookies used for browser-based storage
     :param show_welcome_message: whether to show the welcome message (default: `True`)
+    :param diagnostics: whether to enable the diagnostics endpoint at ``/_nicegui/diagnostics`` (default: `False`)
     :param kwargs: additional keyword arguments are passed to `uvicorn.run`
     """
     if core.script_mode:
@@ -170,6 +172,7 @@ def run(root: Callable | None = None, *,
         unocss=unocss,
         prod_js=prod_js,
         show_welcome_message=show_welcome_message,
+        diagnostics=diagnostics,
     )
     core.root = root
     core.app.config.endpoint_documentation = endpoint_documentation

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,226 @@
+import sys
+from datetime import datetime
+
+from nicegui import ui
+from nicegui.client import Client
+from nicegui.testing import User
+from nicegui.testing.user_simulation import user_simulation
+
+
+async def test_diagnostics_endpoint_returns_json_when_enabled() -> None:
+    async with user_simulation(diagnostics=True) as user:
+        @ui.page('/')
+        def index():
+            ui.label('Hello')
+
+        await user.open('/')
+        response = await user.http_client.get('/_nicegui/diagnostics')
+        assert response.status_code == 200
+        data = response.json()
+        assert 'server' in data
+        assert 'client' in data
+        datetime.fromisoformat(data['timestamp'])
+
+
+async def test_diagnostics_endpoint_returns_404_when_disabled(user: User) -> None:
+    @ui.page('/')
+    def index():
+        ui.label('Hello')
+
+    await user.open('/')
+    response = await user.http_client.get('/_nicegui/diagnostics')
+    assert response.status_code == 404
+
+
+async def test_task_summary_grouped_by_coroutine() -> None:
+    async with user_simulation(diagnostics=True) as user:
+        @ui.page('/')
+        def index():
+            ui.label('Hello')
+
+        await user.open('/')
+        response = await user.http_client.get('/_nicegui/diagnostics')
+        assert response.status_code == 200
+        data = response.json()
+        tasks = data['server']['asyncio_tasks']
+        assert isinstance(tasks['total'], int)
+        assert tasks['total'] > 0
+        assert isinstance(tasks['by_coroutine'], dict)
+        assert len(tasks['by_coroutine']) > 0
+        for key in tasks['by_coroutine']:
+            assert isinstance(key, str)
+
+
+async def test_coroutine_groups_include_count_and_names() -> None:
+    async with user_simulation(diagnostics=True) as user:
+        @ui.page('/')
+        def index():
+            ui.label('Hello')
+
+        await user.open('/')
+        response = await user.http_client.get('/_nicegui/diagnostics')
+        assert response.status_code == 200
+        data = response.json()['server']['asyncio_tasks']
+        for group in data['by_coroutine'].values():
+            assert isinstance(group['count'], int)
+            assert group['count'] > 0
+            assert isinstance(group['names'], list)
+            assert len(group['names']) == group['count']
+            for name in group['names']:
+                assert isinstance(name, str)
+
+
+async def test_memory_metrics_with_source_labels() -> None:
+    async with user_simulation(diagnostics=True) as user:
+        @ui.page('/')
+        def index():
+            ui.label('Hello')
+
+        await user.open('/')
+        response = await user.http_client.get('/_nicegui/diagnostics')
+        assert response.status_code == 200
+        memory = response.json()['server']['memory']
+        assert isinstance(memory['peak_rss_source'], str)
+        assert len(memory['peak_rss_source']) > 0
+        assert isinstance(memory['current_rss_source'], str)
+        assert len(memory['current_rss_source']) > 0
+        if sys.platform == 'linux':
+            assert isinstance(memory['peak_rss_bytes'], int)
+            assert memory['peak_rss_bytes'] > 0
+            assert isinstance(memory['current_rss_bytes'], int)
+            assert memory['current_rss_bytes'] > 0
+
+
+async def test_per_client_detail_with_valid_client_id() -> None:
+    async with user_simulation(diagnostics=True) as user:
+        @ui.page('/')
+        def index():
+            ui.label('Hello')
+
+        await user.open('/')
+        client_id = next(iter(Client.instances))
+        response = await user.http_client.get(f'/_nicegui/diagnostics?client_id={client_id}')
+        assert response.status_code == 200
+        client_data = response.json()['client']
+        assert client_data is not None
+        assert client_data['id'] == client_id
+        assert isinstance(client_data['elements'], int)
+        assert isinstance(client_data['outbox_pending_updates'], int)
+        assert isinstance(client_data['outbox_pending_messages'], int)
+        assert isinstance(client_data['has_socket_connection'], bool)
+
+
+async def test_invalid_client_id_returns_null_with_error() -> None:
+    async with user_simulation(diagnostics=True) as user:
+        @ui.page('/')
+        def index():
+            ui.label('Hello')
+
+        await user.open('/')
+        response = await user.http_client.get('/_nicegui/diagnostics?client_id=nonexistent')
+        assert response.status_code == 200
+        data = response.json()
+        assert data['client'] is None
+        assert data['client_error'] == 'not found'
+        assert 'server' in data
+
+
+async def test_server_config_includes_event_handling_settings() -> None:
+    async with user_simulation(diagnostics=True) as user:
+        @ui.page('/')
+        def index():
+            ui.label('Hello')
+
+        await user.open('/')
+        response = await user.http_client.get('/_nicegui/diagnostics')
+        assert response.status_code == 200
+        config = response.json()['server']['config']
+        assert isinstance(config['async_handlers'], bool)
+        assert isinstance(config['reconnect_timeout'], (int, float))
+        assert isinstance(config['binding_refresh_interval'], (int, float, type(None)))
+        assert isinstance(config['transports'], list)
+        assert len(config['transports']) > 0
+
+
+async def test_diagnostics_view_renders_log_and_refresh_button(user: User) -> None:
+    @ui.page('/')
+    def index():
+        ui.diagnostics_view()
+
+    await user.open('/')
+    await user.should_see('Refresh')
+
+
+async def test_diagnostics_view_append_mode_preserves_history(user: User) -> None:
+    @ui.page('/')
+    def index():
+        ui.diagnostics_view()
+
+    await user.open('/')
+    user.find(ui.button).click()
+    first_separators = len(user.find(content='---').elements)
+    user.find(ui.button).click()
+    second_separators = len(user.find(content='---').elements)
+    assert second_separators > first_separators
+
+
+async def test_diagnostics_view_replace_mode_clears_log(user: User) -> None:
+    @ui.page('/')
+    def index():
+        ui.diagnostics_view(mode='replace')
+
+    await user.open('/')
+    user.find(ui.button).click()
+    first_separators = len(user.find(content='---').elements)
+    assert first_separators > 0
+    user.find(ui.button).click()
+    assert len(user.find(content='---').elements) == first_separators
+
+
+async def test_diagnostics_view_client_scope_includes_client_data(user: User) -> None:
+    @ui.page('/')
+    def index():
+        ui.diagnostics_view(scope='client')
+
+    await user.open('/')
+    user.find(ui.button).click()
+    await user.should_see('Elements:')
+    await user.should_see('Connected:')
+    await user.should_see('Tasks:')
+
+
+async def test_diagnostics_view_global_scope_includes_clients_summary(user: User) -> None:
+    @ui.page('/')
+    def index():
+        ui.diagnostics_view(scope='global')
+
+    await user.open('/')
+    user.find(ui.button).click()
+    await user.should_see('Clients:')
+    await user.should_see('Tasks:')
+
+
+async def test_element_count_reflects_page_content() -> None:
+    async with user_simulation(diagnostics=True) as user:
+        @ui.page('/')
+        def index():
+            for _ in range(10):
+                ui.label('item')
+
+        await user.open('/')
+        client_id = next(iter(Client.instances))
+        response = await user.http_client.get(f'/_nicegui/diagnostics?client_id={client_id}')
+        assert response.status_code == 200
+        elements = response.json()['client']['elements']
+        assert elements >= 10, f'expected at least 10 elements from labels, got {elements}'
+
+
+async def test_diagnostics_view_interval_creates_timer(user: User) -> None:
+    @ui.page('/')
+    def index():
+        ui.diagnostics_view(interval=10)
+
+    await user.open('/')
+    timers = [t for t in user.find(ui.timer).elements if t.interval == 10]
+    assert len(timers) == 1
+    assert timers[0].active

--- a/tests/test_user_simulation_context.py
+++ b/tests/test_user_simulation_context.py
@@ -55,6 +55,22 @@ async def test_with_page_definitions():
         await user.should_see('Page A')
 
 
+async def test_main_file_and_root_raises(tmp_path: Path):
+    main_file = tmp_path / 'main.py'
+    main_file.write_text('from nicegui import ui\nui.run()\n', encoding='utf-8')
+    with pytest.raises(ValueError, match=r'main_file.*root'):
+        async with user_simulation(lambda: None, main_file=main_file):
+            pass
+
+
+async def test_main_file_and_run_kwargs_raises(tmp_path: Path):
+    main_file = tmp_path / 'main.py'
+    main_file.write_text('from nicegui import ui\nui.run()\n', encoding='utf-8')
+    with pytest.raises(ValueError, match=r'main_file.*run_kwargs'):
+        async with user_simulation(main_file=main_file, title='Should fail'):
+            pass
+
+
 @pytest.mark.parametrize('file_content', [
     textwrap.dedent('''
         from nicegui import ui

--- a/website/documentation/content/diagnostics_view_documentation.py
+++ b/website/documentation/content/diagnostics_view_documentation.py
@@ -1,0 +1,63 @@
+from nicegui import ui
+
+from . import doc
+
+
+@doc.demo(ui.diagnostics_view)
+def main_demo() -> None:
+    ui.diagnostics_view()
+
+
+@doc.demo('Diagnostics Endpoint', '''
+    Passing ``diagnostics=True`` to ``ui.run()`` registers a JSON endpoint at ``/_nicegui/diagnostics``.
+    The endpoint returns a snapshot including:
+
+    - ``asyncio_tasks``: total count and breakdown by coroutine name, useful for detecting task leaks
+    - ``background_tasks``: count of tasks managed by ``background_tasks.create()``
+    - ``memory``: current RSS (from ``/proc/self/status`` on Linux) and peak RSS (from ``resource.getrusage``),
+      with source labels indicating where each value came from
+    - ``config``: server settings like ``async_handlers``, ``transports``, ``reconnect_timeout``,
+      and ``binding_refresh_interval``
+    - ``clients_total`` / ``clients_connected``: number of ``Client`` instances and how many have active sockets
+
+    Pass ``?client_id=<id>`` to include per-client detail (element count, outbox queue lengths, socket status).
+    Pass ``?verbose=true`` to include a summary of all connected clients.
+
+    The endpoint is not registered unless explicitly enabled.
+    ``ui.diagnostics_view()`` calls ``collect_snapshot()`` directly and does not require the endpoint.
+''')
+def endpoint_demo() -> None:
+    import json
+
+    from nicegui import diagnostics
+
+    snapshot = diagnostics.collect_snapshot()
+    ui.code(json.dumps(snapshot, indent=2), language='json').classes('w-full max-h-40')
+
+
+@doc.demo('Global Scope', '''
+    By default the diagnostics view shows per-client detail (element count, socket status).
+    Set ``scope='global'`` to show a server-wide summary (total clients, connected count) instead.
+''')
+def global_scope_demo() -> None:
+    ui.diagnostics_view(scope='global')
+
+
+@doc.demo('Auto-Refresh', '''
+    Set the ``interval`` parameter to automatically refresh the diagnostics at a regular interval (in seconds).
+    This is useful for monitoring memory growth or task accumulation over time.
+''')
+def auto_refresh_demo() -> None:
+    ui.diagnostics_view(interval=5)
+
+
+@doc.demo('Replace Mode', '''
+    By default each refresh appends to the log history.
+    Set ``mode='replace'`` to clear previous entries on each refresh,
+    showing only the most recent snapshot.
+''')
+def replace_mode_demo() -> None:
+    ui.diagnostics_view(mode='replace')
+
+
+doc.reference(ui.diagnostics_view)

--- a/website/documentation/content/section_configuration_deployment.py
+++ b/website/documentation/content/section_configuration_deployment.py
@@ -1,7 +1,7 @@
 from nicegui import ui
 
 from ..windows import bash_window, python_window
-from . import doc, run_documentation
+from . import diagnostics_view_documentation, doc, run_documentation
 
 doc.title('Configuration & Deployment')
 
@@ -153,6 +153,8 @@ def background_tasks_demo():
     ui.button('Compute', on_click=lambda: background_tasks.create(compute()))
     ui.button('Backup', on_click=lambda: background_tasks.create(backup()))
 
+
+doc.intro(diagnostics_view_documentation)
 
 doc.text('Custom Vue Components', '''
     You can create custom components by subclassing `ui.element` and implementing a corresponding Vue component.


### PR DESCRIPTION
### Motivation

When debugging NiceGUI applications, runtime state (asyncio tasks, memory usage, client connections, server configuration) requires ad-hoc inspection code.

This adds an opt-in `diagnostics=True` parameter to `ui.run()` that registers a JSON endpoint at `/_nicegui/diagnostics`, and a `ui.diagnostics_view()` element for in-page display.

We have not pre-discussed whether `ui.diagnostics_view` belongs in core (per CONTRIBUTING.md step 1 for new elements). Happy to move it to a separate package if you'd prefer. (Noting that this is stemming from the discussion in #5660.) I renamed it to diagnostics from "health" due to a bit of concept mismatch.



### Implementation

- `diagnostics` field on `AppConfig`, threaded through `ui.run()` → `add_run_config()`
- `nicegui/diagnostics.py`: `collect_snapshot()` returns task counts grouped by coroutine, memory metrics (RSS from `/proc/self/status` and `resource.getrusage`), per-client detail (element count, outbox queue
  lengths, socket status), and server config (`async_handlers`, transports, `reconnect_timeout`, `binding_refresh_interval`)
- `/_nicegui/diagnostics` endpoint registered only when `diagnostics=True`; module not imported otherwise
- `ui.diagnostics_view()` composes Log + Button + optional Timer, calls `collect_snapshot()` directly (no HTTP request)
- `user_simulation` gains `**run_kwargs` forwarding to `ui.run()` to enable testing with `diagnostics=True`
- Memory metrics degrade gracefully on non-Linux/non-POSIX platforms via `ImportError` and `contextlib.suppress(OSError)` guards
- 15 diagnostics tests + 2 `user_simulation` validation tests, all using `User` fixture

### Progress

- [X] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] The implementation is complete. (Nope, this is phase 1 draft, just so that @evnchn can comment)
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [X] Pytests have been added (or are not necessary).
- [X] Documentation has been added (or is not necessary).
