### PR TITLE
Switch Dependabot from `pip` to `uv` ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     labels:
       - "dependencies"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
### Motivation

The current `pip` ecosystem entry only patches `pyproject.toml` and is unaware of `uv.lock`, so every Dependabot bump lands with a stale lock. CI's `uv sync` then silently re-resolves to a different dependency set than the lock advertises — and when re-resolution fails (as in [#6031](https://github.com/zauberzeug/nicegui/pull/6031)–[#6035](https://github.com/zauberzeug/nicegui/pull/6035) right now), the failure surfaces as an opaque resolver error instead of a clear lock-drift signal.

The `uv` ecosystem went GA in Dependabot in March 2025 ([GitHub Changelog](https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/)), and uv's own documentation [recommends it](https://docs.astral.sh/uv/guides/integration/dependabot/) for projects that ship a `uv.lock`.

### Implementation

One-line change: rename the existing entry from `package-ecosystem: "pip"` to `package-ecosystem: "uv"`. All other fields (directory, schedule, ignore rules, labels) are preserved verbatim.

What changes operationally:

- Each Dependabot PR now regenerates `uv.lock` alongside the `pyproject.toml` edit, so CI sees a coherent pyproject + lock pair.
- On `@dependabot rebase` (or when one Dependabot PR merges and another rebases), uv re-runs the locker rather than attempting a text-level 3-way merge — concurrent PRs auto-resolve their lock conflicts instead of piling up.
- The `pip` ecosystem and the `uv` ecosystem are mutually exclusive for the same `pyproject.toml`; this is a swap, not an addition.

This composes well with [#6036](https://github.com/zauberzeug/nicegui/pull/6036) (`uv sync --locked` in CI): with both landed, any future lock-regeneration regression would surface immediately as a CI failure rather than as silent re-resolution. They are independent — either can land first — but landing `--locked` first means this PR's lock-regeneration is verified by every CI run.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests are not necessary. (Dependabot configuration only.)
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)