### PR TITLE
Add ui.lazy: defer rendering of children past the first paint

### DIFF
--- a/nicegui/elements/lazy.js
+++ b/nicegui/elements/lazy.js
@@ -1,0 +1,17 @@
+export default {
+  template: `<div><slot v-if="shouldRender"></slot></div>`,
+  data() {
+    return {
+      shouldRender: false,
+    };
+  },
+  mounted() {
+    this.$nextTick(() => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          this.shouldRender = true;
+        });
+      });
+    });
+  },
+};

--- a/nicegui/elements/lazy.py
+++ b/nicegui/elements/lazy.py
@@ -1,0 +1,12 @@
+from ..element import Element
+
+
+class Lazy(Element, component='lazy.js'):
+    """Lazy element that defers rendering of its children until mounted.
+
+    Child elements are only rendered after the component is mounted and the next Vue tick,
+    which can improve initial page load performance for complex UIs.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -63,6 +63,7 @@ _LAZY_IMPORTS = {
     'keyboard': ('.elements.keyboard', 'Keyboard'),
     'knob': ('.elements.knob', 'Knob'),
     'label': ('.elements.label', 'Label'),
+    'lazy': ('.elements.lazy', 'Lazy'),
     'leaflet': ('.elements.leaflet', 'Leaflet'),
     'line_plot': ('.elements.line_plot', 'LinePlot'),
     'link': ('.elements.link', 'Link'),
@@ -211,6 +212,7 @@ __all__ = [
     'keyboard',
     'knob',
     'label',
+    'lazy',
     'leaflet',
     'left_drawer',
     'line_plot',
@@ -347,6 +349,7 @@ if TYPE_CHECKING:
     from .elements.keyboard import Keyboard as keyboard
     from .elements.knob import Knob as knob
     from .elements.label import Label as label
+    from .elements.lazy import Lazy as lazy
     from .elements.leaflet import Leaflet as leaflet
     from .elements.line_plot import LinePlot as line_plot
     from .elements.link import Link as link


### PR DESCRIPTION
### Motivation

Complex pages that render many subtrees at once block first paint, even when most of those subtrees are off-screen or otherwise non-critical. A lightweight escape hatch to defer "heavy-but-not-urgent" subtrees past the first paint frame would let authors prioritize what the user sees first.

Internally, NiceGUI's own documentation site uses a similar deferred-render pattern for code demos. This PR exposes an equivalent mechanism as a public element so user apps can use it too.

### Implementation

A minimal `ui.lazy` element that wraps its children in `<slot v-if="shouldRender">`. On mount, it flips `shouldRender` to `true` via `nextTick` + two `requestAnimationFrame` calls — that is the standard pattern for "wait until after the browser has laid out and painted the current frame."

```js
mounted() {
  this.$nextTick(() => {
    requestAnimationFrame(() => {
      requestAnimationFrame(() => { this.shouldRender = true; });
    });
  });
}
```

Files:
- `nicegui/elements/lazy.py` — 12-line `Lazy(Element, component='lazy.js')` subclass.
- `nicegui/elements/lazy.js` — Vue component with the defer logic above.
- `nicegui/ui.py` — export in the lazy-import dict, `__all__`, and `TYPE_CHECKING` block.

**Relationship to keep-alive**: this is the complementary opposite of a keep-alive-style mechanism. `ui.lazy` defers *building* the subtree until after first paint; a hypothetical `ui.keep_alive` would *retain* a built subtree across unmount. Both could coexist.

**Note on naming / scope**: this is deliberately the simplest implementation — no `IntersectionObserver`, no priority, no "unmount if hidden" logic. Happy to extend if maintainers prefer a viewport-aware variant, but I'd argue the 2-RAF version covers the dominant use case (tab panels, offscreen-but-eventually-visible content) with near-zero runtime cost.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the security advisory process. (N/A)
- [ ] Pytests — draft PR is inviting API feedback first; happy to add tests if the API shape is accepted.
- [ ] Documentation page — will add after API is blessed.

### Tracking

Tracking fork PR: [evnchn/nicegui#107](https://github.com/evnchn/nicegui/pull/107)