### PR TITLE
Fix `ui.on_exception` not catching exceptions from async event handlers

### DIFF
--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from contextlib import nullcontext
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias, TypeVar, cast
@@ -459,6 +459,15 @@ def handle_event(handler: Handler[EventT] | None, arguments: EventT) -> None:
             else:
                 result = cast(Callable[[], Any], handler)()
         if helpers.should_await(result):
-            background_tasks.create_or_defer(helpers.await_with_context(result, parent_slot), name=str(handler))
+            background_tasks.create_or_defer(_await_and_handle_in_context(result, parent_slot), name=str(handler))
     except Exception as e:
         core.app.handle_exception(e)
+
+
+async def _await_and_handle_in_context(awaitable: Awaitable, context: Slot | nullcontext) -> None:
+    """Await an event handler result within its slot context, handling exceptions in-context."""
+    with context:
+        try:
+            await awaitable
+        except Exception as e:
+            core.app.handle_exception(e)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -153,3 +153,27 @@ async def test_event_memory_leak(screen: Screen):
     await asyncio.sleep(1)
     Client.prune_instances(client_age_threshold=0)
     assert not event.callbacks, 'event callbacks should be cleared after pruning clients'
+
+
+async def test_ui_on_exception(user: User, caplog: pytest.LogCaptureFixture):
+    exceptions: list[Exception] = []
+
+    @ui.page('/')
+    def page():
+        ui.on_exception(exceptions.append)
+
+        def raise_sync():
+            raise RuntimeError('sync error')
+
+        async def raise_async():
+            raise RuntimeError('async error')
+
+        ui.button('Click sync', on_click=raise_sync)
+        ui.button('Click async', on_click=raise_async)
+
+    await user.open('/')
+    user.find('Click sync').click()
+    user.find('Click async').click()
+    await asyncio.sleep(0.1)
+    assert len(exceptions) == 2 and 'sync error' in str(exceptions[0]) and 'async error' in str(exceptions[1])
+    caplog.records.clear()


### PR DESCRIPTION
### Motivation

Since v3.10.0 (PR #5879), `ui.on_exception` no longer catches exceptions raised in async event handlers. Synchronous handlers still work correctly.

The root cause is that #5879 moved async handler awaiting into background tasks via `helpers.await_with_context`. When such a task raises, the exception surfaces through the background task's done callback (`_handle_exceptions`), which calls `core.app.handle_exception(e)` — but at that point the client/slot context is no longer on the context stack. So `app.handle_exception` never delegates to `client.handle_exception`, and per-client `ui.on_exception` handlers are skipped.

Fixes #5945.

### Implementation

Replaced `helpers.await_with_context` in `handle_event` with a new `_await_and_handle_in_context` coroutine that both awaits the result **and** catches exceptions **within** the slot context. This ensures `app.handle_exception` can find the client and dispatch to `ui.on_exception` handlers, restoring the pre-3.10.0 behavior.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.