### PR TITLE
Fix PermissionError on Windows when clearing file-backed storage

### DIFF
--- a/nicegui/persistence/file_persistent_dict.py
+++ b/nicegui/persistence/file_persistent_dict.py
@@ -45,14 +45,15 @@ class FilePersistentDict(PersistentDict):
 
         @background_tasks.await_on_shutdown
         async def async_backup() -> None:
+            if not self:
+                self.filepath.unlink(missing_ok=True)
+                return
             async with aiofiles.open(self.filepath, 'w', encoding=self.encoding) as f:
                 await f.write(json.dumps(self, indent=self.indent))
 
         if core.is_loop_running():
             background_tasks.create_lazy(async_backup(), name=self.filepath.stem)
+        elif not self:
+            self.filepath.unlink(missing_ok=True)
         else:
             self.filepath.write_text(json.dumps(self, indent=self.indent), encoding=self.encoding)
-
-    def clear(self) -> None:
-        super().clear()
-        self.filepath.unlink(missing_ok=True)


### PR DESCRIPTION
### Motivation

On Windows, `FilePersistentDict.clear()` intermittently raised `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process` during teardown (e.g. in pytest fixtures that reset NiceGUI state). Closes #5949.

The race is between the async `backup()` task scheduled by `super().clear()` (which opens the file via `aiofiles` and writes `{}`) and the synchronous `self.filepath.unlink()` that immediately follows. On Windows, open files cannot be deleted.

### Implementation

Move the "delete file when the dict is empty" semantic into `backup()` itself. `backup()` now checks whether the dict is empty and unlinks the file instead of writing `{}`. The `clear()` override is removed — `super().clear()` already triggers `backup()` via `on_change`.

Because `create_lazy` serializes tasks by name, the unlink is automatically ordered after any pending write, removing the race. As a bonus, we no longer write `{}` only to delete it moments later.

Behavior change worth noting: any operation that leaves the dict empty (e.g. popping the last key) will now also delete the file. This generalizes the stated goal from #4074 of not accumulating empty `{}` files on disk.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.