### PR TITLE
Fix sort arrow animation in custom table header cells

### DIFF
--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -441,7 +441,7 @@ class Table(FilterElement, component='table.js'):
             """
             super().__init__('q-tr')
 
-    class header(Element, default_classes='[&>*]:inline'):
+    class header(Element, default_classes='[&>*]:inline-block'):
 
         def __init__(self, column_name: str | None = None) -> None:
             """Header Element


### PR DESCRIPTION
### Motivation

The sort indicator arrow does not animate when clicking on a custom header cell created with `table.header()`.
This is because `Table.header` applies `[&>*]:inline` as a default class, and CSS `transform` (used by Quasar to rotate the arrow) has no effect on `display: inline` elements.

Fixes #5870

MRE:
```py
table = ui.table(rows=[
    {'name': 'Alice', 'age': 18},
    {'name': 'Bob', 'age': 21},
    {'name': 'Carol', 'age': 42},
], row_key='name')

with table.add_slot('header-cell-age'):
    with table.header('age'):
        ui.label('Age')
```

### Implementation

Changed the default class on `Table.header` from `[&>*]:inline` to `[&>*]:inline-block`.
`inline-block` elements support CSS transforms while still flowing inline.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This is not a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
