### PR TITLE
Improve Sortable documentation

### DIFF
--- a/nicegui/elements/mixins/sortable_element.py
+++ b/nicegui/elements/mixins/sortable_element.py
@@ -33,6 +33,8 @@ class SortableElement(Element):
         Note: Setting a custom HTML ID on the container (e.g. via ``.props('id="my-list"')``) is not supported
         and will break the internal slot synchronization.
 
+        *Added in version 3.11.0*
+
         :param options: dictionary of raw SortableJS options (overrides named params like ``animation`` if both are given)
         :param on_end: callback invoked when a sort operation ends (fires on the source container only, even for cross-container moves)
         :param animation: animation duration in seconds (default: 0.15)

--- a/website/documentation/content/sortable_documentation.py
+++ b/website/documentation/content/sortable_documentation.py
@@ -1,4 +1,6 @@
 from nicegui import ui
+from nicegui.elements.sortable.sortable import Sortable
+from nicegui.elements.mixins.sortable_element import SortableElement
 
 from . import doc
 
@@ -7,6 +9,10 @@ from . import doc
     Container elements like `ui.column`, `ui.row`, and `ui.card` can be made sortable via drag-and-drop
     using the `make_sortable()` method.
     It returns a `Sortable` controller for enabling, disabling, or changing the sort behavior.
+
+    Note: Only direct children of the container are sortable; nested containers can be made sortable independently.
+
+    *Added in version 3.11.0*
 ''')
 def main_demo() -> None:
     with ui.card() as card:
@@ -62,3 +68,7 @@ def enable_disable() -> None:
     sortable = card.make_sortable()
     ui.switch('Enable', value=True,
               on_change=lambda e: sortable.enable() if e.value else sortable.disable())
+
+
+doc.reference(SortableElement, title='Reference for SortableElement')
+doc.reference(Sortable, title='Reference for Sortable controller')


### PR DESCRIPTION
### Motivation

The `make_sortable()` API added in 3.11.0 had a few rough edges in its documentation:

- No "Added in version ..." hint, unlike most other recently added APIs.
- No mention of the direct-children-only scoping, which is easy to overlook (the [Cross-Container demo](https://nicegui.io/documentation/sortable) silently works around it by wrapping items in an inner `ui.column`, but never spells the rule out).
- No API reference tables on the documentation page, so the `Sortable` controller's properties (`animation`, `handle`, `group`, `ghost_class`) and methods (`enable`, `disable`, `on_end`) were undiscoverable from the docs.

### Implementation

- Add a "Note: Only direct children of the container are sortable; nested containers can be made sortable independently." line to the intro demo of the Sortable documentation page.
- Add an `*Added in version 3.11.0*` hint to both the website demo intro and the `make_sortable()` docstring (so it surfaces in IDE tooltips too).
- Add `doc.reference(SortableElement, ...)` and `doc.reference(Sortable, title='Reference for Sortable controller')` at the bottom of the documentation page.

### Result

<img width="1138" height="467" alt="Screenshot 2026-04-29 at 17 30 30" src="https://github.com/user-attachments/assets/2b1035ec-b4a5-4b88-9639-525361ff5ad7" />

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been updated.
- [x] No breaking changes to the public API.