### PR TITLE
Fix URL formatting for IPv6 hosts and default ports

### DIFF
--- a/nicegui/helpers/__init__.py
+++ b/nicegui/helpers/__init__.py
@@ -9,7 +9,7 @@ from .functions import (
     normalize_lifecycle_handler,
     should_await,
 )
-from .network import is_port_open, make_url, schedule_browser
+from .network import format_url, is_port_open, schedule_browser
 from .strings import event_type_to_camel_case, kebab_to_camel_case
 from .warnings import warn_once
 
@@ -17,6 +17,7 @@ __all__ = [
     'await_with_context',
     'event_type_to_camel_case',
     'expects_arguments',
+    'format_url',
     'hash_file_path',
     'is_coroutine_function',
     'is_file',
@@ -24,7 +25,6 @@ __all__ = [
     'is_pytest',
     'is_user_simulation',
     'kebab_to_camel_case',
-    'make_url',
     'normalize_lifecycle_handler',
     'require_top_level_layout',
     'schedule_browser',

--- a/nicegui/helpers/__init__.py
+++ b/nicegui/helpers/__init__.py
@@ -9,7 +9,7 @@ from .functions import (
     normalize_lifecycle_handler,
     should_await,
 )
-from .network import is_port_open, schedule_browser
+from .network import is_port_open, make_url, schedule_browser
 from .strings import event_type_to_camel_case, kebab_to_camel_case
 from .warnings import warn_once
 
@@ -24,6 +24,7 @@ __all__ = [
     'is_pytest',
     'is_user_simulation',
     'kebab_to_camel_case',
+    'make_url',
     'normalize_lifecycle_handler',
     'require_top_level_layout',
     'schedule_browser',

--- a/nicegui/helpers/network.py
+++ b/nicegui/helpers/network.py
@@ -19,8 +19,8 @@ def is_port_open(host: str, port: int) -> bool:
         sock.close()
 
 
-def make_url(protocol: str, host: str, port: int) -> str:
-    """Make a URL, bracketing IPv6 hosts and omitting the port for http:80 / https:443."""
+def format_url(protocol: str, host: str, port: int) -> str:
+    """Format a URL, bracketing IPv6 hosts and omitting the port for http:80 / https:443."""
     if ':' in host and not host.startswith('['):
         host = f'[{host}]'
     if (protocol, port) in (('http', 80), ('https', 443)):
@@ -49,7 +49,7 @@ def schedule_browser(protocol: str, host: str, port: int, path: str) -> tuple[th
             if cancel.is_set():
                 return
             time.sleep(0.1)
-        webbrowser.open(f'{make_url(protocol, host, port)}/{path.lstrip("/")}')
+        webbrowser.open(f'{format_url(protocol, host, port)}/{path.lstrip("/")}')
 
     host = host if host != '0.0.0.0' else '127.0.0.1'
     thread = threading.Thread(target=in_thread, args=(protocol, host, port, path), daemon=True)

--- a/nicegui/helpers/network.py
+++ b/nicegui/helpers/network.py
@@ -19,6 +19,19 @@ def is_port_open(host: str, port: int) -> bool:
         sock.close()
 
 
+def make_url(protocol: str, host: str, port: str | int) -> str:
+    """Make a URL from the given protocol, host and port."""
+    if ':' in host and host[0] != '[':
+        host = f'[{host}]'
+
+    url = f'{protocol}://{host}'
+
+    if (protocol, port) not in (('http', 80), ('http', '80'), ('https', 443), ('https', '443')):
+        url += f':{port}'
+
+    return url
+
+
 def schedule_browser(protocol: str, host: str, port: int, path: str) -> tuple[threading.Thread, threading.Event]:
     """Wait non-blockingly for the port to be open, then start a webbrowser.
 
@@ -40,7 +53,7 @@ def schedule_browser(protocol: str, host: str, port: int, path: str) -> tuple[th
             if cancel.is_set():
                 return
             time.sleep(0.1)
-        webbrowser.open(f'{protocol}://{host}:{port}/{path.lstrip("/")}')
+        webbrowser.open(f'{make_url(protocol, host, port)}/{path.lstrip("/")}')
 
     host = host if host != '0.0.0.0' else '127.0.0.1'
     thread = threading.Thread(target=in_thread, args=(protocol, host, port, path), daemon=True)

--- a/nicegui/helpers/network.py
+++ b/nicegui/helpers/network.py
@@ -19,17 +19,13 @@ def is_port_open(host: str, port: int) -> bool:
         sock.close()
 
 
-def make_url(protocol: str, host: str, port: str | int) -> str:
-    """Make a URL from the given protocol, host and port."""
-    if ':' in host and host[0] != '[':
+def make_url(protocol: str, host: str, port: int) -> str:
+    """Make a URL, bracketing IPv6 hosts and omitting the port for http:80 / https:443."""
+    if ':' in host and not host.startswith('['):
         host = f'[{host}]'
-
-    url = f'{protocol}://{host}'
-
-    if (protocol, port) not in (('http', 80), ('http', '80'), ('https', 443), ('https', '443')):
-        url += f':{port}'
-
-    return url
+    if (protocol, port) in (('http', 80), ('https', 443)):
+        return f'{protocol}://{host}'
+    return f'{protocol}://{host}:{port}'
 
 
 def schedule_browser(protocol: str, host: str, port: int, path: str) -> tuple[threading.Thread, threading.Event]:

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -39,7 +39,7 @@ def _open_window(
         time.sleep(0.1)
 
     window_kwargs = {
-        'url': helpers.make_url(protocol, host, port),
+        'url': helpers.format_url(protocol, host, port),
         'title': title,
         'width': width,
         'height': height,

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -39,7 +39,7 @@ def _open_window(
         time.sleep(0.1)
 
     window_kwargs = {
-        'url': f'{protocol}://{host}:{port}',
+        'url': helpers.make_url(protocol, host, port),
         'title': title,
         'width': width,
         'height': height,

--- a/nicegui/welcome.py
+++ b/nicegui/welcome.py
@@ -23,7 +23,7 @@ async def collect_urls() -> None:
     ips = set((await run.io_bound(_get_all_ips)) if host == '0.0.0.0' else [])
     ips.discard('127.0.0.1')
     sorted_ips = ['localhost' if host == '0.0.0.0' else host, *sorted(ips)]
-    urls = [make_url(protocol, ip, port) for ip in sorted_ips]
+    urls = [make_url(protocol, ip, int(port)) for ip in sorted_ips]
     core.app.urls.update(urls)
     if len(urls) >= 2:
         urls[-1] = 'and ' + urls[-1]

--- a/nicegui/welcome.py
+++ b/nicegui/welcome.py
@@ -3,6 +3,7 @@ import os
 import ifaddr
 
 from . import core, run
+from .helpers import make_url
 
 
 def _get_all_ips() -> list[str]:
@@ -22,7 +23,7 @@ async def collect_urls() -> None:
     ips = set((await run.io_bound(_get_all_ips)) if host == '0.0.0.0' else [])
     ips.discard('127.0.0.1')
     sorted_ips = ['localhost' if host == '0.0.0.0' else host, *sorted(ips)]
-    urls = [(f'{protocol}://{ip}:{port}' if port != '80' else f'{protocol}://{ip}') for ip in sorted_ips]
+    urls = [make_url(protocol, ip, port) for ip in sorted_ips]
     core.app.urls.update(urls)
     if len(urls) >= 2:
         urls[-1] = 'and ' + urls[-1]

--- a/nicegui/welcome.py
+++ b/nicegui/welcome.py
@@ -3,7 +3,7 @@ import os
 import ifaddr
 
 from . import core, run
-from .helpers import make_url
+from .helpers import format_url
 
 
 def _get_all_ips() -> list[str]:
@@ -23,7 +23,7 @@ async def collect_urls() -> None:
     ips = set((await run.io_bound(_get_all_ips)) if host == '0.0.0.0' else [])
     ips.discard('127.0.0.1')
     sorted_ips = ['localhost' if host == '0.0.0.0' else host, *sorted(ips)]
-    urls = [make_url(protocol, ip, int(port)) for ip in sorted_ips]
+    urls = [format_url(protocol, ip, int(port)) for ip in sorted_ips]
     core.app.urls.update(urls)
     if len(urls) >= 2:
         urls[-1] = 'and ' + urls[-1]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -31,8 +31,8 @@ def test_format_url():
     assert helpers.format_url('http', 'localhost', 8080) == 'http://localhost:8080'  # non-default port is included
     assert helpers.format_url('https', 'xyz.com', 443) == 'https://xyz.com'  # default port 443 is omitted
     assert helpers.format_url('https', 'xyz.com', 8443) == 'https://xyz.com:8443'  # non-default port is included
-    assert helpers.format_url('http', '::', 80) == 'http://[::]'  # IPv6 address is enclosed in brackets
-    assert helpers.format_url('http', '[::]', 80) == 'http://[::]'  # already bracketed IPv6 address remains unchanged
+    assert helpers.format_url('http', '::', 8080) == 'http://[::]:8080'  # IPv6 address is enclosed in brackets
+    assert helpers.format_url('http', '[::]', 8080) == 'http://[::]:8080'  # already bracketed IPv6 address is unchanged
 
 
 def test_schedule_browser(monkeypatch):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -27,14 +27,12 @@ def test_is_port_open_on_bad_ip():
 
 
 def test_make_url():
-    assert helpers.make_url('http', 'localhost', 80) == 'http://localhost'
-    assert helpers.make_url('http', 'localhost', 8080) == 'http://localhost:8080'
-    assert helpers.make_url('https', 'example.com', 443) == 'https://example.com'
-    assert helpers.make_url('https', 'example.com', 8443) == 'https://example.com:8443'
-    assert helpers.make_url('http', '::', 80) == 'http://[::]'
-    assert helpers.make_url('http', '::', 8080) == 'http://[::]:8080'
-    assert helpers.make_url('http', '[::]', 80) == 'http://[::]'
-    assert helpers.make_url('http', '[::]', 8080) == 'http://[::]:8080'
+    assert helpers.make_url('http', 'localhost', 80) == 'http://localhost'  # default port 80 should be omitted
+    assert helpers.make_url('http', 'localhost', 8080) == 'http://localhost:8080'  # non-default port should be included
+    assert helpers.make_url('https', 'xyz.com', 443) == 'https://xyz.com'  # default port 443 should be omitted
+    assert helpers.make_url('https', 'xyz.com', 8443) == 'https://xyz.com:8443'  # non-default port should be included
+    assert helpers.make_url('http', '::', 80) == 'http://[::]'  # IPv6 address should be enclosed in brackets
+    assert helpers.make_url('http', '[::]', 80) == 'http://[::]'  # already bracketed IPv6 address remains unchanged
 
 
 def test_schedule_browser(monkeypatch):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -63,10 +63,7 @@ def test_schedule_browser(monkeypatch):
             sock.listen()
             # port opened
             time.sleep(1)
-            if port == 80:
-                assert called_with_url == f'http://{host}/my-path'
-            else:
-                assert called_with_url == f'http://{host}:{port}/my-path'
+            assert called_with_url == f'http://{host}:{port}/my-path'
 
         finally:
             cancel_event.set()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -26,13 +26,13 @@ def test_is_port_open_on_bad_ip():
     assert not helpers.is_port_open('1.2', 0), 'should not be able to connect to a bad IP'
 
 
-def test_make_url():
-    assert helpers.make_url('http', 'localhost', 80) == 'http://localhost'  # default port 80 should be omitted
-    assert helpers.make_url('http', 'localhost', 8080) == 'http://localhost:8080'  # non-default port should be included
-    assert helpers.make_url('https', 'xyz.com', 443) == 'https://xyz.com'  # default port 443 should be omitted
-    assert helpers.make_url('https', 'xyz.com', 8443) == 'https://xyz.com:8443'  # non-default port should be included
-    assert helpers.make_url('http', '::', 80) == 'http://[::]'  # IPv6 address should be enclosed in brackets
-    assert helpers.make_url('http', '[::]', 80) == 'http://[::]'  # already bracketed IPv6 address remains unchanged
+def test_format_url():
+    assert helpers.format_url('http', 'localhost', 80) == 'http://localhost'  # default port 80 is omitted
+    assert helpers.format_url('http', 'localhost', 8080) == 'http://localhost:8080'  # non-default port is included
+    assert helpers.format_url('https', 'xyz.com', 443) == 'https://xyz.com'  # default port 443 is omitted
+    assert helpers.format_url('https', 'xyz.com', 8443) == 'https://xyz.com:8443'  # non-default port is included
+    assert helpers.format_url('http', '::', 80) == 'http://[::]'  # IPv6 address is enclosed in brackets
+    assert helpers.format_url('http', '[::]', 80) == 'http://[::]'  # already bracketed IPv6 address remains unchanged
 
 
 def test_schedule_browser(monkeypatch):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -29,12 +29,8 @@ def test_is_port_open_on_bad_ip():
 def test_make_url():
     assert helpers.make_url('http', 'localhost', 80) == 'http://localhost'
     assert helpers.make_url('http', 'localhost', 8080) == 'http://localhost:8080'
-    assert helpers.make_url('http', 'localhost', '80') == 'http://localhost'
-    assert helpers.make_url('http', 'localhost', '8080') == 'http://localhost:8080'
     assert helpers.make_url('https', 'example.com', 443) == 'https://example.com'
     assert helpers.make_url('https', 'example.com', 8443) == 'https://example.com:8443'
-    assert helpers.make_url('https', 'example.com', '443') == 'https://example.com'
-    assert helpers.make_url('https', 'example.com', '8443') == 'https://example.com:8443'
     assert helpers.make_url('http', '::', 80) == 'http://[::]'
     assert helpers.make_url('http', '::', 8080) == 'http://[::]:8080'
     assert helpers.make_url('http', '[::]', 80) == 'http://[::]'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -26,6 +26,21 @@ def test_is_port_open_on_bad_ip():
     assert not helpers.is_port_open('1.2', 0), 'should not be able to connect to a bad IP'
 
 
+def test_make_url():
+    assert helpers.make_url('http', 'localhost', 80) == 'http://localhost'
+    assert helpers.make_url('http', 'localhost', 8080) == 'http://localhost:8080'
+    assert helpers.make_url('http', 'localhost', '80') == 'http://localhost'
+    assert helpers.make_url('http', 'localhost', '8080') == 'http://localhost:8080'
+    assert helpers.make_url('https', 'example.com', 443) == 'https://example.com'
+    assert helpers.make_url('https', 'example.com', 8443) == 'https://example.com:8443'
+    assert helpers.make_url('https', 'example.com', '443') == 'https://example.com'
+    assert helpers.make_url('https', 'example.com', '8443') == 'https://example.com:8443'
+    assert helpers.make_url('http', '::', 80) == 'http://[::]'
+    assert helpers.make_url('http', '::', 8080) == 'http://[::]:8080'
+    assert helpers.make_url('http', '[::]', 80) == 'http://[::]'
+    assert helpers.make_url('http', '[::]', 8080) == 'http://[::]:8080'
+
+
 def test_schedule_browser(monkeypatch):
     called_with_url = None
 
@@ -48,7 +63,11 @@ def test_schedule_browser(monkeypatch):
             sock.listen()
             # port opened
             time.sleep(1)
-            assert called_with_url == f'http://{host}:{port}/my-path'
+            if port == 80:
+                assert called_with_url == f'http://{host}/my-path'
+            else:
+                assert called_with_url == f'http://{host}:{port}/my-path'
+
         finally:
             cancel_event.set()
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -58,7 +58,6 @@ def test_schedule_browser(monkeypatch):
             # port opened
             time.sleep(1)
             assert called_with_url == f'http://{host}:{port}/my-path'
-
         finally:
             cancel_event.set()
 


### PR DESCRIPTION
## Motivation

Three related issues with how NiceGUI prints/uses server URLs:

1. **IPv6 hosts were not bracketed.** Running with `host='::'` printed `http://:::8000`, which is not a valid URL and not clickable. Per RFC 3986, IPv6 literals must be wrapped in `[...]`.

2. **Default-port handling was inconsistent across code paths.** The welcome banner (`welcome.py`), the `show=True` browser launcher (`helpers.schedule_browser`), and native mode (`native_mode._open_window`) each constructed URLs by hand, and only `welcome.py` tried to elide the port — and only for `port == '80'` regardless of protocol, so `https` + port 80 emitted `https://host` (wrong) while `https` + port 443 emitted `https://host:443` (verbose).

3. **No single source of truth.** Every site duplicated the `f'{protocol}://{host}:{port}'` pattern, making the IPv6 fix and default-port handling impossible to apply uniformly.

## Implementation

- Introduce `helpers.format_url(protocol, host, port)` which:
  - Wraps IPv6 hosts (`':' in host`, not already bracketed) in `[...]`.
  - Omits the port for the protocol's default (`http:80`, `https:443`).
- Route `welcome.py`, `schedule_browser`, and `native_mode._open_window` through `format_url`.
- Add `tests/test_helpers.py::test_format_url` covering each feature with one assertion.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated or are not necessary.
- [x] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.
