### PR TITLE
Use `uv sync --locked` in Copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Install Python
         run: uv python install 3.10
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: Install pre-commit hooks
         run: uv run pre-commit install


### PR DESCRIPTION
### Motivation

[#6036](https://github.com/zauberzeug/nicegui/pull/6036) added `--locked` to the CI gates (`_check.yml` and `_test.yml`) but deliberately left this Copilot setup workflow on a bare `uv sync` to keep that PR's diff scoped. Following up here.

The whole point of `copilot-setup-steps.yml` per [GitHub's own coding-agent docs](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent/customizing-the-development-environment-for-copilot-coding-agent) is to install dependencies *deterministically* before the agent starts work, so the agent boots into a known-good environment rather than relying on trial-and-error dep discovery:

> "deterministically install tools or dependencies before Copilot starts work"

> "Copilot can discover and install these dependencies itself via a process of trial and error, but this can be slow and unreliable, given the non-deterministic nature of large language models (LLMs)"

Bare `uv sync` silently re-resolves whenever `pyproject.toml` and `uv.lock` drift. That's the same class of bug that hit Dependabot PRs [#6031](https://github.com/zauberzeug/nicegui/pull/6031)–[#6035](https://github.com/zauberzeug/nicegui/pull/6035) last week — the resolver dies on a Python 3.14 marker split that the lock would otherwise have pinned past, and the failure surfaces as an opaque "Install dependencies" job error. With `--locked`, drift fails fast with a clear "lock is out of date" message instead of a stalled agent session.

### Implementation

One-line change to `.github/workflows/copilot-setup-steps.yml`: `uv sync` → `uv sync --locked`.

If a Copilot task is itself to update dependencies, the agent can run `uv lock && uv sync` after editing `pyproject.toml`; the setup step's job is to establish a coherent baseline, not to be permissive about drift.

`uv lock --check` against current `main` is clean, so this is a no-op for green builds and only raises the floor for future drift.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests are not necessary. (CI-only change to an existing workflow.)
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)