### PR TITLE
Fix SemLock fork/spawn RuntimeError in `ui.run(native=True, reload=True)`

### DIFF
--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -12,8 +12,7 @@ from typing import Any
 from .. import run
 from ..logging import log
 
-# spawn context so primitives can be pickled into uvicorn's spawn-context ChangeReload worker (#1841)
-_SPAWN_CTX = multiprocessing.get_context('spawn')
+SPAWN_CONTEXT = multiprocessing.get_context('spawn')  # match uvicorn's ChangeReload worker (#1841)
 
 method_queue: Queue | None = None
 response_queue: Queue | None = None
@@ -24,9 +23,9 @@ event_sender: Connection | None = None
 def create_queues() -> None:
     """Create the message queues and event pipe. (For internal use only.)"""
     global method_queue, response_queue, event_receiver, event_sender  # pylint: disable=global-statement # noqa: PLW0603
-    method_queue = _SPAWN_CTX.Queue()
-    response_queue = _SPAWN_CTX.Queue()
-    event_receiver, event_sender = _SPAWN_CTX.Pipe(duplex=False)
+    method_queue = SPAWN_CONTEXT.Queue()
+    response_queue = SPAWN_CONTEXT.Queue()
+    event_receiver, event_sender = SPAWN_CONTEXT.Pipe(duplex=False)
 
 
 def remove_queues() -> None:

--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -2,14 +2,18 @@
 from __future__ import annotations
 
 import inspect
+import multiprocessing
 import warnings
 from collections.abc import Callable
-from multiprocessing import Pipe, Queue
+from multiprocessing import Queue
 from multiprocessing.connection import Connection
 from typing import Any
 
 from .. import run
 from ..logging import log
+
+# spawn context so primitives can be pickled into uvicorn's spawn-context ChangeReload worker (#1841)
+_SPAWN_CTX = multiprocessing.get_context('spawn')
 
 method_queue: Queue | None = None
 response_queue: Queue | None = None
@@ -20,9 +24,9 @@ event_sender: Connection | None = None
 def create_queues() -> None:
     """Create the message queues and event pipe. (For internal use only.)"""
     global method_queue, response_queue, event_receiver, event_sender  # pylint: disable=global-statement # noqa: PLW0603
-    method_queue = Queue()
-    response_queue = Queue()
-    event_receiver, event_sender = Pipe(duplex=False)
+    method_queue = _SPAWN_CTX.Queue()
+    response_queue = _SPAWN_CTX.Queue()
+    event_receiver, event_sender = _SPAWN_CTX.Pipe(duplex=False)
 
 
 def remove_queues() -> None:

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -244,7 +244,7 @@ def run(root: Callable | None = None, *,
         width, height = window_size or (800, 600)
         native_host = '127.0.0.1' if host == '0.0.0.0' else host
         if reload:
-            shutdown_event = multiprocessing.Event()
+            shutdown_event = multiprocessing.get_context('spawn').Event()  # match uvicorn ChangeReload worker (#1841)
         native_favicon = str(Path(favicon).resolve()) if favicon and helpers.is_file(favicon) else None
         native_module.activate(protocol, native_host, port, title, width, height, fullscreen, frameless,
                                shutdown_event, native_favicon)

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -244,7 +244,7 @@ def run(root: Callable | None = None, *,
         width, height = window_size or (800, 600)
         native_host = '127.0.0.1' if host == '0.0.0.0' else host
         if reload:
-            shutdown_event = multiprocessing.get_context('spawn').Event()  # match uvicorn ChangeReload worker (#1841)
+            shutdown_event = native_module.native.SPAWN_CONTEXT.Event()
         native_favicon = str(Path(favicon).resolve()) if favicon and helpers.is_file(favicon) else None
         native_module.activate(protocol, native_host, port, title, width, height, fullscreen, frameless,
                                shutdown_event, native_favicon)


### PR DESCRIPTION
### Motivation

Fixes #1841. `ui.run(native=True, reload=True)` raises `RuntimeError: A SemLock created in a fork context is being shared with a process in a spawn context.` on CPython ≥ 3.11.5. NiceGUI's native-mode `Queue`/`Pipe`/`Event` use the default (fork) context, but uvicorn's `ChangeReload` worker is spawn-context, so when ChangeReload pickles parent state for the worker the fork-context SemLocks fail the cross-context check that landed in [cpython#77377](https://github.com/python/cpython/issues/77377). Older CPython silently corrupted state instead of raising, which is the long tail of "leaked semaphore" / "semaphore released too many times" reports in the same issue.

Empirical evidence — distro × backend × Python sweep, exact 3.11.4↔3.11.5 boundary, upstream commit, all in [#1841 (comment)](https://github.com/zauberzeug/nicegui/issues/1841#issuecomment-4408850083).

### Implementation

Switch the three affected primitives to an explicit `multiprocessing.get_context('spawn')`. This is the pattern Python's docs recommend for libraries ([Contexts and start methods](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods): *"Libraries using multiprocessing should be designed to allow their users to provide their own multiprocessing context"*) and what CPython's own SemLock error message tells you to do (*"Please use the same context to create multiprocessing objects and Process"*). Pywebview already uses the same pattern in [`examples/pystray_icon.py`](https://github.com/r0x0r/pywebview/blob/master/examples/pystray_icon.py).

The alternative considered — `multiprocessing.set_start_method('spawn', force=True)` — was rejected because it mutates the user's global default and would break user code that relies on fork (CoW model loading, post-fork file descriptors, ML pipelines). The patch here keeps the user's default untouched and only spawn-types NiceGUI's three IPC primitives.

Verified on `python:3.12-slim` Docker against the patched repo via `PYTHONPATH` (no monkeypatch): unpatched fires `SEMLOCK_FIRED`, patched runs to event-loop block. After-import `multiprocessing.get_start_method(allow_none=True)` is unchanged; `mp.get_context('fork').Queue()` in user code still works.

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.

---

*Drafted by Claude Code working with @evnchn — empirical investigation across distros / CPython patch versions, then surgical fix matching pywebview's existing pattern.*
