### PR TITLE
Fix incorrect identifiers in CodeMirror findLanguage error message

### DIFF
--- a/nicegui/elements/codemirror/codemirror.js
+++ b/nicegui/elements/codemirror/codemirror.js
@@ -50,8 +50,8 @@ export default {
         for (const alias of [language.name, ...language.alias])
           if (name.toLowerCase() === alias.toLowerCase()) return language;
 
-      console.error(`Language not found: ${this.language}`);
-      console.info("Supported language names:", languages.map((lang) => lang.name).join(", "));
+      console.error(`Language not found: ${name}`);
+      console.info("Supported language names:", this.languages.map((lang) => lang.name).join(", "));
       return null;
     },
     // Get the names of all supported languages

--- a/nicegui/elements/codemirror/codemirror.js
+++ b/nicegui/elements/codemirror/codemirror.js
@@ -68,9 +68,8 @@ export default {
         return;
       }
 
-      const lang_description = this.findLanguage(language, this.languages);
+      const lang_description = this.findLanguage(language);
       if (!lang_description) {
-        console.error("Language not found:", language);
         return;
       }
 


### PR DESCRIPTION
### Motivation

`findLanguage` is called with a `name` argument that is searched against the supported languages. When no match is found, the error message previously referenced `this.language` (the editor's currently configured language prop) instead of the actual `name` being searched, so it reported the wrong language as missing. The follow-up `console.info` line then referenced a bare `languages` identifier that does not exist in scope, which threw a `ReferenceError` before the supported-name hint could be printed.

### Implementation

- Use `name` for the error message so the log line reflects the actual lookup that failed.
- Use `this.languages` for the supported-names list so the hint actually prints instead of throwing a `ReferenceError`.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests are not necessary. (Error-path log message; existing tests pass.)
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
