### PR TITLE
Fix `ReferenceError` from dangling weakref proxies in `ui.run_with`

### DIFF
--- a/nicegui/ui_run_with.py
+++ b/nicegui/ui_run_with.py
@@ -1,4 +1,5 @@
 import gc
+import weakref
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -113,16 +114,15 @@ def run_with(
     async def lifespan_wrapper(app):
         def _get_server_instance() -> uvicorn.Server | None:
             for obj in gc.get_objects():
-                try:
-                    if isinstance(obj, uvicorn.Server):
-                        wrapped = obj.config.loaded_app
-                        while wrapped is not None:
-                            if wrapped is app:
-                                return obj
-                            wrapped = getattr(wrapped, 'app', None)
-                except ReferenceError:
-                    pass
-
+                if type(obj) in weakref.ProxyTypes:
+                    continue  # skip weakref proxies: isinstance() would raise ReferenceError if the referent is dead
+                if not isinstance(obj, uvicorn.Server):
+                    continue
+                wrapped = obj.config.loaded_app
+                while wrapped is not None:
+                    if wrapped is app:
+                        return obj
+                    wrapped = getattr(wrapped, 'app', None)
             return None
         if (instance := _get_server_instance()) is not None:
             Server.instance = instance

--- a/nicegui/ui_run_with.py
+++ b/nicegui/ui_run_with.py
@@ -112,12 +112,17 @@ def run_with(
     @asynccontextmanager
     async def lifespan_wrapper(app):
         def _get_server_instance() -> uvicorn.Server | None:
-            for server in (obj for obj in gc.get_objects() if isinstance(obj, uvicorn.Server)):
-                wrapped = server.config.loaded_app
-                while wrapped is not None:
-                    if wrapped is app:
-                        return server
-                    wrapped = getattr(wrapped, 'app', None)
+            for obj in gc.get_objects():
+                try:
+                    if isinstance(obj, uvicorn.Server):
+                        wrapped = obj.config.loaded_app
+                        while wrapped is not None:
+                            if wrapped is app:
+                                return obj
+                            wrapped = getattr(wrapped, 'app', None)
+                except ReferenceError:
+                    pass
+
             return None
         if (instance := _get_server_instance()) is not None:
             Server.instance = instance

--- a/tests/test_run_with.py
+++ b/tests/test_run_with.py
@@ -1,4 +1,3 @@
-import gc
 import weakref
 
 import pytest
@@ -13,25 +12,10 @@ def test_run_with_rejects_self_mount():
         ui.run_with(app)
 
 
-class _Weak:
-    pass
-
-
-@pytest.mark.asyncio
-async def test_get_server_instance_handles_dead_weakref():
-    """Iterating gc.get_objects() with isinstance() should handle dead weakref proxies."""
-    original = gc.get_objects
-
-    def patched():
-        obj = _Weak()
-        proxy = weakref.proxy(obj)
-        del obj
-        return [proxy, *original()]
-
-    gc.get_objects = patched
+async def test_run_with_tolerates_dangling_weakref_proxy():
+    """A dangling weakref.proxy in gc.get_objects() must not crash ui.run_with() startup."""
+    _ = weakref.proxy(set())  # referent is unreferenced, proxy is dangling immediately
     fastapi_app = FastAPI()
-    ui.run_with(app=fastapi_app)
-
-    # should not fail
-    async with fastapi_app.router.lifespan_context(fastapi_app) as _ct:
+    ui.run_with(fastapi_app)
+    async with fastapi_app.router.lifespan_context(fastapi_app):
         pass

--- a/tests/test_run_with.py
+++ b/tests/test_run_with.py
@@ -12,7 +12,7 @@ def test_run_with_rejects_self_mount():
         ui.run_with(app)
 
 
-async def test_run_with_tolerates_dangling_weakref_proxy():
+async def test_run_with_tolerates_dangling_weakref_proxy(nicegui_reset_globals):
     """A dangling weakref.proxy in gc.get_objects() must not crash ui.run_with() startup."""
     _ = weakref.proxy(set())  # referent is unreferenced, proxy is dangling immediately
     fastapi_app = FastAPI()

--- a/tests/test_run_with.py
+++ b/tests/test_run_with.py
@@ -1,4 +1,8 @@
+import gc
+import weakref
+
 import pytest
+from fastapi import FastAPI
 
 from nicegui import app, ui
 
@@ -7,3 +11,27 @@ def test_run_with_rejects_self_mount():
     """Passing nicegui.app to ui.run_with() would mount it into itself and cause infinite recursion on unmatched paths."""
     with pytest.raises(ValueError, match='must be called with your own FastAPI app'):
         ui.run_with(app)
+
+
+class _Weak:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_get_server_instance_handles_dead_weakref():
+    """Iterating gc.get_objects() with isinstance() should handle dead weakref proxies."""
+    original = gc.get_objects
+
+    def patched():
+        obj = _Weak()
+        proxy = weakref.proxy(obj)
+        del obj
+        return [proxy, *original()]
+
+    gc.get_objects = patched
+    fastapi_app = FastAPI()
+    ui.run_with(app=fastapi_app)
+
+    # should not fail
+    async with fastapi_app.router.lifespan_context(fastapi_app) as _ct:
+        pass


### PR DESCRIPTION
### Motivation
Fix implementation for managing weakref in lifespan context manager of `run_with`
Related issue https://github.com/zauberzeug/nicegui/issues/5979
<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->

<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation
Decomposition of a pythonic list comprehension that provokes the error
<!-- What is the concept behind the implementation? How does it work? -->

<!-- Include any important technical decisions or trade-offs made. -->

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated or are not necessary. <!--Remove the option that does not apply.-->
- [x] Documentation has been added/updated or is not necessary. <!--Remove the option that does not apply.-->
- [x] No breaking changes to the public API or migration steps are described above. <!--Remove the option that does not apply.-->
