### PR TITLE
Fix @keyframes and other at-rules being mangled in scoped styles

### DIFF
--- a/nicegui/vbuild.py
+++ b/nicegui/vbuild.py
@@ -81,19 +81,23 @@ class VueParser(HTMLParser):  # pylint: disable=abstract-method  # pylint assume
 
 def add_css_prefix(css: str, prefix: str) -> str:
     """Add the prefix (CSS selector) to all rules in ``css``."""
-    media_queries: list[tuple[str, str]] = []
-    while '@media' in css:
-        p1 = css.find('@media', 0)
-        p2 = css.find('{', p1) + 1
-        level = 1
-        while level > 0:
-            level += 1 if css[p2] == '{' else -1 if css[p2] == '}' else 0
-            p2 += 1
-        block = css[p1:p2]
-        media_def = block[:block.find('{')].strip()
-        media_css = block[block.find('{') + 1:block.rfind('}')].strip()
-        css = css.replace(block, '')
-        media_queries.append((media_def, add_css_prefix(media_css, prefix)))
+    # extract at-rules whose bodies are descriptors, keyframe keywords or other non-selector syntax; emitted verbatim
+    css, verbatim_blocks = _extract_at_rules(css, (
+        r'@(?:(?:-\w+-)?keyframes|'
+        r'font-face|font-feature-values|font-palette-values|page|property|counter-style|color-profile)\b'
+    ))
+    verbatim = [re.sub(r'\s+', ' ', b).strip() for b in verbatim_blocks]
+
+    # extract at-rules whose bodies contain regular CSS rules with DOM selectors; inner rules receive the scope prefix
+    css, conditional_blocks = _extract_at_rules(css, r'@(?:media|supports|container|layer|scope)\b')
+    conditional: list[str] = []
+    for block in conditional_blocks:
+        if block.endswith(';'):  # statement form, e.g. `@layer reset, theme;`
+            conditional.append(re.sub(r'\s+', ' ', block).strip())
+        else:
+            header = block[:block.find('{')].strip()
+            body = block[block.find('{') + 1:block.rfind('}')].strip()
+            conditional.append(f'{header} {{ {add_css_prefix(body, prefix)} }}')
 
     lines: list[str] = []
     css = re.sub(re.compile(r'/\*.*?\*/', re.DOTALL), '', css)
@@ -105,5 +109,34 @@ def add_css_prefix(css: str, prefix: str) -> str:
         else:
             line = [i.strip() for i in selectors.split(',')]
         lines.append(', '.join(line) + ' {' + declarations.strip())
-    lines.extend(f'{d} {{ {c} }}' for d, c in media_queries)
+    lines.extend(conditional)
+    lines.extend(verbatim)
     return '\n'.join(lines).strip()
+
+
+def _extract_at_rules(css: str, pattern: str) -> tuple[str, list[str]]:
+    """Extract at-rules matching ``pattern`` from ``css``.
+
+    Returns the CSS with matches removed and a list of the extracted rules in source order.
+    Block-form rules are returned with balanced braces; statement-form rules include the trailing ``;``.
+    """
+    rules: list[str] = []
+    while True:
+        match = re.search(pattern, css)
+        if not match:
+            return css, rules
+        p1 = match.start()
+        brace = css.find('{', p1)
+        semi = css.find(';', p1)
+        if brace == -1 and semi == -1:
+            return css, rules
+        if semi != -1 and (brace == -1 or semi < brace):
+            p2 = semi + 1
+        else:
+            p2 = brace + 1
+            level = 1
+            while level > 0:
+                level += 1 if css[p2] == '{' else -1 if css[p2] == '}' else 0
+                p2 += 1
+        rules.append(css[p1:p2])
+        css = css[:p1] + css[p2:]

--- a/tests/test_vbuild.py
+++ b/tests/test_vbuild.py
@@ -98,6 +98,51 @@ def test_template_with_script():
     ''')
 
 
+def test_template_with_at_rules():
+    check('''
+        <template>
+            <h1>Hello, World!</h1>
+        </template>
+        <style scoped>
+            h1 {
+                animation: fade 1s;
+                font-family: 'MyFont';
+            }
+            @keyframes fade {
+                from { opacity: 0; }
+                to { opacity: 1; }
+            }
+            @-webkit-keyframes slide {
+                0% { transform: translateX(0); }
+                100% { transform: translateX(100px); }
+            }
+            @font-face {
+                font-family: 'MyFont';
+                src: url('/fonts/my.woff2') format('woff2');
+            }
+            @supports (display: grid) {
+                h1 { display: grid; }
+            }
+            @layer reset, theme;
+            @layer theme {
+                h1:hover { color: red; }
+            }
+        </style>
+    ''', html='''
+        <script type="text/x-template" id="tpl-TEST">
+            <h1 data-TEST>Hello, World!</h1>
+        </script>
+    ''', css='''
+        *[data-TEST] h1 {animation: fade 1s; font-family: 'MyFont'; }
+        @supports (display: grid) { *[data-TEST] h1 {display: grid; } }
+        @layer reset, theme;
+        @layer theme { *[data-TEST] h1:hover {color: red; } }
+        @keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+        @-webkit-keyframes slide { 0% { transform: translateX(0); } 100% { transform: translateX(100px); } }
+        @font-face { font-family: 'MyFont'; src: url('/fonts/my.woff2') format('woff2'); }
+    ''', js='')
+
+
 def test_multiple_templates():
     with pytest.raises(ValueError, match='File contains more than one template'):
         check('''


### PR DESCRIPTION
### Motivation

Fixes #5969.

In Vue SFC `<style>` blocks, `@keyframes` (and any at-rule with nested braces) broke the generated CSS: the rule regex `[^}]+{[^}]+}` stopped at the first `}` inside the keyframes body, producing `@keyframes name { from { … }` with the closing brace missing — which silently broke every subsequent rule in the same `<style>`.

The same class of bug also affected `@supports`, `@container`, `@layer <name> { … }`, `@scope`, and `@font-feature-values`. Descriptor-only at-rules (`@font-face`, `@page`, `@property`, `@counter-style`, `@font-palette-values`, `@color-profile`) weren't producing corrupt output, but the scope prefix was being applied to them, which is semantically wrong.

### Implementation

`add_css_prefix` now extracts at-rules up front via a shared helper `_extract_at_rules` that uses balanced-brace matching, so the main rule-splitting regex never sees nested at-rule braces.

Two categories are handled separately:

- **Verbatim** (`@keyframes` incl. vendor-prefixed, `@font-face`, `@font-feature-values`, `@font-palette-values`, `@page`, `@property`, `@counter-style`, `@color-profile`): bodies are descriptors or non-DOM-selector keywords (`from`/`to`/`N%`), so the block is emitted as-is with whitespace normalized.
- **Conditional** (`@media`, `@supports`, `@container`, `@layer`, `@scope`): bodies contain regular rules whose inner selectors still need the scope prefix, so the body is recursed through `add_css_prefix`. Statement forms like `@layer reset, theme;` are preserved in source order so layer ordering is not lost.

The existing `@media` special case is replaced by this general mechanism.

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.