### PR TITLE
Make `enable()`, `disable()`, `set_enabled()` and `set_visibility()` chainable

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -478,7 +478,7 @@ class Element(Visibility):
     def move(self,
              target_container: Element | None = None,
              target_index: int = -1, *,
-             target_slot: str | None = None) -> None:
+             target_slot: str | None = None) -> Self:
         """Move the element to another container.
 
         :param target_container: container to move the element to (default: the parent container)
@@ -505,6 +505,7 @@ class Element(Visibility):
         parent_slot.children.insert(target_index, self)
 
         target_container.update()
+        return self
 
     def remove(self, element: Element | int) -> None:
         """Remove a child element.

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -39,7 +39,7 @@ TAG_CHAR = TAG_START_CHAR + r'|-|\.|[0-9]|\u00B7|[\u0300-\u036F]|[\u203F-\u2040]
 TAG_PATTERN = re.compile(fr'^({TAG_START_CHAR})({TAG_CHAR})*$')
 
 
-class Element(Visibility, helpers.NoImplicitAwait):
+class Element(Visibility):
     component: Component | None = None
     exposed_libraries: ClassVar[list[Library]] = []
     _default_props: ClassVar[dict[str, Any]] = {}

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -39,7 +39,7 @@ TAG_CHAR = TAG_START_CHAR + r'|-|\.|[0-9]|\u00B7|[\u0300-\u036F]|[\u203F-\u2040]
 TAG_PATTERN = re.compile(fr'^({TAG_START_CHAR})({TAG_CHAR})*$')
 
 
-class Element(Visibility):
+class Element(Visibility, helpers.NoImplicitAwait):
     component: Component | None = None
     exposed_libraries: ClassVar[list[Library]] = []
     _default_props: ClassVar[dict[str, Any]] = {}

--- a/nicegui/elements/audio.py
+++ b/nicegui/elements/audio.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, resolve_defaults
 from .mixins.source_element import SourceElement
 
@@ -33,7 +35,7 @@ class Audio(SourceElement, component='audio.js'):
         self._props.set_bool('muted', muted)
         self._props.set_bool('loop', loop)
 
-    def set_source(self, source: str | Path) -> None:
+    def set_source(self, source: str | Path) -> Self:
         return super().set_source(source)
 
     def seek(self, seconds: float) -> None:

--- a/nicegui/elements/button_dropdown.py
+++ b/nicegui/elements/button_dropdown.py
@@ -60,14 +60,17 @@ class DropdownButton(IconElement, TextElement, DisableableElement, BackgroundCol
     def _text_to_model_text(self, text: str) -> None:
         self._props['label'] = text
 
-    def open(self) -> None:
+    def open(self) -> Self:
         """Open the dropdown."""
         self.value = True
+        return self
 
-    def close(self) -> None:
+    def close(self) -> Self:
         """Close the dropdown."""
         self.value = False
+        return self
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle the dropdown."""
         self.value = not self.value
+        return self

--- a/nicegui/elements/choice_element.py
+++ b/nicegui/elements/choice_element.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from typing_extensions import Self
+
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.value_element import ValueElement
 
@@ -52,7 +54,7 @@ class ChoiceElement(ValueElement[Any]):
             self._update_options()
         super().update()
 
-    def set_options(self, options: list | dict, *, value: Any = ...) -> None:
+    def set_options(self, options: list | dict, *, value: Any = ...) -> Self:
         """Set the options of this choice element.
 
         :param options: The new options.
@@ -62,3 +64,4 @@ class ChoiceElement(ValueElement[Any]):
         if value is not ...:
             self.value = value
         self.update()
+        return self

--- a/nicegui/elements/codemirror/codemirror.py
+++ b/nicegui/elements/codemirror/codemirror.py
@@ -1,6 +1,8 @@
 from itertools import accumulate, chain, repeat
 from typing import Literal, get_args
 
+from typing_extensions import Self
+
 from ...defaults import DEFAULT_PROP, resolve_defaults
 from ...elements.mixins.disableable_element import DisableableElement
 from ...elements.mixins.value_element import ValueElement
@@ -310,9 +312,10 @@ class CodeMirror(ValueElement[str], DisableableElement,
     def theme(self, theme: SUPPORTED_THEMES) -> None:
         self._props['theme'] = theme
 
-    def set_theme(self, theme: SUPPORTED_THEMES) -> None:
+    def set_theme(self, theme: SUPPORTED_THEMES) -> Self:
         """Sets the theme of the editor."""
         self._props['theme'] = theme
+        return self
 
     @property
     def supported_themes(self) -> list[str]:
@@ -328,9 +331,10 @@ class CodeMirror(ValueElement[str], DisableableElement,
     def language(self, language: SUPPORTED_LANGUAGES | None = None) -> None:
         self._props['language'] = language
 
-    def set_language(self, language: SUPPORTED_LANGUAGES | None = None) -> None:
+    def set_language(self, language: SUPPORTED_LANGUAGES | None = None) -> Self:
         """Sets the language of the editor (case-insensitive)."""
         self._props['language'] = language
+        return self
 
     @property
     def supported_languages(self) -> list[str]:
@@ -349,12 +353,13 @@ class CodeMirror(ValueElement[str], DisableableElement,
     def line_wrapping(self, value: bool) -> None:
         self._props['line-wrapping'] = value
 
-    def set_line_wrapping(self, value: bool) -> None:
+    def set_line_wrapping(self, value: bool) -> Self:
         """Sets whether line wrapping is enabled.
 
         *Added in version 3.2.0*
         """
         self._props['line-wrapping'] = value
+        return self
 
     def _event_args_to_value(self, e: GenericEventArguments) -> str:
         """The event contains a change set which is applied to the current value."""

--- a/nicegui/elements/color_input.py
+++ b/nicegui/elements/color_input.py
@@ -2,6 +2,8 @@ import re
 from colorsys import rgb_to_yiq
 from typing import Any
 
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..events import Handler, ValueChangeEventArguments
 from .button import Button as button
@@ -46,11 +48,12 @@ class ColorInput(LabelElement, ValueElement[str | None], DisableableElement):
         self.preview = preview
         self._update_preview()
 
-    def open_picker(self) -> None:
+    def open_picker(self) -> Self:
         """Open the color picker"""
         if self.value:
             self.picker.set_color(self.value)
         self.picker.open()
+        return self
 
     def _handle_value_change(self, value: Any) -> None:
         super()._handle_value_change(value)

--- a/nicegui/elements/color_picker.py
+++ b/nicegui/elements/color_picker.py
@@ -29,12 +29,13 @@ class ColorPicker(Menu):
                     handle_event(handler, ColorPickEventArguments(sender=self, client=self.client, color=e.args))
             self.q_color = Element('q-color').on('change', handle_change)
 
-    def set_color(self, color: str) -> None:
+    def set_color(self, color: str) -> Self:
         """Set the color of the picker.
 
         :param color: the color to set
         """
         self.q_color.props(f'model-value="{color}"')
+        return self
 
     def on_pick(self, callback: Handler[ColorPickEventArguments]) -> Self:
         """Add a callback to be invoked when a color is picked."""

--- a/nicegui/elements/context_menu.py
+++ b/nicegui/elements/context_menu.py
@@ -1,3 +1,5 @@
+from typing_extensions import Self
+
 from ..element import Element
 
 
@@ -14,10 +16,12 @@ class ContextMenu(Element):
         self._props['context-menu'] = True
         self._props['touch-position'] = True
 
-    def open(self) -> None:
+    def open(self) -> Self:
         """Open the context menu."""
         self.run_method('show')
+        return self
 
-    def close(self) -> None:
+    def close(self) -> Self:
         """Close the context menu."""
         self.run_method('hide')
+        return self

--- a/nicegui/elements/dark_mode.py
+++ b/nicegui/elements/dark_mode.py
@@ -1,3 +1,5 @@
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, resolve_defaults
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.value_element import ValueElement
@@ -23,15 +25,17 @@ class DarkMode(ValueElement[bool | None], component='dark_mode.js'):
         """
         super().__init__(value=value, on_value_change=on_change)
 
-    def enable(self) -> None:
+    def enable(self) -> Self:
         """Enable dark mode."""
         self.value = True
+        return self
 
-    def disable(self) -> None:
+    def disable(self) -> Self:
         """Disable dark mode."""
         self.value = False
+        return self
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle dark mode.
 
         This method will raise a ValueError if dark mode is set to auto.
@@ -39,10 +43,12 @@ class DarkMode(ValueElement[bool | None], component='dark_mode.js'):
         if self.value is None:
             raise ValueError('Cannot toggle dark mode when it is set to auto.')
         self.value = not self.value
+        return self
 
-    def auto(self) -> None:
+    def auto(self) -> Self:
         """Set dark mode to auto.
 
         This will use the client's system preference.
         """
         self.value = None
+        return self

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -2,6 +2,8 @@ import asyncio
 import weakref
 from typing import Any
 
+from typing_extensions import Self
+
 from ..context import context
 from ..defaults import DEFAULT_PROPS, resolve_defaults
 from ..element import Element
@@ -44,13 +46,15 @@ class Dialog(ValueElement[bool], component='dialog.js'):
             self._submitted = asyncio.Event()
         return self._submitted
 
-    def open(self) -> None:
+    def open(self) -> Self:
         """Open the dialog."""
         self.value = True
+        return self
 
-    def close(self) -> None:
+    def close(self) -> Self:
         """Close the dialog."""
         self.value = False
+        return self
 
     def __await__(self):
         self._result = None

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -7,10 +7,11 @@ from typing_extensions import Self
 from ..context import context
 from ..defaults import DEFAULT_PROPS, resolve_defaults
 from ..element import Element
+from ..helpers import NoImplicitAwait
 from .mixins.value_element import ValueElement
 
 
-class Dialog(ValueElement[bool], component='dialog.js'):
+class Dialog(ValueElement[bool], NoImplicitAwait, component='dialog.js'):
 
     @resolve_defaults
     def __init__(self, *, value: bool = DEFAULT_PROPS['model-value'] | False) -> None:

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -2,8 +2,6 @@ import asyncio
 import weakref
 from typing import Any
 
-from typing_extensions import Self
-
 from ..context import context
 from ..defaults import DEFAULT_PROPS, resolve_defaults
 from ..element import Element
@@ -46,15 +44,13 @@ class Dialog(ValueElement[bool], component='dialog.js'):
             self._submitted = asyncio.Event()
         return self._submitted
 
-    def open(self) -> Self:
+    def open(self) -> None:
         """Open the dialog."""
         self.value = True
-        return self
 
-    def close(self) -> Self:
+    def close(self) -> None:
         """Close the dialog."""
         self.value = False
-        return self
 
     def __await__(self):
         self._result = None

--- a/nicegui/elements/drawer.py
+++ b/nicegui/elements/drawer.py
@@ -1,5 +1,7 @@
 from typing import Any, Literal
 
+from typing_extensions import Self
+
 from ..context import context
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..helpers import require_top_level_layout
@@ -62,20 +64,23 @@ class Drawer(ValueElement[bool | None], default_classes='nicegui-drawer'):
                 )
             self.client.on_connect(_request_value)
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle the drawer"""
         if self.value is None:
             self.run_method('toggle')
         else:
             self.value = not self.value
+        return self
 
-    def show(self) -> None:
+    def show(self) -> Self:
         """Show the drawer"""
         self.value = True
+        return self
 
-    def hide(self) -> None:
+    def hide(self) -> Self:
         """Hide the drawer"""
         self.value = False
+        return self
 
     def _handle_value_change(self, value: Any) -> None:
         super()._handle_value_change(value)

--- a/nicegui/elements/expansion.py
+++ b/nicegui/elements/expansion.py
@@ -1,3 +1,5 @@
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
@@ -34,13 +36,15 @@ class Expansion(SortableElement, IconElement, TextElement, ValueElement[bool], D
         self._props.set_optional('caption', caption)
         self._props.set_optional('group', group)
 
-    def open(self) -> None:
+    def open(self) -> Self:
         """Open the expansion."""
         self.value = True
+        return self
 
-    def close(self) -> None:
+    def close(self) -> Self:
         """Close the expansion."""
         self.value = False
+        return self
 
     def _render_markdown(self) -> str:
         parts = []

--- a/nicegui/elements/fab.py
+++ b/nicegui/elements/fab.py
@@ -35,17 +35,20 @@ class Fab(ValueElement[bool], LabelElement, IconElement, BackgroundColorElement,
         super().__init__(tag='q-fab', value=value, label=label, background_color=color, icon=icon)
         self._props['direction'] = direction
 
-    def open(self) -> None:
+    def open(self) -> Self:
         """Open the FAB."""
         self.value = True
+        return self
 
-    def close(self) -> None:
+    def close(self) -> Self:
         """Close the FAB."""
         self.value = False
+        return self
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle the FAB."""
         self.value = not self.value
+        return self
 
 
 class FabAction(LabelElement, IconElement, BackgroundColorElement, DisableableElement):

--- a/nicegui/elements/footer.py
+++ b/nicegui/elements/footer.py
@@ -1,3 +1,5 @@
+from typing_extensions import Self
+
 from ..context import context
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..helpers import require_top_level_layout
@@ -42,14 +44,17 @@ class Footer(ValueElement[bool], default_classes='nicegui-footer'):
 
         self.move(target_index=-1)
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle the footer"""
         self.value = not self.value
+        return self
 
-    def show(self) -> None:
+    def show(self) -> Self:
         """Show the footer"""
         self.value = True
+        return self
 
-    def hide(self) -> None:
+    def hide(self) -> Self:
         """Hide the footer"""
         self.value = False
+        return self

--- a/nicegui/elements/fullscreen.py
+++ b/nicegui/elements/fullscreen.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, resolve_defaults
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.value_element import ValueElement
@@ -45,17 +47,20 @@ class Fullscreen(ValueElement[bool], component='fullscreen.js'):
     def require_escape_hold(self, value: bool) -> None:
         self._props['require-escape-hold'] = value
 
-    def enter(self) -> None:
+    def enter(self) -> Self:
         """Enter fullscreen mode."""
         self.value = True
+        return self
 
-    def exit(self) -> None:
+    def exit(self) -> Self:
         """Exit fullscreen mode."""
         self.value = False
+        return self
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle fullscreen mode."""
         self.value = not self.value
+        return self
 
     def _handle_value_change(self, value: Any) -> None:
         super()._handle_value_change(value)

--- a/nicegui/elements/header.py
+++ b/nicegui/elements/header.py
@@ -1,3 +1,5 @@
+from typing_extensions import Self
+
 from ..context import context
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..helpers import require_top_level_layout
@@ -47,14 +49,17 @@ class Header(ValueElement[bool], component='header.js', default_classes='nicegui
 
         self._props.add_rename('add_scroll_padding', 'add-scroll-padding')  # DEPRECATED: remove in NiceGUI 4.0
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle the header"""
         self.value = not self.value
+        return self
 
-    def show(self) -> None:
+    def show(self) -> Self:
         """Show the header"""
         self.value = True
+        return self
 
-    def hide(self) -> None:
+    def hide(self) -> Self:
         """Hide the header"""
         self.value = False
+        return self

--- a/nicegui/elements/image.py
+++ b/nicegui/elements/image.py
@@ -5,6 +5,8 @@ import time
 from contextlib import suppress
 from pathlib import Path
 
+from typing_extensions import Self
+
 from .. import optional_features
 from ..logging import log
 from .mixins.source_element import SourceElement
@@ -27,7 +29,7 @@ class Image(SourceElement, component='image.js'):
         """
         super().__init__(source=source)
 
-    def set_source(self, source: str | Path | PIL_Image) -> None:
+    def set_source(self, source: str | Path | PIL_Image) -> Self:
         return super().set_source(source)
 
     def _set_props(self, source: str | Path | PIL_Image) -> None:

--- a/nicegui/elements/input.py
+++ b/nicegui/elements/input.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..events import Handler, ValueChangeEventArguments
 from .icon import Icon
@@ -76,9 +78,10 @@ class Input(LabelElement, ValidationElement[str | None], DisableableElement, com
         if suffix is not None:
             self._props['suffix'] = suffix
 
-    def set_autocomplete(self, autocomplete: list[str] | None) -> None:
+    def set_autocomplete(self, autocomplete: list[str] | None) -> Self:
         """Set the autocomplete list."""
         self._props['_autocomplete'] = autocomplete
+        return self
 
     @property
     def prefix(self) -> str | None:

--- a/nicegui/elements/interactive_image.py
+++ b/nicegui/elements/interactive_image.py
@@ -78,7 +78,7 @@ class InteractiveImage(SourceElement, ContentElement, component='interactive_ima
         if on_mouse:
             self.on_mouse(on_mouse)
 
-    def set_source(self, source: str | Path | PIL_Image) -> None:
+    def set_source(self, source: str | Path | PIL_Image) -> Self:
         return super().set_source(source)
 
     def on_mouse(self, on_mouse: Handler[MouseEventArguments]) -> Self:

--- a/nicegui/elements/leaflet/leaflet.py
+++ b/nicegui/elements/leaflet/leaflet.py
@@ -116,17 +116,17 @@ class Leaflet(Element, component='leaflet.js', esm={'nicegui-leaflet': 'dist'}, 
             return NullResponse()
         return super().run_method(name, *args, timeout=timeout)
 
-    def set_center(self, center: tuple[float, float]) -> None:
+    def set_center(self, center: tuple[float, float]) -> Self:
         """Set the center location of the map."""
-        if self._props['center'] == center:
-            return
-        self._props['center'] = center
+        if self._props['center'] != center:
+            self._props['center'] = center
+        return self
 
-    def set_zoom(self, zoom: int) -> None:
+    def set_zoom(self, zoom: int) -> Self:
         """Set the zoom level of the map."""
-        if self._props['zoom'] == zoom:
-            return
-        self._props['zoom'] = zoom
+        if self._props['zoom'] != zoom:
+            self._props['zoom'] = zoom
+        return self
 
     def remove_layer(self, layer: Layer) -> None:
         """Remove a layer from the map."""

--- a/nicegui/elements/leaflet/leaflet_layers.py
+++ b/nicegui/elements/leaflet/leaflet_layers.py
@@ -84,7 +84,7 @@ class Marker(Layer):
         self.options['draggable'] = value
         return self
 
-    def move(self, lat: float, lng: float) -> None:
+    def move(self, lat: float, lng: float) -> Self:
         """Move the marker to a new position.
 
         :param lat: latitude
@@ -92,3 +92,4 @@ class Marker(Layer):
         """
         self.latlng = (lat, lng)
         self.run_method('setLatLng', (lat, lng))
+        return self

--- a/nicegui/elements/menu.py
+++ b/nicegui/elements/menu.py
@@ -1,3 +1,5 @@
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROPS, resolve_defaults
 from ..events import ClickEventArguments, Handler
 from .context_menu import ContextMenu
@@ -29,17 +31,20 @@ class Menu(ValueElement[bool]):
     def _render_markdown(self) -> str:
         return self._children_to_markdown() if self.value else ''
 
-    def open(self) -> None:
+    def open(self) -> Self:
         """Open the menu."""
         self.value = True
+        return self
 
-    def close(self) -> None:
+    def close(self) -> Self:
         """Close the menu."""
         self.value = False
+        return self
 
-    def toggle(self) -> None:
+    def toggle(self) -> Self:
         """Toggle the menu."""
         self.value = not self.value
+        return self
 
 
 class MenuItem(Item):

--- a/nicegui/elements/mixins/color_elements.py
+++ b/nicegui/elements/mixins/color_elements.py
@@ -33,9 +33,10 @@ class BackgroundColorElement(Element):
         self.background_color = background_color
         self._handle_background_color_change(background_color)
 
-    def set_background_color(self, background_color: str | None) -> None:
+    def set_background_color(self, background_color: str | None) -> Self:
         """Set the background color of this element."""
         self.background_color = background_color
+        return self
 
     def _handle_background_color_change(self, background_color: str | None) -> None:
         # Clear previous color based on tracked state
@@ -140,9 +141,10 @@ class TextColorElement(Element):
         self.text_color = text_color
         self._handle_text_color_change(text_color)
 
-    def set_text_color(self, text_color: str | None) -> None:
+    def set_text_color(self, text_color: str | None) -> Self:
         """Set the text color of this element."""
         self.text_color = text_color
+        return self
 
     def _handle_text_color_change(self, text_color: str | None) -> None:
         # Clear previous color based on tracked state

--- a/nicegui/elements/mixins/content_element.py
+++ b/nicegui/elements/mixins/content_element.py
@@ -85,12 +85,13 @@ class ContentElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_content(self, content: str) -> None:
+    def set_content(self, content: str) -> Self:
         """Set the content of this element.
 
         :param content: The new content.
         """
         self.content = content
+        return self
 
     def _handle_content_change(self, content: str) -> None:
         """Called when the content of this element changes.

--- a/nicegui/elements/mixins/disableable_element.py
+++ b/nicegui/elements/mixins/disableable_element.py
@@ -23,13 +23,15 @@ class DisableableElement(Element):
             return True
         return not self.enabled and self.ignores_events_when_disabled
 
-    def enable(self) -> None:
+    def enable(self) -> Self:
         """Enable the element."""
         self.enabled = True
+        return self
 
-    def disable(self) -> None:
+    def disable(self) -> Self:
         """Disable the element."""
         self.enabled = False
+        return self
 
     def bind_enabled_to(self,
                         target_object: Any,
@@ -99,9 +101,10 @@ class DisableableElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_enabled(self, value: bool) -> None:
+    def set_enabled(self, value: bool) -> Self:
         """Set the enabled state of the element."""
         self.enabled = value
+        return self
 
     def _handle_enabled_change(self, enabled: bool) -> None:
         """Called when the element is enabled or disabled.

--- a/nicegui/elements/mixins/filter_element.py
+++ b/nicegui/elements/mixins/filter_element.py
@@ -85,12 +85,13 @@ class FilterElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_filter(self, filter_: str) -> None:
+    def set_filter(self, filter_: str) -> Self:
         """Set the filter of this element.
 
         :param filter: The new filter.
         """
         self.filter = filter_
+        return self
 
     def _handle_filter_change(self, filter_: str) -> None:
         """Called when the filter of this element changes.

--- a/nicegui/elements/mixins/icon_element.py
+++ b/nicegui/elements/mixins/icon_element.py
@@ -84,12 +84,13 @@ class IconElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_icon(self, icon: str | None) -> None:
+    def set_icon(self, icon: str | None) -> Self:
         """Set the icon of this element.
 
         :param icon: The new icon.
         """
         self.icon = icon
+        return self
 
     def _handle_icon_change(self, icon: str | None) -> None:
         """Called when the icon of this element changes.

--- a/nicegui/elements/mixins/label_element.py
+++ b/nicegui/elements/mixins/label_element.py
@@ -84,12 +84,13 @@ class LabelElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_label(self, label: str | None) -> None:
+    def set_label(self, label: str | None) -> Self:
         """Set the label of this element.
 
         :param label: The new label.
         """
         self.label = label
+        return self
 
     def _handle_label_change(self, label: str | None) -> None:
         """Called when the label of this element changes.

--- a/nicegui/elements/mixins/name_element.py
+++ b/nicegui/elements/mixins/name_element.py
@@ -84,12 +84,13 @@ class NameElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_name(self, name: str) -> None:
+    def set_name(self, name: str) -> Self:
         """Set the name of this element.
 
         :param name: The new name.
         """
         self.name = name
+        return self
 
     def _handle_name_change(self, name: str) -> None:
         """Called when the name of this element changes.

--- a/nicegui/elements/mixins/selectable_element.py
+++ b/nicegui/elements/mixins/selectable_element.py
@@ -105,12 +105,13 @@ class SelectableElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_selected(self, selected: bool) -> None:
+    def set_selected(self, selected: bool) -> Self:
         """Set the selection state of this element.
 
         :param selected: The new selection state.
         """
         self.selected = selected
+        return self
 
     def _handle_selection_change(self, selected: bool) -> None:
         """Called when the selection state of this element changes.

--- a/nicegui/elements/mixins/source_element.py
+++ b/nicegui/elements/mixins/source_element.py
@@ -91,12 +91,13 @@ class SourceElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_source(self, source: Any) -> None:
+    def set_source(self, source: Any) -> Self:
         """Set the source of this element.
 
         :param source: The new source.
         """
         self.source = source
+        return self
 
     def _handle_source_change(self, source: Any) -> None:
         """Called when the source of this element changes.

--- a/nicegui/elements/mixins/text_element.py
+++ b/nicegui/elements/mixins/text_element.py
@@ -84,12 +84,13 @@ class TextElement(Element):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_text(self, text: str) -> None:
+    def set_text(self, text: str) -> Self:
         """Set the text of this element.
 
         :param text: The new text.
         """
         self.text = text
+        return self
 
     def _handle_text_change(self, text: str) -> None:
         """Called when the text of this element changes.

--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -121,12 +121,13 @@ class ValueElement(Element, Generic[ValueT]):
              self_strict=False, other_strict=strict)
         return self
 
-    def set_value(self, value: ValueT) -> None:
+    def set_value(self, value: ValueT) -> Self:
         """Set the value of this element.
 
         :param value: The value to set.
         """
         self.value = value
+        return self
 
     def _handle_value_change(self, value: Any) -> None:
         previous_value = self._props.get(self.VALUE_PROP)

--- a/nicegui/elements/mixins/visibility.py
+++ b/nicegui/elements/mixins/visibility.py
@@ -101,12 +101,13 @@ class Visibility:
              self_strict=False, other_strict=strict)
         return self
 
-    def set_visibility(self, visible: bool) -> None:
+    def set_visibility(self, visible: bool) -> Self:
         """Set the visibility of this element.
 
         :param visible: Whether the element should be visible.
         """
         self.visible = visible
+        return self
 
     def _handle_visibility_change(self, visible: str) -> None:
         """Called when the visibility of this element changes.

--- a/nicegui/elements/notification.py
+++ b/nicegui/elements/notification.py
@@ -197,7 +197,7 @@ class Notification(Element, component='notification.js'):
         """Dismiss the notification."""
         self.run_method('dismiss')
 
-    def set_visibility(self, visible: bool) -> None:
+    def set_visibility(self, visible: bool) -> Self:
         raise NotImplementedError('Use `dismiss()` to remove the notification. See #3670 for more information.')
 
     def _render_markdown(self) -> str:

--- a/nicegui/elements/scene/scene_objects.py
+++ b/nicegui/elements/scene/scene_objects.py
@@ -1,5 +1,7 @@
 import math
 
+from typing_extensions import Self
+
 from .scene_object3d import Object3D
 
 
@@ -276,15 +278,17 @@ class Texture(Object3D):
         """
         super().__init__('texture', url, coordinates)
 
-    def set_url(self, url: str) -> None:
+    def set_url(self, url: str) -> Self:
         """Change the URL of the texture image."""
         self.args[0] = url
         self.scene.run_method('set_texture_url', self.id, url)
+        return self
 
-    def set_coordinates(self, coordinates: list[list[list[float] | None]]) -> None:
+    def set_coordinates(self, coordinates: list[list[list[float] | None]]) -> Self:
         """Change the texture coordinates."""
         self.args[1] = coordinates
         self.scene.run_method('set_texture_coordinates', self.id, coordinates)
+        return self
 
 
 class SpotLight(Object3D):
@@ -331,13 +335,14 @@ class PointCloud(Object3D):
         if colors is not None:
             self.material(color=None)
 
-    def set_points(self, points: list[list[float]], colors: list[list[float]] | None = None) -> None:
+    def set_points(self, points: list[list[float]], colors: list[list[float]] | None = None) -> Self:
         """Change the points and colors of the point cloud."""
         self.args[0] = points
         self.args[1] = colors
         self.scene.run_method('set_points', self.id, points, colors)
         if colors is not None:
             self.material(color=None)
+        return self
 
 
 class AxesHelper(Object3D):

--- a/nicegui/elements/slide_item.py
+++ b/nicegui/elements/slide_item.py
@@ -129,6 +129,7 @@ class SlideItem(DisableableElement):
                                                                                       side=e.args.get('side', side))))
         return self
 
-    def reset(self) -> None:
+    def reset(self) -> Self:
         """Reset the slide item to its initial state."""
         self.run_method('reset')
+        return self

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -411,9 +411,10 @@ class Table(FilterElement, component='table.js'):
         self.is_fullscreen = value
         return self
 
-    def toggle_fullscreen(self) -> None:
+    def toggle_fullscreen(self) -> Self:
         """Toggle fullscreen mode."""
         self.is_fullscreen = not self.is_fullscreen
+        return self
 
     def add_rows(self, rows: list[dict]) -> None:
         """Add rows to the table."""

--- a/nicegui/elements/table.py
+++ b/nicegui/elements/table.py
@@ -379,12 +379,13 @@ class Table(FilterElement, component='table.js'):
     def selection(self, value: Literal[None, 'single', 'multiple']) -> None:
         self._props['selection'] = value or 'none'
 
-    def set_selection(self, value: Literal[None, 'single', 'multiple']) -> None:
+    def set_selection(self, value: Literal[None, 'single', 'multiple']) -> Self:
         """Set the selection type.
 
         *Added in version 2.11.0*
         """
         self.selection = value
+        return self
 
     @property
     def pagination(self) -> dict:
@@ -405,9 +406,10 @@ class Table(FilterElement, component='table.js'):
         """Set fullscreen mode."""
         self._props['fullscreen'] = value
 
-    def set_fullscreen(self, value: bool) -> None:
+    def set_fullscreen(self, value: bool) -> Self:
         """Set fullscreen mode."""
         self.is_fullscreen = value
+        return self
 
     def toggle_fullscreen(self) -> None:
         """Toggle fullscreen mode."""

--- a/nicegui/elements/timer.py
+++ b/nicegui/elements/timer.py
@@ -1,5 +1,7 @@
 from contextlib import AbstractContextManager, nullcontext
 
+from typing_extensions import Self
+
 from ..client import Client, ClientConnectionTimeout
 from ..element import Element
 from ..logging import log
@@ -43,5 +45,5 @@ class Timer(BaseTimer, Element, component='timer.js'):
             assert parent_slot is not None
             parent_slot.parent.remove(self)
 
-    def set_visibility(self, visible: bool) -> None:
+    def set_visibility(self, visible: bool) -> Self:
         raise NotImplementedError('Use `activate()`, `deactivate()` or `cancel()`. See #3670 for more information.')

--- a/nicegui/elements/upload.py
+++ b/nicegui/elements/upload.py
@@ -116,9 +116,10 @@ class Upload(LabelElement, DisableableElement, component='upload.js'):
         self.on('rejected', lambda: handle_event(callback, UiEventArguments(sender=self, client=self.client)), args=[])
         return self
 
-    def reset(self) -> None:
+    def reset(self) -> Self:
         """Clear the upload queue."""
         self.run_method('reset')
+        return self
 
     def _handle_delete(self) -> None:
         app.remove_route(self._props['url'])

--- a/nicegui/elements/video.py
+++ b/nicegui/elements/video.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from typing_extensions import Self
+
 from ..defaults import DEFAULT_PROP, resolve_defaults
 from .mixins.source_element import SourceElement
 
@@ -33,7 +35,7 @@ class Video(SourceElement, component='video.js'):
         self._props.set_bool('muted', muted)
         self._props.set_bool('loop', loop)
 
-    def set_source(self, source: str | Path) -> None:
+    def set_source(self, source: str | Path) -> Self:
         return super().set_source(source)
 
     def seek(self, seconds: float) -> None:

--- a/nicegui/helpers/__init__.py
+++ b/nicegui/helpers/__init__.py
@@ -3,6 +3,7 @@ import os
 from .elements import require_top_level_layout
 from .files import hash_file_path, is_file
 from .functions import (
+    NoImplicitAwait,
     await_with_context,
     expects_arguments,
     is_coroutine_function,
@@ -14,6 +15,7 @@ from .strings import event_type_to_camel_case, kebab_to_camel_case, remove_inden
 from .warnings import warn_once
 
 __all__ = [
+    'NoImplicitAwait',
     'await_with_context',
     'event_type_to_camel_case',
     'expects_arguments',

--- a/nicegui/helpers/functions.py
+++ b/nicegui/helpers/functions.py
@@ -36,6 +36,10 @@ def expects_arguments(func: Callable) -> bool:
                for p in signature(func).parameters.values())
 
 
+class NoImplicitAwait:
+    """Marker base for awaitables that must not be implicitly awaited by event handlers."""
+
+
 def should_await(result: Any) -> TypeGuard[Awaitable[Any]]:
     """Determine if a result should be awaited.
 
@@ -44,13 +48,10 @@ def should_await(result: Any) -> TypeGuard[Awaitable[Any]]:
 
     Note: We want to await an awaitable result even if the handler is not an async function (like a lambda statement).
 
-    UI elements that happen to implement ``__await__`` (currently only ``Dialog``) are excluded:
-    their await semantics are meant for explicit ``await my_dialog`` in async code,
-    not for accidentally surfacing as the return value of a chainable mutator like ``dialog.close()``.
-    Handlers that genuinely need to await something either return a coroutine or are themselves ``async``.
+    Subclasses of ``NoImplicitAwait`` are also excluded
+    so that chainable mutators returning ``self`` on awaitable elements (like ``Dialog``) are not silently awaited.
     """
-    from ..element import Element  # pylint: disable=import-outside-toplevel
-    return isinstance(result, Awaitable) and not isinstance(result, (Element, AwaitableResponse, asyncio.Task))
+    return isinstance(result, Awaitable) and not isinstance(result, (NoImplicitAwait, AwaitableResponse, asyncio.Task))
 
 
 async def await_with_context(awaitable: Awaitable[_T], context: AbstractContextManager) -> _T:

--- a/nicegui/helpers/functions.py
+++ b/nicegui/helpers/functions.py
@@ -43,8 +43,14 @@ def should_await(result: Any) -> TypeGuard[Awaitable[Any]]:
     (i.e. not an ``AwaitableResponse`` or an ``asyncio.Task``).
 
     Note: We want to await an awaitable result even if the handler is not an async function (like a lambda statement).
+
+    UI elements that happen to implement ``__await__`` (currently only ``Dialog``) are excluded:
+    their await semantics are meant for explicit ``await my_dialog`` in async code,
+    not for accidentally surfacing as the return value of a chainable mutator like ``dialog.close()``.
+    Handlers that genuinely need to await something either return a coroutine or are themselves ``async``.
     """
-    return isinstance(result, Awaitable) and not isinstance(result, (AwaitableResponse, asyncio.Task))
+    from ..element import Element  # pylint: disable=import-outside-toplevel
+    return isinstance(result, Awaitable) and not isinstance(result, (Element, AwaitableResponse, asyncio.Task))
 
 
 async def await_with_context(awaitable: Awaitable[_T], context: AbstractContextManager) -> _T:


### PR DESCRIPTION
### Motivation

Closes #6014.

In #6014 a user tried to disable a `ui.dropdown_button` inline as part of a `with` statement. Because `.disable()` and `.set_enabled(False)` return `None`, the only chainable option was `.props('disabled')` — which silently misbehaves with `split=True` (the HTML `disabled` attribute falls through to the wrapper `<div>` instead of the inner buttons, so the click handler still fires).

The misbehavior with `split=True` is not actually a NiceGUI bug — `.props('disabled')` is the wrong prop name (Quasar's prop is `disable`, without the trailing `d`). But the user's underlying motivation is reasonable: they wanted a fluent form usable inside `with`. Today we don't offer one for enabled/visible state, even though `.props(...)`, `.classes(...)`, `.style(...)` and the `bind_*` methods already return `Self`.

### Implementation

Change the return type of the following methods from `None` to `Self` and add `return self`:

- `DisableableElement.enable()`
- `DisableableElement.disable()`
- `DisableableElement.set_enabled(value)`
- `Visibility.set_visibility(visible)`

This is a backward-compatible change — existing call sites ignore the return value, and the new return value matches the documented "fluent interface returns `Self`" convention in `CONTRIBUTING.md`. It enables patterns like:

```python
with ui.dropdown_button('Start', split=True, on_click=...).disable():
    ui.menu_item('...')

with ui.card().set_visibility(show_advanced):
    ...
```

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
- [x] Should the event handler exclude elements to allow `Dialog.open()` be chainable?