### PR TITLE
Fix `Client has been deleted` warning spam on reload (#6058)

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -16,7 +16,7 @@ from starlette.background import BackgroundTask
 from typing_extensions import Self
 
 from . import background_tasks, binding, core, helpers, json, storage
-from .awaitable_response import AwaitableResponse, NullResponse
+from .awaitable_response import AwaitableResponse
 from .dependencies import generate_resources
 from .element import Element
 from .favicon import get_favicon_url
@@ -262,8 +262,6 @@ class Client:
 
         :return: AwaitableResponse that can be awaited to get the result of the JavaScript code
         """
-        if self._deleted:
-            return NullResponse()
         request_id = str(uuid.uuid4())
         target_id = self._temporary_socket_id or self.id
 

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -16,7 +16,7 @@ from starlette.background import BackgroundTask
 from typing_extensions import Self
 
 from . import background_tasks, binding, core, helpers, json, storage
-from .awaitable_response import AwaitableResponse
+from .awaitable_response import AwaitableResponse, NullResponse
 from .dependencies import generate_resources
 from .element import Element
 from .favicon import get_favicon_url
@@ -132,6 +132,11 @@ class Client:
     def has_socket_connection(self) -> bool:
         """Whether the client is connected."""
         return self.tab_id is not None
+
+    @property
+    def is_deleted(self) -> bool:
+        """Whether the client has been deleted (e.g. by browser disconnect after ``reconnect_timeout``)."""
+        return self._deleted
 
     @property
     def head_html(self) -> str:
@@ -257,6 +262,8 @@ class Client:
 
         :return: AwaitableResponse that can be awaited to get the result of the JavaScript code
         """
+        if self._deleted:
+            return NullResponse()
         request_id = str(uuid.uuid4())
         target_id = self._temporary_socket_id or self.id
 

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -412,7 +412,12 @@ class Element(Visibility):
 
     def update(self) -> None:
         """Update the element on the client side."""
+        if self.client.is_deleted:
+            return  # silent: client teardown race (e.g. browser reload during async callback)
         if self.is_deleted:
+            helpers.warn_once(f'Element {self.id} has been deleted but is still being used. '
+                              'This is most likely a bug in your application code.',
+                              stack_info=True)
             return
         self.client.outbox.enqueue_update(self)
 
@@ -428,6 +433,13 @@ class Element(Visibility):
         """
         if not core.is_loop_running():
             return NullResponse()
+        if self.client.is_deleted:
+            return NullResponse()  # silent: client teardown race
+        if self.is_deleted:
+            helpers.warn_once(f'Element {self.id} has been deleted but is still being used. '
+                              'This is most likely a bug in your application code.',
+                              stack_info=True)
+            return NullResponse()
         return self.client.run_javascript(
             f'return runMethod({self.id}, {json.dumps(name)}, {json.dumps(args)})', timeout=timeout,
         )
@@ -441,6 +453,13 @@ class Element(Visibility):
         :param timeout: maximum time to wait for a response (default: 1 second)
         """
         if not core.is_loop_running():
+            return NullResponse()
+        if self.client.is_deleted:
+            return NullResponse()  # silent: client teardown race
+        if self.is_deleted:
+            helpers.warn_once(f'Element {self.id} has been deleted but is still being used. '
+                              'This is most likely a bug in your application code.',
+                              stack_info=True)
             return NullResponse()
         return self.client.run_javascript(
             f'return getComputedProp({self.id}, {json.dumps(prop_name)})', timeout=timeout,

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -410,14 +410,26 @@ class Element(Visibility):
         args = events.GenericEventArguments(sender=self, client=self.client, args=msg['args'])
         events.handle_event(listener.handler, args)
 
-    def update(self) -> None:
-        """Update the element on the client side."""
+    def _is_safe_to_interact(self) -> bool:
+        """Return True if it is safe to send messages to this element's client.
+
+        Silent when the *client* has been deleted (e.g. browser reload race past ``reconnect_timeout``):
+        an async callback resuming after the teardown is not a user bug. Emits a one-shot warning
+        when the *element* has been explicitly deleted but the client is still alive: that is a real
+        use-after-free in user code and worth surfacing.
+        """
         if self.client.is_deleted:
-            return  # silent: client teardown race (e.g. browser reload during async callback)
+            return False
         if self.is_deleted:
-            helpers.warn_once(f'Element {self.id} has been deleted but is still being used. '
+            helpers.warn_once(f'{self} (id={self.id}) has been deleted but is still being used. '
                               'This is most likely a bug in your application code.',
                               stack_info=True)
+            return False
+        return True
+
+    def update(self) -> None:
+        """Update the element on the client side."""
+        if not self._is_safe_to_interact():
             return
         self.client.outbox.enqueue_update(self)
 
@@ -431,14 +443,7 @@ class Element(Visibility):
         :param args: arguments to pass to the method
         :param timeout: maximum time to wait for a response (default: 1 second)
         """
-        if not core.is_loop_running():
-            return NullResponse()
-        if self.client.is_deleted:
-            return NullResponse()  # silent: client teardown race
-        if self.is_deleted:
-            helpers.warn_once(f'Element {self.id} has been deleted but is still being used. '
-                              'This is most likely a bug in your application code.',
-                              stack_info=True)
+        if not core.is_loop_running() or not self._is_safe_to_interact():
             return NullResponse()
         return self.client.run_javascript(
             f'return runMethod({self.id}, {json.dumps(name)}, {json.dumps(args)})', timeout=timeout,
@@ -452,14 +457,7 @@ class Element(Visibility):
         :param prop_name: name of the computed prop
         :param timeout: maximum time to wait for a response (default: 1 second)
         """
-        if not core.is_loop_running():
-            return NullResponse()
-        if self.client.is_deleted:
-            return NullResponse()  # silent: client teardown race
-        if self.is_deleted:
-            helpers.warn_once(f'Element {self.id} has been deleted but is still being used. '
-                              'This is most likely a bug in your application code.',
-                              stack_info=True)
+        if not core.is_loop_running() or not self._is_safe_to_interact():
             return NullResponse()
         return self.client.run_javascript(
             f'return getComputedProp({self.id}, {json.dumps(prop_name)})', timeout=timeout,

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -415,15 +415,16 @@ class Element(Visibility):
 
         Silent when the *client* has been deleted (e.g. browser reload race past ``reconnect_timeout``)
         or already garbage-collected: an async callback resuming after the teardown is not a user bug.
-        Emits a one-shot warning when the *element* has been explicitly deleted but the client is still
-        alive: that is a real use-after-free in user code and worth surfacing.
+        Emits a one-shot warning when the *element* has been explicitly deleted but the client is still alive:
+        that is a real use-after-free in user code and worth surfacing.
         """
         client = self._client()
         if client is None or client.is_deleted:
             return False
         if self.is_deleted:
-            helpers.warn_once(f'{self} (id={self.id}) has been deleted but is still being used. '
-                              'This is most likely a bug in your application code.',
+            helpers.warn_once('An element has been deleted but is still being used. '
+                              'This is most likely a bug in your application code. '
+                              'See https://github.com/zauberzeug/nicegui/issues/3028 for more information.',
                               stack_info=True)
             return False
         return True

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -413,12 +413,13 @@ class Element(Visibility):
     def _is_safe_to_interact(self) -> bool:
         """Return True if it is safe to send messages to this element's client.
 
-        Silent when the *client* has been deleted (e.g. browser reload race past ``reconnect_timeout``):
-        an async callback resuming after the teardown is not a user bug. Emits a one-shot warning
-        when the *element* has been explicitly deleted but the client is still alive: that is a real
-        use-after-free in user code and worth surfacing.
+        Silent when the *client* has been deleted (e.g. browser reload race past ``reconnect_timeout``)
+        or already garbage-collected: an async callback resuming after the teardown is not a user bug.
+        Emits a one-shot warning when the *element* has been explicitly deleted but the client is still
+        alive: that is a real use-after-free in user code and worth surfacing.
         """
-        if self.client.is_deleted:
+        client = self._client()
+        if client is None or client.is_deleted:
             return False
         if self.is_deleted:
             helpers.warn_once(f'{self} (id={self.id}) has been deleted but is still being used. '

--- a/nicegui/helpers/warnings.py
+++ b/nicegui/helpers/warnings.py
@@ -8,3 +8,8 @@ def warn_once(message: str, *, stack_info: bool = False) -> None:
     if message not in _shown_warnings:
         log.warning(message, stack_info=stack_info)
         _shown_warnings.add(message)
+
+
+def reset() -> None:
+    """Forget which warnings have already been shown (e.g. between tests)."""
+    _shown_warnings.clear()

--- a/nicegui/testing/general.py
+++ b/nicegui/testing/general.py
@@ -7,6 +7,7 @@ from starlette.routing import Route
 
 from .. import app, binding, core, dependencies, event, run, ui
 from ..client import Client
+from ..helpers import warnings
 
 
 def prepare_simulation() -> None:
@@ -58,6 +59,7 @@ def nicegui_reset_globals():
     Client.shared_body_html = ''
     app.reset()
     binding.reset()
+    warnings.reset()
 
     gc.collect()
 

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -1,7 +1,11 @@
+import logging
 import weakref
 
+import pytest
+
 from nicegui import binding, ui
-from nicegui.testing import Screen
+from nicegui.helpers import warnings as _warnings
+from nicegui.testing import Screen, User
 
 
 def test_remove_element_by_reference(screen: Screen):
@@ -194,6 +198,58 @@ def test_slot_children_cleared_on_delete(screen: Screen):
     screen.click('Delete')
     screen.should_contain('Deleted')
     assert len(labels) == 0, 'all labels should be deleted immediately'
+
+
+async def test_run_method_silent_after_client_delete(user: User, caplog: pytest.LogCaptureFixture):
+    """Mutations on elements after the client has been deleted (e.g. browser reload race
+    past reconnect_timeout) must be silent — user code did nothing wrong. See issue #6058."""
+    captured: dict = {}
+
+    @ui.page('/')
+    def page():
+        captured['label'] = ui.label('hi')
+
+    await user.open('/')
+    label = captured['label']
+    label.client.delete()
+    assert label.client.is_deleted
+    assert label.is_deleted  # cascaded
+
+    _warnings._shown_warnings.clear()  # pylint: disable=protected-access
+    caplog.clear()
+    caplog.set_level(logging.WARNING, logger='nicegui')
+    label.run_method('foo')
+    label.update()
+    label.get_computed_prop('bar')
+
+    warning_records = [r for r in caplog.records if 'deleted' in r.message.lower()]
+    assert warning_records == [], f'expected silent, got: {[r.message for r in warning_records]}'
+
+
+async def test_run_method_warns_after_explicit_element_delete(user: User, caplog: pytest.LogCaptureFixture):
+    """Calling a method on an explicitly deleted element while the client is still alive
+    is a user bug and should produce a visible (one-shot) warning. See issue #6058."""
+    captured: dict = {}
+
+    @ui.page('/')
+    def page():
+        with ui.row() as row:
+            captured['label'] = ui.label('hi')
+            captured['row'] = row
+
+    await user.open('/')
+    label = captured['label']
+    captured['row'].remove(label)
+    assert label.is_deleted
+    assert not label.client.is_deleted
+
+    _warnings._shown_warnings.clear()  # pylint: disable=protected-access
+    caplog.clear()
+    caplog.set_level(logging.WARNING, logger='nicegui')
+    label.run_method('foo')
+
+    warning_records = [r for r in caplog.records if 'still being used' in r.message]
+    assert warning_records, f'expected warning, got: {[r.message for r in caplog.records]}'
 
 
 def test_event_listeners_cleared_on_delete(screen: Screen):

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -1,10 +1,9 @@
-import logging
 import weakref
 
 import pytest
 
 from nicegui import binding, ui
-from nicegui.helpers import warnings as _warnings
+from nicegui.helpers.warnings import _shown_warnings
 from nicegui.testing import Screen, User
 
 
@@ -215,9 +214,8 @@ async def test_run_method_silent_after_client_delete(user: User, caplog: pytest.
     assert label.client.is_deleted
     assert label.is_deleted  # cascaded
 
-    _warnings._shown_warnings.clear()  # pylint: disable=protected-access
+    _shown_warnings.clear()
     caplog.clear()
-    caplog.set_level(logging.WARNING, logger='nicegui')
     label.run_method('foo')
     label.update()
     label.get_computed_prop('bar')
@@ -243,9 +241,8 @@ async def test_run_method_warns_after_explicit_element_delete(user: User, caplog
     assert label.is_deleted
     assert not label.client.is_deleted
 
-    _warnings._shown_warnings.clear()  # pylint: disable=protected-access
+    _shown_warnings.clear()
     caplog.clear()
-    caplog.set_level(logging.WARNING, logger='nicegui')
     label.run_method('foo')
 
     warning_records = [r for r in caplog.records if 'still being used' in r.message]

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -3,7 +3,6 @@ import weakref
 import pytest
 
 from nicegui import binding, ui
-from nicegui.helpers.warnings import _shown_warnings
 from nicegui.testing import Screen, User
 
 
@@ -199,54 +198,28 @@ def test_slot_children_cleared_on_delete(screen: Screen):
     assert len(labels) == 0, 'all labels should be deleted immediately'
 
 
-async def test_run_method_silent_after_client_delete(user: User, caplog: pytest.LogCaptureFixture):
-    """Mutations on elements after the client has been deleted (e.g. browser reload race
-    past reconnect_timeout) must be silent — user code did nothing wrong. See issue #6058."""
-    captured: dict = {}
+@pytest.mark.parametrize('deletion_method', ['client_delete', 'element_delete'])
+async def test_usage_after_delete(user: User, caplog: pytest.LogCaptureFixture, deletion_method: str):
+    """Using an element after deletion is silent when the client is gone (benign reload race)
+    but warns once when only the element was deleted (a user bug). See issue #6058."""
+    label = None
 
     @ui.page('/')
     def page():
-        captured['label'] = ui.label('hi')
+        nonlocal label
+        label = ui.label('hi')
 
     await user.open('/')
-    label = captured['label']
-    label.client.delete()
-    assert label.client.is_deleted
-    assert label.is_deleted  # cascaded
+    assert isinstance(label, ui.label)
+    (label.client if deletion_method == 'client_delete' else label).delete()
+    assert label.client.is_deleted == (deletion_method == 'client_delete')
+    assert label.is_deleted
 
-    _shown_warnings.clear()
-    caplog.clear()
     label.run_method('foo')
     label.update()
     label.get_computed_prop('bar')
-
-    warning_records = [r for r in caplog.records if 'deleted' in r.message.lower()]
-    assert warning_records == [], f'expected silent, got: {[r.message for r in warning_records]}'
-
-
-async def test_run_method_warns_after_explicit_element_delete(user: User, caplog: pytest.LogCaptureFixture):
-    """Calling a method on an explicitly deleted element while the client is still alive
-    is a user bug and should produce a visible (one-shot) warning. See issue #6058."""
-    captured: dict = {}
-
-    @ui.page('/')
-    def page():
-        with ui.row() as row:
-            captured['label'] = ui.label('hi')
-            captured['row'] = row
-
-    await user.open('/')
-    label = captured['label']
-    captured['row'].remove(label)
-    assert label.is_deleted
-    assert not label.client.is_deleted
-
-    _shown_warnings.clear()
-    caplog.clear()
-    label.run_method('foo')
-
-    warning_records = [r for r in caplog.records if 'still being used' in r.message]
-    assert warning_records, f'expected warning, got: {[r.message for r in caplog.records]}'
+    expected_warnings = 0 if deletion_method == 'client_delete' else 1
+    assert len([record for record in caplog.records if 'still being used' in record.message]) == expected_warnings
 
 
 def test_event_listeners_cleared_on_delete(screen: Screen):


### PR DESCRIPTION
### Motivation

Fixes #6058. Opening the example page and reloading it floods the server log with `Client has been deleted but is still being used.` warnings (each with a stack trace), even though user code does nothing wrong.

The root cause is an asymmetry between `Element.update()` and `Element.run_method()`:

- `Element.update()` short-circuits on `is_deleted` (silent), so regular elements like `ui.label` work fine when a timer callback mutates them after `await`.
- `Element.run_method()` has no such guard. Scene objects mutate via `scene.run_method(...)`, so every mutation between awaits schedules an `AwaitableResponse._fire` task that hits `Outbox.enqueue_message` → `Client.check_existence()` *after* `Client.delete()` ran (deferred by `reconnect_timeout`).

A naive fix — mirror the `is_deleted` guard from `update()` onto `run_method()` — would also silence the case where user code explicitly calls `element.delete()` and then accidentally uses the element again. That's a real use-after-free worth surfacing, so the silent-blanket approach loses important signal.

### Implementation

Two-tier deletion guard, factored into `Element._is_safe_to_interact()`:

| Case | Behavior | Rationale |
| ---- | -------- | --------- |
| `client.is_deleted` (e.g. browser reload race past `reconnect_timeout`) | silent no-op | User code did nothing wrong; the timer's in-flight coroutine just outlived the client. |
| `element.is_deleted` but client alive (explicit `element.delete()` then misuse) | one-shot warning with `stack_info=True` via `helpers.warn_once` | Real bug in user code; deserves a stack trace. |
| both alive | proceed | Normal path. |

Applied to `Element.update()`, `Element.run_method()`, and `Element.get_computed_prop()` so the three I/O paths stay symmetric. The discriminator uses a new public `Client.is_deleted` property mirroring the existing `Element.is_deleted`.

`Client.check_existence()` (called from `outbox.enqueue_message`) is left untouched: direct `client.run_javascript()` calls on a deleted client still warn via that path, since they bypass the element-layer guard and are inherently more deliberate user actions.

#### Behavior change worth flagging

`Element.update()` previously silenced *both* deletion cases. After this PR, it silences only the disconnect race and emits a one-shot warning for the explicit-element-delete-then-misuse case. Net effect: more signal for buggy user code, less noise for benign reload races. Not a public API break — same method signature, same return — but downstream code that relied on `update()` being silent after `element.delete()` will see a new warning (deduped, one-shot per element id).

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added: `test_run_method_silent_after_client_delete` and `test_run_method_warns_after_explicit_element_delete` in `tests/test_element_delete.py`. All 10 tests in that file pass; `test_keep_alive.py` and `test_scene.py` also pass with no regressions.
- [x] Documentation has been added (docstrings on `Client.is_deleted` and `Element._is_safe_to_interact`); no user-facing docs needed.
- [x] No breaking changes to the public API; one behavior change to `Element.update()` is documented above.

---

Development history and review iteration on my fork: evnchn/nicegui#154 (closed in favor of this PR).