### PR TITLE
Hide ui.upload route from OpenAPI schema by default

### DIFF
--- a/nicegui/elements/upload.py
+++ b/nicegui/elements/upload.py
@@ -4,6 +4,7 @@ from fastapi import Request
 from starlette.datastructures import UploadFile
 from typing_extensions import Self
 
+from .. import core
 from ..defaults import DEFAULT_PROP, resolve_defaults
 from ..events import Handler, MultiUploadEventArguments, UiEventArguments, UploadEventArguments, handle_event
 from ..nicegui import app
@@ -70,7 +71,7 @@ class Upload(LabelElement, DisableableElement, component='upload.js'):
         self._upload_handlers = [on_upload] if on_upload else []
         self._multi_upload_handlers = [on_multi_upload] if on_multi_upload else []
 
-        @app.post(self._props['url'])
+        @app.post(self._props['url'], include_in_schema=core.app.config.endpoint_documentation in {'internal', 'all'})
         async def upload_route(request: Request) -> dict[str, str]:
             for begin_upload_handler in self._begin_upload_handlers:
                 handle_event(begin_upload_handler, UiEventArguments(sender=self, client=self.client))

--- a/tests/test_endpoint_docs.py
+++ b/tests/test_endpoint_docs.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
 
-from nicegui import Client, __version__, ui
+from nicegui import __version__, ui
 from nicegui.testing import Screen
 
 
@@ -9,14 +9,15 @@ from nicegui.testing import Screen
 def test_endpoint_documentation(screen: Screen, endpoint_documentation: str):
     screen.ui_run_kwargs['fastapi_docs'] = True
     screen.ui_run_kwargs['endpoint_documentation'] = endpoint_documentation
+    uploads: list[ui.upload] = []
 
     @ui.page('/')
     def page():
         ui.markdown('Hey!')
-        ui.upload()
+        uploads.append(ui.upload())
 
     screen.open('/')
-    client_id = next(iter(Client.instances))
+    upload = uploads[0]
 
     if endpoint_documentation == 'none':
         expected_paths = set()
@@ -29,7 +30,7 @@ def test_endpoint_documentation(screen: Screen, endpoint_documentation: str):
             f'/_nicegui/{__version__}/resources/{{key}}/{{path}}',
             f'/_nicegui/{__version__}/dynamic_resources/{{name}}',
             f'/_nicegui/{__version__}/esm/{{key}}/{{path}}',
-            f'/_nicegui/client/{client_id}/upload/5',
+            f'/_nicegui/client/{upload.client.id}/upload/{upload.id}',
         }
     elif endpoint_documentation == 'all':
         expected_paths = {
@@ -39,7 +40,7 @@ def test_endpoint_documentation(screen: Screen, endpoint_documentation: str):
             f'/_nicegui/{__version__}/resources/{{key}}/{{path}}',
             f'/_nicegui/{__version__}/dynamic_resources/{{name}}',
             f'/_nicegui/{__version__}/esm/{{key}}/{{path}}',
-            f'/_nicegui/client/{client_id}/upload/5',
+            f'/_nicegui/client/{upload.client.id}/upload/{upload.id}',
         }
     else:
         raise ValueError(f'Unknown endpoint documentation setting: {endpoint_documentation}')

--- a/tests/test_endpoint_docs.py
+++ b/tests/test_endpoint_docs.py
@@ -1,69 +1,47 @@
 import httpx
 import pytest
 
-from nicegui import __version__, ui
+from nicegui import Client, __version__, ui
 from nicegui.testing import Screen
 
 
-@pytest.fixture(autouse=True)
-def activate_fastapi_docs(screen: Screen):
+@pytest.mark.parametrize('endpoint_documentation', ['none', 'page', 'internal', 'all'])
+def test_endpoint_documentation(screen: Screen, endpoint_documentation: str):
     screen.ui_run_kwargs['fastapi_docs'] = True
-
-
-def get_openapi_paths() -> set[str]:
-    return set(httpx.get(f'http://localhost:{Screen.PORT}/openapi.json', timeout=5).json()['paths'])
-
-
-def test_endpoint_documentation_default(screen: Screen):
-    @ui.page('/')
-    def page():
-        ui.markdown('Hey!')
-
-    screen.open('/')
-    assert get_openapi_paths() == set()
-
-
-def test_endpoint_documentation_page_only(screen: Screen):
-    screen.ui_run_kwargs['endpoint_documentation'] = 'page'
+    screen.ui_run_kwargs['endpoint_documentation'] = endpoint_documentation
 
     @ui.page('/')
     def page():
         ui.markdown('Hey!')
+        ui.upload()
 
     screen.open('/')
-    assert get_openapi_paths() == {'/'}
+    client_id = next(iter(Client.instances))
 
+    if endpoint_documentation == 'none':
+        expected_paths = set()
+    elif endpoint_documentation == 'page':
+        expected_paths = {'/'}
+    elif endpoint_documentation == 'internal':
+        expected_paths = {
+            f'/_nicegui/{__version__}/libraries/{{key}}',
+            f'/_nicegui/{__version__}/components/{{key}}',
+            f'/_nicegui/{__version__}/resources/{{key}}/{{path}}',
+            f'/_nicegui/{__version__}/dynamic_resources/{{name}}',
+            f'/_nicegui/{__version__}/esm/{{key}}/{{path}}',
+            f'/_nicegui/client/{client_id}/upload/5',
+        }
+    elif endpoint_documentation == 'all':
+        expected_paths = {
+            '/',
+            f'/_nicegui/{__version__}/libraries/{{key}}',
+            f'/_nicegui/{__version__}/components/{{key}}',
+            f'/_nicegui/{__version__}/resources/{{key}}/{{path}}',
+            f'/_nicegui/{__version__}/dynamic_resources/{{name}}',
+            f'/_nicegui/{__version__}/esm/{{key}}/{{path}}',
+            f'/_nicegui/client/{client_id}/upload/5',
+        }
+    else:
+        raise ValueError(f'Unknown endpoint documentation setting: {endpoint_documentation}')
 
-def test_endpoint_documentation_internal_only(screen: Screen):
-    screen.ui_run_kwargs['endpoint_documentation'] = 'internal'
-
-    @ui.page('/')
-    def page():
-        ui.markdown('Hey!')
-
-    screen.open('/')
-    assert get_openapi_paths() == {
-        f'/_nicegui/{__version__}/libraries/{{key}}',
-        f'/_nicegui/{__version__}/components/{{key}}',
-        f'/_nicegui/{__version__}/resources/{{key}}/{{path}}',
-        f'/_nicegui/{__version__}/dynamic_resources/{{name}}',
-        f'/_nicegui/{__version__}/esm/{{key}}/{{path}}',
-    }
-
-
-def test_endpoint_documentation_all(screen: Screen):
-    screen.ui_run_kwargs['endpoint_documentation'] = 'all'
-
-    @ui.page('/')
-    def page():
-        ui.markdown('Hey!')
-
-    screen.open('/')
-    assert get_openapi_paths() == {
-        '/',
-        f'/_nicegui/{__version__}/libraries/{{key}}',
-        f'/_nicegui/{__version__}/components/{{key}}',
-        f'/_nicegui/{__version__}/resources/{{key}}/{{path}}',
-        f'/_nicegui/{__version__}/dynamic_resources/{{name}}',
-        f'/_nicegui/{__version__}/esm/{{key}}/{{path}}',
-    }
+    assert set(httpx.get(f'http://localhost:{Screen.PORT}/openapi.json', timeout=5).json()['paths']) == expected_paths


### PR DESCRIPTION
### Motivation

When `fastapi_docs=True` is enabled, the `POST /_nicegui/client/{client_id}/upload/{element_id}` endpoint behind every `ui.upload()` shows up in `/docs` and `/openapi.json` — even with the default `endpoint_documentation='none'`, which is documented to hide internal `/_nicegui/...` routes.

Reproduction:

```python
from nicegui import ui

@ui.page('/')
def main_page():
    ui.upload()
    ui.link('Go to documentation', '/docs')

ui.run(fastapi_docs=True)
```

### Implementation

The filter loop in `ui_run.py` that applies `endpoint_documentation` to `/_nicegui/...` routes runs once at server startup. The upload route is registered lazily inside `Upload.__init__`, i.e. on the first page visit, so the filter never sees it and FastAPI's default `include_in_schema=True` sticks.

The fix passes `include_in_schema` explicitly at the `@app.post(...)` site in `elements/upload.py`, mirroring the same `endpoint_documentation in {'internal', 'all'}` policy.

The existing `test_endpoint_docs.py` is consolidated into a single parametrized test that adds `ui.upload()` to the page and asserts the exact expected `/openapi.json` path set for each of `'none'`, `'page'`, `'internal'`, `'all'` — including the dynamic `POST /_nicegui/client/.../upload/...` route for `'internal'` and `'all'`.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.