### PR TITLE
Restructure AI agent instructions

### DIFF
--- a/.cursor/commands/explain.md
+++ b/.cursor/commands/explain.md
@@ -2,7 +2,7 @@
 description: Explain what the current code does
 ---
 
-Check README.md, AGENTS.md, and CONTRIBUTING.md, then explain what this code does, focusing on:
+Explain what this code does, focusing on:
 
 - Main purpose and functionality
 - Key patterns or approaches used

--- a/.cursor/commands/review-branch.md
+++ b/.cursor/commands/review-branch.md
@@ -2,5 +2,5 @@
 description: Review current branch
 ---
 
-Read README.md, AGENTS.md, and CONTRIBUTING.md, then review the current branch according to .github/copilot-instructions.md.
-Provide specific, actionable feedback adhering to the principles in AGENTS.md and CONTRIBUTING.md.
+Review the current branch according to REVIEW.md.
+Provide specific, actionable feedback.

--- a/.cursor/commands/review-uncommitted.md
+++ b/.cursor/commands/review-uncommitted.md
@@ -2,7 +2,6 @@
 description: Review local uncommitted modifications
 ---
 
-Read README.md, AGENTS.md, and CONTRIBUTING.md, then review the local uncommitted modifications according to .github/copilot-instructions.md.
+Review the local uncommitted modifications according to REVIEW.md.
 Obviously I intend to commit them later.
 I just want your feedback on the changes and ideas for improvements.
-Provide specific, actionable feedback adhering to the principles in AGENTS.md and CONTRIBUTING.md.

--- a/.cursor/commands/simplify.md
+++ b/.cursor/commands/simplify.md
@@ -2,8 +2,7 @@
 description: Suggest ways to simplify the current code
 ---
 
-Ensure you understand the project by reading README.md, AGENTS.md, and CONTRIBUTING.md,
-then review the current code and suggest simplifications.
+Review the current code and suggest simplifications.
 
 Look for:
 
@@ -13,4 +12,4 @@ Look for:
 - Opportunities to use standard patterns
 - Blocking operations that should be async
 
-Propose concrete, simpler alternatives adhering to the principles in AGENTS.md and CONTRIBUTING.md.
+Propose concrete, simpler alternatives.

--- a/.cursor/commands/summarize-branch.md
+++ b/.cursor/commands/summarize-branch.md
@@ -2,8 +2,8 @@
 description: Summarize current branch
 ---
 
-Read README.md, AGENTS.md, and CONTRIBUTING.md, then write a short PR description.
-Lead with the motivation of the change, then explain what changed and design decisions made.
+Write a PR description following the template in [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md).
+Lead with the motivation of the change, then explain what changed and the design decisions made.
 Also mention special assumptions or risks implied by the changes.
 
 Consider NiceGUI-specific concerns:

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -7,5 +7,5 @@ alwaysApply: true
 **Read these files before working:**
 
 1. [README.md](../../README.md) - Project overview and setup
-2. [AGENTS.md](../../AGENTS.md) - AI agent guidelines and code review instructions
+2. [AGENTS.md](../../AGENTS.md) - AI agent guidelines
 3. [CONTRIBUTING.md](../../CONTRIBUTING.md) - Coding standards and workflow

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -9,15 +9,3 @@ alwaysApply: true
 1. [README.md](../../README.md) - Project overview and setup
 2. [AGENTS.md](../../AGENTS.md) - AI agent guidelines and code review instructions
 3. [CONTRIBUTING.md](../../CONTRIBUTING.md) - Coding standards and workflow
-
-## Quick Reference
-
-- Use single quotes in Python
-- 120 character line length
-- Never block the event loop – use `run.cpu_bound()`, `run.io_bound()`, or `background_tasks.create()`
-- Never use `asyncio.create_task()` – use `background_tasks.create()` instead
-- Think from first principles
-- Discuss significant changes before implementing
-- Keep code simple and self-explanatory
-- Write tests for new features (use `User` fixture when possible, `Screen` only when browser/JS needed)
-- Public API (`nicegui.*`) requires backward compatibility

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,10 +3,5 @@
 **Read these files before working:**
 
 1. [README.md](../README.md) - Project overview and setup
-2. [AGENTS.md](../AGENTS.md) - AI agent guidelines and code review instructions
+2. [AGENTS.md](../AGENTS.md) - AI agent guidelines
 3. [CONTRIBUTING.md](../CONTRIBUTING.md) - Coding standards and workflow
-
----
-
-> For detailed guidelines, review practices, and coding principles, see [AGENTS.md](../AGENTS.md).
-> Copilot will treat this file and [AGENTS.md](../AGENTS.md) as authoritative for review behavior.

--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -1,0 +1,6 @@
+---
+applyTo: '**'
+excludeAgent: cloud-agent
+---
+
+When reviewing this PR, follow [REVIEW.md](../../REVIEW.md) — it lists what to look for, defines the severity vocabulary, and sets the tone for reviews.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     hooks:
       - id: mdformat
         args: ["--wrap", "keep", "--number"]
-        exclude: ^\.cursor/
         additional_dependencies:
+          - mdformat-frontmatter
           - mdformat-gfm
           - mdformat-simple-breaks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,187 +1,34 @@
 # AI Agent Guidelines for NiceGUI
 
-> **For**: AI assistants (Cursor, GitHub Copilot, Codex, etc.) working on NiceGUI codebase \
-> **About**: The project, examples and architecture is described in [README.md](README.md) \
-> **Standards**: All coding standards are in [CONTRIBUTING.md](CONTRIBUTING.md) – follow those rules
+This file gives AI assistants project-specific behavioral guidance. For coding standards, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Core Principles
+## Pair Programming
 
-### Think from First Principles
+Work as a pair programmer, not a silent code generator:
 
-Don't settle for the first solution.
-Question assumptions and think deeply about the true nature of the problem before implementing.
-
-### Pair Programming Approach
-
-We work together as pair programmers, switching seamlessly between driver and navigator:
-
-- **Requirements first**: Verify requirements are correct before implementing, especially when writing/changing tests
-- **Discuss strategy**: Present options and trade-offs when uncertain about approach
-- **Step-by-step for large changes**: Break down significant refactorings and get confirmation at each step
-- **Challenge assumptions**: If the user makes wrong assumptions or states untrue facts, correct them directly
-
-### Simplicity First
-
-- Prefer simple, straightforward solutions
-- Avoid over-engineering
-- Remove obsolete code rather than working around it
-- Code should be self-explanatory
-
-Note: See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed style principles, code organization rules, and async/event loop requirements.
-
-## API Stability
-
-- `nicegui.*` is **public API** – breaking changes need deprecation paths
-- New parameters must have sensible defaults for backward compatibility
-- Validate user inputs at API boundaries for critical operations
-
-## Common Patterns
-
-### Element Creation
-
-Look at similar elements in `nicegui/elements/` for patterns on initialization, props handling, and event binding.
+- **Think from first principles**: Don't settle for the first solution; question assumptions about the true nature of the problem.
+- **Requirements first**: Verify requirements before implementing, especially when writing or changing tests.
+- **Research before guessing**: Search the codebase for similar patterns; check online sources for verification.
+- **Discuss before deciding**: When strategy is unclear, present options and trade-offs to the user instead of choosing silently.
+- **Step-by-step for large changes**: Break down significant refactorings and get confirmation along the way.
+- **Challenge assumptions**: If the user states something untrue, correct them directly.
 
 ## What to Avoid
 
-- **Global mutable state** in library code
-- **Blocking I/O** in async handlers or WebSocket paths
-- **Broad exception catching** without proper error context
-- **Debug prints** in library code (use proper logging)
-- **Unnecessary dependencies** – check if existing code suffices
-- **Duplicate logic** – consolidate when introducing new patterns
-- **Overwriting .env files** without explicit user confirmation
+- **Overwriting `.env` files** without explicit user confirmation
 - **Creating new files** when editing existing ones would suffice
+- **Global mutable state** in library code
+- **Unnecessary dependencies** — check if existing code suffices first
 
-## Path-Specific Context
+## Before Claiming a Task Complete
 
-- `nicegui/` – Core library (public API), highest stability requirements
-- `examples/` – Standalone demos, must be minimal and runnable
-- `website/` – Documentation site, keep in sync with code behavior
-- `tests/` – Test suite, prefer pytest patterns
-- `main.py` – Runs the nicegui.io website locally
-
-## Quick Verification
-
-Before claiming a task complete, verify:
-
-1. No blocking operations in async code?
-2. Public API backward compatible?
-3. Tests passing? (see CONTRIBUTING.md)
-4. Linters passing? (see CONTRIBUTING.md)
-5. Debug code removed?
-
-## When Uncertain
-
-- **Check online sources** for inspiration or verification rather than guessing
-- **Search the codebase** for similar patterns before inventing new ones
-- **Ask the user** by presenting options and trade-offs if strategy is unclear
-- **Start broad, then narrow**: Explore with semantic search, then drill into specific files
+Run the project's tests and linters (see [CONTRIBUTING.md](CONTRIBUTING.md)) and review your own diff for unintended scope creep.
 
 ## Creating Pull Requests
 
-When creating a pull request, always use the repository's PR template (`.github/PULL_REQUEST_TEMPLATE.md`) with its **Motivation**, **Implementation**, and **Progress** sections. Do not invent alternative formats like "Summary" or "Test plan".
+Always use the repository's PR template ([`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)) with its **Motivation**, **Implementation**, and **Progress** sections.
+Do not invent alternative formats like "Summary" or "Test plan".
 
----
+## Reviewing Pull Requests
 
-## Code Review Guidelines
-
-**Purpose**: Maximize signal/noise, protect API stability, and offload maintainers.
-Act as a _single, concise reviewer_.
-Prefer one structured top-level comment with suggested diffs over many line-by-line nits.
-
-**Standards Reference**: Before starting a review, internalize all coding standards, style guidelines, and contribution workflows defined in CONTRIBUTING.md and the principles above.
-
-### Scope & Tone
-
-- Audience: PR authors and maintainers of `zauberzeug/nicegui`
-- Voice: concise, technical, actionable. No style opinions when linters/formatters are green
-- Output format: one summary + grouped findings (**BLOCKER**, **MAJOR**, **CLEANUP**) + **suggested diff** blocks where possible
-
-### Severity Mapping
-
-#### BLOCKER (if violated ⇒ request changes)
-
-1. **Security/Secrets**: leaked creds/keys, unsafe eval/exec, command injection, uncontrolled deserialization, path traversal, template injection
-2. **Concurrency/Async correctness**: event loop blocking (long CPU/I/O in async handlers), missing awaits, race conditions, deadlocks, using `asyncio.create_task()` instead of `background_tasks.create()`, non-thread-safe mutations in background tasks
-3. **Public API stability**: breaking changes in `nicegui.*` without explicit deprecation path. New params must be backward compatible with sensible defaults
-4. **Performance regressions on hot paths**: O(n²) additions, synchronous I/O, unnecessary per-request heavyweight objects
-5. **Docs/Examples mismatch**: code diverges from documented behavior, examples stop working
-6. **Tests & CI**: missing or incomplete tests; ignoring configured linters/type checks (see [CONTRIBUTING.md](CONTRIBUTING.md) for test requirements)
-7. **PR description quality**: missing/vague problem statement, motivation per PR template requirements
-8. **Formatting & placement**: unformatted files (violates [CONTRIBUTING.md](CONTRIBUTING.md) pre-commit requirements), surprising file placement without rationale
-9. **Explanation of the change**: missing/vague explanation of motivations behind the change, why it is needed, what is the impact
-
-#### MAJOR (should be fixed before merge)
-
-1. **Error-handling gaps**: exceptions swallowed, broad `except:`, unvalidated user input
-2. **File/feature placement**: unexpected location or architecture drift; justify location or move accordingly
-3. **Unnecessary complexity**: simpler design meets requirements (violates [CONTRIBUTING.md](CONTRIBUTING.md) "prefer simple solutions" principle)
-4. **Resource hygiene**: unclosed files/sockets/tasks; memory leaks; missing context managers
-5. **Logging/observability**: noisy logs, missing error context; debug prints in library code
-6. **Cross-platform pitfalls**: Windows paths, locale/timezone assumptions, reliance on system binaries without guards
-
-#### CLEANUP (suggest quick diffs)
-
-1. **Readability**: complex logic without NOTE comments; magic numbers; missing docstrings on public API
-2. **Test coverage**: edge cases untested (empty/None, large payloads, cancellation)
-3. **Micro-perf**: avoid tiny allocations in tight loops; cache pure results; defer imports in cold paths
-
-### Path-Specific Guidance
-
-- `nicegui/` (library): treat as **public API**. Ensure new props/arguments have defaults; validate inputs; add/extend tests
-- `examples/`: keep minimal and runnable; ensure no hidden dependencies; prefer idiomatic NiceGUI usage
-- `website/` & docs: verify snippets still run; avoid drift between docs and code
-- `tests/`: prefer fast, deterministic tests; isolate network and time; use fixtures over sleeps
-
-### Review Structure
-
-Structure your review comment like this:
-
-**Summary**
-
-What changed, risk hotspots, and migration impact in 2-4 bullets.
-
-**BLOCKER**
-
-Itemized violations of critical rules with short rationale and reproduction if relevant.
-
-**MAJOR**
-
-Concrete issues that should be fixed pre-merge.
-
-**CLEANUP**
-
-Low-noise, quick-win improvements.
-
-**Suggested diffs**
-
-Use GitHub's suggestion blocks (apply only if trivial and safe):
-
-```diff
-- data = Path('config.json').read_text()
-+ with Path('config.json').open() as f:
-+     data = f.read()
-```
-
-### Review Behavior
-
-- Prefer **one** top-comment; avoid scatter
-- If evidence is weak/speculative, ask a short question instead of asserting
-- If change is broad: propose a tiny follow-up PR rather than expanding this one
-
-### Review Checklist
-
-Mental checklist before posting review:
-
-1. Public API surface changed? Defaults/backward compatibility preserved?
-2. Async paths non-blocking? Tasks cleaned up? Timeouts and cancellations handled?
-3. Secrets and security basics ok? Inputs validated? No dangerous eval/exec?
-4. Tests: added/updated? any flakiness? coverage for edge cases?
-5. Docs/examples updated if behavior changed?
-
----
-
-> This file complements [CONTRIBUTING.md](CONTRIBUTING.md).
-> For style rules, formatting, and detailed contribution workflow, see CONTRIBUTING.md.
->
-> Maintainers: update this file as conventions evolve.
+Follow [REVIEW.md](REVIEW.md) — it lists what to look for, defines the severity vocabulary, and sets the tone for reviews.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,80 @@
+# Code Review Guidelines for NiceGUI
+
+This file augments any review prompt — the built-in `/review` command, Cursor commands, or an ad-hoc "review this" request.
+It defines _what to look for_ and _how to label severity_, but leaves the layout to whatever invokes the review.
+For coding rules, see [CONTRIBUTING.md](CONTRIBUTING.md); for general agent guidance, see [AGENTS.md](AGENTS.md).
+
+## What to look for
+
+- **Security**
+  - Leaked credentials, secrets, or API keys
+  - Unsafe `eval`/`exec`, command injection, uncontrolled deserialization, path traversal, template injection
+  - Unvalidated user input at API boundaries
+- **Async & concurrency**
+  - Blocking I/O inside `async def` (CPU-bound work, sync file I/O, blocking network calls)
+  - Missing `await`, race conditions, deadlocks
+  - `asyncio.create_task()` instead of `background_tasks.create()` — the GC may drop unfinished tasks
+  - Non-thread-safe mutations from background tasks
+- **Public API stability** (`nicegui.*`)
+  - Breaking changes without an explicit deprecation path
+  - New parameters without backward-compatible defaults
+- **Performance**
+  - O(n²) work on hot paths, synchronous I/O in request handlers, heavyweight objects per request
+  - Tight-loop allocations; cache pure results; defer cold-path imports
+- **Error handling**
+  - Exceptions swallowed silently, broad `except:` clauses
+  - Missing input validation at system boundaries
+- **Resource hygiene**
+  - Unclosed files, sockets, or tasks; missing context managers; memory leaks
+- **Logging & observability**
+  - Noisy logs, missing error context, debug prints in library code
+- **Tests**
+  - New features and bug fixes need tests (see CONTRIBUTING.md for `User` vs `Screen` fixture choice)
+  - Edge cases: empty/None, large payloads, cancellation
+  - Flakiness, time-dependence, hidden network deps
+- **Docs & examples**
+  - Code that diverges from documented behavior
+  - Examples that no longer run
+  - Missing docstrings on the public API surface
+- **Formatting & placement**
+  - Files unformatted (violates pre-commit)
+  - Surprising file placement without rationale; architecture drift
+- **PR description**
+  - Missing or vague motivation per [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)
+  - Unclear problem statement or impact
+- **Cross-platform**
+  - Windows path assumptions, locale/timezone hardcoding, reliance on system binaries without guards
+- **Readability**
+  - Complex logic without `# NOTE:` comments explaining intent; magic numbers
+
+## Severity vocabulary
+
+Present findings as a numbered list, with the severity label in parentheses after the title:
+
+```
+1. **Title of the finding** (major) — body explaining the issue and the suggested fix.
+```
+
+Labels:
+
+- **blocking** — security holes, broken public API, broken tests, failing CI, examples that stop working, missing PR motivation. Worth requesting changes.
+- **major** — error-handling gaps, unnecessary complexity, resource leaks, cross-platform pitfalls, surprising placement. Worth addressing pre-merge but not strictly blocking.
+- **minor** — readability nits, missing docstrings, edge-case test gaps, micro-perf. Reviewer's leave-or-take.
+
+When the severity is obvious from the finding, the label can be omitted.
+For long reviews, findings can be grouped under severity sub-headings (`### Blocking`, `### Major`, `### Minor`) — restart numbering in each.
+
+## Path-specific guidance
+
+- `nicegui/` (library): treat as **public API**. Defaults on new args; validate inputs; add or extend tests
+- `examples/`: keep minimal and runnable; no hidden dependencies; idiomatic NiceGUI
+- `website/` and docs: verify snippets still run; avoid drift between docs and code
+- `tests/`: prefer fast, deterministic tests; isolate network and time; fixtures over sleeps
+
+## Tone & behavior
+
+- Concise, technical, actionable. No style opinions when linters/formatters are green.
+- Use GitHub suggestion blocks for trivial, safe diffs.
+- If evidence is weak, ask a question instead of asserting.
+- If the change is broad, propose a small follow-up PR rather than expanding this one.
+- Drop `#L...` line anchors in file links — they don't render in PR comments. Put the line range in the link text or prose instead.


### PR DESCRIPTION
### Motivation

The AGENTS.md / `.cursor/rules` / `.github/copilot-instructions.md` setup had accumulated:

- Code review guidelines mixed into general agent guidance, making AGENTS.md a 188-line file with two unrelated concerns.
- Duplication between AGENTS.md, CONTRIBUTING.md, and `.cursor/rules/general.mdc` (e.g., "no `asyncio.create_task()`", "single quotes", "120 char line length" appearing in three places).
- Cursor slash commands starting with "Read README.md, AGENTS.md, and CONTRIBUTING.md" preambles even though `.cursor/rules/general.mdc` (always-apply) already loads those files.
- Decorative blockquote headers and footers across multiple files that didn't earn their keep.
- A structural conflict between AGENTS.md's prescribed Summary/BLOCKER/MAJOR/CLEANUP review layout and the layouts that built-in `/review` commands prescribe.

### Implementation

- **Extracted REVIEW.md** from AGENTS.md. The new file lists _what to look for_ (security, async, public API, performance, tests, etc.) and defines a severity vocabulary (`blocking` / `major` / `minor` as inline labels), but explicitly leaves the _layout_ to whatever invokes the review. This removes the layout conflict.
- **Trimmed AGENTS.md** from 188 → 34 lines. Kept only agent-specific content: pair-programming framing, `.env`/file-creation safety, "before claiming complete" verification, pointers to the PR template and REVIEW.md.
- **Added `.github/instructions/review.instructions.md`** with `excludeAgent: "cloud-agent"` so Copilot's PR review feature picks up REVIEW.md, without loading it for general coding sessions.
- **Cleaned up `.cursor/rules/general.mdc`** — removed the "Quick Reference" section that duplicated CONTRIBUTING.md.
- **Trimmed all `.cursor/commands/*.md`** — dropped redundant "Read README.md, AGENTS.md, and CONTRIBUTING.md" preambles and "adhering to the principles..." trailers. `summarize-branch.md` now explicitly references the PR template.
- **Tightened `.github/copilot-instructions.md`** — removed REVIEW.md from the unconditional read list and dropped the decorative blockquote footer.
- **Removed blockquote headers/footers** across AGENTS.md and REVIEW.md.
- **Added `mdformat-frontmatter` to `.pre-commit-config.yaml`** so YAML frontmatter in markdown files is preserved (needed by the new `review.instructions.md` and the existing `.cursor/commands/*.md` files). Dropped the now-unnecessary `exclude: ^\.cursor/` line — it was a workaround for the same issue.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been updated.
- [x] No breaking changes to the public API.