### PR TITLE
Use `uv sync --locked` in CI

### DIFF
--- a/.github/workflows/_check.yml
+++ b/.github/workflows/_check.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Install Python
         run: uv python install 3.10
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: ${{ matrix.target.name }}
         run: uv run ${{ matrix.target.command }}

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Python
         run: uv python install ${{ matrix.python }}
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: ${{ matrix.python }} / ${{ matrix.scope }}
         if: matrix.scope == 'pytest'
         run: uv run pytest
@@ -46,4 +46,4 @@ jobs:
         run: ./test_startup.sh
       - name: Restore dependencies for effective caching
         if: matrix.scope == 'startup' && always()
-        run: uv sync
+        run: uv sync --locked


### PR DESCRIPTION
### Motivation

`uv sync` (without `--locked`) silently re-resolves dependencies whenever `pyproject.toml` and `uv.lock` drift. CI then runs against a different dependency set than the lock claims, and resolver failures surface as opaque "Install dependencies" job errors instead of a clear lock-drift diagnostic.

A concrete instance is visible right now: Dependabot PRs [#6031](https://github.com/zauberzeug/nicegui/pull/6031), [#6032](https://github.com/zauberzeug/nicegui/pull/6032), [#6033](https://github.com/zauberzeug/nicegui/pull/6033), [#6034](https://github.com/zauberzeug/nicegui/pull/6034), [#6035](https://github.com/zauberzeug/nicegui/pull/6035) all fail at the `uv sync` step. Dependabot only patches `pyproject.toml` (the `pip` ecosystem does not understand `uv.lock`), so each PR carries a stale lock; the `uv sync` step then attempts a fresh resolve and dies on a workspace-shadow corner case for the Python 3.14 marker split. With `--locked`, the failure mode would instead be a one-line "lock is out of date" message, pointing immediately at the real cause.

### Implementation

Add `--locked` to every `uv sync` invocation in the two reusable CI workflows (`_check.yml` and `_test.yml`). Per the [uv docs](https://docs.astral.sh/uv/reference/cli/#uv-sync--locked), `--locked` "asserts that the `uv.lock` will remain unchanged" and exits with an error if the lockfile is missing or out of date.

Verified locally with `uv lock --check` against `main` — the lock is currently in sync with `pyproject.toml`, so this change is a no-op for green builds and only raises the floor for future drift. `copilot-setup-steps.yml` is intentionally left alone to keep the diff scoped to CI gates.

This is the first of two small, independent PRs aimed at the broader Dependabot-drift problem. The follow-up will switch the Dependabot ecosystem from `pip` to `uv` so that the lock is regenerated alongside `pyproject.toml`; landing `--locked` first means any future lock-regeneration mistake fails loudly in CI instead of being papered over by silent re-resolution.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests are not necessary. (CI-only change to existing workflows.)
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)