### PR TITLE
fix: propagate CancelledError in run.cpu_bound / run.io_bound

### DIFF
--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -67,7 +67,7 @@ async def _run(executor: Any, callback: Callable[P, R], *args: P.args, **kwargs:
         if 'cannot schedule new futures after shutdown' not in str(e):
             raise
     except asyncio.CancelledError:
-        pass
+        raise
     return  # type: ignore  # the assumption is that the user's code no longer cares about this value
 
 


### PR DESCRIPTION
## Summary

Fixes #5925.

`_run()` was silently swallowing `asyncio.CancelledError`, causing `cpu_bound` and `io_bound` to return `None` instead of propagating the cancellation. This made it impossible for callers to distinguish a legitimate `None` return from a cancelled task, leading to downstream `TypeError`s.

## Change

One-line change in `nicegui/run.py`: replace `pass` with `raise` in the `CancelledError` handler so the exception propagates to the caller.

## Test plan

- Existing test suite should pass (cancellation during shutdown is already handled by the `is_stopping` guard above)
- Callers that need to handle cancellation can now use `try/except asyncio.CancelledError`