### PR TITLE
Preserve aspect ratio in `ui.interactive_image` when `size` is not set

### DIFF
--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -1,6 +1,6 @@
 export default {
   template: `
-    <div :style="{ position: 'relative', aspectRatio: size ? size[0] / size[1] : undefined }">
+    <div :style="{ position: 'relative', aspectRatio: aspectRatio }">
       <img
         ref="img"
         :src="computed_src"
@@ -147,6 +147,13 @@ export default {
     },
   },
   computed: {
+    aspectRatio() {
+      if (this.size) return this.size[0] / this.size[1];
+      if (this.loaded_image_width && this.loaded_image_height) {
+        return this.loaded_image_width / this.loaded_image_height;
+      }
+      return undefined;
+    },
     onCrossEvents() {
       if (!this.cross && !this.$slots.cross) return {};
       return {


### PR DESCRIPTION
### Motivation

Fixes #5978.

Sponsor logos on https://nicegui.io render stretched on Safari. Root cause: `ui.interactive_image` sets `aspect-ratio` on its outer `<div>` only when an explicit `size` prop is provided. Without `size`, the div's width is left to the flex/block layout algorithm, and the inner `<img style="width:100%;height:100%">` stretches to match. Different browsers resolve this ambiguity differently — Chrome falls back to the image's intrinsic width, Safari stretches the flex item.

### Implementation

When no `size` prop is supplied, derive the outer div's `aspect-ratio` from the image's `naturalWidth / naturalHeight` once it loads:

```js
aspectRatio() {
  if (this.size) return this.size[0] / this.size[1];
  if (this.loaded_image_width && this.loaded_image_height) {
    return this.loaded_image_width / this.loaded_image_height;
  }
  return undefined;
}
```

Trade-offs:

- Users with `size` set: unchanged.
- Users with both CSS dimensions set (`w-64 h-32`): unchanged — CSS ignores `aspect-ratio` when both dimensions are explicit.
- Users with only one CSS dimension set: previously rendered at a browser-dependent width; now snaps to the natural aspect ratio on load. Before load the div still has no dimensions, so it grows from zero to the correct size when the image arrives — just like a plain `<img>` would.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.