### PR TITLE
Enhance xterm example: configurable command, PTY resize, lifecycle hardening

### DIFF
--- a/examples/xterm/main.py
+++ b/examples/xterm/main.py
@@ -1,27 +1,63 @@
 #!/usr/bin/env python3
-"""Example for connecting a `Xterm` element with a `Bash` process running in a pty.
+"""Example for connecting a `Xterm` element with a process running in a pty.
 
-WARNING: This example gives the clients full access to the server through Bash. Use with caution!
+Pass a command as argument to run something other than bash, e.g.::
+
+    python main.py top
+    python main.py "python3 -m textual_paint"
+
+WARNING: This example gives the clients full access to the server through a shell process. Use with caution!
 """
 import fcntl
 import os
 import pty
+import shlex
 import signal
 import struct
+import sys
 import termios
 from functools import partial
 
 from nicegui import core, events, ui
 
+command = shlex.split(sys.argv[1]) if len(sys.argv) > 1 else ['/bin/bash']
+
 
 @ui.page('/')
-def _page():
-    terminal = ui.xterm().classes('w-full')
+async def _page():
+    ui.query('.nicegui-content').classes('p-0')  # remove padding so the terminal can fill the viewport
+    terminal = ui.xterm().classes('w-screen h-screen')
     ui.element('q-resize-observer').on('resize', terminal.fit)
 
+    pty_pid = 0
+    pty_fd = -1
+
+    @terminal.on_data
+    def terminal_to_pty(event: events.XtermDataEventArguments):
+        try:
+            os.write(pty_fd, event.data.encode('utf-8'))
+        except OSError:
+            pass  # error writing to the pty; probably the process was exited
+
+    @terminal.on_resize
+    def resize_terminal(event: events.XtermResizeEventArguments):
+        if pty_fd < 0:
+            return
+        fcntl.ioctl(pty_fd, termios.TIOCSWINSZ, struct.pack('HHHH', event.rows, event.cols, 0, 0))
+
+    @ui.context.client.on_delete
+    def kill_process():
+        if pty_fd >= 0:
+            os.close(pty_fd)
+            os.kill(pty_pid, signal.SIGKILL)
+            print('Terminal closed')
+
+    await ui.context.client.connected()
     pty_pid, pty_fd = pty.fork()  # create a new pseudo-terminal (pty) fork of the process
     if pty_pid == pty.CHILD:
-        os.execv('/bin/bash', ('bash',))  # child process of the fork gets replaced with "bash"
+        os.environ['TERM'] = 'xterm-256color'
+        os.environ['COLORTERM'] = 'truecolor'
+        os.execvp(command[0], command)  # replace the child process with the requested command
     print('Terminal opened')
 
     @partial(core.loop.add_reader, pty_fd)
@@ -29,28 +65,11 @@ def _page():
         try:
             data = os.read(pty_fd, 1024)
         except OSError:
-            print('Stopping reading from pty')  # error reading the pty; probably bash was exited
+            print('Stopping reading from pty')  # error reading the pty; probably the process was exited
             core.loop.remove_reader(pty_fd)
         else:
-            terminal.write(data)
-
-    @terminal.on_data
-    def terminal_to_pty(event: events.XtermDataEventArguments):
-        try:
-            os.write(pty_fd, event.data.encode('utf-8'))
-        except OSError:
-            pass  # error writing to the pty; probably bash was exited
-
-    @terminal.on_resize
-    def resize_terminal(event: events.XtermResizeEventArguments):
-        fcntl.ioctl(pty_fd, termios.TIOCSWINSZ, struct.pack('HHHH', event.rows, event.cols, 0, 0))
-        print(f'Terminal resized to {event.cols}x{event.rows}')
-
-    @ui.context.client.on_delete
-    def kill_bash():
-        os.close(pty_fd)
-        os.kill(pty_pid, signal.SIGKILL)
-        print('Terminal closed')
+            if not terminal.is_deleted:
+                terminal.write(data)
 
 
 ui.run()


### PR DESCRIPTION
### Motivation

The `examples/xterm` demo was a minimal shell-only demonstration. Two pain points become visible as soon as someone tries to use it for anything real:

1. The command is hardcoded to `/bin/bash`. If you want to show a TUI (`htop`, Textual, `vim`), you can only get there by editing the source.
2. There is a race on startup: the PTY is forked before the client has connected, so the first burst of output is silently dropped. And on exit, `on_delete` does not check whether the PTY was ever opened.

### Implementation

Single-file change to `examples/xterm/main.py`:

- **Configurable command** via `sys.argv[1]`, split with `shlex.split` and exec'd with `os.execvp` (argv list, no shell interpolation — the CLI arg is the server operator's own input, not client input, and there is no shell invoked). Default is still `/bin/bash`.
- **PTY resize** continues to use the typed `terminal.on_resize` handler introduced in #5858, with an added guard so a resize event arriving before `pty.fork()` is a no-op instead of a crash.
- **Startup race fix**: `await ui.context.client.connected()` before `pty.fork()`. Ensures the terminal has mounted and is ready to receive data before the process starts emitting.
- **Teardown hardening**: `on_delete` guards with `pty_fd >= 0`; `pty_to_terminal` guards `terminal.write` with `is_deleted` to avoid writing into a torn-down element.
- **Viewport sizing**: `.nicegui-content { padding: 0 }` + `w-screen h-screen` so the terminal fills the window — otherwise TUIs render in a tiny strip.
- **Child environment**: `TERM=xterm-256color` + `COLORTERM=truecolor`, so color-aware TUIs render correctly.

### Not a security fix

The existing hardcoded `os.execv('/bin/bash', ('bash',))` had no user input and no shell — there is no pre-existing vulnerability. The new CLI-arg path uses `shlex.split` + `execvp` which takes an argv list and does not spawn a shell, so there is no shell-interpolation surface even with the new feature.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] The implementation is complete.
- [x] If this PR addresses a security issue, it has been coordinated via the security advisory process. (N/A — not a security fix, see above.)
- [x] Pytests are not necessary — `examples/*` is not covered by the test suite.
- [ ] Documentation — example code is self-documenting via the module docstring and the `WARNING` block; no external docs page changes needed.

### Tracking

Tracking fork PR: [evnchn/nicegui#96](https://github.com/evnchn/nicegui/pull/96)