### PR TITLE
Fix invalid Python code shown in SPA demo

### DIFF
--- a/website/documentation/intro.py
+++ b/website/documentation/intro.py
@@ -35,7 +35,8 @@ def create_intro() -> None:
                 {'name': 'New York', 'lat': 40.7119, 'lon': -74.0027},
                 {'name': 'London', 'lat': 51.5074, 'lon': -0.1278},
                 {'name': 'Tokyo', 'lat': 35.6863, 'lon': 139.7722},
-            ]).on('row-click', lambda e: sub_pages._render('/map/{lat}/{lon}', lat=e.args[1]['lat'], lon=e.args[1]['lon']))  # nopep8 # HIDE
+            ]).on('row-click',  # HIDE
+                  lambda e: sub_pages._render('/map/{lat}/{lon}', lat=e.args[1]['lat'], lon=e.args[1]['lon']))  # HIDE
             # ]).on('row-click', lambda e: ui.navigate.to(f'/map/{e.args[1]["lat"]}/{e.args[1]["lon"]}'))
 
         def map_page(lat: float, lon: float):


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->
The demo code at [https://nicegui.io/#single-page_applications](https://nicegui.io/#single-page_applications) currently shows invalid Python code (`Table.on(...)` is sort-of called twice):

<img width="1509" height="618" alt="image" src="https://github.com/user-attachments/assets/14ad18f4-9beb-4194-9802-fe1d84eba209" />

After this change:

<img width="1509" height="597" alt="image" src="https://github.com/user-attachments/assets/06e7c768-07ad-47d8-a558-0761f49ce3ea" />

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->
<!-- Include any important technical decisions or trade-offs made -->
Moved a misplaced `# HIDE` comment to the correct line.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
