### PR TITLE
Fix Nested Sub Pages doc demo link target and label

### DIFF
--- a/website/documentation/content/sub_pages_documentation.py
+++ b/website/documentation/content/sub_pages_documentation.py
@@ -328,7 +328,7 @@ def nested_sub_pages_demo():
 
     def other():
         ui.label('sub page')
-        # ui.link('Go to main', '/')
+        # ui.link('Go to sub main', '/other')
         # ui.link('Go to A', '/other/a')
         # ui.link('Go to B', '/other/b')
         # ui.sub_pages({
@@ -338,7 +338,7 @@ def nested_sub_pages_demo():
         # }).classes('border border-gray-200 p-2')
         routes = {'/': sub_main, '/a': sub_page_a, '/b': sub_page_b}  # HIDE
         sub_pages = FakeSubPages(routes).classes('border border-gray-200 p-2')  # HIDE
-        sub_pages.link('Go to main', '/')  # HIDE
+        sub_pages.link('Go to sub main', '/')  # HIDE
         sub_pages.link('Go to A', '/a')  # HIDE
         sub_pages.link('Go to B', '/b')  # HIDE
         sub_pages.init()  # HIDE


### PR DESCRIPTION
### Motivation

In the Nested Sub Pages documentation demo, the link inside `other()` labeled "Go to main" was ambiguous — the outer `main` and the nested `sub_main` were both essentially called "main". Worse, the commented real-code line `ui.link('Go to main', '/')` would actually navigate to the _outer_ main, while the rendered FakeSubPages demo (which resolves `/` against the nested routes) showed `sub_main`. So the comment and the demo disagreed on what the link does.

Reported by @aisartag in #5999.

### Implementation

- Rename the link label from "Go to main" to "Go to sub main" so it's unambiguous which page is meant.
- Change the commented real-code URL from `/` to `/other` so a reader copying the snippet actually lands on `sub_main` (outer matches `/other` → `other()` → nested `/` → `sub_main`), matching what the rendered demo shows.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been updated.
- [x] No breaking changes to the public API.