### PR TITLE
Restructure CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ There are several ways to help out, depending on what you want to do:
 - **Report a bug or request a feature** → see [Reporting issues](#reporting-issues)
 - **Report a security vulnerability** → see [Reporting security vulnerabilities](#reporting-security-vulnerabilities)
 - **Contribute code or documentation** → see [Contributing code and documentation](#contributing-code-and-documentation)
-- **Create video content** → see [Video and tutorial content](#video-and-tutorial-content)
+- **Create video or tutorial content** → see [Video and tutorial content](#video-and-tutorial-content)
 
 For non-trivial work, please discuss your approach with maintainers before implementing.
 If you're unsure, present options and trade-offs first.
@@ -49,8 +49,8 @@ For larger changes, work step-by-step and confirm direction with maintainers alo
 > If you've found a security vulnerability, do **not** open a public issue.
 > See [Reporting security vulnerabilities](#reporting-security-vulnerabilities) instead.
 
-If you encounter a bug or other issue with NiceGUI, the best way to report it is by opening a new issue on our [GitHub repository](https://github.com/zauberzeug/nicegui).
-When creating the issue, please provide a clear and concise description of the problem, including any relevant error messages and code snippets.
+If you encounter a bug or other issue with NiceGUI, please [open a new issue](https://github.com/zauberzeug/nicegui/issues/new/choose) using one of the templates.
+Provide a clear and concise description of the problem, including any relevant error messages and code snippets.
 If possible, include steps to reproduce the issue.
 
 ## Reporting security vulnerabilities
@@ -243,7 +243,7 @@ Run these from the project root:
 > 3. Your `main` branch should stay in sync with the upstream repository.
 
 > [!NOTE]
-> **AI co-authorship:** if you used an AI coding agent to help write your PR, please check that the commit message includes a `Co-authored-by:` trailer.
+> **AI co-authorship:** if you used an AI assistant to help write your PR, please check that the commit message includes a `Co-authored-by:` trailer.
 > Some agents add it automatically; others don't, and some silently **remove** existing ones when amending or rebasing.
 > If missing, add the appropriate line (PRs are welcome to add lines for other agents):
 >

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,10 @@
 We're thrilled that you're interested in contributing to NiceGUI!
 Here are some guidelines that will help you get started.
 
-## About This Project
+We follow a [Code of Conduct](https://github.com/zauberzeug/nicegui/blob/main/CODE_OF_CONDUCT.md).
+By participating, you agree to abide by its terms.
+
+## About NiceGUI
 
 NiceGUI is a Python library for building web-based user interfaces with minimal code.
 It's designed to be simple, powerful, and fun to use.
@@ -27,48 +30,52 @@ It's designed to be simple, powerful, and fun to use.
 - **Tailwind CSS 4** - Styling
 - **pytest** - Testing framework
 
+## Ways to contribute
+
+There are several ways to help out, depending on what you want to do:
+
+- **Report a bug or request a feature** → see [Reporting issues](#reporting-issues)
+- **Report a security vulnerability** → see [Reporting security vulnerabilities](#reporting-security-vulnerabilities)
+- **Contribute code or documentation** → see [Contributing code and documentation](#contributing-code-and-documentation)
+- **Create video content** → see [Video and tutorial content](#video-and-tutorial-content)
+
+For non-trivial work, please discuss your approach with maintainers before implementing.
+If you're unsure, present options and trade-offs first.
+For larger changes, work step-by-step and confirm direction with maintainers along the way.
+
 ## Reporting issues
+
+> [!IMPORTANT]
+> If you've found a security vulnerability, do **not** open a public issue.
+> See [Reporting security vulnerabilities](#reporting-security-vulnerabilities) instead.
 
 If you encounter a bug or other issue with NiceGUI, the best way to report it is by opening a new issue on our [GitHub repository](https://github.com/zauberzeug/nicegui).
 When creating the issue, please provide a clear and concise description of the problem, including any relevant error messages and code snippets.
 If possible, include steps to reproduce the issue.
 
-## Code of Conduct
+## Reporting security vulnerabilities
 
-We follow a [Code of Conduct](https://github.com/zauberzeug/nicegui/blob/main/CODE_OF_CONDUCT.md) to ensure that everyone who participates in the NiceGUI community feels welcome and safe.
-By participating, you agree to abide by its terms.
+Security issues are handled through GitHub's private vulnerability reporting, not public issues, so we can discuss and patch in a secure workspace before disclosure.
 
-## Contributing code
+See [SECURITY.md](SECURITY.md) for the full policy and the supported reporting channels.
 
-We are excited that you want to contribute code to NiceGUI.
-We're always looking for bug fixes, performance improvements, and new features.
+## Contributing code and documentation
 
-### AI Assistant Integration
+We are excited that you want to contribute to NiceGUI.
+We're always looking for bug fixes, performance improvements, new features, and documentation improvements.
 
-This project is designed to work well with AI assistants like Cursor, GitHub Copilot, and others.
-See [AGENTS.md](AGENTS.md) for guidelines specifically for AI assistants that complement this contributing guide.
+### Set up your environment
 
-We provide review instructions for PR reviews in [.github/copilot-instructions.md](.github/copilot-instructions.md).
-You should review your changes with an AI assistant before committing/pushing:
+First, fork the repository on GitHub and clone your fork locally:
 
-In Cursor or VS Code with GitHub Copilot Chat:
+```bash
+git clone https://github.com/YOUR_USERNAME/nicegui.git
+cd nicegui
+```
 
-Select Agent Mode with claude-4.5-sonnet and write: `Review my current branch according to @.github/copilot-instructions.md`
+Then pick a development setup that fits your workflow:
 
-> [!TIP]
-> In Cursor, you can use these custom commands for easy access:
->
-> - `/review-uncommitted` - Review your local uncommitted changes
-> - `/review-changes` - Review your current branch vs main
-
-Ensure to address any valid feedback.
-That will make your life and that of the maintainers much easier.
-
-## Setup
-
-### Dev Container
-
-The simplest way to setup a fully functioning development environment is to start our Dev Container in VS Code:
+**Option 1: Dev Container** — the simplest way. Start our Dev Container in VS Code:
 
 1. Ensure you have VS Code, Docker and the Dev Containers extension installed.
 2. Open the project root directory in VS Code.
@@ -76,35 +83,25 @@ The simplest way to setup a fully functioning development environment is to star
 4. Wait until the image has been built. (On first launch, watch the terminal for a GitHub authentication prompt.)
 5. Happy coding.
 
-### Locally
+**Option 2: Locally** — you need Python 3.10+ and [uv](https://docs.astral.sh/uv/) installed.
 
-To set up a local development environment for NiceGUI, you'll need to have Python 3.10+ and [uv](https://docs.astral.sh/uv/) installed.
-
-You can install uv using:
+Install uv:
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-Then use the following command to install NiceGUI in editable mode with all dependencies:
+Then install NiceGUI in editable mode with all dependencies:
 
 ```bash
 uv sync
 ```
 
-This will install the `nicegui` package and all its dependencies, and link it to your local development environment so that changes you make to the code will be immediately reflected.
+This installs the `nicegui` package and all its dependencies and links it to your local development environment so that changes you make to the code will be immediately reflected.
 Thereby enabling you to use your local version of NiceGUI in other projects.
 To run the tests you need some additional setup which is described in [tests/README.md](https://github.com/zauberzeug/nicegui/blob/main/tests/README.md).
 
-There is no special Python version required for development.
-At Zauberzeug we mainly use 3.12.
-This means we sometimes miss some incompatibilities with older versions.
-But these will hopefully be uncovered by the GitHub Actions (see below).
-Also we use the 3.10 Docker container described below to verify compatibility in cases of uncertainty.
-
-### Plain Docker
-
-You can also use Docker for development by starting the development container using the command:
+**Option 3: Plain Docker** — start the development container:
 
 ```bash
 ./docker.sh up app
@@ -116,37 +113,60 @@ The configuration is written in the `docker-compose.yml` file and automatically 
 Every code change will result in reloading the content.
 We use Python 3.10 as a base to ensure compatibility (see `development.dockerfile`).
 
-To view the log output, use the command
+To view the log output, use the command:
 
 ```bash
 ./docker.sh log
 ```
 
-## Coding Style Guide
+> [!TIP]
+> Open `nicegui.code-workspace` in VSCode with the recommended extensions to format on save while you work.
 
-This section covers our formatting conventions, style principles, workflow practices, and automated linting enforcement.
+### Coding conventions
 
-### Formatting
+The conventions below cover both general Python style and NiceGUI-specific patterns.
 
-We follow **PEP 8** with a few deviations (see Style Principles below).
+- **Principles**
+  - Always prefer simple solutions
+  - Avoid duplication — check the codebase for similar functionality before adding new patterns
+  - Remove obsolete code rather than working around it
+  - When fixing bugs, exhaust existing patterns before introducing new ones; if you must introduce a new one, remove the old approach so logic doesn't duplicate
+- **Style**
+  - Follow **PEP 8** with a 120 character line length
+  - Use single quotes in Python, double quotes in JavaScript
+  - Use f-strings wherever possible (mark performance-critical exceptions with `# NOTE:`)
+  - Use `# NOTE:` prefix for important implementation details and non-obvious code
+  - No mutable defaults (`[]`, `{}`) without `# noqa: B006` and a justification — prefer `None`
+  - Put high-level/interesting code at the top of files; helper functions go below their usage
+  - Each sentence in documentation goes on a new line ([why](https://nick.groenen.me/notes/one-sentence-per-line/))
+- **Async and background tasks**
+  - No blocking I/O in async code — sync I/O blocks the event loop and freezes every connected client
+  - Use `background_tasks.create()`, never `asyncio.create_task()` — the garbage collector might drop unfinished tasks
+  - Use `helpers.should_await()` to check if a result should be awaited
+  - Use `helpers.expects_arguments()` to check if a handler expects arguments
+  - Use `core.app.handle_exception()` for exceptions in background tasks
+- **Error handling**
+  - Use `with contextlib.suppress(...)` instead of try/except/pass for cleaner exception handling
+  - Catch `ImportError` for optional dependencies, not `ModuleNotFoundError` — covers both missing and broken installations
+  - Use assertions for internal invariants (e.g., `assert self.current_scene is not None`)
+  - Raise descriptive exceptions (`ValueError`, `RuntimeError`) with helpful messages
+- **Elements** (core library)
+  - **Mixins**: Elements use mixin composition; inheritance order matters for Python's Method Resolution Order (MRO)
+  - **Props vs. attributes**: Use `self._props` for data that syncs to Vue/frontend; use instance attributes for Python-only state
+  - **Context managers**: Elements can be used as context managers (`with element:`) for slot/child management
+  - **Component registration**: Use class parameters for components: `component='file.js'`, `esm={'package': 'dist'}`, `default_classes='css-class'`
+- **Memory** (core library)
+  - **Weakref pattern**: Use `self._element = weakref.ref(element)` to avoid circular references (which require more costly garbage collection).
+    When dereferencing, always check for `None`: `element = self._element(); if element is not None: element.update()`
+  - **WeakValueDictionary**: Use for caches that shouldn't prevent garbage collection by means of CPython's reference counting
+- **Binding** (core library)
+  - **BindableProperty**: Use with `cast(Self, sender)` in on-change handlers for type safety
+  - **Triple underscore storage**: BindableProperty stores values in `___property_name` attributes
+  - **Batch updates**: Use `suspend_updates()` context manager when changing properties in `update()` to avoid infinite cycles
+- **Method returns**: Methods that support chaining (fluent interface) return `Self` from `typing_extensions`, enabling the builder pattern (`element.method1().method2().method3()`)
+- **Dataclasses**: Prefer `@dataclass(kw_only=True, slots=True)`
+- **Tests**: Include tests for new features and bug fixes. Prefer the `User` fixture (fast, runs in the same async context as NiceGUI, no browser); use the `Screen` fixture only when testing browser/JavaScript interactions.
 
-We use [autopep8](https://github.com/hhatto/autopep8) with a 120 character line length to format our code.
-Before submitting a pull request, please run
-
-```bash
-uv run autopep8 --max-line-length=120 --in-place --recursive .
-```
-
-on your code to ensure that it meets our formatting guidelines.
-Alternatively you can use VSCode, open the nicegui.code-workspace file and install the recommended extensions.
-Then the formatting rules are applied whenever you save a file.
-
-In our point of view, the Black formatter is sometimes a bit too strict.
-There are cases where one or the other arrangement of, e.g., function arguments is more readable than the other.
-Then we like the flexibility to either put all arguments on separate lines or only put the lengthy event handler
-on a second line and leave the other arguments as they are.
-
-**Fluent Interface Formatting:**
 When chaining methods (builder pattern), use backslash line continuation:
 
 ```python
@@ -155,241 +175,49 @@ ui.button('Click me') \
     .on('click', lambda: ui.notify('Hello'))
 ```
 
-### Style Principles
+### Before submitting a pull request
 
-- Always prefer simple solutions
-- Avoid having files over 200-300 lines of code. Refactor at that point
-- Use single quotes for strings in Python, double quotes in JavaScript
-- Use `# NOTE:` prefix for important implementation details and non-obvious code
-- Use f-strings wherever possible for better readability (except in performance-critical sections which should be marked with `# NOTE:` comments)
-- Follow autopep8 formatting with 120 character line length
-- Never use mutable defaults (`[]`, `{}`) without `# noqa: B006` and justification; prefer `None` as default
-- Put high-level/interesting code at the top of files; helper functions should be below their usage
-- Each sentence in documentation should be on a new line
-- Ensure proper use of async (no blocking operations)
-- **Never use `asyncio.create_task()`**, because the garbage collector might remove unfinished tasks.
-  Always use `background_tasks.create()` which takes better care of task lifecycle management.
-- **Use `with contextlib.suppress(...)`** from the standard library instead of try-except-pass blocks
-  for cleaner, more declarative exception handling.
-- **Catch `ImportError` for optional dependencies** instead of `ModuleNotFoundError`
-  to handle both missing and broken installations.
+Run these from the project root:
 
-### Workflow Guidelines
+1. **Format and lint** with pre-commit:
 
-- Always simplify the implementation as much as possible:
-  - Avoid duplication of code whenever possible, which means checking for other areas of the codebase that might already have similar code and functionality
-  - Remove obsolete code
-  - Ensure the code is not too complicated
-  - Strive to have minimal maintenance burden and self explanatory code without the need of additional comments
-- Be careful to only make changes that are requested or are well understood and related to the change being requested
-- When fixing an issue or bug, do not introduce a new pattern or technology without first exhausting all options for the existing implementation.
-  And if you finally do this, make sure to remove the old implementation afterwards so we don't have duplicate logic
-- Keep the codebase very clean and organized
-- Create tests for new features and bugfixes: use `Screen` fixture only when browser is involved (JavaScript etc.),
-  otherwise the `User` fixture should be preferred as it is much faster and simpler to use (test runs in same async context as NiceGUI)
-- Run tests before submitting any changes
-- Format code using autopep8 before submitting changes
-- Use pre-commit hooks to ensure coding style compliance
-- When adding new features, include corresponding tests
-- For documentation, ensure each sentence is on a new line
-- Discuss before implementing and if an approach is unclear, present options and trade-offs
-- Approach large changes step-by-step and get confirmation before drastic refactorings
-- Think from first principles: Always question your assumptions to find the true nature of problems
+   ```bash
+   uv run pre-commit run --all-files
+   ```
 
-### Linting
+   Hooks are installed by `uv sync` (run `uv run pre-commit install` once if they aren't).
+   They run autopep8 (120 char line length), `ruff check . --fix`, trailing-whitespace removal, end-of-file fixing, and single-quote enforcement.
 
-We use [pre-commit](https://github.com/pre-commit/pre-commit) to make sure the coding style is enforced.
-If you used `uv sync` to install the dependencies, pre-commit should already have been installed then.
-Now run this command to install the git commit hooks used in this project:
+   > [!TIP]
+   > If pre-commit fails with `RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.10'`, install Python 3.10 and make sure it's available in your `PATH`.
 
-```bash
-uv run pre-commit install
-```
+2. **Run tests** with pytest:
 
-After that you can make sure your code satisfies the coding style by running the following command:
+   ```bash
+   uv run pytest
+   ```
 
-```bash
-uv run pre-commit run --all-files
-```
+   Tests require python-selenium with ChromeDriver — see [tests/README.md](https://github.com/zauberzeug/nicegui/blob/main/tests/README.md) for setup.
 
-> [!TIP]
-> The command may fail with
->
-> > RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.10'
->
-> You will need to install Python 3.10 and make sure it is available in your `PATH`.
+3. **Add documentation** for new features and behavior changes:
 
-These checks will also run automatically before every commit:
+   - **Element demos** live in `website/documentation/content/<element>_documentation.py`.
+     Use `@doc.demo(ui.some_new_element)` for the main description (the docstring is shown as description text, in restructured-text) and `@doc.demo('Title', 'Description')` for additional interactive demos.
+     Reference the page from `website/documentation/content/section_*.py` via `@doc.intro(...)`.
+     Update `website/documentation/content/overview.py` with a link to the new element.
+   - **Standalone examples** live in `examples/`.
+     Keep each focused on one concept and as minimal as possible.
+     To properly render on the website, they need to contain a README.md with
+     at least a title (level 1 heading),
+     a one-sentence description and
+     a screenshot of the running example (960x540 WEBP).
 
-- Run autopep8 with 120 character line length.
-- Run `uv run ruff check . --fix` to check the code and sort imports.
-- Remove trailing whitespace.
-- Fix end of files.
-- Enforce single quotes.
+### Submitting a pull request
 
-> [!NOTE]
->
-> **Regarding single or double quotes:** > [PEP 8](https://peps.python.org/pep-0008/) doesn't give any recommendation, so we simply chose single quotes and sticked with it.
-> On qwerty keyboards it's a bit easier to type, is visually less cluttered, and it works well for strings containing double quotes from the English language.
-
-> [!NOTE]
->
-> **We use f-strings** where ever possible because they are generally more readable - once you get used to them.
-> There are only a few places in the code base where performance really matters and f-strings might not be the best choice.
-> These places should be marked with a `# NOTE: ...` comment when diverging from f-string usage.
-
-## NiceGUI-Specific Patterns
-
-Beyond standard Python conventions, NiceGUI has developed specific architectural patterns to handle its unique requirements:
-real-time UI synchronization between Python and Vue.js, efficient memory management with many short-lived objects, and a fluent API design.
-
-When contributing to the core library (`nicegui/` directory), you'll encounter these patterns.
-They may seem unusual at first, but they solve specific problems related to NiceGUI's architecture.
-Understanding these patterns will help you write code that fits naturally into the existing codebase.
-
-### Element Architecture
-
-- **Mixins**: Elements use mixin composition; inheritance order matters for Python's Method Resolution Order (MRO)
-- **Props vs. Attributes**: Use `self._props` for data that syncs to Vue/frontend; use instance attributes for Python-only state
-- **Context Managers**: Elements can be used as context managers (`with element:`) for slot/child management
-- **Component Registration**: Use class parameters for components: `component='file.js'`, `esm={'package': 'dist'}`, `default_classes='css-class'`
-
-### Memory Management
-
-- **Weakref Pattern**: Use `self._element = weakref.ref(element)` to avoid circular references
-  (which require more costly garbage collection).
-  When dereferencing, always check for `None`: `element = self._element(); if element is not None: element.update()`
-- **WeakValueDictionary**: Use for caches that shouldn't prevent garbage collection by means of the reference counting mechanism of CPython
-
-### Binding System
-
-- **BindableProperty**: Use with `cast(Self, sender)` in on-change handlers for type safety
-- **Triple Underscore Storage**: BindableProperty stores values in `___property_name` attributes
-- **Batch Updates**: Use `suspend_updates()` context manager when changing properties in `update()` method to avoid infinite cycles
-
-### Async and Background Tasks
-
-- Use `helpers.should_await()` to check if a result should be awaited
-- Use `helpers.expects_arguments()` to check if a handler expects arguments
-- Use `core.app.handle_exception()` for handling exceptions in background tasks
-
-### Method Returns
-
-- Methods that support chaining (fluent interface) return `Self` from `typing_extensions`
-- This enables the builder pattern: `element.method1().method2().method3()`
-
-### Error Handling
-
-- Use assertions for internal invariants (e.g., `assert self.current_scene is not None`)
-- Raise descriptive exceptions (`ValueError`, `RuntimeError`) with helpful messages
-- Use `core.app.handle_exception()` for global exception handling in background tasks
-
-### Dataclasses
-
-- Prefer `@dataclass(kw_only=True, slots=True)` for dataclasses
-
-## Running tests
-
-Our tests are built with pytest and require python-selenium with ChromeDriver.
-See [tests/README.md](https://github.com/zauberzeug/nicegui/blob/main/tests/README.md) for detailed installation instructions and more infos about the test infrastructure and tricks for daily usage.
-
-### User vs Screen Fixtures
-
-- **Use `User` fixture when possible**: Fast, runs in the same async context as NiceGUI, no browser needed
-- **Use `Screen` fixture only when necessary**: Required when testing browser/JavaScript interactions, but slower
-
-Before submitting a pull request, please make sure that all tests are passing.
-To run them all, use the following command in the root directory of NiceGUI:
-
-```bash
-uv run pytest
-```
-
-## Documentation
-
-### New Elements
-
-If you plan to implement a new element you can follow these suggestions:
-
-1. Ensure with the maintainers that the element is a good fit for NiceGUI core;
-   otherwise it may be better to create a separate git repository for it.
-2. Clone the NiceGUI repository and install the requirements including the project itself with `uv sync`.
-3. Launch `main.py` in the root directory: `uv run main.py`.
-4. Create a `test.py` file or similar where you can experiment with your new element.
-5. Look at other similar elements and how they are implemented in `nicegui/elements`.
-6. Create a new file with your new element alongside the existing ones.
-7. Make sure your element works as expected.
-8. Add a documentation file in `website/documentation/content`.
-   By calling the `@doc.demo(...)` function with an element as a parameter the docstring is used as a description.
-   The docstrings are written in restructured-text.
-   Make sure to use the correct syntax (like double backticks for code).
-   Refer to the new documentation page using `@doc.intro(...)` in any documentation section `website/documentation/content/section_*.py`.
-9. Create a pull-request (see below).
-
-### Additional Demos
-
-There is a separate page for each element where multiple interactive demos can be listed.
-Please help us grow the number of insightful demos by following these easy steps:
-
-1. Clone the NiceGUI repository and install the requirements including the project itself with `uv sync`.
-2. Launch `main.py` in the root directory with `uv run main.py`.
-3. In the newly opened browser window you can navigate to the documentation page where you want to change something.
-4. Open the code in your editor (for example [website/documentation/content/table_documentation.py](https://github.com/zauberzeug/nicegui/blob/main/website/documentation/content/table_documentation.py)).
-5. In the `more()` function insert an inner function containing your demo code.
-6. Add the `@text_demo` decorator to explain the demo.
-7. Make sure the result looks as expected in the rendered documentation.
-8. Create a pull-request (see below).
-
-Your contributions are much appreciated.
-
-### Documentation Formatting
-
-Because it has [numerous benefits](https://nick.groenen.me/notes/one-sentence-per-line/) we write each sentence in a new line.
-Use backslash at end of line for line breaks without paragraph breaks.
-
-### Examples
-
-Besides the documentation with interactive demos (see above) we collect useful, compact stand-alone examples.
-Each example should be about one concept.
-Please try to make them as minimal as possible to show what is needed to get some kind of functionality.
-We are happy to merge pull requests with new examples which show new concepts, ideas or interesting use cases.
-To list your addition on the website itself, you can use the `example_link` function below the
-["In-depth examples" section heading](https://github.com/zauberzeug/nicegui/blob/8a86d2064f8f4464f3819ac5c6763a2cb2d0e990/main.py#L242).
-The title should match the example folder name when [snake case converted](https://github.com/zauberzeug/nicegui/blob/8a86d2064f8f4464f3819ac5c6763a2cb2d0e990/website/style.py#L31).
-
-## Node dependencies
-
-We use package.json files to pin the versions of node dependencies.
-There is a `package.json` file in the root directory for core dependencies
-and additional `package.json` files in `nicegui/elements/.../` directories for individual UI elements.
-They are usually updated by the maintainers during major releases.
-
-To update or add new dependencies, we follow these steps:
-
-1. Use `npm` or other derivative tools, modify the `package.json` file with new versions or add dependencies.
-2. Run `npm install` to install the new dependencies.
-   Any conflicts in installation will be caught at this moment.
-3. Run `npm run build` to copy the dependencies into the `nicegui/static/` directory or
-   to bundle the dependencies in the `nicegui/elements/.../` directories.
-
-The following tools are used to update other resources:
-
-- fetch_google_fonts.py for fetching the Google Fonts
-- fetch_languages.py to update the list of supported languages in language.py
-- fetch_milestone.py to prepare the release notes for a given milestone
-- fetch_sponsors.py to update the list of sponsors on the website and in the README.md file
-- summarize_dependencies.py to update the dependencies in the DEPENDENCIES.md file
-
-## Pull requests
-
-To get started:
-
-1. **Fork** the repository on GitHub
-2. **Clone** your fork to your local filesystem
-3. **Create a feature branch** (e.g., `git checkout -b fix-button-alignment` or `git checkout -b add-dark-mode`)
-4. Make your changes, **commit** them to your branch
-5. **Push** your feature branch to your fork (e.g., `git push origin fix-button-alignment`)
-6. Open a **pull request (PR)** from your feature branch with a detailed description of your changes
+1. **Create a feature branch** (e.g., `git checkout -b fix-button-alignment` or `git checkout -b add-dark-mode`)
+2. **Commit** your changes to your branch
+3. **Push** your feature branch to your fork (e.g., `git push origin fix-button-alignment`)
+4. Open a **pull request (PR)** from your feature branch with a detailed description of your changes
    (the PR button is shown on the GitHub website of your forked repository)
 
 > [!IMPORTANT]
@@ -399,32 +227,21 @@ To get started:
 > 2. It highly increases the chance of an unclean commit history,
 > 3. Your `main` branch should stay in sync with the upstream repository.
 
-When submitting a PR, please make sure that the code follows the existing coding style and that all tests are passing.
-If you're adding a new feature, please include tests that cover the new functionality.
+> [!NOTE]
+> **AI co-authorship:** if you used an AI coding agent to help write your PR, please check that the commit message includes a `Co-authored-by:` trailer.
+> Some agents add it automatically; others don't, and some silently **remove** existing ones when amending or rebasing.
+> If missing, add the appropriate line (PRs are welcome to add lines for other agents):
+>
+> ```
+> Co-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
+> Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
+> Co-authored-by: opencode <noreply@opencode.ai>
+> ```
 
-### AI Co-Authorship
-
-If you used an AI coding agent to help write your PR, please check for co-authorship attribution in your commit messages.
-This helps maintainers understand the origin of changes and smooths the review process.
-
-Some agents add a `Co-authored-by` trailer automatically, but others do not.
-Some even silently **remove** existing co-authorship lines when amending or rebasing commits.
-If you find it missing, please include the appropriate line for your agent in your commit message (pick one):
-
-```
-Co-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
-Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
-Co-authored-by: opencode <noreply@opencode.ai>
-```
-
-> [!TIP]
-> PRs are welcome to add co-authorship lines for other coding agents not yet listed here.
-
-## YouTube
+## Video and tutorial content
 
 We welcome and support video and tutorial contributions to the NiceGUI community!
-As recently [highlighted in a conversation on YouTube](https://www.youtube.com/watch?v=HiNNe4Q32U4&lc=UgyRcZCOZ9i5z6GuDcJ4AaABAg),
-creating and sharing tutorials or showcasing projects using NiceGUI can be an excellent way to help others learn and grow,
+Creating and sharing tutorials or showcasing projects using NiceGUI can be an excellent way to help others learn and grow,
 while also spreading the word about our library.
 
 Please note that NiceGUI is pronounced like "nice guy," which might be helpful to know when creating any video content.
@@ -434,6 +251,33 @@ we kindly ask that you credit our repository, our YouTube channel, and any relev
 By doing so, you'll be contributing to the growth of our community and helping us receive more amazing pull requests and feature suggestions.
 
 We're thrilled to see your creations and look forward to watching your videos. Happy video-making!
+
+## For maintainers
+
+### Updating node dependencies
+
+We use `package.json` files to pin the versions of node dependencies.
+There is one in the root directory for core dependencies and additional ones in `nicegui/elements/.../` directories for individual UI elements.
+They are usually updated during major releases.
+
+To update or add a dependency:
+
+1. Use `npm` or other tools to modify the `package.json` file.
+2. Run `npm install` to install the new dependencies. Any conflicts will be caught at this point.
+3. Run `npm run build` to copy the dependencies into the `nicegui/static/` directory or to bundle them in the `nicegui/elements/.../` directories.
+
+### Updating other resources
+
+The following scripts update various resources:
+
+- `deploy.py` — deploys nicegui.io to Fly.io
+- `extract_core_libraries.py` — extracts core JS/CSS libraries from `node_modules` into `nicegui/static/`
+- `fetch_google_fonts.py` — fetches the Google Fonts
+- `fetch_languages.py` — updates the list of supported languages in `language.py`
+- `fetch_milestone.py` — prepares the release notes for a given milestone
+- `fetch_sponsors.py` — updates the list of sponsors on the website and in `README.md`
+- `summarize_dependencies.py` — updates `DEPENDENCIES.md`
+- `set_scale.sh` — sets the Fly.io machine count per region for nicegui.io
 
 ## Thank you!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ There are several ways to help out, depending on what you want to do:
 
 - **Report a bug or request a feature** → see [Reporting issues](#reporting-issues)
 - **Report a security vulnerability** → see [Reporting security vulnerabilities](#reporting-security-vulnerabilities)
+- **Beta-test the development version** → see [Beta-testing](#beta-testing)
 - **Contribute code or documentation** → see [Contributing code and documentation](#contributing-code-and-documentation)
 - **Create video or tutorial content** → see [Video and tutorial content](#video-and-tutorial-content)
 
@@ -58,6 +59,16 @@ If possible, include steps to reproduce the issue.
 Security issues are handled through GitHub's private vulnerability reporting, not public issues, so we can discuss and patch in a secure workspace before disclosure.
 
 See [SECURITY.md](SECURITY.md) for the full policy and the supported reporting channels.
+
+## Beta-testing
+
+If you have an existing NiceGUI project, you can help us catch regressions before they ship by running it against the development version:
+
+```bash
+pip install -U git+https://github.com/zauberzeug/nicegui.git@main
+```
+
+If anything breaks, behaves worse than the current release, or feels off, please [open an issue](https://github.com/zauberzeug/nicegui/issues/new/choose).
 
 ## Contributing code and documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 We're thrilled that you're interested in contributing to NiceGUI!
 Here are some guidelines that will help you get started.
 
-We follow a [Code of Conduct](https://github.com/zauberzeug/nicegui/blob/main/CODE_OF_CONDUCT.md).
+We follow a [Code of Conduct](CODE_OF_CONDUCT.md).
 By participating, you agree to abide by its terms.
 
 ## About NiceGUI
@@ -97,9 +97,9 @@ Then install NiceGUI in editable mode with all dependencies:
 uv sync
 ```
 
-This installs the `nicegui` package and all its dependencies and links it to your local development environment so that changes you make to the code will be immediately reflected.
-Thereby enabling you to use your local version of NiceGUI in other projects.
-To run the tests you need some additional setup which is described in [tests/README.md](https://github.com/zauberzeug/nicegui/blob/main/tests/README.md).
+This installs the `nicegui` package in editable mode, so code changes are reflected immediately.
+You can also use your local version of NiceGUI in other projects.
+To run the tests you need some additional setup which is described in [tests/README.md](tests/README.md).
 
 **Option 3: Plain Docker** — start the development container:
 
@@ -127,11 +127,14 @@ To view the log output, use the command:
 The conventions below cover both general Python style and NiceGUI-specific patterns.
 
 - **Principles**
+
   - Always prefer simple solutions
   - Avoid duplication — check the codebase for similar functionality before adding new patterns
   - Remove obsolete code rather than working around it
   - When fixing bugs, exhaust existing patterns before introducing new ones; if you must introduce a new one, remove the old approach so logic doesn't duplicate
+
 - **Style**
+
   - Follow **PEP 8** with a 120 character line length
   - Use single quotes in Python, double quotes in JavaScript
   - Use f-strings wherever possible (mark performance-critical exceptions with `# NOTE:`)
@@ -139,41 +142,53 @@ The conventions below cover both general Python style and NiceGUI-specific patte
   - No mutable defaults (`[]`, `{}`) without `# noqa: B006` and a justification — prefer `None`
   - Put high-level/interesting code at the top of files; helper functions go below their usage
   - Each sentence in documentation goes on a new line ([why](https://nick.groenen.me/notes/one-sentence-per-line/))
+
 - **Async and background tasks**
+
   - No blocking I/O in async code — sync I/O blocks the event loop and freezes every connected client
   - Use `background_tasks.create()`, never `asyncio.create_task()` — the garbage collector might drop unfinished tasks
   - Use `helpers.should_await()` to check if a result should be awaited
   - Use `helpers.expects_arguments()` to check if a handler expects arguments
   - Use `core.app.handle_exception()` for exceptions in background tasks
+
 - **Error handling**
+
   - Use `with contextlib.suppress(...)` instead of try/except/pass for cleaner exception handling
   - Catch `ImportError` for optional dependencies, not `ModuleNotFoundError` — covers both missing and broken installations
   - Use assertions for internal invariants (e.g., `assert self.current_scene is not None`)
   - Raise descriptive exceptions (`ValueError`, `RuntimeError`) with helpful messages
+
 - **Elements** (core library)
+
   - **Mixins**: Elements use mixin composition; inheritance order matters for Python's Method Resolution Order (MRO)
   - **Props vs. attributes**: Use `self._props` for data that syncs to Vue/frontend; use instance attributes for Python-only state
   - **Context managers**: Elements can be used as context managers (`with element:`) for slot/child management
   - **Component registration**: Use class parameters for components: `component='file.js'`, `esm={'package': 'dist'}`, `default_classes='css-class'`
+
 - **Memory** (core library)
+
   - **Weakref pattern**: Use `self._element = weakref.ref(element)` to avoid circular references (which require more costly garbage collection).
     When dereferencing, always check for `None`: `element = self._element(); if element is not None: element.update()`
   - **WeakValueDictionary**: Use for caches that shouldn't prevent garbage collection by means of CPython's reference counting
+
 - **Binding** (core library)
+
   - **BindableProperty**: Use with `cast(Self, sender)` in on-change handlers for type safety
   - **Triple underscore storage**: BindableProperty stores values in `___property_name` attributes
   - **Batch updates**: Use `suspend_updates()` context manager when changing properties in `update()` to avoid infinite cycles
-- **Method returns**: Methods that support chaining (fluent interface) return `Self` from `typing_extensions`, enabling the builder pattern (`element.method1().method2().method3()`)
+
+- **Method chaining**: Methods that support chaining (fluent interface) return `Self` from `typing_extensions`, enabling the builder pattern.
+  When chaining, use backslash line continuation:
+
+  ```python
+  ui.button('Click me') \
+      .classes('bg-green') \
+      .on('click', lambda: ui.notify('Hello'))
+  ```
+
 - **Dataclasses**: Prefer `@dataclass(kw_only=True, slots=True)`
+
 - **Tests**: Include tests for new features and bug fixes. Prefer the `User` fixture (fast, runs in the same async context as NiceGUI, no browser); use the `Screen` fixture only when testing browser/JavaScript interactions.
-
-When chaining methods (builder pattern), use backslash line continuation:
-
-```python
-ui.button('Click me') \
-    .classes('bg-green') \
-    .on('click', lambda: ui.notify('Hello'))
-```
 
 ### Before submitting a pull request
 
@@ -197,7 +212,7 @@ Run these from the project root:
    uv run pytest
    ```
 
-   Tests require python-selenium with ChromeDriver — see [tests/README.md](https://github.com/zauberzeug/nicegui/blob/main/tests/README.md) for setup.
+   Tests require python-selenium with ChromeDriver — see [tests/README.md](tests/README.md) for setup.
 
 3. **Add documentation** for new features and behavior changes:
 


### PR DESCRIPTION
### Motivation

The previous CONTRIBUTING.md mixed concerns and had significant duplication:

- "Critical rules at a glance", "Style rules", and "Core library conventions" each restated the same async/memory/error-handling rules.
- Top-level sections were ordered haphazardly — non-code topics (Code of Conduct, AI tooling) sat between project setup and the code workflow.
- Maintainer-only content (npm deps, fetch/deploy scripts) was mixed in with contributor guidance.
- Documentation contributions had their own section that mostly duplicated setup steps.

### Implementation

Restructured the document around the contributor's journey:

- **Top-level sections** now follow the contribution path: About → Ways to contribute → Reporting issues → Reporting security vulnerabilities → Contributing code and documentation → Video → For maintainers → Thank you.
- **New "Ways to contribute"** branches readers to the right path.
- **New "Reporting security vulnerabilities"** section, with an explicit warning at the top of "Reporting issues" pointing to it.
- **Single Coding conventions list** replaces three overlapping sections (Critical rules / Coding style / Core library conventions); rules grouped by topic (Principles, Style, Async, Error handling, Elements, Memory, Binding, Method returns, Dataclasses, Tests) with each appearing exactly once.
- **New "Before submitting a pull request"** bundles pre-PR checks as numbered steps: format/lint via pre-commit, run pytest, add documentation.
- **Documentation folded into code section** — "Add documentation" is step 3 of pre-PR checks rather than its own H2; element demos and standalone-example requirements are bullets there.
- **New "For maintainers"** isolates npm dep updates and fetch/deploy scripts from contributor-facing content; \`deploy.py\`, \`extract_core_libraries.py\`, \`set_scale.sh\` added to the script list.
- **Removed** outdated AI tooling section, Black formatter commentary, "200-300 line" file-size aspiration, duplicate "Documentation formatting" subsection.
- **AI co-authorship** demoted from H4 to a NOTE callout inside "Submitting a pull request".

Net: 442 → 300 lines (-32%), zero rule duplication.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been updated.
- [x] No breaking changes to the public API.