### PR TITLE
Clear streaming client cookie jar between On Air range-requests

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -94,6 +94,7 @@ class Air:
             url = next(iter(u for u in core.app.urls if self.remote_url != u)) + data['path']
             data['params']['nicegui_chunk_size'] = 1024
             request = httpx.Request(data['method'], url, params=data['params'], headers=headers)
+            self.streaming_client.cookies.clear()  # avoid unbounded memory growth from accumulated Set-Cookie entries
             response = await self.streaming_client.send(request, stream=True)
             stream_id = str(uuid4())
             self.streams[stream_id] = Stream(data=response.aiter_bytes(), response=response)


### PR DESCRIPTION
### Motivation

`self.streaming_client` in `nicegui/air.py` is a long-lived `httpx.AsyncClient` shared across every On Air range-request in the app process. Each response that carries a `Set-Cookie` header adds an entry to the client's cookie jar, and the jar is never cleared. Same-name cookies are overwritten, so in practice the jar tends to stabilize rather than grow forever — but it can still retain more state than we need over the lifetime of the process.

The accumulated cookies also do not affect outgoing traffic, since `_handle_range_request` dispatches via `httpx.Request(...)` + `client.send(request)`, which the httpx docs describe as "sent as-is, unmodified" — the client-level jar is bypassed.

### Implementation

Clear the cookie jar immediately before each `send()` call in `_handle_range_request`. Clearing before (rather than after) keeps the guarantee robust against exceptions or task cancellation during the send.

One-line change. No behavior change for the httpx wire traffic today.

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
