### PR TITLE
Fix RuntimeError when click handler deletes the clicked element during testing

### DIFF
--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -46,11 +46,13 @@ class UserInteraction(Generic[T]):
                             element.value = option
                             break
 
-                for listener in list(element._event_listeners.values()):  # pylint: disable=protected-access
+                for listener in element._event_listeners.values():  # pylint: disable=protected-access
                     if listener.type != event:
                         continue
                     event_arguments = events.GenericEventArguments(sender=element, client=self.user.client, args=args)
                     events.handle_event(listener.handler, event_arguments)
+                    if element.is_deleted:
+                        break
         return self
 
     def type(self, text: str) -> Self:
@@ -139,12 +141,14 @@ class UserInteraction(Generic[T]):
                     element.update()
                     return self
 
-                for listener in list(element._event_listeners.values()):  # pylint: disable=protected-access
+                for listener in element._event_listeners.values():  # pylint: disable=protected-access
                     if listener.element_id != element.id:
                         continue
                     args = not element.value if isinstance(element, (ui.checkbox, ui.switch)) else None
                     event_arguments = events.GenericEventArguments(sender=element, client=self.user.client, args=args)
                     events.handle_event(listener.handler, event_arguments)
+                    if element.is_deleted:
+                        break
         return self
 
     def clear(self) -> Self:

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -46,7 +46,7 @@ class UserInteraction(Generic[T]):
                             element.value = option
                             break
 
-                for listener in element._event_listeners.values():  # pylint: disable=protected-access
+                for listener in list(element._event_listeners.values()):  # pylint: disable=protected-access
                     if listener.type != event:
                         continue
                     event_arguments = events.GenericEventArguments(sender=element, client=self.user.client, args=args)
@@ -139,7 +139,7 @@ class UserInteraction(Generic[T]):
                     element.update()
                     return self
 
-                for listener in element._event_listeners.values():  # pylint: disable=protected-access
+                for listener in list(element._event_listeners.values()):  # pylint: disable=protected-access
                     if listener.element_id != element.id:
                         continue
                     args = not element.value if isinstance(element, (ui.checkbox, ui.switch)) else None

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -893,10 +893,15 @@ async def test_clearing_container_with_button_inside(user: User) -> None:
 
         def rebuild():
             with container.clear():
-                ui.button('click me', on_click=rebuild)
+                ui.button('click me') \
+                    .on('click', lambda: ui.notify('First handler')) \
+                    .on('click', rebuild) \
+                    .on('click', lambda: ui.notify('Last handler'))
 
         rebuild()
 
     await user.open('/')
     user.find('click me').click()
+    await user.should_see('First handler')
     await user.should_see('click me')
+    await user.should_not_see('Last handler')

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -884,3 +884,19 @@ async def test_switching_tabs_wrapped_in_row(user: User) -> None:
     await user.open('/')
     user.find('A').click()
     await user.should_see('Switching to A')
+
+
+async def test_clearing_container_with_button_inside(user: User) -> None:
+    @ui.page('/')
+    def page():
+        container = ui.row()
+
+        def rebuild():
+            with container.clear():
+                ui.button('click me', on_click=rebuild)
+
+        rebuild()
+
+    await user.open('/')
+    user.find('click me').click()
+    await user.should_see('click me')


### PR DESCRIPTION
### Motivation

Fixes #5937. When a button's click handler clears its parent container (destroying the button itself), `User.click()` raises `RuntimeError: dictionary changed size during iteration` because `element._event_listeners` is mutated mid-loop via `_handle_delete()` -> `_event_listeners.clear()`.

### Implementation

After each handler fires, check `element.is_deleted` and `break` out of the listener loop. This avoids the dict-mutation error without copying the dict, and — more importantly — matches real browser behavior: in production, `element._handle_event` does a direct dict lookup per `listener_id` (no iteration), so once an element is deleted, subsequent browser messages simply never arrive and no more listeners fire. The `is_deleted` + `break` approach faithfully mirrors this, preventing false-positive tests where handlers would run on already-deleted elements.

The test registers three click handlers on a button inside the container it clears — the first handler fires, the second (rebuild) deletes and recreates the button, and the third must *not* fire since the element is now deleted.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
