### PR TITLE
fix: resolve DEFAULT_LOCAL_SCOPE class variable at runtime in Element…

### DIFF
--- a/nicegui/element_filter.py
+++ b/nicegui/element_filter.py
@@ -27,7 +27,7 @@ class ElementFilter(Generic[T]):
     def __init__(self: ElementFilter[Element], *,
                  marker: str | list[str] | None = None,
                  content: str | list[str] | None = None,
-                 local_scope: bool = DEFAULT_LOCAL_SCOPE,
+                 local_scope: bool | None = None,
                  only_visible: bool = False,
                  ) -> None:
         ...
@@ -37,7 +37,7 @@ class ElementFilter(Generic[T]):
                  kind: type[T],
                  marker: str | list[str] | None = None,
                  content: str | list[str] | None = None,
-                 local_scope: bool = DEFAULT_LOCAL_SCOPE,
+                 local_scope: bool | None = None,
                  only_visible: bool = False,
                  ) -> None:
         ...
@@ -46,7 +46,7 @@ class ElementFilter(Generic[T]):
                  kind: type[T] | None = None,
                  marker: str | list[str] | None = None,
                  content: str | list[str] | None = None,
-                 local_scope: bool = DEFAULT_LOCAL_SCOPE,
+                 local_scope: bool | None = None,
                  only_visible: bool = False,
                  ) -> None:
         """ElementFilter
@@ -81,6 +81,9 @@ class ElementFilter(Generic[T]):
         :param local_scope: if ``True``, only elements within the current scope are returned; by default the whole page is searched (this default behavior can be changed with ``ElementFilter.DEFAULT_LOCAL_SCOPE = True``)
         :param only_visible: if ``True``, filter out elements that are not visible or whose ancestors are not visible
         """
+        if local_scope is None:
+            local_scope = self.DEFAULT_LOCAL_SCOPE
+
         self._kind = kind
         self._markers = marker.split() if isinstance(marker, str) else marker or []
         self._contents = [content] if isinstance(content, str) else content or []

--- a/tests/test_element_filter.py
+++ b/tests/test_element_filter.py
@@ -328,78 +328,17 @@ async def test_typing(user: User):
     await user.open('/')
 
 
-async def test_default_local_scope_true(user: User):
-    """Test that setting ElementFilter.DEFAULT_LOCAL_SCOPE = True works at runtime."""
+@pytest.mark.parametrize('default_local_scope', [True, False])
+async def test_default_local_scope(user: User, default_local_scope, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(ElementFilter, 'DEFAULT_LOCAL_SCOPE', default_local_scope)
+
     @ui.page('/')
     def page():
-        ui.button('button A')
-        ui.label('label A')
+        ui.label('A')
         with ui.row():
-            ui.button('button B')
-            ui.label('label B')
-
-            # Set DEFAULT_LOCAL_SCOPE to True
-            original_value = ElementFilter.DEFAULT_LOCAL_SCOPE
-            try:
-                ElementFilter.DEFAULT_LOCAL_SCOPE = True
-                # Without explicit local_scope parameter, should use DEFAULT_LOCAL_SCOPE = True
-                assert texts(ElementFilter()) == ['button B', 'label B']
-            finally:
-                # Restore original value
-                ElementFilter.DEFAULT_LOCAL_SCOPE = original_value
-
-    await user.open('/')
-
-
-async def test_default_local_scope_false(user: User):
-    """Test that setting ElementFilter.DEFAULT_LOCAL_SCOPE = False works at runtime."""
-    @ui.page('/')
-    def page():
-        ui.button('button A')
-        ui.label('label A')
-        with ui.row():
-            ui.button('button B')
-            ui.label('label B')
-
-            # Set DEFAULT_LOCAL_SCOPE to False (should be default, but test explicitly)
-            original_value = ElementFilter.DEFAULT_LOCAL_SCOPE
-            try:
-                ElementFilter.DEFAULT_LOCAL_SCOPE = False
-                # Without explicit local_scope parameter, should use DEFAULT_LOCAL_SCOPE = False
-                # This should find all elements on the page, not just in local scope
-                result = texts(ElementFilter(kind=ui.button))
-                assert 'button A' in result
-                assert 'button B' in result
-            finally:
-                # Restore original value
-                ElementFilter.DEFAULT_LOCAL_SCOPE = original_value
-
-    await user.open('/')
-
-
-async def test_explicit_local_scope_overrides_default(user: User):
-    """Test that passing local_scope=True explicitly still works and overrides DEFAULT_LOCAL_SCOPE."""
-    @ui.page('/')
-    def page():
-        ui.button('button A')
-        ui.label('label A')
-        with ui.row():
-            ui.button('button B')
-            ui.label('label B')
-
-            # Set DEFAULT_LOCAL_SCOPE to False
-            original_value = ElementFilter.DEFAULT_LOCAL_SCOPE
-            try:
-                ElementFilter.DEFAULT_LOCAL_SCOPE = False
-                # Explicitly pass local_scope=True, should override the default
-                assert texts(ElementFilter(local_scope=True)) == ['button B', 'label B']
-
-                # Explicitly pass local_scope=False, should search whole page
-                result = texts(ElementFilter(kind=ui.button, local_scope=False))
-                assert 'button A' in result
-                assert 'button B' in result
-            finally:
-                # Restore original value
-                ElementFilter.DEFAULT_LOCAL_SCOPE = original_value
+            ui.label('B')
+            assert texts(ElementFilter(kind=ui.label)) == (['B'] if default_local_scope else ['A', 'B'])
+            assert texts(ElementFilter(kind=ui.label, local_scope=True)) == ['B']
+            assert texts(ElementFilter(kind=ui.label, local_scope=False)) == ['A', 'B']
 
     await user.open('/')

--- a/tests/test_element_filter.py
+++ b/tests/test_element_filter.py
@@ -326,3 +326,80 @@ async def test_typing(user: User):
         _ = ElementFilter()  # ElementFilter[Element]
 
     await user.open('/')
+
+
+async def test_default_local_scope_true(user: User):
+    """Test that setting ElementFilter.DEFAULT_LOCAL_SCOPE = True works at runtime."""
+    @ui.page('/')
+    def page():
+        ui.button('button A')
+        ui.label('label A')
+        with ui.row():
+            ui.button('button B')
+            ui.label('label B')
+
+            # Set DEFAULT_LOCAL_SCOPE to True
+            original_value = ElementFilter.DEFAULT_LOCAL_SCOPE
+            try:
+                ElementFilter.DEFAULT_LOCAL_SCOPE = True
+                # Without explicit local_scope parameter, should use DEFAULT_LOCAL_SCOPE = True
+                assert texts(ElementFilter()) == ['button B', 'label B']
+            finally:
+                # Restore original value
+                ElementFilter.DEFAULT_LOCAL_SCOPE = original_value
+
+    await user.open('/')
+
+
+async def test_default_local_scope_false(user: User):
+    """Test that setting ElementFilter.DEFAULT_LOCAL_SCOPE = False works at runtime."""
+    @ui.page('/')
+    def page():
+        ui.button('button A')
+        ui.label('label A')
+        with ui.row():
+            ui.button('button B')
+            ui.label('label B')
+
+            # Set DEFAULT_LOCAL_SCOPE to False (should be default, but test explicitly)
+            original_value = ElementFilter.DEFAULT_LOCAL_SCOPE
+            try:
+                ElementFilter.DEFAULT_LOCAL_SCOPE = False
+                # Without explicit local_scope parameter, should use DEFAULT_LOCAL_SCOPE = False
+                # This should find all elements on the page, not just in local scope
+                result = texts(ElementFilter(kind=ui.button))
+                assert 'button A' in result
+                assert 'button B' in result
+            finally:
+                # Restore original value
+                ElementFilter.DEFAULT_LOCAL_SCOPE = original_value
+
+    await user.open('/')
+
+
+async def test_explicit_local_scope_overrides_default(user: User):
+    """Test that passing local_scope=True explicitly still works and overrides DEFAULT_LOCAL_SCOPE."""
+    @ui.page('/')
+    def page():
+        ui.button('button A')
+        ui.label('label A')
+        with ui.row():
+            ui.button('button B')
+            ui.label('label B')
+
+            # Set DEFAULT_LOCAL_SCOPE to False
+            original_value = ElementFilter.DEFAULT_LOCAL_SCOPE
+            try:
+                ElementFilter.DEFAULT_LOCAL_SCOPE = False
+                # Explicitly pass local_scope=True, should override the default
+                assert texts(ElementFilter(local_scope=True)) == ['button B', 'label B']
+
+                # Explicitly pass local_scope=False, should search whole page
+                result = texts(ElementFilter(kind=ui.button, local_scope=False))
+                assert 'button A' in result
+                assert 'button B' in result
+            finally:
+                # Restore original value
+                ElementFilter.DEFAULT_LOCAL_SCOPE = original_value
+
+    await user.open('/')


### PR DESCRIPTION
### Motivation

Fixes #6005

The bug: `ElementFilter.DEFAULT_LOCAL_SCOPE = True` has no effect because Python evaluates default argument values once when the function is defined, so `local_scope` stays bound to the original `False` value even after `DEFAULT_LOCAL_SCOPE` is changed.

This prevents users from changing the default behavior of `ElementFilter` at runtime, which is the documented and intended functionality.

### Implementation

Changed the local_scope parameter from `local_scope: bool = DEFAULT_LOCAL_SCOPE` to `local_scope: bool | None = None` in all method signatures (both `@overload` decorators and the actual `__init__` method).

Added runtime evaluation at the start of `__init__`:

```py
if local_scope is None:
    local_scope = self.DEFAULT_LOCAL_SCOPE
```

This ensures that `DEFAULT_LOCAL_SCOPE` is evaluated every time `ElementFilter` is instantiated, not just once at function definition time. This is the standard Python pattern for handling runtime-evaluated defaults.

The fix maintains full backward compatibility:

- Explicit `local_scope=True` or `local_scope=False` still works as before
- Default behavior (when no parameter is passed) now correctly respects the current value of `DEFAULT_LOCAL_SCOPE`

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary (existing docstring already describes this behavior).
- [x] No breaking changes to the public API.