### PR TITLE
Fix silent page reload on every reconnect after first ack

### DIFF
--- a/nicegui/outbox.py
+++ b/nicegui/outbox.py
@@ -170,7 +170,7 @@ class Outbox:
                 return
 
         # target message ID not found, reload the page
-        self.client.run_javascript('window.location.reload()')
+        self.client.run_javascript('console.log("reloading because outbox rewind failed"); window.location.reload()')
 
     def prune_history(self, next_message_id: MessageId) -> None:
         """Prune the message history up to the given message ID."""

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -418,6 +418,9 @@ function createApp(elements, options) {
             ? ["polling", ...options.transports]
             : options.transports,
       });
+      window.socket.io.on("reconnect_attempt", () => {
+        options.query.next_message_id = window.nextMessageId;
+      });
       window.did_handshake = false;
       const messageHandlers = {
         connect: () => {

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -419,6 +419,7 @@ function createApp(elements, options) {
             : options.transports,
       });
       window.socket.io.on("reconnect_attempt", () => {
+        // keep the otherwise-frozen reconnect query in sync to avoid triggering a reload (see #6019)
         options.query.next_message_id = window.nextMessageId;
       });
       window.did_handshake = false;

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -6,7 +6,6 @@ import httpx
 import pytest
 from fastapi import HTTPException
 from fastapi.responses import PlainTextResponse
-from selenium.webdriver.common.by import By
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from nicegui import app, background_tasks, ui
@@ -314,57 +313,6 @@ def test_warning_about_to_late_responses(screen: Screen):
     screen.open('/')
     screen.should_contain('NiceGUI page')
     screen.assert_py_logger('ERROR', re.compile('it was returned after the HTML had been delivered to the client'))
-
-
-def test_reconnecting_without_page_reload(screen: Screen):
-    @ui.page('/', reconnect_timeout=3.0)
-    def page():
-        ui.input('Input').props('autofocus')
-        ui.button('drop connection', on_click=lambda: ui.run_javascript('socket.io.engine.close()'))
-
-    screen.open('/')
-    screen.type('hello')
-    screen.click('drop connection')
-    screen.wait(2.0)
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
-    assert element.get_attribute('value') == 'hello', 'input should be preserved after reconnect (i.e. no page reload)'
-
-
-def test_reconnecting_after_ack_does_not_reload(screen: Screen):
-    @ui.page('/', reconnect_timeout=3.0)
-    def page():
-        ui.input('Input').props('autofocus')
-        label = ui.label('0')
-        ui.timer(0.2, lambda: label.set_text(str(int(label.text) + 1)))
-
-    screen.open('/')
-    screen.type('hello')
-    initial_document_id = screen.selenium.execute_script('return window.documentId;')
-
-    screen.wait(4.0)  # > 3s for the periodic ack to fire and prune message 0 server-side
-    assert screen.selenium.execute_script('return Number(window.nextMessageId);') > 0
-
-    screen.selenium.execute_script('window.socket.io.engine.transport.onClose("transport close");')  # drop connection
-    screen.wait(4.0)
-    assert screen.selenium.execute_script('return window.socket.connected;')
-    assert screen.selenium.execute_script('return window.documentId;') == initial_document_id
-    assert screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]').get_attribute('value') == 'hello'
-
-
-def test_reconnect_attempt_refreshes_query_next_message_id(screen: Screen):
-    @ui.page('/', reconnect_timeout=3.0)
-    def page():
-        label = ui.label('0')
-        ui.timer(0.2, lambda: label.set_text(str(int(label.text) + 1)))
-
-    screen.open('/')
-    screen.wait(1.5)
-    assert screen.selenium.execute_script('return Number(window.socket.io.opts.query.next_message_id);') == 0
-    assert screen.selenium.execute_script('return Number(window.nextMessageId);') > 0
-
-    screen.selenium.execute_script('window.socket.io.engine.transport.onClose("transport close");')
-    screen.wait(2.0)
-    assert screen.selenium.execute_script('return Number(window.socket.io.opts.query.next_message_id);') > 0
 
 
 def test_ip(screen: Screen):

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -348,7 +348,7 @@ def test_reconnecting_after_ack_does_not_reload(screen: Screen):
 
     screen.open('/')
     screen.type('hello')
-    screen.wait(4.0)
+    screen.wait(5.0)  # > 3s for the periodic ack to fire and prune message 0 server-side
     initial_document_id = screen.selenium.execute_script('return window.documentId;')
     assert screen.selenium.execute_script('return Number(window.nextMessageId);') > 0
     screen.click('drop connection')

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -333,27 +333,22 @@ def test_reconnecting_without_page_reload(screen: Screen):
 def test_reconnecting_after_ack_does_not_reload(screen: Screen):
     @ui.page('/', reconnect_timeout=3.0)
     def page():
+        ui.input('Input').props('autofocus')
         label = ui.label('0')
         ui.timer(0.2, lambda: label.set_text(str(int(label.text) + 1)))
 
-        ui.input('Input').props('autofocus')
-        ui.button('drop connection', on_click=lambda: ui.run_javascript(
-            'socket.io.engine.transport.onClose("transport close")'
-        ))
-
     screen.open('/')
     screen.type('hello')
-    screen.wait(5.0)  # > 3s for the periodic ack to fire and prune message 0 server-side
     initial_document_id = screen.selenium.execute_script('return window.documentId;')
+
+    screen.wait(4.0)  # > 3s for the periodic ack to fire and prune message 0 server-side
     assert screen.selenium.execute_script('return Number(window.nextMessageId);') > 0
-    screen.click('drop connection')
+
+    screen.selenium.execute_script('window.socket.io.engine.transport.onClose("transport close");')  # drop connection
     screen.wait(4.0)
     assert screen.selenium.execute_script('return window.socket.connected;')
-    document_id_after = screen.selenium.execute_script('return window.documentId;')
-    assert document_id_after == initial_document_id, \
-        'window.documentId must persist (no hard reload) after auto-reconnect that follows an ack'
-    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
-    assert element.get_attribute('value') == 'hello', 'input value should be preserved across the reconnect'
+    assert screen.selenium.execute_script('return window.documentId;') == initial_document_id
+    assert screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]').get_attribute('value') == 'hello'
 
 
 def test_reconnect_attempt_refreshes_query_next_message_id(screen: Screen):
@@ -364,16 +359,12 @@ def test_reconnect_attempt_refreshes_query_next_message_id(screen: Screen):
 
     screen.open('/')
     screen.wait(1.5)
-
-    initial_query = screen.selenium.execute_script('return Number(window.socket.io.opts.query.next_message_id);')
-    assert initial_query == 0
+    assert screen.selenium.execute_script('return Number(window.socket.io.opts.query.next_message_id);') == 0
     assert screen.selenium.execute_script('return Number(window.nextMessageId);') > 0
 
     screen.selenium.execute_script('window.socket.io.engine.transport.onClose("transport close");')
     screen.wait(2.0)
-
-    updated_query = screen.selenium.execute_script('return Number(window.socket.io.opts.query.next_message_id);')
-    assert updated_query > 0, f'options.query.next_message_id should be refreshed on reconnect (got {updated_query})'
+    assert screen.selenium.execute_script('return Number(window.socket.io.opts.query.next_message_id);') > 0
 
 
 def test_ip(screen: Screen):

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -333,13 +333,8 @@ def test_reconnecting_without_page_reload(screen: Screen):
 def test_reconnecting_after_ack_does_not_reload(screen: Screen):
     @ui.page('/', reconnect_timeout=3.0)
     def page():
-        state = {'n': 0}
         label = ui.label('0')
-
-        def tick():
-            state['n'] += 1
-            label.set_text(str(state['n']))
-        ui.timer(0.2, tick)
+        ui.timer(0.2, lambda: label.set_text(str(int(label.text) + 1)))
 
         ui.input('Input').props('autofocus')
         ui.button('drop connection', on_click=lambda: ui.run_javascript(
@@ -364,13 +359,8 @@ def test_reconnecting_after_ack_does_not_reload(screen: Screen):
 def test_reconnect_attempt_refreshes_query_next_message_id(screen: Screen):
     @ui.page('/', reconnect_timeout=3.0)
     def page():
-        state = {'n': 0}
         label = ui.label('0')
-
-        def tick():
-            state['n'] += 1
-            label.set_text(str(state['n']))
-        ui.timer(0.2, tick)
+        ui.timer(0.2, lambda: label.set_text(str(int(label.text) + 1)))
 
     screen.open('/')
     screen.wait(1.5)
@@ -383,8 +373,7 @@ def test_reconnect_attempt_refreshes_query_next_message_id(screen: Screen):
     screen.wait(2.0)
 
     updated_query = screen.selenium.execute_script('return Number(window.socket.io.opts.query.next_message_id);')
-    assert updated_query > 0, \
-        f'options.query.next_message_id should be refreshed on reconnect (got {updated_query})'
+    assert updated_query > 0, f'options.query.next_message_id should be refreshed on reconnect (got {updated_query})'
 
 
 def test_ip(screen: Screen):

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -330,6 +330,63 @@ def test_reconnecting_without_page_reload(screen: Screen):
     assert element.get_attribute('value') == 'hello', 'input should be preserved after reconnect (i.e. no page reload)'
 
 
+def test_reconnecting_after_ack_does_not_reload(screen: Screen):
+    @ui.page('/', reconnect_timeout=3.0)
+    def page():
+        state = {'n': 0}
+        label = ui.label('0')
+
+        def tick():
+            state['n'] += 1
+            label.set_text(str(state['n']))
+        ui.timer(0.2, tick)
+
+        ui.input('Input').props('autofocus')
+        ui.button('drop connection', on_click=lambda: ui.run_javascript(
+            'socket.io.engine.transport.onClose("transport close")'
+        ))
+
+    screen.open('/')
+    screen.type('hello')
+    screen.wait(4.0)
+    initial_document_id = screen.selenium.execute_script('return window.documentId;')
+    assert screen.selenium.execute_script('return Number(window.nextMessageId);') > 0
+    screen.click('drop connection')
+    screen.wait(4.0)
+    assert screen.selenium.execute_script('return window.socket.connected;')
+    document_id_after = screen.selenium.execute_script('return window.documentId;')
+    assert document_id_after == initial_document_id, \
+        'window.documentId must persist (no hard reload) after auto-reconnect that follows an ack'
+    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
+    assert element.get_attribute('value') == 'hello', 'input value should be preserved across the reconnect'
+
+
+def test_reconnect_attempt_refreshes_query_next_message_id(screen: Screen):
+    @ui.page('/', reconnect_timeout=3.0)
+    def page():
+        state = {'n': 0}
+        label = ui.label('0')
+
+        def tick():
+            state['n'] += 1
+            label.set_text(str(state['n']))
+        ui.timer(0.2, tick)
+
+    screen.open('/')
+    screen.wait(1.5)
+
+    initial_query = screen.selenium.execute_script('return Number(window.socket.io.opts.query.next_message_id);')
+    assert initial_query == 0
+    assert screen.selenium.execute_script('return Number(window.nextMessageId);') > 0
+
+    screen.selenium.execute_script('window.socket.io.engine.transport.onClose("transport close");')
+    screen.wait(2.0)
+
+    updated_query = screen.selenium.execute_script('return Number(window.socket.io.opts.query.next_message_id);')
+    assert updated_query > 0, \
+        f'options.query.next_message_id should be refreshed on reconnect (got {updated_query})'
+
+
 def test_ip(screen: Screen):
     @ui.page('/')
     def page():

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -1,0 +1,55 @@
+from selenium.webdriver.common.by import By
+
+from nicegui import ui
+from nicegui.testing import Screen
+
+
+def test_reconnecting_without_page_reload(screen: Screen):
+    @ui.page('/', reconnect_timeout=3.0)
+    def page():
+        ui.input('Input').props('autofocus')
+        ui.button('drop connection', on_click=lambda: ui.run_javascript('socket.io.engine.close()'))
+
+    screen.open('/')
+    screen.type('hello')
+    screen.click('drop connection')
+    screen.wait(2.0)
+    element = screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]')
+    assert element.get_attribute('value') == 'hello', 'input should be preserved after reconnect (i.e. no page reload)'
+
+
+def test_reconnecting_after_ack_does_not_reload(screen: Screen):
+    @ui.page('/', reconnect_timeout=3.0)
+    def page():
+        ui.input('Input').props('autofocus')
+        label = ui.label('0')
+        ui.timer(0.2, lambda: label.set_text(str(int(label.text) + 1)))
+
+    screen.open('/')
+    screen.type('hello')
+    initial_document_id = screen.selenium.execute_script('return window.documentId;')
+
+    screen.wait(4.0)  # > 3s for the periodic ack to fire and prune message 0 server-side
+    assert screen.selenium.execute_script('return Number(window.nextMessageId);') > 0
+
+    screen.selenium.execute_script('window.socket.io.engine.transport.onClose("transport close");')  # drop connection
+    screen.wait(4.0)
+    assert screen.selenium.execute_script('return window.socket.connected;')
+    assert screen.selenium.execute_script('return window.documentId;') == initial_document_id
+    assert screen.selenium.find_element(By.XPATH, '//*[@aria-label="Input"]').get_attribute('value') == 'hello'
+
+
+def test_reconnect_attempt_refreshes_query_next_message_id(screen: Screen):
+    @ui.page('/', reconnect_timeout=3.0)
+    def page():
+        label = ui.label('0')
+        ui.timer(0.2, lambda: label.set_text(str(int(label.text) + 1)))
+
+    screen.open('/')
+    screen.wait(1.5)
+    assert screen.selenium.execute_script('return Number(window.socket.io.opts.query.next_message_id);') == 0
+    assert screen.selenium.execute_script('return Number(window.nextMessageId);') > 0
+
+    screen.selenium.execute_script('window.socket.io.engine.transport.onClose("transport close");')
+    screen.wait(2.0)
+    assert screen.selenium.execute_script('return Number(window.socket.io.opts.query.next_message_id);') > 0


### PR DESCRIPTION
### Motivation

Every WebSocket auto-reconnect after the first periodic ack triggers a silent `window.location.reload()`, dropping the user's scroll position, open dialogs, in-flight form input, and other client-side state.
This affects any deployment behind a proxy with a finite WebSocket tunnel timeout (nginx `proxy_read_timeout`, AWS ALB `idle_timeout`, Cloudflare's WS timeout, Scaleway LB `timeout_tunnel`, etc.) — i.e. nearly every production NiceGUI app.

The root cause is a three-way interaction:

1. The socket.io `query` object is frozen at app mount in `nicegui.js`: `next_message_id=0` is baked into every reconnect URL and handshake payload for the lifetime of the page.
2. The browser sends an `ack` every 3s with its current next-expected ID; the server's ack handler prunes everything below that from `Outbox.message_history`.
3. After the first ack, message ID `0` is no longer in history.
   On the next reconnect the server receives `next_message_id=0` from the (frozen) query, calls `Outbox.try_rewind(0)`, fails to find ID `0`, and falls through to `self.client.run_javascript('window.location.reload()')`.

### Implementation

Update `options.query.next_message_id` from `window.nextMessageId` on each socket.io `reconnect_attempt` so the (frozen) initial value of `0` is not sent in the reconnect URL and handshake payload. Without this, once the periodic ack pruned message `0` from `Outbox.message_history`, every auto-reconnect would fall through `Outbox.try_rewind` to `window.location.reload()` — losing scroll position, open dialogs, and in-flight form state on every transient WS drop behind any proxy with a finite tunnel timeout.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.