### PR TITLE
Fix KeyError when validating after error prop is removed

### DIFF
--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -46,7 +46,7 @@ class ValidationElement(ValueElement[ValueT]):
         :param error: The optional error message
         """
         new_error_prop = None if error is None and self.validation is None else (error is not None)
-        if self._error == error and self._props['error'] == new_error_prop:
+        if self._error == error and self._props.get('error') == new_error_prop:
             return
         self._error = error
         self._props['error'] = new_error_prop

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -134,6 +134,16 @@ def test_setting_error_without_validation(screen: Screen):
     screen.should_contain('Something is wrong')
 
 
+def test_validate_after_removing_error_prop(screen: Screen):
+    @ui.page('/')
+    def page():
+        input_ = ui.input('Name', value='valid', validation=lambda v: None if v else 'required')
+        ui.button('Remove error', on_click=lambda: input_.props(remove='error error-message').validate())
+
+    screen.open('/')
+    screen.click('Remove error')
+
+
 def test_autocompletion(screen: Screen):
     input_ = None
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -138,10 +138,11 @@ def test_validate_after_removing_error_prop(screen: Screen):
     @ui.page('/')
     def page():
         input_ = ui.input('Name', value='valid', validation=lambda v: None if v else 'required')
-        ui.button('Remove error', on_click=lambda: input_.props(remove='error error-message').validate())
+        ui.button('Reset', on_click=lambda: (input_.props(remove='error error-message').validate(), ui.label('done')))
 
     screen.open('/')
-    screen.click('Remove error')
+    screen.click('Reset')
+    screen.should_contain('done')
 
 
 def test_autocompletion(screen: Screen):


### PR DESCRIPTION
### Motivation

Closes #5977.

`ValidationElement.error` setter compared `self._props['error']` directly. If a user had previously removed the `error` prop via `element.props(remove='error error-message')`, the next call to `validate()` would raise `KeyError: 'error'`.

### Implementation

Replace the bare subscript with `.get()` so the comparison is robust to the prop having been removed externally. Behavior is otherwise unchanged: a missing prop compares not-equal to the new value and the setter proceeds to re-seed both `error` and `error-message`.

Adds a regression test that reproduces the original repro: `ui.input(validation=...)`, `props(remove='error error-message')`, then `validate()` — must not raise.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytest has been added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
