### PR TITLE
Raise a clear error when ui.run_with() is called with nicegui.app itself

### DIFF
--- a/nicegui/ui_run_with.py
+++ b/nicegui/ui_run_with.py
@@ -63,6 +63,12 @@ def run_with(
     :param session_middleware_kwargs: additional keyword arguments passed to SessionMiddleware that creates the session cookies used for browser-based storage
     :param show_welcome_message: whether to show the welcome message (default: `True`)
     """
+    if app is core.app:
+        raise ValueError(
+            'ui.run_with() must be called with your own FastAPI app, not nicegui.app. '
+            'Mounting nicegui.app into itself causes infinite recursion on unmatched paths. '
+            'If you do not have your own FastAPI app, use ui.run() instead.'
+        )
     if core.script_mode:
         log.warning(
             'NiceGUI elements were created outside of a page context before ui.run_with() was called.\n'

--- a/tests/test_run_with.py
+++ b/tests/test_run_with.py
@@ -1,0 +1,9 @@
+import pytest
+
+from nicegui import app, ui
+
+
+def test_run_with_rejects_self_mount():
+    """Passing nicegui.app to ui.run_with() would mount it into itself and cause infinite recursion on unmatched paths."""
+    with pytest.raises(ValueError, match='must be called with your own FastAPI app'):
+        ui.run_with(app)


### PR DESCRIPTION
### Motivation

A user privately reported that requests to unknown paths cause an "infinite" connection with CPU pegged at 100% and steadily growing RAM, but only when running their app under bare uvicorn (`USE_UVICORN=1 uvicorn main:ng_app`) and not under `ui.run()`.

The root cause is a self-mount loop in their setup:

```python
from nicegui import app as ng_app  # this is core.app
...
ui.run_with(ng_app, ...)            # passes our own app as the "parent"
```

`ui.run_with()` does `parent_app.mount('/', core.app)`. When the parent is `core.app` itself, every request that doesn't match a registered route falls through to the mount, which dispatches back into `core.app`, which re-enters the mount, recursing in the ASGI stack until resources are exhausted.

This is a misuse of the API — `ui.run_with()` is meant to mount NiceGUI on top of *your own* FastAPI app (see [examples/fastapi/main.py](../blob/main/examples/fastapi/main.py)) — but the failure mode is silent and severe enough to be worth a guard.

Not a security issue: not reachable in any documented configuration; the same `app.mount('/', app)` in plain Starlette/FastAPI behaves identically.

### Implementation

Added a guard at the top of `ui.run_with()` that raises `ValueError` if `app is core.app`, before any state mutation. The message points the user at `ui.run()` as the right alternative when they don't have their own FastAPI app.

Added a one-line test that calls `ui.run_with(app)` and asserts the guard fires.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.