### PR TITLE
Add `ui.keep_alive` to mount children eagerly regardless of visibility

### DIFF
--- a/nicegui/elements/keep_alive.py
+++ b/nicegui/elements/keep_alive.py
@@ -27,7 +27,7 @@ class KeepAlive(Element, component='keep_alive_anchor.js'):
         Note that this keeps the children alive for the full lifetime of the client, which costs memory.
         Only use it where eager mounting is actually required.
 
-        *Added in version 3.x.0*
+        *Added in version 3.11.0*
         """
         super().__init__()
         with context.client.layout:

--- a/nicegui/elements/keep_alive.py
+++ b/nicegui/elements/keep_alive.py
@@ -12,11 +12,18 @@ class KeepAlive(Element, component='keep_alive_anchor.js'):
         Wraps its children so they stay mounted in the DOM even when the surrounding container is currently not visible
         (e.g. an inactive ``ui.tab_panel``, a closed ``ui.dialog`` or ``ui.menu``, or a sub-page that is not currently routed to).
 
-        Method calls and events on the inner elements (such as writing to a not-yet-visible ``ui.xterm``
-        or reading data from an ``ui.aggrid`` whose tab has never been opened) are dispatched as usual.
+        This is useful for elements whose client-side state would otherwise be lost or unreachable before first display:
+        writing to a ``ui.xterm`` inside a never-opened tab, reading ``ui.aggrid.get_client_data()`` from a closed dialog,
+        or preserving edit history in a ``ui.codemirror`` across navigation.
+        Method calls and events on the inner elements are executed immediately on the live component instance —
+        they are never buffered or replayed.
 
         Internally the children are rendered into a hidden host at the page root
         and teleported to the wrapper's location whenever it becomes visible.
+        As a consequence, the server-side element tree parents the children to this host, not to the surrounding container:
+        ``descendants()`` on the apparent parent and scoped ``ui.element_filter`` will not traverse into the subtree.
+        Keep a direct reference to the inner elements if you need to reach them programmatically.
+
         Note that this keeps the children alive for the full lifetime of the client, which costs memory.
         Only use it where eager mounting is actually required.
 

--- a/nicegui/elements/keep_alive.py
+++ b/nicegui/elements/keep_alive.py
@@ -1,0 +1,52 @@
+from typing_extensions import Self
+
+from ..context import context
+from ..element import Element
+
+
+class KeepAlive(Element, component='keep_alive_anchor.js'):
+
+    def __init__(self) -> None:
+        """Keep Alive
+
+        Wraps its children so they stay mounted in the DOM even when the surrounding container is currently not visible
+        (e.g. an inactive ``ui.tab_panel``, a closed ``ui.dialog`` or ``ui.menu``, or a sub-page that is not currently routed to).
+
+        Method calls and events on the inner elements (such as writing to a not-yet-visible ``ui.xterm``
+        or reading data from an ``ui.aggrid`` whose tab has never been opened) are dispatched as usual.
+
+        Internally the children are rendered into a hidden host at the page root
+        and teleported to the wrapper's location whenever it becomes visible.
+        Note that this keeps the children alive for the full lifetime of the client, which costs memory.
+        Only use it where eager mounting is actually required.
+
+        *Added in version 3.x.0*
+        """
+        super().__init__()
+        with context.client.layout:
+            self._host = _KeepAliveHost(anchor=self)
+        self._props['host-id'] = self._host.id
+
+    def __enter__(self) -> Self:
+        # Children declared inside `with ui.keep_alive(): ...` belong to the stable host,
+        # not to the anchor that may be unmounted at any time.
+        self._host.__enter__()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self._host.__exit__(*exc)
+
+    def _handle_delete(self) -> None:
+        # NOTE: the host may already be queued for deletion if the entire client is being torn down,
+        # in which case its parent slot has already cleared it from its children list.
+        host_slot = self._host.parent_slot
+        if not self._host.is_deleted and host_slot is not None and self._host in host_slot.children:
+            self._host.delete()
+        super()._handle_delete()
+
+
+class _KeepAliveHost(Element, component='keep_alive_host.js'):
+
+    def __init__(self, *, anchor: Element) -> None:
+        super().__init__()
+        self._props['anchor-selector'] = f'#{anchor.html_id}'

--- a/nicegui/elements/keep_alive.py
+++ b/nicegui/elements/keep_alive.py
@@ -14,9 +14,9 @@ class KeepAlive(Element, component='keep_alive_anchor.js'):
 
         This is useful for elements whose client-side state would otherwise be lost or unreachable before first display:
         writing to a ``ui.xterm`` inside a never-opened tab, reading ``ui.aggrid.get_client_data()`` from a closed dialog,
-        or preserving edit history in a ``ui.codemirror`` across navigation.
-        Method calls and events on the inner elements are executed immediately on the live component instance —
-        they are never buffered or replayed.
+        or preserving edit history in a ``ui.codemirror`` when switching between tabs.
+        Method calls and events on the inner elements are executed immediately on the live component instance.
+        They are never buffered or replayed.
 
         Internally the children are rendered into a hidden host at the page root
         and teleported to the wrapper's location whenever it becomes visible.
@@ -26,6 +26,9 @@ class KeepAlive(Element, component='keep_alive_anchor.js'):
 
         Note that this keeps the children alive for the full lifetime of the client, which costs memory.
         Only use it where eager mounting is actually required.
+        Because state is tied to the client, ``ui.keep_alive`` cannot preserve anything across ``@ui.page`` navigation,
+        which creates a fresh client every time;
+        it only helps within a single page (inactive tabs, closed dialogs, unrouted sub-pages).
 
         *Added in version 3.11.0*
         """

--- a/nicegui/elements/keep_alive_anchor.js
+++ b/nicegui/elements/keep_alive_anchor.js
@@ -1,0 +1,12 @@
+export default {
+  template: `<div style="display: contents"></div>`, // make anchor transparent to layout for correct sizing of children
+  props: {
+    hostId: Number,
+  },
+  mounted() {
+    this.$nextTick(() => getElement(this.hostId)?.setAnchorReady(true)); // wait for root app to be fully mounted
+  },
+  beforeUnmount() {
+    getElement(this.hostId)?.setAnchorReady(false);
+  },
+};

--- a/nicegui/elements/keep_alive_host.js
+++ b/nicegui/elements/keep_alive_host.js
@@ -1,5 +1,3 @@
-const CACHE_ID = "nicegui-keep-alive-cache";
-
 export default {
   template: `
     <Teleport :to="target">
@@ -10,20 +8,11 @@ export default {
     anchorSelector: String,
   },
   data() {
-    return { target: `#${CACHE_ID}` };
-  },
-  beforeMount() {
-    if (!document.getElementById(CACHE_ID)) {
-      const cache = document.createElement("div");
-      cache.id = CACHE_ID;
-      cache.style.display = "none";
-      cache.setAttribute("aria-hidden", "true");
-      document.body.appendChild(cache);
-    }
+    return { target: "#nicegui-keep-alive-cache" };
   },
   methods: {
     setAnchorReady(ready) {
-      this.target = ready ? this.anchorSelector : `#${CACHE_ID}`;
+      this.target = ready ? this.anchorSelector : "#nicegui-keep-alive-cache";
     },
   },
 };

--- a/nicegui/elements/keep_alive_host.js
+++ b/nicegui/elements/keep_alive_host.js
@@ -1,0 +1,28 @@
+const CACHE_ID = "nicegui-keep-alive-cache";
+
+export default {
+  template: `
+    <Teleport :to="target">
+      <slot></slot>
+    </Teleport>
+  `,
+  props: {
+    anchorSelector: String,
+  },
+  data() {
+    return { target: `#${CACHE_ID}` };
+  },
+  beforeMount() {
+    if (!document.getElementById(CACHE_ID)) {
+      const cache = document.createElement("div");
+      cache.id = CACHE_ID;
+      cache.style.display = "none";
+      document.body.appendChild(cache);
+    }
+  },
+  methods: {
+    setAnchorReady(ready) {
+      this.target = ready ? this.anchorSelector : `#${CACHE_ID}`;
+    },
+  },
+};

--- a/nicegui/elements/keep_alive_host.js
+++ b/nicegui/elements/keep_alive_host.js
@@ -17,6 +17,7 @@ export default {
       const cache = document.createElement("div");
       cache.id = CACHE_ID;
       cache.style.display = "none";
+      cache.setAttribute("aria-hidden", "true");
       document.body.appendChild(cache);
     }
   },

--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -128,6 +128,7 @@
     </style>
     <div id="esm-fallback">Your browser does not support ES modules.<br />Please use a modern browser.</div>
     <div id="app" {% if unocss %}class="nicegui-unocss-loading" {% endif %}></div>
+    <div id="nicegui-keep-alive-cache" style="display: none" aria-hidden="true"></div>
     <div id="popup" class="nicegui-error-popup" aria-hidden="true">
       <span>{{ translations.connection_lost }}</span>
       <span>{{ translations.trying_to_reconnect }}</span>

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -59,6 +59,7 @@ __all__ = [
     'item_section',
     'joystick',
     'json_editor',
+    'keep_alive',
     'keyboard',
     'knob',
     'label',
@@ -194,6 +195,7 @@ from .elements.item import ItemLabel as item_label
 from .elements.item import ItemSection as item_section
 from .elements.joystick import Joystick as joystick
 from .elements.json_editor import JsonEditor as json_editor
+from .elements.keep_alive import KeepAlive as keep_alive
 from .elements.keyboard import Keyboard as keyboard
 from .elements.knob import Knob as knob
 from .elements.label import Label as label

--- a/tests/test_keep_alive.py
+++ b/tests/test_keep_alive.py
@@ -1,0 +1,139 @@
+from nicegui import ui
+from nicegui.testing import Screen
+
+
+def test_xterm_in_unopened_tab(screen: Screen) -> None:
+    @ui.page('/')
+    def page():
+        with ui.tabs() as tabs:
+            ui.tab('One')
+            ui.tab('Two')
+        with ui.tab_panels(tabs, value='One'):
+            with ui.tab_panel('One'):
+                ui.label('First tab')
+            with ui.tab_panel('Two'):
+                with ui.keep_alive():
+                    terminal = ui.xterm()
+        ui.button('Write', on_click=lambda: terminal.write('Hello, Terminal!'))
+
+    screen.open('/')
+    screen.click('Write')
+    screen.click('Two')
+    screen.should_contain('Hello, Terminal!')
+
+
+def test_aggrid_get_client_data_in_closed_dialog(screen: Screen) -> None:
+    data: list = []
+
+    @ui.page('/')
+    def page():
+        with ui.dialog() as dialog:
+            with ui.keep_alive():
+                grid = ui.aggrid({'columnDefs': [{'field': 'name'}], 'rowData': [{'name': 'Alice'}, {'name': 'Bob'}]})
+
+        @ui.button('Read').on_click
+        async def _():
+            data[:] = await grid.get_client_data()
+
+        ui.button('Open', on_click=dialog.open)
+
+    screen.open('/')
+    screen.click('Read')  # without keep_alive this would silently return [] until the dialog has been opened
+    screen.wait_for(lambda: data == [{'name': 'Alice'}, {'name': 'Bob'}])
+
+
+def test_visible_children_render_in_place(screen: Screen) -> None:
+    @ui.page('/')
+    def page():
+        with ui.card().classes('card'):
+            with ui.keep_alive():
+                ui.label('Inside keep_alive')
+
+    screen.open('/')
+    screen.should_contain('Inside keep_alive')
+    assert 'Inside keep_alive' in screen.find_by_css('.card').text
+
+
+def test_deletion_cleans_up_host(screen: Screen) -> None:
+    wrapper: ui.keep_alive | None = None
+
+    @ui.page('/')
+    def page():
+        nonlocal wrapper
+        with ui.card() as card:
+            with ui.keep_alive() as wrapper:
+                ui.label('Inside keep_alive')
+        ui.button('Drop', on_click=card.delete)
+
+    screen.open('/')
+    screen.should_contain('Inside keep_alive')
+    assert wrapper is not None
+
+    screen.click('Drop')
+    screen.wait_for(lambda: wrapper.is_deleted)
+    screen.wait_for(lambda: wrapper._host.is_deleted)  # pylint: disable=protected-access
+
+
+def test_xterm_in_unopened_menu(screen: Screen) -> None:
+    @ui.page('/')
+    def page():
+        with ui.button('Menu'):
+            with ui.menu():
+                with ui.keep_alive():
+                    terminal = ui.xterm()
+        ui.button('Write', on_click=lambda: terminal.write('Hello, Menu!'))
+
+    screen.open('/')
+    screen.click('Write')
+    screen.click('Menu')
+    screen.should_contain('Hello, Menu!')
+
+
+def test_nested_keep_alive(screen: Screen) -> None:
+    @ui.page('/')
+    def page():
+        with ui.tabs() as tabs:
+            ui.tab('One')
+            ui.tab('Two')
+        with ui.tab_panels(tabs, value='One'):
+            with ui.tab_panel('One'):
+                ui.label('First tab')
+            with ui.tab_panel('Two'):
+                with ui.keep_alive():
+                    with ui.dialog() as dialog, ui.card():
+                        with ui.keep_alive():
+                            terminal = ui.xterm()
+                        ui.button('Close', on_click=dialog.close)
+                    ui.button('Open dialog', on_click=dialog.open)
+        ui.button('Write', on_click=lambda: terminal.write('Hello, Nested!'))
+
+    screen.open('/')
+    screen.click('Write')  # neither the tab panel nor the dialog have ever been opened
+    screen.click('Two')
+    screen.click('Open dialog')
+    screen.should_contain('Hello, Nested!')
+
+
+def test_inside_sub_pages_cleans_up_on_navigation(screen: Screen) -> None:
+    @ui.page('/')
+    @ui.page('/other')
+    def index():
+        ui.sub_pages({'/': home, '/other': other})
+
+    def home():
+        with ui.keep_alive():
+            ui.label('Inside keep_alive')
+        ui.link('Go to other', '/other')
+        ui.label(f'element count: {len(ui.context.client.elements)}')
+
+    def other():
+        ui.link('Back home', '/')
+
+    screen.open('/')
+    screen.should_contain('Inside keep_alive')
+    initial = screen.find('element count:').text
+
+    screen.click('Go to other')
+    screen.click('Back home')
+    screen.should_contain('Inside keep_alive')
+    screen.should_contain(initial)  # no orphaned host from first visit

--- a/website/documentation/content/keep_alive_documentation.py
+++ b/website/documentation/content/keep_alive_documentation.py
@@ -13,21 +13,22 @@ def main_demo() -> None:
             ui.label('Open the second tab to see the buffered output.')
         with ui.tab_panel('Terminal'):
             with ui.keep_alive():
-                terminal = ui.xterm()
+                terminal = ui.xterm({'cols': 28, 'rows': 9})
 
     ui.button('Write hello', on_click=lambda: terminal.writeln('Hello, NiceGUI!'))
 
 
 @doc.demo('Reading data from a hidden AG Grid', '''
-    Without `ui.keep_alive`, calling `get_client_data` on a `ui.aggrid` inside an unopened tab or closed dialog
+    An editable `ui.aggrid` lets users modify cells client-side, and `get_client_data` reads those changes back.
+    Without `ui.keep_alive`, calling it on a grid inside an unopened tab or closed dialog
     would silently return an empty list because the grid has not been mounted yet.
     Wrapping the grid in `ui.keep_alive` mounts it eagerly, so its API is reachable immediately.
 ''')
 def aggrid_demo() -> None:
-    with ui.dialog() as dialog:
+    with ui.dialog() as dialog, ui.card().classes('min-w-96'):
         with ui.keep_alive():
             grid = ui.aggrid({
-                'columnDefs': [{'field': 'name'}, {'field': 'age'}],
+                'columnDefs': [{'field': 'name', 'editable': True}, {'field': 'age'}],
                 'rowData': [{'name': 'Alice', 'age': 18}, {'name': 'Bob', 'age': 21}],
             })
         ui.button('Close', on_click=dialog.close)

--- a/website/documentation/content/keep_alive_documentation.py
+++ b/website/documentation/content/keep_alive_documentation.py
@@ -1,0 +1,42 @@
+from nicegui import ui
+
+from . import doc
+
+
+@doc.demo(ui.keep_alive)
+def main_demo() -> None:
+    with ui.tabs() as tabs:
+        ui.tab('Other')
+        ui.tab('Terminal')
+    with ui.tab_panels(tabs, value='Other'):
+        with ui.tab_panel('Other'):
+            ui.label('Open the second tab to see the buffered output.')
+        with ui.tab_panel('Terminal'):
+            with ui.keep_alive():
+                terminal = ui.xterm()
+
+    ui.button('Write hello', on_click=lambda: terminal.writeln('Hello, NiceGUI!'))
+
+
+@doc.demo('Reading data from a hidden AG Grid', '''
+    Without `ui.keep_alive`, calling `get_client_data` on a `ui.aggrid` inside an unopened tab or closed dialog
+    would silently return an empty list because the grid has not been mounted yet.
+    Wrapping the grid in `ui.keep_alive` mounts it eagerly, so its API is reachable immediately.
+''')
+def aggrid_demo() -> None:
+    with ui.dialog() as dialog:
+        with ui.keep_alive():
+            grid = ui.aggrid({
+                'columnDefs': [{'field': 'name'}, {'field': 'age'}],
+                'rowData': [{'name': 'Alice', 'age': 18}, {'name': 'Bob', 'age': 21}],
+            })
+        ui.button('Close', on_click=dialog.close)
+
+    async def show_data():
+        ui.notify(await grid.get_client_data())
+
+    ui.button('Open dialog', on_click=dialog.open)
+    ui.button('Read data', on_click=show_data)
+
+
+doc.reference(ui.keep_alive)

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -310,6 +310,7 @@ def map_of_nicegui():
             - [`ui.download`](/documentation/download): download a file to the client
             - [`ui.fullscreen`](/documentation/fullscreen): enter, exit and toggle fullscreen mode
             - [`ui.keyboard`](/documentation/keyboard): define keyboard event handlers
+            - [`ui.keep_alive`](/documentation/keep_alive): keep elements alive even when they are not visible
             - [`ui.navigate`](/documentation/navigate): let the browser navigate to another location
             - [`ui.notify`](/documentation/notify): show a notification
             - [`ui.on`](/documentation/generic_events#custom_events): register an event handler

--- a/website/documentation/content/section_page_layout.py
+++ b/website/documentation/content/section_page_layout.py
@@ -10,6 +10,7 @@ from . import (
     expansion_documentation,
     fullscreen_documentation,
     grid_documentation,
+    keep_alive_documentation,
     list_documentation,
     menu_documentation,
     slide_item_documentation,
@@ -87,6 +88,7 @@ def clear_containers_demo():
 
 
 doc.intro(teleport_documentation)
+doc.intro(keep_alive_documentation)
 doc.intro(expansion_documentation)
 doc.intro(scroll_area_documentation)
 doc.intro(separator_documentation)


### PR DESCRIPTION
### Motivation

Several elements with significant client-side state — `ui.xterm`, `ui.aggrid`, `ui.codemirror`, ECharts, ... — are unreachable when their host container has not been mounted yet. Writing to a `ui.xterm` inside a never-opened `ui.tab_panel` silently drops the data; calling `await grid.get_client_data()` on an `ui.aggrid` inside a closed `ui.dialog` silently returns `[]`. Existing workarounds are element-specific and don't generalise to elements whose state can't be reconstructed from props (xterm's scrollback, codemirror's edit history, ...).

Resolves:

- #5839 — `ui.xterm` writes to a not-yet-mounted terminal are lost
- #3033 — `ui.aggrid.get_client_data()` returns `[]` for grids inside an inactive `ui.tab_panel`

Possibly superseded:

- PR #5645 — the AG-Grid-specific phantom-clone workaround for #3033.

  **Proposal:** close in favour of `ui.keep_alive` for the common case. The phantom-clone is a memory optimisation (row data only, no live grid instance), so if anyone has a read-only-grid-in-1000-tabs scenario it could be re-opened as an optional fast path; otherwise the simpler unified mechanism wins.

- PR #5924 — the xterm-specific call-buffering workaround for #5839.

  **Proposal:** close in favour of `ui.keep_alive`. xterm.js holds state beyond the write log (cursor position, ANSI modes, scrollback dimensions) so replaying buffered writes onto a fresh terminal can desync that state; keeping the same component instance alive is the more honest fix.

In both cases the right follow-up — independent of `ui.keep_alive` — is to stop the *silent* failure when an unmounted element is interacted with (`aggrid.get_client_data()` returning `[]`, `xterm.write()` swallowing bytes). A loud warning that suggests `ui.keep_alive` would surface the issue at the right moment, instead of leaving users to debug it.

### Implementation

A new `ui.keep_alive` wraps its children so they are mounted eagerly into a hidden host at the page root, and teleported into the user's slot whenever that slot becomes visible. The same component instance is reused across show/hide cycles, so internal state survives — and method calls on the inner elements work the entire time, before the slot is ever revealed for the first time.

The element creates two NiceGUI elements per use:

- A **`_KeepAliveHost`** placed in `client.layout` (always-mounted q-layout). The user's children are reparented here via overrides of `__enter__` / `__exit__`, so they are alive for the lifetime of the client.
- A small **anchor** `<div>` placed at the original slot location. It has `display: contents` so it does not introduce its own layout box — children get sized by the user's actual container (a flex `q-card`, a tab panel's content area, ...).

The host renders its slot through a `<Teleport :to="target">` and switches `target` between the anchor's selector and a global hidden `#nicegui-keep-alive-cache` div. The signal between anchor and host stays entirely on the client (no extra round-trip to the server). When the keep_alive is cascade-deleted, `_handle_delete` cleans up the host.

This mirrors the existing `ui.dialog` "canary" trick (dialog lives in `client.layout`, sentinel element in the user's slot deletes it when collected); a follow-up could extract a shared `_HostedElement` base.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation has been added/updated.
- [x] No breaking changes to the public API.

#### Open questions before merge

- [ ] **Name**: `ui.keep_alive` overlaps Vue's `<KeepAlive>` and they do roughly opposite things (Vue's caches between unmount/remount; this prevents unmount in the first place). Worth deciding now since renaming after merge is breaking. Candidates: `ui.persistent`, `ui.always_mounted`, `ui.eager`.
- [x] **Version placeholder** in the docstring (`*Added in version 3.x.0*`) needs to be updated to the actual release.