### PR TITLE
Use public API imports in examples, tests, and website

### DIFF
--- a/examples/custom_binding/main.py
+++ b/examples/custom_binding/main.py
@@ -4,15 +4,14 @@ from typing import cast
 
 from typing_extensions import Self
 
-from nicegui import ui
-from nicegui.binding import BindableProperty, bind_from
+from nicegui import binding, ui
 
 
 class colorful_label(ui.label):
     """A label with a bindable background color."""
 
     # This class variable defines what happens when the background property changes.
-    background = BindableProperty(
+    background = binding.BindableProperty(
         on_change=lambda sender, value: cast(Self, sender)._handle_background_change(value))
 
     def __init__(self, text: str = '') -> None:
@@ -35,8 +34,8 @@ for city in temperatures:
     # Bind background color from temperature.
     # There is also a bind_to method which would propagate changes from the label to the temperatures dictionary
     # and a bind method which would propagate changes both ways.
-    bind_from(self_obj=label, self_name='background',
-              other_obj=temperatures, other_name=city,
-              backward=lambda t: 'bg-green' if t < 10 else 'bg-yellow' if t < 20 else 'bg-orange')
+    binding.bind_from(self_obj=label, self_name='background',
+                      other_obj=temperatures, other_name=city,
+                      backward=lambda t: 'bg-green' if t < 10 else 'bg-yellow' if t < 20 else 'bg-orange')
 
 ui.run()

--- a/examples/custom_vue_component/counter.py
+++ b/examples/custom_vue_component/counter.py
@@ -1,9 +1,9 @@
 from collections.abc import Callable
 
-from nicegui.element import Element
+from nicegui import ui
 
 
-class Counter(Element, component='counter.js'):
+class Counter(ui.element, component='counter.js'):
 
     def __init__(self, title: str, *, on_change: Callable | None = None) -> None:
         super().__init__()

--- a/examples/custom_vue_component/on_off.py
+++ b/examples/custom_vue_component/on_off.py
@@ -1,9 +1,9 @@
 from collections.abc import Callable
 
-from nicegui.element import Element
+from nicegui import ui
 
 
-class OnOff(Element, component='on_off.vue'):
+class OnOff(ui.element, component='on_off.vue'):
 
     def __init__(self, title: str, *, on_change: Callable | None = None) -> None:
         super().__init__()

--- a/examples/fullcalendar/fullcalendar.py
+++ b/examples/fullcalendar/fullcalendar.py
@@ -2,11 +2,10 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from nicegui.element import Element
-from nicegui.events import handle_event
+from nicegui import events, ui
 
 
-class FullCalendar(Element, component='fullcalendar.js'):
+class FullCalendar(ui.element, component='fullcalendar.js'):
 
     def __init__(self, options: dict[str, Any], on_click: Callable | None = None) -> None:
         """FullCalendar
@@ -23,7 +22,7 @@ class FullCalendar(Element, component='fullcalendar.js'):
         self._update_method = 'update_calendar'
 
         if on_click:
-            self.on('click', lambda e: handle_event(on_click, e))
+            self.on('click', lambda e: events.handle_event(on_click, e))
 
     def add_event(self, title: str, start: str, end: str, **kwargs) -> None:
         """Add an event to the calendar.

--- a/examples/slideshow/main.py
+++ b/examples/slideshow/main.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 from pathlib import Path
 
-from nicegui import app, ui
-from nicegui.events import KeyEventArguments
+from nicegui import app, events, ui
 
 ui.query('.nicegui-content').classes('p-0')  # remove padding from the main content
 
@@ -11,7 +10,7 @@ files = sorted(f.name for f in folder.glob('*.jpg'))
 state = {'index': 0}
 
 
-def handle_key(event: KeyEventArguments) -> None:
+def handle_key(event: events.KeyEventArguments) -> None:
     if event.action.keydown:
         if event.key.arrow_right:
             state['index'] += 1

--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -10,7 +10,6 @@ import httpx
 import socketio
 
 from nicegui import Client, ElementFilter, ui
-from nicegui.element import Element
 from nicegui.nicegui import _on_handshake
 from nicegui.outbox import Message
 
@@ -22,7 +21,7 @@ from .user_notify import UserNotify
 # pylint: disable=protected-access
 
 
-T = TypeVar('T', bound=Element)
+T = TypeVar('T', bound=ui.element)
 
 
 class User:
@@ -179,7 +178,7 @@ class User:
     @overload
     def find(self,
              target: str,
-             ) -> UserInteraction[Element]:
+             ) -> UserInteraction[ui.element]:
         ...
 
     @overload
@@ -193,7 +192,7 @@ class User:
              *,
              marker: str | list[str] | None = None,
              content: str | list[str] | None = None,
-             ) -> UserInteraction[Element]:
+             ) -> UserInteraction[ui.element]:
         ...
 
     @overload
@@ -221,7 +220,7 @@ class User:
         return UserInteraction(self, elements, target)
 
     @property
-    def current_layout(self) -> Element:
+    def current_layout(self) -> ui.element:
         """Return the root layout element of the current page."""
         return self._client.layout
 

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -5,14 +5,13 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 from typing_extensions import Self
 
 from nicegui import background_tasks, events, ui
-from nicegui.element import Element
 from nicegui.elements.mixins.disableable_element import DisableableElement
 from nicegui.elements.mixins.value_element import ValueElement
 
 if TYPE_CHECKING:
     from .user import User
 
-T = TypeVar('T', bound=Element)
+T = TypeVar('T', bound=ui.element)
 
 
 class UserInteraction(Generic[T]):

--- a/nicegui/testing/user_navigate.py
+++ b/nicegui/testing/user_navigate.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from nicegui import Client, background_tasks
-from nicegui.element import Element
+from nicegui import Client, background_tasks, ui
 from nicegui.functions.navigate import Navigate
 
 if TYPE_CHECKING:
@@ -17,8 +16,8 @@ class UserNavigate(Navigate):
         super().__init__()
         self.user = user
 
-    def to(self, target: Callable[..., Any] | str | Element, new_tab: bool = False) -> None:
-        if isinstance(target, Element):
+    def to(self, target: Callable[..., Any] | str | ui.element, new_tab: bool = False) -> None:
+        if isinstance(target, ui.element):
             # NOTE navigation to an element does not do anything in the user simulation (the whole content is always visible)
             return
         path = Client.page_routes[target] if callable(target) else target

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,8 +4,7 @@ from typing import Literal
 import pytest
 from selenium.webdriver.common.by import By
 
-from nicegui import ui
-from nicegui.events import ClickEventArguments
+from nicegui import events, ui
 from nicegui.testing import Screen
 
 
@@ -13,7 +12,7 @@ def click_sync_no_args():
     ui.label('click_sync_no_args')
 
 
-def click_sync_with_args(_: ClickEventArguments):
+def click_sync_with_args(_: events.ClickEventArguments):
     ui.label('click_sync_with_args')
 
 
@@ -22,7 +21,7 @@ async def click_async_no_args():
     ui.label('click_async_no_args')
 
 
-async def click_async_with_args(_: ClickEventArguments):
+async def click_async_with_args(_: events.ClickEventArguments):
     await asyncio.sleep(0.1)
     ui.label('click_async_with_args')
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -308,6 +308,7 @@ def test_ip(screen: Screen):
     screen.open('/')
     screen.should_contain('127.0.0.1')
 
+
 @pytest.mark.parametrize('path', ['/', None])
 def test_multicast(screen: Screen, path: str | None):
     def update():

--- a/website/documentation/content/keyboard_documentation.py
+++ b/website/documentation/content/keyboard_documentation.py
@@ -5,9 +5,9 @@ from . import doc
 
 @doc.demo(ui.keyboard)
 def main_demo() -> None:
-    from nicegui.events import KeyEventArguments
+    from nicegui import events
 
-    def handle_key(e: KeyEventArguments):
+    def handle_key(e: events.KeyEventArguments):
         if e.key == 'f' and not e.action.repeat:
             if e.action.keyup:
                 ui.notify('f was just released')

--- a/website/star.py
+++ b/website/star.py
@@ -1,5 +1,4 @@
 from nicegui import ui
-from nicegui.element import Element
 from website import svg
 
 STYLE = '''
@@ -35,8 +34,8 @@ STAR = '''
 def add_star() -> ui.link:
     ui.add_css(STYLE)
     with ui.link(target='https://github.com/zauberzeug/nicegui/').classes('star-container') as link:
-        with Element('svg').props('viewBox="0 0 24 24"').classes('star'):
-            Element('path').props('d="M23.555,8.729a1.505,1.505,0,0,0-1.406-.98H16.062a.5.5,0,0,1-.472-.334L13.405,1.222a1.5,1.5,0,0,0-2.81,0l-.005.016L8.41,7.415a.5.5,0,0,1-.471.334H1.85A1.5,1.5,0,0,0,.887,10.4l5.184,4.3a.5.5,0,0,1,.155.543L4.048,21.774a1.5,1.5,0,0,0,2.31,1.684l5.346-3.92a.5.5,0,0,1,.591,0l5.344,3.919a1.5,1.5,0,0,0,2.312-1.683l-2.178-6.535a.5.5,0,0,1,.155-.543l5.194-4.306A1.5,1.5,0,0,0,23.555,8.729Z"')
+        with ui.element('svg').props('viewBox="0 0 24 24"').classes('star'):
+            ui.element('path').props('d="M23.555,8.729a1.505,1.505,0,0,0-1.406-.98H16.062a.5.5,0,0,1-.472-.334L13.405,1.222a1.5,1.5,0,0,0-2.81,0l-.005.016L8.41,7.415a.5.5,0,0,1-.471.334H1.85A1.5,1.5,0,0,0,.887,10.4l5.184,4.3a.5.5,0,0,1,.155.543L4.048,21.774a1.5,1.5,0,0,0,2.31,1.684l5.346-3.92a.5.5,0,0,1,.591,0l5.344,3.919a1.5,1.5,0,0,0,2.312-1.683l-2.178-6.535a.5.5,0,0,1,.155-.543l5.194-4.306A1.5,1.5,0,0,0,23.555,8.729Z"')
         with ui.tooltip('').classes('bg-[#486991] w-96 p-4'):
             with ui.row().classes('items-center no-wrap'):
                 svg.face().classes('w-14 stroke-white stroke-[1pt]')


### PR DESCRIPTION
### Motivation

Non-library code (examples, tests, website, testing utilities) was importing internal modules directly (e.g. `from nicegui.element import Element`, `from nicegui.events import handle_event`). These should use the public API (`ui.element`, `events.handle_event`, etc.) to stay resilient against internal restructuring.

### Implementation

Mechanical replacement of internal imports with their public API equivalents across examples/, tests/, website/, and nicegui/testing/. No behavioral changes.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This is not a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)