### PR TITLE
Add AG Grid demo for adding rows without losing client-side edits

### DIFF
--- a/website/documentation/content/aggrid_documentation.py
+++ b/website/documentation/content/aggrid_documentation.py
@@ -45,6 +45,33 @@ def adding_rows():
     ui.button('Add row', on_click=add)
 
 
+@doc.demo('Adding rows without losing client-side edits', '''
+    Mutating `grid.options['rowData']` triggers a full rebuild on the client and discards any in-progress cell edits.
+
+    An AG Grid [transaction](https://www.ag-grid.com/javascript-data-grid/data-update-transactions/)
+    adds rows without rebuilding the grid, so unsaved edits are preserved.
+    Wrap the `rowData` mutation in `grid.props.suspend_updates()`
+    to keep the server-side list in sync without firing the rebuild.
+
+    Try it: start editing a cell, then click *Add row* without leaving the cell —
+    your edit stays intact.
+''')
+def adding_rows_preserving_edits():
+    def add():
+        row = {'Name': f'Row {len(grid.options["rowData"])}'}
+        with grid.props.suspend_updates():
+            grid.options['rowData'].append(row)
+        grid.run_grid_method('applyTransaction', {'add': [row]})
+        grid.run_grid_method('ensureIndexVisible', len(grid.options['rowData']) - 1)
+
+    grid = ui.aggrid({
+        'columnDefs': [{'field': 'Name', 'editable': True}],
+        'rowData': [],
+        'stopEditingWhenCellsLoseFocus': True,
+    }).classes('h-52')
+    ui.button('Add row', on_click=add)
+
+
 @doc.demo('Select AG Grid Rows', '''
     You can add checkboxes to grid cells to allow the user to select single or multiple rows.
 


### PR DESCRIPTION
### Motivation

Appending to `grid.options['rowData']` triggers a full client-side rebuild that discards any in-progress cell edits. Users hit this regularly — see [discussion #5952](https://github.com/zauberzeug/nicegui/discussions/5952) — and the workaround so far has been `await grid.load_client_data()`, which doesn't actually prevent the rebuild, it just papers over the data loss.

### Implementation

Adds a new `@doc.demo` right after the existing *Adding rows* section showing the idiomatic AG Grid pattern: `applyTransaction` inside `grid.props.suspend_updates()`. The server-side `rowData` stays in sync without firing a rebuild, so client edits survive.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been added.
- [x] No breaking changes to the public API.