### PR TITLE
Declare PyPI trove classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,25 @@ keywords = [
     "interface",
     "live",
 ]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Web Environment",
+    "Framework :: AsyncIO",
+    "Framework :: FastAPI",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Topic :: Software Development :: User Interfaces",
+    "Topic :: Software Development :: Widget Sets",
+    "Typing :: Typed",
+]
 dependencies = [
     "typing-extensions>=4.0.0",
     "markdown2>=2.4.7,!=2.4.11",


### PR DESCRIPTION
### Motivation

`pyproject.toml` currently has no `classifiers` table, so NiceGUI's [PyPI page](https://pypi.org/project/nicegui/) shows an empty Classifiers sidebar and the package doesn't appear in any of PyPI's faceted search filters — Python version, framework, topic, development status, or OS. PyPI's [classifier index](https://pypi.org/classifiers/) is the canonical list and is used directly as the search-result filter UI.

### How comparable libraries handle this

Sampled raw classifiers from PyPI's JSON API (`https://pypi.org/pypi/<name>/json`) for seven peers:

| Classifier | Streamlit | Gradio | Dash | Panel | Shiny | Reflex | Anvil |
|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| Development Status :: 5 - Production/Stable | ✓ | ✓ | ✓ | ✓ | ✓ | (Beta) | ✓ |
| Intended Audience :: Developers | ✓ | | ✓ | ✓ | ✓ | | ✓ |
| Operating System :: OS Independent | | ✓ | | ✓ | | | |
| Environment :: Web Environment | ✓ | | ✓ | | | | |
| Programming Language :: Python :: 3.10–3.14 | ✓ | 3.10–3.13 | 3.8–3.12 | ✓ | ✓ | ✓ | through 3.11 |
| Topic :: Software Development :: Libraries :: Application Frameworks | ✓ | | ✓ | | | | |
| Topic :: Software Development :: Widget Sets | ✓ | | ✓ | | | | |

Every entry in this PR's list is either a direct match for what one or more of these peers declares, or it's deliberately omitted (see "Skipped on purpose" below).

### What this PR adds beyond the cohort

Three classifiers that **no library in the sampled cohort declares**, but that NiceGUI legitimately qualifies for and that act as real discovery wins on PyPI's facet UI:

- **`Framework :: AsyncIO`** — NiceGUI is async-native; Streamlit/Gradio/Dash/Panel are sync-rerun models. PyPI surfaces a dedicated AsyncIO filter; declaring this puts NiceGUI in front of devs explicitly searching for async UI frameworks.
- **`Framework :: FastAPI`** — NiceGUI is built on FastAPI (`fastapi>=0.109.1` in `dependencies`). Dash declares `Framework :: Flask` for the same reason; this is the FastAPI analogue.
- **`Typing :: Typed`** — `nicegui/py.typed` is shipped, so the claim is honest. None of the cohort declares this, despite many of them shipping types.

### Implementation

One additive `classifiers` table inserted between the existing `keywords` and `dependencies` blocks. No reflow of surrounding fields, no dependency or build impact, `uv lock --check` clean.

The Python version classifiers (3.10 through 3.14) were verified against the actual test matrix in `.github/workflows/ci-gate.yml:30` rather than just trusting `requires-python`.

### Skipped on purpose

- **`License :: OSI Approved :: MIT License`** — `pyproject.toml:8` already declares `license = "MIT"` per [PEP 639](https://peps.python.org/pep-0639/), which PyPI now reads directly. Adding the classifier would be redundant; some peers (Dash, Anvil, Shiny) still ship it for older-tool compat, but `pyproject.toml` is already PEP-639 forward, so consistency wins.
- **`Programming Language :: Python :: 3 :: Only`** — Gradio includes it; no semantic value beyond the per-version entries.
- **`Intended Audience :: Science/Research`** and the industry verticals (Healthcare, Finance, Manufacturing, Education) — Dash and Panel both declare these; for a general-purpose UI framework the claim is overstated and dilutes the search facets.
- **`Topic :: Scientific/Engineering :: Visualization`** — accurate for some uses (chart elements, plotly integration) but, again, narrows positioning.

Happy to add or remove anything if you have a preference — the diff is purely metadata, so editing is cheap.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests are not necessary. (Metadata-only change.)
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)