### PR TITLE
Always trigger material needsUpdate in scene .material()

### DIFF
--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -385,7 +385,7 @@ export default {
       if (!material) return;
       const vertexColors = color === null;
       material.color.set(vertexColors ? "#ffffff" : color);
-      material.needsUpdate = material.vertexColors != vertexColors;
+      material.needsUpdate = true;
       material.vertexColors = vertexColors;
       material.opacity = opacity;
       if (side == "front") material.side = THREE.FrontSide;


### PR DESCRIPTION
### Motivation

The condition in `scene.material(...)` was

```js
material.needsUpdate = material.vertexColors != vertexColors;
```

which only marked the material dirty when the vertex-color flag flipped.
But the same call also writes `color`, `opacity`, and `side`, so calling `.material('red')` followed by `.material('blue')` left `needsUpdate=false` for the second call and the color change was silently dropped on the next render.

### Implementation

Set `material.needsUpdate = true` unconditionally so all property changes take effect on the next frame.

One-line change in `nicegui/elements/scene/scene.js`. No public API change.
This is one of several small slices being carved out of #5964 — opening it as a standalone PR per the splitting discussion on that thread.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [ ] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests are not necessary. (One-line correctness fix to a render-state flag; existing scene tests exercise this path.)
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.