### PR TITLE
Surface llms.txt in the homepage CTA alongside the JSON documentation index

### DIFF
--- a/website/components/cta_section.py
+++ b/website/components/cta_section.py
@@ -16,7 +16,8 @@ def create() -> None:
             cta_button('Documentation', on_click=lambda: ui.navigate.to('/documentation')).classes('mb-12')
             ui.markdown('''
                 **Or, let your AI do it!**
-                Most LLMs already know NiceGUI, and
-                our [documentation index](/documentation/section_configuration_deployment#documentation_index)
-                puts the full API into a single JSON file.
+                Most LLMs already know NiceGUI. For the rest, paste our
+                [LLM reference](/llms.txt) — a single Markdown drop-in — or point a
+                RAG pipeline at the [documentation index](/documentation/section_configuration_deployment#documentation_index)
+                for the full API as JSON.
             ''').classes(f'{d.TEXT_15PX} {d.TEXT_SECONDARY} max-w-120')

--- a/website/components/cta_section.py
+++ b/website/components/cta_section.py
@@ -16,8 +16,8 @@ def create() -> None:
             cta_button('Documentation', on_click=lambda: ui.navigate.to('/documentation')).classes('mb-12')
             ui.markdown('''
                 **Or, let your AI do it!**
-                Most LLMs already know NiceGUI. For the rest, paste our
-                [LLM reference](/llms.txt) — a single Markdown drop-in — or point a
-                RAG pipeline at the [documentation index](/documentation/section_configuration_deployment#documentation_index)
+                Most LLMs already know NiceGUI.
+                For the rest, paste our [LLM reference](/llms.txt) (a single Markdown drop-in),
+                or point a RAG pipeline at the [documentation index](/documentation/section_configuration_deployment#documentation_index)
                 for the full API as JSON.
             ''').classes(f'{d.TEXT_15PX} {d.TEXT_SECONDARY} max-w-120')


### PR DESCRIPTION
_Drafted by @evnchn with Claude Code (Opus 4.7); diff and rendered copy reviewed before pushing._

### Motivation

#6021 landed `nicegui/llms.md`, the `/llms.txt` route, and a footer link, but the homepage CTA still only mentions the older [machine-readable JSON `documentation_index`](/documentation/section_configuration_deployment#documentation_index). The two artifacts serve different jobs:

- **`llms.txt`** — one condensed Markdown file you paste into a prompt
- **`documentation_index`** — full-content JSON for RAG / agent tooling

A visitor on the homepage who wants to "let the AI do it" should see both on the discovery surface.

### Implementation

One-line copy change to the existing `ui.markdown` block in `website/components/cta_section.py` — no styling, structure, or new files. The new copy frames the two artifacts as complementary (paste-in vs. RAG) and links each to its use case:

```markdown
**Or, let your AI do it!**
Most LLMs already know NiceGUI. For the rest, paste our
[LLM reference](/llms.txt) — a single Markdown drop-in — or point a
RAG pipeline at the [documentation index](/documentation/section_configuration_deployment#documentation_index)
for the full API as JSON.
```

Link label "LLM reference" matches the existing footer link added in #6021.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary. (Copy-only change to a single `ui.markdown` string; no logic or routes touched.)
- [x] Documentation has been added/updated.
- [x] No breaking changes to the public API or migration steps are described above.
