### PR TITLE
Fix run.cpu_bound/io_bound return type to R | None

### DIFF
--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -1,4 +1,5 @@
 import asyncio
+import enum
 import logging
 import signal
 import traceback
@@ -8,7 +9,7 @@ from concurrent.futures.process import BrokenProcessPool
 from contextlib import suppress
 from functools import partial
 from pickle import PicklingError
-from typing import Any, TypeVar
+from typing import Any, Generic, TypeVar
 
 from typing_extensions import ParamSpec
 
@@ -19,6 +20,46 @@ thread_pool = ThreadPoolExecutor()
 
 P = ParamSpec('P')
 R = TypeVar('R')
+
+
+class _Sentinel(enum.Enum):
+    NONE_MARKER = 'none_marker'
+
+
+NONE_MARKER = _Sentinel.NONE_MARKER
+'''Sentinel returned by :class:`wrap_none`-wrapped callbacks when they legitimately return ``None``.
+
+Use ``result is run.NONE_MARKER`` to detect this case. Plain ``result is None`` then means the
+``cpu_bound`` / ``io_bound`` call was cancelled or the app is shutting down.
+'''
+
+
+class wrap_none(Generic[P, R]):  # pylint: disable=invalid-name
+    """Wrap a callable so that a legitimate ``None`` return becomes :data:`NONE_MARKER`.
+
+    Use to distinguish "the callback returned ``None``" from "``cpu_bound`` / ``io_bound`` aborted"
+    when both can occur::
+
+        result = await run.cpu_bound(run.wrap_none(my_func), arg1)
+        if result is None:
+            ...  # run was cancelled / app shutting down
+        elif result is run.NONE_MARKER:
+            ...  # my_func returned None
+        else:
+            ...  # real value
+
+    Implemented as a module-level callable class (not a closure) so the wrapper itself is picklable
+    and survives ``cpu_bound``'s process boundary.
+    """
+
+    def __init__(self, fn: Callable[P, R]) -> None:
+        self.fn = fn
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R | _Sentinel:
+        result = self.fn(*args, **kwargs)
+        if result is None:
+            return NONE_MARKER
+        return result
 
 
 def setup() -> None:
@@ -58,9 +99,9 @@ def safe_callback(callback: Callable, *args, **kwargs) -> Any:
         raise SubprocessException(type(e).__name__, str(e), traceback.format_exc()) from None
 
 
-async def _run(executor: Any, callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+async def _run(executor: Any, callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R | None:
     if core.app.is_stopping:
-        return  # type: ignore  # the assumption is that the user's code no longer cares about this value
+        return None
     try:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(executor, partial(callback, *args, **kwargs))
@@ -69,16 +110,20 @@ async def _run(executor: Any, callback: Callable[P, R], *args: P.args, **kwargs:
             raise
     except asyncio.CancelledError:
         pass
-    return  # type: ignore  # the assumption is that the user's code no longer cares about this value
+    return None
 
 
-async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R | None:
     """Run a CPU-bound function in a separate process.
 
     `run.cpu_bound` needs to execute the function in a separate process.
     For this it needs to transfer the whole state of the passed function to the process (which is done with pickle).
     It is encouraged to create static methods (or free functions) which get all the data as simple parameters (eg. no class/ui logic)
     and return the result (instead of writing it in class properties or global variables).
+
+    Returns ``None`` (instead of the callback's result) when the call is cancelled or the app is shutting down.
+    If the callback itself may legitimately return ``None``, wrap it with :class:`wrap_none`
+    to distinguish the two cases.
     """
     global process_pool  # pylint: disable=global-statement # noqa: PLW0603
 
@@ -100,8 +145,13 @@ async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs)
             raise e
 
 
-async def io_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
-    """Run an I/O-bound function in a separate thread."""
+async def io_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R | None:
+    """Run an I/O-bound function in a separate thread.
+
+    Returns ``None`` (instead of the callback's result) when the call is cancelled or the app is shutting down.
+    If the callback itself may legitimately return ``None``, wrap it with :class:`wrap_none`
+    to distinguish the two cases.
+    """
     return await _run(thread_pool, callback, *args, **kwargs)
 
 

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -60,7 +60,7 @@ def safe_callback(callback: Callable, *args, **kwargs) -> Any:
 
 async def _run(executor: Any, callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R | None:
     if core.app.is_stopping:
-        return None
+        return None  # DEPRECATED: This is an interim shape. NiceGUI 4.0 will instead raise CancelledError in this case.
     try:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(executor, partial(callback, *args, **kwargs))
@@ -69,7 +69,7 @@ async def _run(executor: Any, callback: Callable[P, R], *args: P.args, **kwargs:
             raise
     except asyncio.CancelledError:
         pass
-    return None
+    return None  # DEPRECATED: This is an interim shape. NiceGUI 4.0 will instead raise CancelledError in this case.
 
 
 async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R | None:

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -1,5 +1,4 @@
 import asyncio
-import enum
 import logging
 import signal
 import traceback
@@ -9,7 +8,7 @@ from concurrent.futures.process import BrokenProcessPool
 from contextlib import suppress
 from functools import partial
 from pickle import PicklingError
-from typing import Any, Generic, TypeVar
+from typing import Any, TypeVar
 
 from typing_extensions import ParamSpec
 
@@ -20,46 +19,6 @@ thread_pool = ThreadPoolExecutor()
 
 P = ParamSpec('P')
 R = TypeVar('R')
-
-
-class _Sentinel(enum.Enum):
-    NONE_MARKER = 'none_marker'
-
-
-NONE_MARKER = _Sentinel.NONE_MARKER
-'''Sentinel returned by :class:`wrap_none`-wrapped callbacks when they legitimately return ``None``.
-
-Use ``result is run.NONE_MARKER`` to detect this case. Plain ``result is None`` then means the
-``cpu_bound`` / ``io_bound`` call was cancelled or the app is shutting down.
-'''
-
-
-class wrap_none(Generic[P, R]):  # pylint: disable=invalid-name
-    """Wrap a callable so that a legitimate ``None`` return becomes :data:`NONE_MARKER`.
-
-    Use to distinguish "the callback returned ``None``" from "``cpu_bound`` / ``io_bound`` aborted"
-    when both can occur::
-
-        result = await run.cpu_bound(run.wrap_none(my_func), arg1)
-        if result is None:
-            ...  # run was cancelled / app shutting down
-        elif result is run.NONE_MARKER:
-            ...  # my_func returned None
-        else:
-            ...  # real value
-
-    Implemented as a module-level callable class (not a closure) so the wrapper itself is picklable
-    and survives ``cpu_bound``'s process boundary.
-    """
-
-    def __init__(self, fn: Callable[P, R]) -> None:
-        self.fn = fn
-
-    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R | _Sentinel:
-        result = self.fn(*args, **kwargs)
-        if result is None:
-            return NONE_MARKER
-        return result
 
 
 def setup() -> None:
@@ -122,8 +81,8 @@ async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs)
     and return the result (instead of writing it in class properties or global variables).
 
     Returns ``None`` (instead of the callback's result) when the call is cancelled or the app is shutting down.
-    If the callback itself may legitimately return ``None``, wrap it with :class:`wrap_none`
-    to distinguish the two cases.
+    This ``None`` return is an interim shape: NiceGUI 4.0 will instead raise ``CancelledError`` in these cases,
+    so ``if result is None: ...`` checks should be treated as temporary.
     """
     global process_pool  # pylint: disable=global-statement # noqa: PLW0603
 
@@ -149,8 +108,8 @@ async def io_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) 
     """Run an I/O-bound function in a separate thread.
 
     Returns ``None`` (instead of the callback's result) when the call is cancelled or the app is shutting down.
-    If the callback itself may legitimately return ``None``, wrap it with :class:`wrap_none`
-    to distinguish the two cases.
+    This ``None`` return is an interim shape: NiceGUI 4.0 will instead raise ``CancelledError`` in these cases,
+    so ``if result is None: ...`` checks should be treated as temporary.
     """
     return await _run(thread_pool, callback, *args, **kwargs)
 

--- a/nicegui/welcome.py
+++ b/nicegui/welcome.py
@@ -20,7 +20,7 @@ async def collect_urls() -> None:
     protocol = os.environ.get('NICEGUI_PROTOCOL')
     if not host or not port or not protocol:
         return
-    ips = set((await run.io_bound(_get_all_ips)) if host == '0.0.0.0' else [])
+    ips = set((await run.io_bound(_get_all_ips) or []) if host == '0.0.0.0' else [])
     ips.discard('127.0.0.1')
     sorted_ips = ['localhost' if host == '0.0.0.0' else host, *sorted(ips)]
     urls = [format_url(protocol, ip, int(port)) for ip in sorted_ips]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -110,25 +110,3 @@ async def test_returns_none_when_app_is_stopping(user: User, func: Callable):
 
     await user.open('/')
     await user.should_see('result=None')
-
-
-def returns_none() -> None:
-    return None
-
-
-def returns_value() -> str:
-    return 'real'
-
-
-@pytest.mark.parametrize('func', [run.cpu_bound, run.io_bound])
-async def test_wrap_none_disambiguates(user: User, func: Callable):
-    @ui.page('/')
-    async def index():
-        none_result = await func(run.wrap_none(returns_none))
-        value_result = await func(run.wrap_none(returns_value))
-        ui.label(f'none={none_result is run.NONE_MARKER}')
-        ui.label(f'value={value_result}')
-
-    await user.open('/')
-    await user.should_see('none=True')
-    await user.should_see('value=real')

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -8,6 +8,7 @@ from pickle import PicklingError
 import pytest
 
 from nicegui import app, run, ui
+from nicegui.app.app import State
 from nicegui.testing import User
 
 
@@ -93,3 +94,41 @@ async def test_run_cpu_bound_survive_bad_function(user: User):
 
     await user.open('/')
     await user.should_see('excellent')
+
+
+@pytest.mark.parametrize('func', [run.cpu_bound, run.io_bound])
+async def test_returns_none_when_app_is_stopping(user: User, func: Callable):
+    @ui.page('/')
+    async def index():
+        original_state = app._state  # pylint: disable=protected-access
+        app._state = State.STOPPING  # pylint: disable=protected-access
+        try:
+            result = await func(delayed_hello)
+            ui.label(f'result={result}')
+        finally:
+            app._state = original_state  # pylint: disable=protected-access
+
+    await user.open('/')
+    await user.should_see('result=None')
+
+
+def returns_none() -> None:
+    return None
+
+
+def returns_value() -> str:
+    return 'real'
+
+
+@pytest.mark.parametrize('func', [run.cpu_bound, run.io_bound])
+async def test_wrap_none_disambiguates(user: User, func: Callable):
+    @ui.page('/')
+    async def index():
+        none_result = await func(run.wrap_none(returns_none))
+        value_result = await func(run.wrap_none(returns_value))
+        ui.label(f'none={none_result is run.NONE_MARKER}')
+        ui.label(f'value={value_result}')
+
+    await user.open('/')
+    await user.should_see('none=True')
+    await user.should_see('value=real')

--- a/website/documentation/content/section_action_events.py
+++ b/website/documentation/content/section_action_events.py
@@ -103,37 +103,6 @@ def io_bound_demo():
     ui.button('Download', on_click=handle_click)
 
 
-@doc.demo('Distinguishing cancellation from a legitimate `None`', '''
-    Both `run.cpu_bound` and `run.io_bound` return `None` when the call is cancelled
-    or the app is shutting down — regardless of the callback's signature.
-    If your callback may itself legitimately return `None`, you cannot tell the two cases apart from the return value alone.
-
-    Wrap the callback with `run.wrap_none` so a legitimate `None` becomes `run.NONE_MARKER` (a picklable sentinel).
-    Plain `None` then unambiguously means the call was aborted.
-
-    Note: `run.wrap_none` is implemented as a callable class rather than a closure,
-    so the wrapper itself survives pickling across `cpu_bound`'s process boundary.
-    A bare `object()` does not — `pickle` constructs a fresh instance on the parent side,
-    and `result is SENTINEL` then always returns `False`.
-''')
-def sentinel_demo():
-    from nicegui import run
-
-    def lookup(key: str) -> str | None:
-        return None if key == 'missing' else f'value_for_{key}'
-
-    async def handle_click():
-        result = await run.io_bound(run.wrap_none(lookup), 'missing')
-        if result is None:
-            ui.notify('run was cancelled / app shutting down')
-        elif result is run.NONE_MARKER:
-            ui.notify('lookup returned None (genuine)')
-        else:
-            ui.notify(f'lookup returned {result}')
-
-    ui.button('Lookup', on_click=handle_click)
-
-
 doc.intro(run_javascript_documentation)
 doc.intro(clipboard_documentation)
 doc.intro(event_documentation)

--- a/website/documentation/content/section_action_events.py
+++ b/website/documentation/content/section_action_events.py
@@ -103,6 +103,37 @@ def io_bound_demo():
     ui.button('Download', on_click=handle_click)
 
 
+@doc.demo('Distinguishing cancellation from a legitimate `None`', '''
+    Both `run.cpu_bound` and `run.io_bound` return `None` when the call is cancelled
+    or the app is shutting down — regardless of the callback's signature.
+    If your callback may itself legitimately return `None`, you cannot tell the two cases apart from the return value alone.
+
+    Wrap the callback with `run.wrap_none` so a legitimate `None` becomes `run.NONE_MARKER` (a picklable sentinel).
+    Plain `None` then unambiguously means the call was aborted.
+
+    Note: `run.wrap_none` is implemented as a callable class rather than a closure,
+    so the wrapper itself survives pickling across `cpu_bound`'s process boundary.
+    A bare `object()` does not — `pickle` constructs a fresh instance on the parent side,
+    and `result is SENTINEL` then always returns `False`.
+''')
+def sentinel_demo():
+    from nicegui import run
+
+    def lookup(key: str) -> str | None:
+        return None if key == 'missing' else f'value_for_{key}'
+
+    async def handle_click():
+        result = await run.io_bound(run.wrap_none(lookup), 'missing')
+        if result is None:
+            ui.notify('run was cancelled / app shutting down')
+        elif result is run.NONE_MARKER:
+            ui.notify('lookup returned None (genuine)')
+        else:
+            ui.notify(f'lookup returned {result}')
+
+    ui.button('Lookup', on_click=handle_click)
+
+
 doc.intro(run_javascript_documentation)
 doc.intro(clipboard_documentation)
 doc.intro(event_documentation)


### PR DESCRIPTION
### Motivation

`run.cpu_bound` and `run.io_bound` are annotated as returning `R`, but at runtime both silently return `None` when the call is cancelled or the app is shutting down (suppressed `# type: ignore` markers in the existing code). This is the bug reported in #5925 — downstream code that trusts the `R` return type hits `TypeError`s on `None` when shutdown races a `run.*_bound` call.

The earlier attempt to fix this in #5926 used a `strict: bool` kwarg with overloads to opt into raise-on-cancel. Two backwards-compat blockers killed that approach:

1. **`strict` is stolen from `P.kwargs`** — any callback with its own `strict` kwarg (SQLAlchemy, Pydantic, JSON schema validators, etc.) silently loses that argument. Structural to "steal a kwarg from `P.kwargs`"; no chosen kwarg name is safe.
2. **Switching the default to "raise on cancel"** is a runtime breaking change for 3.x.

There's also a hard typing constraint: PEP 612 forbids keyword args between `*args: P.args` and `**kwargs: P.kwargs`, so the interleaved `strict` overloads in #5926 fail mypy with `Arguments not allowed after ParamSpec.args` (also see [python/typing#1009](https://github.com/python/typing/issues/1009), [discuss.python.org](https://discuss.python.org/t/using-concatenate-and-paramspec-with-a-keyword-argument/32283)).

### Agreed direction

Per the [review discussion](https://github.com/zauberzeug/nicegui/pull/6056#issuecomment-4707711318): **NiceGUI 4.0 will raise `CancelledError` on cancel/shutdown** instead of returning `None`, making the return type honestly `R` again and matching normal `await` semantics — the silent-`None` sentinel was the actual root bug.

Given that, this PR is **trimmed to the minimum-correct interim kernel** for the 3.x window, so #5925's silent-`None` `TypeError`s stop being invisible — without adding public surface we'd deprecate at 4.0.

### Implementation

**Type-only correction** (runtime unchanged):
- `_run`, `cpu_bound`, `io_bound` now annotate `R | None` to match runtime reality. The `# type: ignore` markers go away.
- `nicegui/welcome.py` now `or []`-guards `run.io_bound` in `collect_urls`.
- Docstrings on `cpu_bound`/`io_bound` note the `None` return is **interim** — 4.0 will raise instead — so callers writing `if result is None: ...` know it's a temporary shape.
- New test `test_returns_none_when_app_is_stopping` (parametrized over `cpu_bound` + `io_bound`).

**Dropped from the earlier revision of this PR** (kept on record in the thread for anyone who needs the disambiguation pattern in the 3.x window): the `wrap_none` / `NONE_MARKER` sentinel helper, its demo in `section_action_events.py`, and `test_wrap_none_disambiguates`. With 4.0 raising on abort, a plain `None` will unambiguously mean "the callback returned `None`", so the wrapper has nothing left to do — not worth shipping two public names with a ~5-month shelf life.

### Release note

The annotation change from `R` to `R | None` is **type-level only; runtime behavior is unchanged.** mypy may flag new errors in user code that previously typed a `run.cpu_bound` / `run.io_bound` result as non-Optional `R`. Those errors are **surfaced latent bugs, not regressions** — the value could already be `None` at runtime on cancel/shutdown (#5925). The migration is a `None`-check now; at 4.0 it becomes a `try/except CancelledError`.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added (`test_returns_none_when_app_is_stopping`, parametrized over `cpu_bound` + `io_bound`).
- [x] Documentation has been updated (interim-`None` note in the `cpu_bound`/`io_bound` docstrings).
- [x] About breaking changes to the public API: Type-level breaking (annotation now `R | None`); runtime behavior unchanged. See **Release note** above.

---

Closes #5925.
Alternative to #5926 — see that thread for the design discussion.
