### PR TITLE
Skip outbox echo when server stored value matches client emit

### DIFF
--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -15,7 +15,7 @@ class ValueElement(Element, Generic[ValueT]):
     LOOPBACK: bool | None = True
     '''Whether to set the new value directly on the client or after getting an update from the server.
 
-    - ``True``: The value is updated by sending a change event to the server which responds with an update.
+    - ``True``: The value is updated by sending a change event to the server; the server echoes back unless the value matches what the client just sent.
     - ``False``: The value is updated by setting the VALUE_PROP directly on the client.
     - ``None``: The value is updated automatically by the Vue element.
     '''
@@ -43,9 +43,14 @@ class ValueElement(Element, Generic[ValueT]):
             self.on_value_change(on_value_change)
 
         def handle_change(e: GenericEventArguments) -> None:
-            self._send_update_on_value_change = self.LOOPBACK is True
-            self.set_value(self._event_args_to_value(e))
-            self._send_update_on_value_change = True
+            self._send_update_on_value_change = False
+            try:
+                self.set_value(self._event_args_to_value(e))
+            finally:
+                self._send_update_on_value_change = True
+            # skip the echo when the server's value matches what the client locally rendered (see #5933)
+            if self.LOOPBACK is True and self._props[self.VALUE_PROP] != e.args:
+                self.update()
         self.on(f'update:{self.VALUE_PROP}', handle_change, [None], throttle=throttle)
 
     def on_value_change(self, callback: Handler[ValueChangeEventArguments[ValueT]]) -> Self:

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -272,8 +272,10 @@ function renderRecursively(elements, id, propsContext) {
         else setTimeout(delayed_emitter, 10);
       };
       throttle(delayed_emitter, event.throttle, event.leading_events, event.trailing_events, event.listener_id);
-      if (element.props["loopback"] === False && event.type == "update:modelValue") {
-        element.props["model-value"] = args;
+      // mirror locally so the client-rendered value survives re-render when the server elides the echo (see #5933)
+      if ((element.props["loopback"] === true || element.props["loopback"] === false)
+          && event.type == "update:modelValue") {
+        element.props["model-value"] = args[0];
       }
     };
 

--- a/tests/test_value_echo_skip.py
+++ b/tests/test_value_echo_skip.py
@@ -1,0 +1,175 @@
+"""Tests for the client-value echo skip optimization in ValueElement (see #5933)."""
+
+from collections.abc import Callable
+
+import pytest
+
+from nicegui import ui
+from nicegui.elements.mixins.value_element import ValueElement
+from nicegui.helpers import event_type_to_camel_case
+from nicegui.testing import User
+
+
+class PlainValue(ValueElement[str]):
+
+    def __init__(self, *, value: str = '', on_change: Callable | None = None) -> None:
+        super().__init__(tag='div', value=value, on_value_change=on_change)
+
+
+class TruncatingValue(ValueElement[str]):
+
+    def __init__(self, *, value: str = '') -> None:
+        super().__init__(tag='div', value=value)
+
+    def _value_to_model_value(self, value):  # type: ignore[override]
+        return (value or '')[:3]
+
+
+def _outbox_has_update_for(element) -> bool:
+    return element.id in element.client.outbox.updates
+
+
+def _simulate_client_change(element, value) -> None:
+    event_name = event_type_to_camel_case(f'update:{element.VALUE_PROP}')
+    listeners = element._event_listeners  # pylint: disable=protected-access
+    try:
+        listener_id = next(lid for lid, listener in listeners.items() if listener.type == event_name)
+    except StopIteration:
+        types = sorted({listener.type for listener in listeners.values()})
+        raise AssertionError(f'no {event_name!r} listener on {element!r}; have: {types}') from None
+    element._handle_event({'listener_id': listener_id, 'args': value})  # pylint: disable=protected-access
+
+
+def _single(user: User, kind):
+    return next(iter(user.find(kind=kind).elements))
+
+
+async def test_pure_echo_is_skipped(user: User):
+    @ui.page('/')
+    def page():
+        PlainValue(value='')
+
+    await user.open('/')
+    elem = _single(user, PlainValue)
+    elem.client.outbox.updates.clear()
+    _simulate_client_change(elem, 'hello')
+    assert elem.value == 'hello'
+    assert not _outbox_has_update_for(elem)
+
+
+async def test_server_transform_is_echoed(user: User):
+    @ui.page('/')
+    def page():
+        TruncatingValue(value='')
+
+    await user.open('/')
+    elem = _single(user, TruncatingValue)
+    elem.client.outbox.updates.clear()
+    _simulate_client_change(elem, 'abcdef')
+    assert elem._props[elem.VALUE_PROP] == 'abc'  # pylint: disable=protected-access
+    assert _outbox_has_update_for(elem)
+
+
+async def test_on_change_correction_is_echoed(user: User):
+    @ui.page('/')
+    def page():
+        PlainValue(value='', on_change=lambda e: setattr(e.sender, 'value', str(e.value).upper()))
+
+    await user.open('/')
+    elem = _single(user, PlainValue)
+    elem.client.outbox.updates.clear()
+    _simulate_client_change(elem, 'hello')
+    assert elem.value == 'HELLO'
+    assert _outbox_has_update_for(elem)
+
+
+async def test_side_effect_update_in_handler_flows_through(user: User):
+    @ui.page('/')
+    def page():
+        PlainValue(value='', on_change=lambda e: e.sender.classes('error'))
+
+    await user.open('/')
+    elem = _single(user, PlainValue)
+    elem.client.outbox.updates.clear()
+    _simulate_client_change(elem, 'x')
+    assert _outbox_has_update_for(elem)
+
+
+async def test_loopback_false_still_skips(user: User):
+    @ui.page('/')
+    def page():
+        ui.input(value='')
+
+    await user.open('/')
+    inp = _single(user, ui.input)
+    inp.client.outbox.updates.clear()
+    _simulate_client_change(inp, 'hello')
+    assert inp.value == 'hello'
+    assert not _outbox_has_update_for(inp)
+
+
+async def test_to_dict_still_carries_value(user: User):
+    @ui.page('/')
+    def page():
+        PlainValue(value='initial')
+
+    await user.open('/')
+    elem = _single(user, PlainValue)
+    _simulate_client_change(elem, 'client_typed')
+    assert elem._to_dict()['props'][elem.VALUE_PROP] == 'client_typed'  # pylint: disable=protected-access
+
+
+@pytest.mark.parametrize('factory, kind, emit', [
+    (lambda: ui.checkbox('cb'), ui.checkbox, True),
+    (lambda: ui.switch('sw'), ui.switch, True),
+    (lambda: ui.dialog(), ui.dialog, True),
+    (lambda: ui.menu(), ui.menu, True),
+    (lambda: ui.expansion('exp'), ui.expansion, True),
+    (lambda: ui.select(options=['a', 'b'], value='a'), ui.select, {'value': 1, 'label': 'b'}),
+])
+async def test_real_loopback_true_elements_skip_echo(user: User, factory, kind, emit):
+    @ui.page('/')
+    def page():
+        factory()
+
+    await user.open('/')
+    elem = _single(user, kind)
+    elem.client.outbox.updates.clear()
+    _simulate_client_change(elem, emit)
+    assert not _outbox_has_update_for(elem)
+
+
+async def test_rapid_toggles_do_not_enqueue_outbox_update(user: User):
+    @ui.page('/')
+    def page():
+        ui.checkbox('cb')
+
+    await user.open('/')
+    cb = _single(user, ui.checkbox)
+    cb.client.outbox.updates.clear()
+    for i in range(50):
+        _simulate_client_change(cb, bool(i % 2))
+    assert cb.id not in cb.client.outbox.updates
+
+
+async def test_set_value_exception_does_not_leak_suppression(user: User, caplog: pytest.LogCaptureFixture):
+    class Raising(ValueElement[str]):
+        def __init__(self) -> None:
+            super().__init__(tag='div', value='')
+
+        def _value_to_model_value(self, value):  # type: ignore[override]
+            if value == 'BOOM':
+                raise ValueError('nope')
+            return value
+
+    @ui.page('/')
+    def page():
+        Raising()
+
+    await user.open('/')
+    elem = _single(user, Raising)
+    _simulate_client_change(elem, 'BOOM')  # handle_event swallows + logs the ValueError
+    caplog.clear()
+    elem.client.outbox.updates.clear()
+    elem.value = 'legit'  # server-driven change must still flow
+    assert _outbox_has_update_for(elem)


### PR DESCRIPTION
*Authored on Evan's behalf by Claude Code (Opus 4.7, 1M-context). Reviewed and approved by Evan before submission.*

### Motivation

LOOPBACK=True `ValueElement` subclasses (checkbox, switch, dialog, menu, expansion, select, radio, toggle, slider, …) currently echo every client-originated value change: `handle_change → set_value → _handle_value_change → update() → outbox sends the full element state back, including the value the client just emitted`. The echo is redundant — the client already has that value — and on high-latency links it races user input (see #5185).

Implements the approach @falkoschindler proposed in the review of #5728: *"don't resend values that came from the client."* Supersedes the closed #5933, which attempted the same goal via wire-format stripping + a JS prop-merge but broke Quasar components using `model-value` as UI state and would have silently dropped every server-initiated prop *removal* via the merge contract.

### Implementation

**Python** (`nicegui/elements/mixins/value_element.py`) — `handle_change` suspends the inner `update()` during `set_value`, then conditionally fires it only when `_props[VALUE_PROP]` diverges from `e.args` (the raw client emit). Transforms via `_value_to_model_value`, `on_change` handler corrections, and unrelated prop mutations still propagate because their post-state differs from `e.args` or because they enqueue through their own `update()` calls.

**JavaScript** (`nicegui/static/nicegui.js`) — extend the existing LOOPBACK=False local-prop-update branch to also cover LOOPBACK=True. The client-side mirror is what makes the server's elided echo safe: Vue's next re-render reads the locally-stored `model-value` instead of the stale one. Also fixes a latent shape bug in the local assignment: `args[0]` (the emitted scalar) instead of `args` (the rest-parameter array). The array form happened to work for `ui.number` because Quasar's `QInput` coerces, but would have broken for booleans on the new path.

`_to_dict` is unchanged → reconnections still receive the authoritative full snapshot including `VALUE_PROP`.

LOOPBACK=False (`ui.input`, `ui.number`, …) and LOOPBACK=None (`ui.fullscreen`, codemirror) behavior is preserved — the final `if self.LOOPBACK is True` guard scopes the new echo path to elements that previously echoed.

<details>
<summary>Why <code>try/finally</code> around <code>set_value</code> (pre-empting the "looks defensive, drop it?" question)</summary>

```python
self._send_update_on_value_change = False     # transient suppress
try:
    self.set_value(self._event_args_to_value(e))
finally:
    self._send_update_on_value_change = True
```

The flag is an instance attribute that persists across calls. If `set_value` raises — a user-overridden `_value_to_model_value`, a binding peer's setter, or a synchronous `on_change` handler — `handle_event` catches it at the boundary, but the flag stays at `False`. Every subsequent server-driven `element.value = X` then silently skips its `update()` call, killing the outbox for that element's lifetime.

The pre-PR code didn't need `try/finally` because it assigned `self._send_update_on_value_change = self.LOOPBACK is True` on entry — the safe end-state. This PR enters with the unsafe transient state, so the restore line becomes load-bearing. Covered by `test_set_value_exception_does_not_leak_suppression` (mutation-verified: removing `try/finally` makes that test fail).

</details>

Closes #5933. Tracks #5185.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation has been added/updated or is not necessary. <!-- LOOPBACK docstring updated; no public API change. -->
- [x] No breaking changes to the public API or migration steps are described above.
