### PR TITLE
Fix worker traceback on Ctrl-C in run.cpu_bound

### DIFF
--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import signal
 import traceback
 from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
@@ -24,7 +25,7 @@ def setup() -> None:
     """Setup the process pool. (For internal use only.)"""
     global process_pool  # pylint: disable=global-statement # noqa: PLW0603
     try:
-        process_pool = ProcessPoolExecutor()
+        process_pool = ProcessPoolExecutor(initializer=_ignore_sigint)
     except NotImplementedError:
         logging.warning('Failed to initialize ProcessPoolExecutor')
 
@@ -94,7 +95,7 @@ async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs)
         try:
             await _run(process_pool, safe_callback, lambda: None)
         except BrokenProcessPool:
-            process_pool = ProcessPoolExecutor()
+            process_pool = ProcessPoolExecutor(initializer=_ignore_sigint)
         finally:
             raise e
 
@@ -128,6 +129,11 @@ def tear_down() -> None:
         _kill_processes()
         process_pool.shutdown(wait=True, cancel_futures=True)
     thread_pool.shutdown(wait=False, cancel_futures=True)
+
+
+def _ignore_sigint() -> None:
+    """Ignore SIGINT in worker processes so only the parent handles Ctrl-C (see #6025)."""
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
 def _kill_processes() -> None:


### PR DESCRIPTION
### Motivation

Closes #6025.

After calling `run.cpu_bound`, pressing Ctrl-C prints an alarming traceback even though shutdown actually succeeds:

```
Process SpawnProcess-1:1:
Traceback (most recent call last):
  ...
  File ".../concurrent/futures/process.py", line 242, in _process_worker
    call_item = call_queue.get(block=True)
  ...
KeyboardInterrupt
```

Root cause: SIGINT is delivered to the whole foreground process group. The parent (uvicorn) handles it gracefully and `_shutdown()` calls `run.tear_down()` → `_kill_processes()` to terminate workers. But the workers themselves had no custom SIGINT handler, so the default raised `KeyboardInterrupt` mid-`call_queue.get()` and dumped a traceback before the parent could kill them.

### Implementation

Pass `initializer=_ignore_sigint` to `ProcessPoolExecutor` (both in `setup()` and in the `BrokenProcessPool` recovery path). The initializer installs `signal.SIG_IGN` for `SIGINT` so workers stay quiet — the parent's existing `tear_down()` is what actually stops them.

The `multiprocessing.Manager()` traceback the reporter also mentions in the progress example is a stdlib quirk outside NiceGUI's surface; it's not addressed here.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.