### PR TITLE
Fix in-page drag-and-drop in native mode

### DIFF
--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -64,8 +64,11 @@ def _bind_pywebview_events(window: webview.Window, event_sender: Connection) -> 
             pass
 
     def bind_drop() -> None:
-        window.dom.document.events.dragover += \
-            webview.dom.DOMEventHandler(lambda _: 0, True, False)  # type: ignore[arg-type]
+        window.evaluate_js('''
+            document.addEventListener("dragover", function(e) {
+              if (e.dataTransfer && e.dataTransfer.types.indexOf("Files") >= 0) e.preventDefault();
+            });
+        ''')
         window.dom.document.events.drop += \
             webview.dom.DOMEventHandler(lambda e: send('drop', files=[  # type: ignore[arg-type]
                 file_.get('pywebviewFullPath', '') for file_ in e.get('dataTransfer', {}).get('files', [])


### PR DESCRIPTION
### Motivation

The native window event IPC bridge (#5866, released in 3.9.0) introduced a document-level `dragover` handler with `preventDefault()` to support dropping files from the OS into the pywebview window. This unconditionally prevents the default behavior for *all* dragover events, including in-page element drags. As a result, HTML5 drag-and-drop between elements (e.g. the Trello Cards example) stopped working in native mode.

Fixes #5940.

### Implementation

Replace the pywebview `DOMEventHandler` for `dragover` with a raw JavaScript listener that only calls `preventDefault()` when files are being dragged from outside the browser. This is detected by checking whether `dataTransfer.types` contains `"Files"`. In-page drags (which use types like `"text/plain"`) are left untouched, so element-level `dragover`, `dragleave`, and `drop` handlers work normally again.

The `drop` handler remains unchanged since its `preventDefault()` during bubbling is harmless for in-page drags (the element-level handler has already processed the event) and still necessary for native file drops (prevents the browser from navigating to the dropped file).

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary (native mode is currently untested).
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.