### PR TITLE
Dedent `ui.mermaid` content like `ui.markdown` does

### DIFF
--- a/nicegui/elements/code.py
+++ b/nicegui/elements/code.py
@@ -1,9 +1,9 @@
 import asyncio
 import time
 
+from ..helpers import remove_indentation
 from .button import Button as button
 from .markdown import Markdown as markdown
-from .markdown import remove_indentation
 from .mixins.content_element import ContentElement
 from .timer import Timer as timer
 

--- a/nicegui/elements/markdown.py
+++ b/nicegui/elements/markdown.py
@@ -8,6 +8,7 @@ from fastapi.responses import PlainTextResponse
 from pygments.formatters import HtmlFormatter  # pylint: disable=no-name-in-module
 
 from .. import core
+from ..helpers import remove_indentation
 from .mixins.content_element import ContentElement
 
 
@@ -74,14 +75,3 @@ class Markdown(ContentElement, component='markdown.js', default_classes='nicegui
 def prepare_content(content: str, extras: str) -> str:
     """Render Markdown content to HTML."""
     return markdown2.markdown(remove_indentation(content), extras=extras.split())
-
-
-def remove_indentation(text: str) -> str:
-    """Remove indentation from a multi-line string based on the indentation of the first non-empty line."""
-    lines = text.splitlines()
-    while lines and not lines[0].strip():
-        lines.pop(0)
-    if not lines:
-        return ''
-    indentation = len(lines[0]) - len(lines[0].lstrip())
-    return '\n'.join(line[indentation:] for line in lines)

--- a/nicegui/elements/mermaid/mermaid.py
+++ b/nicegui/elements/mermaid/mermaid.py
@@ -2,7 +2,7 @@ from typing_extensions import Self
 
 from ...defaults import DEFAULT_PROP, resolve_defaults
 from ...events import Handler, MermaidNodeClickEventArguments, handle_event
-from ..markdown import remove_indentation
+from ...helpers import remove_indentation
 from ..mixins.content_element import ContentElement
 
 

--- a/nicegui/elements/mermaid/mermaid.py
+++ b/nicegui/elements/mermaid/mermaid.py
@@ -2,6 +2,7 @@ from typing_extensions import Self
 
 from ...defaults import DEFAULT_PROP, resolve_defaults
 from ...events import Handler, MermaidNodeClickEventArguments, handle_event
+from ..markdown import remove_indentation
 from ..mixins.content_element import ContentElement
 
 
@@ -52,8 +53,9 @@ class Mermaid(ContentElement, component='mermaid.js', esm={'nicegui-mermaid': 'd
         return self
 
     def _handle_content_change(self, content: str) -> None:
-        self._props[self.CONTENT_PROP] = content.strip()
-        self.run_method('update', content.strip())
+        content = remove_indentation(content)
+        self._props[self.CONTENT_PROP] = content
+        self.run_method('update', content)
 
     def _render_markdown(self) -> str:
         return f'```mermaid\n{self.content}\n```' if self.content else ''

--- a/nicegui/elements/restructured_text.py
+++ b/nicegui/elements/restructured_text.py
@@ -3,7 +3,8 @@ from functools import lru_cache
 
 from docutils.core import publish_parts
 
-from .markdown import Markdown, remove_indentation
+from ..helpers import remove_indentation
+from .markdown import Markdown
 
 
 class ReStructuredText(Markdown):

--- a/nicegui/helpers/__init__.py
+++ b/nicegui/helpers/__init__.py
@@ -10,7 +10,7 @@ from .functions import (
     should_await,
 )
 from .network import format_url, is_port_open, schedule_browser
-from .strings import event_type_to_camel_case, kebab_to_camel_case
+from .strings import event_type_to_camel_case, kebab_to_camel_case, remove_indentation
 from .warnings import warn_once
 
 __all__ = [
@@ -26,6 +26,7 @@ __all__ = [
     'is_user_simulation',
     'kebab_to_camel_case',
     'normalize_lifecycle_handler',
+    'remove_indentation',
     'require_top_level_layout',
     'schedule_browser',
     'should_await',

--- a/nicegui/helpers/strings.py
+++ b/nicegui/helpers/strings.py
@@ -6,3 +6,14 @@ def kebab_to_camel_case(string: str) -> str:
 def event_type_to_camel_case(string: str) -> str:
     """Convert an event type string to camelCase."""
     return '.'.join(kebab_to_camel_case(part) if part != '-' else part for part in string.split('.'))
+
+
+def remove_indentation(text: str) -> str:
+    """Remove indentation from a multi-line string based on the indentation of the first non-empty line."""
+    lines = text.splitlines()
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    if not lines:
+        return ''
+    indentation = len(lines[0]) - len(lines[0].lstrip())
+    return '\n'.join(line[indentation:] for line in lines)

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -49,6 +49,26 @@ def test_mermaid_with_line_breaks(screen: Screen):
     screen.should_contain('Verification: Test')
 
 
+def test_mermaid_with_yaml_frontmatter(screen: Screen):
+    @ui.page('/')
+    def page():
+        ui.mermaid('''
+            ---
+            displayMode: compact
+            ---
+            gantt
+                title A Gantt Diagram
+                dateFormat YYYY-MM-DD
+                section Section
+                    A task          :a1, 2014-01-01, 30d
+                    Another task    :after a1, 20d
+        ''')
+
+    screen.open('/')
+    screen.should_contain('A Gantt Diagram')
+    screen.should_not_contain('Syntax error in text')
+
+
 def test_replace_mermaid(screen: Screen):
     @ui.page('/')
     def page():

--- a/tests/test_vbuild.py
+++ b/tests/test_vbuild.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from nicegui.elements.markdown import remove_indentation
+from nicegui.helpers import remove_indentation
 from nicegui.vbuild import VBuild
 
 

--- a/website/documentation/content/doc/api.py
+++ b/website/documentation/content/doc/api.py
@@ -13,7 +13,7 @@ from nicegui import app as nicegui_app
 from nicegui import Client
 from nicegui import ui as nicegui_ui
 from nicegui.functions.navigate import Navigate
-from nicegui.elements.markdown import remove_indentation
+from nicegui.helpers import remove_indentation
 
 from .page import DocumentationPage
 from .part import Demo, DocumentationPart

--- a/website/documentation/reference.py
+++ b/website/documentation/reference.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from nicegui import binding, ui
-from nicegui.elements.markdown import remove_indentation
+from nicegui.helpers import remove_indentation
 
 from .. import design as d
 from ..design import create_anchor_name, subheading

--- a/website/documentation/windows.py
+++ b/website/documentation/windows.py
@@ -1,7 +1,6 @@
 from collections.abc import Callable
 
 from nicegui import helpers, ui
-from nicegui.elements.markdown import remove_indentation
 
 from .. import design as d
 from ..design import phosphor_icon
@@ -26,7 +25,7 @@ def code_window(code: str = '', *, title: str = 'main.py', language: str = 'pyth
                         .props('flat round size=xs').classes('opacity-30 hover:opacity-100 transition-opacity'):
                     phosphor_icon('ph-copy').classes('text-base')
         if code:
-            ui.markdown(f'````{language}\n{remove_indentation(code)}\n````') \
+            ui.markdown(f'````{language}\n{helpers.remove_indentation(code)}\n````') \
                 .classes('w-full grow py-2 overflow-x-auto [&_pre]:px-4 [&_pre]:w-fit [&_pre]:min-w-full')
     return window
 


### PR DESCRIPTION
### Motivation

`ui.markdown` already auto-dedents its content via `remove_indentation`, but `ui.mermaid` only stripped outer whitespace.
Identical triple-quoted strings therefore behaved differently between the two elements.

The discrepancy becomes a hard error with Mermaid's YAML front-matter (e.g. `displayMode: compact` for compact-mode Gantt charts), which requires `---` markers at column 0.
Any leading indentation makes Mermaid bail out with _"Diagrams beginning with --- are not valid. If you were trying to use a YAML front-matter, please use un-indented `---` blocks"_.

Refs discussion #6011.

### Implementation

- Promote `remove_indentation` from `nicegui/elements/markdown.py` to `nicegui/helpers/strings.py` and re-export it via `nicegui.helpers`.
  It is no longer markdown-specific now that `ui.mermaid` uses it as well, and lifting it removes the cross-element dependency from `mermaid` → `markdown`.
- Update all existing call sites (`code`, `markdown`, `restructured_text`, `tests/test_vbuild.py`, three website files) to import from the new location.
- Use `remove_indentation` inside `Mermaid._handle_content_change`, replacing the previous `content.strip()` calls.
  Since `remove_indentation` already drops leading whitespace-only lines and produces no leading whitespace on the first line, no extra `.strip()` is needed; Mermaid is fine with any trailing whitespace.
- Add a regression test `test_mermaid_with_yaml_frontmatter` that places a YAML front-matter block inside an indented triple-quoted string and verifies the chart renders without a syntax error.

This is not a breaking change in practice: Mermaid is whitespace-insensitive at the start of lines for every diagram type, so removing a uniform leading indent is a no-op for existing diagrams.
The four demos in `mermaid_documentation.py` continue to render identically.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytest has been added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.