### PR TITLE
Improved authentication example

### DIFF
--- a/examples/authentication/main.py
+++ b/examples/authentication/main.py
@@ -14,6 +14,7 @@ from nicegui import app, ui
 # in reality users passwords would obviously need to be hashed
 passwords = {'user1': 'pass1', 'user2': 'pass2'}
 
+# top-level static routes like /favicon.ico must be unrestricted, otherwise the middleware redirects them to /login
 unrestricted_page_routes = {'/favicon.ico', '/login'}
 
 

--- a/examples/authentication/main.py
+++ b/examples/authentication/main.py
@@ -56,7 +56,7 @@ def login(redirect_to: str = '/') -> RedirectResponse | None:
     def try_login() -> None:
         if passwords.get(username.value) == password.value:
             app.storage.user.update(username=username.value, authenticated=True)
-            ui.navigate.to(redirect_to)
+            ui.navigate.to(redirect_to)  # go back to where the user wanted to go
         else:
             ui.notify('Wrong username or password', color='negative')
 

--- a/examples/authentication/main.py
+++ b/examples/authentication/main.py
@@ -61,7 +61,7 @@ def login(redirect_to: str = '/') -> RedirectResponse | None:
             ui.notify('Wrong username or password', color='negative')
 
     with ui.card().classes('absolute-center items-stretch'):
-        username = ui.input('Username').props('autofocus').on('keydown.enter', try_login)
+        username = ui.input('Username').props('autofocus').on('keydown.enter', lambda: password.run_method('focus'))
         password = ui.input('Password', password=True, password_toggle_button=True).on('keydown.enter', try_login)
         ui.button('Log in', on_click=try_login)
 

--- a/examples/authentication/main.py
+++ b/examples/authentication/main.py
@@ -14,7 +14,7 @@ from nicegui import app, ui
 # in reality users passwords would obviously need to be hashed
 passwords = {'user1': 'pass1', 'user2': 'pass2'}
 
-unrestricted_page_routes = {'/login'}
+unrestricted_page_routes = {'/favicon.ico', '/login'}
 
 
 @app.add_middleware
@@ -25,10 +25,16 @@ class AuthMiddleware(BaseHTTPMiddleware):
     """
 
     async def dispatch(self, request: Request, call_next):
-        if not app.storage.user.get('authenticated', False):
-            if not request.url.path.startswith('/_nicegui') and request.url.path not in unrestricted_page_routes:
-                return RedirectResponse(f'/login?redirect_to={request.url.path}')
-        return await call_next(request)
+        path = request.url.path
+
+        if (
+            app.storage.user.get('authenticated', False)
+            or path in unrestricted_page_routes
+            or path.startswith('/_nicegui')
+        ):
+            return await call_next(request)
+
+        return RedirectResponse(f'/login?redirect_to={path}')
 
 
 @ui.page('/')
@@ -49,20 +55,36 @@ def test_page() -> None:
 
 @ui.page('/login')
 def login(redirect_to: str = '/') -> RedirectResponse | None:
-    def try_login() -> None:  # local function to avoid passing username and password as arguments
-        if passwords.get(username.value) == password.value:
-            app.storage.user.update({'username': username.value, 'authenticated': True})
-            ui.navigate.to(redirect_to)  # go back to where the user wanted to go
-        else:
-            ui.notify('Wrong username or password', color='negative')
-
     if app.storage.user.get('authenticated', False):
         return RedirectResponse('/')
-    with ui.card().classes('absolute-center'):
-        username = ui.input('Username').on('keydown.enter', try_login)
+
+    def try_login() -> None:  # local function to avoid passing username and password as arguments
+        if not username.value:
+            ui.notify('Missing username', color='negative')
+            focus(username)
+            return
+
+        if not password.value:
+            focus(password)
+            return
+
+        if passwords.get(username.value) != password.value:
+            ui.notify('Wrong username or password', color='negative')
+            return
+
+        app.storage.user.update(username=username.value, authenticated=True)
+        ui.navigate.to(redirect_to)  # go back to where the user wanted to go
+
+    with ui.card().classes('absolute-center items-stretch'):
+        username = ui.input('Username').props('autofocus').on('keydown.enter', try_login)
         password = ui.input('Password', password=True, password_toggle_button=True).on('keydown.enter', try_login)
         ui.button('Log in', on_click=try_login)
+
     return None
+
+
+def focus(element):
+    ui.run_javascript(f'getElement({element.id}).$refs.qRef.focus()')
 
 
 if __name__ in {'__main__', '__mp_main__'}:

--- a/examples/authentication/main.py
+++ b/examples/authentication/main.py
@@ -27,14 +27,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         path = request.url.path
-
-        if (
-            app.storage.user.get('authenticated', False)
-            or path in unrestricted_page_routes
-            or path.startswith('/_nicegui')
-        ):
+        if app.storage.user.get('authenticated') or path in unrestricted_page_routes or path.startswith('/_nicegui'):
             return await call_next(request)
-
         return RedirectResponse(f'/login?redirect_to={path}')
 
 
@@ -56,25 +50,15 @@ def test_page() -> None:
 
 @ui.page('/login')
 def login(redirect_to: str = '/') -> RedirectResponse | None:
-    if app.storage.user.get('authenticated', False):
+    if app.storage.user.get('authenticated'):
         return RedirectResponse('/')
 
-    def try_login() -> None:  # local function to avoid passing username and password as arguments
-        if not username.value:
-            ui.notify('Missing username', color='negative')
-            username.run_method('focus')
-            return
-
-        if not password.value:
-            password.run_method('focus')
-            return
-
-        if passwords.get(username.value) != password.value:
+    def try_login() -> None:
+        if passwords.get(username.value) == password.value:
+            app.storage.user.update(username=username.value, authenticated=True)
+            ui.navigate.to(redirect_to)
+        else:
             ui.notify('Wrong username or password', color='negative')
-            return
-
-        app.storage.user.update(username=username.value, authenticated=True)
-        ui.navigate.to(redirect_to)  # go back to where the user wanted to go
 
     with ui.card().classes('absolute-center items-stretch'):
         username = ui.input('Username').props('autofocus').on('keydown.enter', try_login)

--- a/examples/authentication/main.py
+++ b/examples/authentication/main.py
@@ -61,11 +61,11 @@ def login(redirect_to: str = '/') -> RedirectResponse | None:
     def try_login() -> None:  # local function to avoid passing username and password as arguments
         if not username.value:
             ui.notify('Missing username', color='negative')
-            focus(username)
+            username.run_method('focus')
             return
 
         if not password.value:
-            focus(password)
+            password.run_method('focus')
             return
 
         if passwords.get(username.value) != password.value:
@@ -81,10 +81,6 @@ def login(redirect_to: str = '/') -> RedirectResponse | None:
         ui.button('Log in', on_click=try_login)
 
     return None
-
-
-def focus(element):
-    ui.run_javascript(f'getElement({element.id}).$refs.qRef.focus()')
 
 
 if __name__ in {'__main__', '__mp_main__'}:


### PR DESCRIPTION
### Motivation

The current authentication example has a few small problems:

- favicons are showing inconsistently
  - png favicons are shown only when logged in, emoji favicons always work
- the username/password page has unexpected (/no) focusing logic
- the widgets are not aligned

### Implementation

- png favicons are accessed via `/favicon.ico` (emojis are inlined)
  - => added `"/favicon.ico"` to `unrestricted_page_routes`
- enter on both username and password tried to log in
  - => implemented the more usual input focus logic:
    - auto-focus username
    - enter on username --> focus password
    - enter on password --> try to log in
- added `items-stretch` to `ui.card()`
- also, simplified `AuthMiddleware.dispatch` by inverting the logic as it was a bit hard to understand

In particular the favicon problem is not easy to understand when it happens. So, having it in the example is probably a good idea. I imagine, the same problem might trigger elsewhere as well, e.g., for `robots.txt`. This might warrant a comment somewhere? (where?)

If the `items-stretch` is desired, I can add a new screenshot...

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes.
