### PR TITLE
Fix `User` test simulation for select options with `None` as value

### DIFF
--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -87,11 +87,12 @@ class UserInteraction(Generic[T]):
 
                 if isinstance(element, ui.select):
                     if element.is_showing_popup:
+                        _NOT_FOUND = object()
                         if isinstance(element.options, dict):
-                            target_value = next((k for k, v in element.options.items() if v == self.target), None)
+                            target_value = next((k for k, v in element.options.items() if v == self.target), _NOT_FOUND)
                         else:
-                            target_value = self.target if self.target in element._values else None  # pylint: disable=protected-access
-                        if target_value is not None:
+                            target_value = self.target if self.target in element._values else _NOT_FOUND  # pylint: disable=protected-access
+                        if target_value is not _NOT_FOUND:
                             # User clicked on a valid option: update the value and close the popup
                             if element.multiple:
                                 if target_value in element.value:

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -555,6 +555,22 @@ async def test_select_keeps_value_when_toggling_popup(user: User):
     await user.should_see('value = Apple')
 
 
+async def test_select_none_value(user: User) -> None:
+    @ui.page('/')
+    def _():
+        select = ui.select({'a': 'A', None: 'B'}, value=None)
+        ui.label().bind_text_from(select, 'value', lambda v: f'Value: {v}')
+
+    await user.open('/')
+    user.find(ui.select).click()
+    user.find('A').click()
+    await user.should_see('Value: a')
+
+    user.find(ui.select).click()
+    user.find('B').click()
+    await user.should_see('Value: None')
+
+
 async def test_upload_table(user: User) -> None:
     @ui.page('/')
     def page():


### PR DESCRIPTION
### Motivation

Closes #5880.

When using `None` as a dictionary key in `ui.select` options (e.g. `{None: '-', 'fast': '--mode-fast'}`), the `User` test fixture fails to set the value back to `None` when clicking that option. The real browser behavior is correct — this is purely a bug in the simulated click logic.

### Implementation

The `UserInteraction.click()` method used `None` as the default sentinel for `next()` when looking up a select option key by its label. When `None` is a legitimate option key, the subsequent `if target_value is not None` check incorrectly treats it as "not found" and skips the value update.

Replaced `None` with a local `_NOT_FOUND` sentinel object and switched to identity comparison (`is not _NOT_FOUND`).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This is not a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
- [x] Does `ui.radio` simulation need a similar fix? → No.