### PR TITLE
Support clicking `ui.tab` in user simulation

### DIFF
--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -114,6 +114,11 @@ class UserInteraction(Generic[T]):
                     element.value = target_value
                     return self
 
+                elif isinstance(element, ui.tab):
+                    if isinstance(element.tabs, ui.tabs):
+                        element.tabs.value = element.props['name']
+                    return self
+
                 elif isinstance(element, ui.tree) and isinstance(self.target, str):
                     NODE_KEY = element.props.get('node-key')
                     LABEL_KEY = element.props.get('label-key')

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -843,3 +843,15 @@ async def test_storage_tab_persists_across_navigation(user: User) -> None:
     await user.open('/other')
     user.find('Read value').click()
     await user.should_see('ABC')
+
+
+async def test_switching_tabs(user: User) -> None:
+    @ui.page('/')
+    def _():
+        with ui.tabs(on_change=lambda e: ui.notify(f'Switching to {e.value}')):
+            ui.tab('A')
+            ui.tab('B')
+
+    await user.open('/')
+    user.find('A').click()
+    await user.should_see('Switching to A')


### PR DESCRIPTION
### Motivation

Clicking a `ui.tab` element in the user simulation testing framework had no effect — the parent `ui.tabs` value was never updated, so `on_change` callbacks were not triggered. This made it impossible to test tab switching with the `User` fixture.

Fixes #5885.

### Implementation

Added a `ui.tab` case to `UserInteraction.click()`, following the same pattern used for `ui.radio` and `ui.select`: when a tab is clicked, its parent `ui.tabs` element's value is set to the tab's name, which triggers the `on_change` callback.

A corresponding test (`test_switching_tabs`) verifies the fix.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] This is not a security issue.
- [x] Pytest has been added.
- [x] Documentation is not necessary.