### PR TITLE
fix(xterm): preserve writes issued before mount in hidden tab panels

### DIFF
--- a/nicegui/elements/xterm/xterm.js
+++ b/nicegui/elements/xterm/xterm.js
@@ -3,6 +3,13 @@ import { loadResource } from "../../static/utils/resources.js";
 
 export default {
   template: "<div></div>",
+  data() {
+    return {
+      terminal: null,
+      fit_addon: null,
+      pending_calls: [],
+    };
+  },
   mounted() {
     // Create terminal with addons
     this.terminal = new Terminal(this.options);
@@ -17,34 +24,48 @@ export default {
         this.terminal[key]((e) => this.$emit(key.slice(2).toLowerCase(), e));
       });
 
+    for (const [name, args] of this.pending_calls) {
+      runMethod(this.terminal, name, args);
+    }
+    this.pending_calls = [];
+
     // NOTE: wait for window.path_prefix to be set
     this.$nextTick().then(() => loadResource(window.path_prefix + `${this.resourcePath}/xterm.css`));
   },
   methods: {
+    run_terminal_or_queue(name, ...args) {
+      if (!this.terminal) {
+        this.pending_calls.push([name, args]);
+        return;
+      }
+      return runMethod(this.terminal, name, args);
+    },
     getRows() {
-      return this.terminal.rows;
+      return this.terminal?.rows;
     },
     getColumns() {
-      return this.terminal.cols;
+      return this.terminal?.cols;
     },
     fit() {
-      this.fit_addon.fit();
+      if (this.fit_addon) {
+        this.fit_addon.fit();
+      }
     },
     input(data, wasUserInput = true) {
-      return this.terminal.input(data, wasUserInput);
+      return this.run_terminal_or_queue("input", data, wasUserInput);
     },
     write(data) {
-      return this.terminal.write(data);
+      return this.run_terminal_or_queue("write", data);
     },
     writeln(data) {
-      return this.terminal.writeln(data);
+      return this.run_terminal_or_queue("writeln", data);
     },
     run_terminal_method(name, ...args) {
       if (name.startsWith(":")) {
         name = name.slice(1);
         args = args.map((arg) => new Function(`return (${arg});`).call(this.terminal));
       }
-      return runMethod(this.terminal, name, args);
+      return this.run_terminal_or_queue(name, ...args);
     },
   },
   props: {

--- a/tests/test_xterm.py
+++ b/tests/test_xterm.py
@@ -99,3 +99,22 @@ def test_run_terminal_method(screen: Screen) -> None:
     screen.open('/')
     screen.should_contain('Hello NiceGUI!')
     screen.should_contain('Selected text: nicegui.io')
+
+
+def test_write_while_xterm_is_in_inactive_tab_panel(screen: Screen) -> None:
+    @ui.page('/')
+    def page() -> None:
+        with ui.tabs() as tabs:
+            ui.tab('One')
+            ui.tab('Two')
+
+        with ui.tab_panels(tabs, value='One'):
+            with ui.tab_panel('One'):
+                ui.button('Write while hidden', on_click=lambda: terminal.writeln('This is queued output'))
+            with ui.tab_panel('Two'):
+                terminal = ui.xterm()
+
+    screen.open('/')
+    screen.click('Write while hidden')
+    screen.click('Two')
+    screen.should_contain('This is queued output')


### PR DESCRIPTION
## Summary
- fix `ui.xterm` calls (`write`, `writeln`, `input`, and `run_terminal_method`) when invoked before the Vue component is mounted
- queue pending terminal method calls and replay them once `mounted()` creates the terminal instance
- keep behavior unchanged when terminal is already mounted

## Why
Issue #5839 reports lost output when writing to an xterm inside an inactive `ui.tab_panel`. In that case the component can be unmounted and method calls happen before `this.terminal` exists on the frontend, so output is dropped.

## Tests
- add regression test `test_write_while_xterm_is_in_inactive_tab_panel`
  - writes to xterm while hidden in tab "Two"
  - switches to tab "Two"
  - asserts the text is present

## Notes
I could not run the test suite in this environment because `pytest` is unavailable, but the added test follows existing `Screen` patterns in this repository.

Closes #5839
