### PR TITLE
Use spawn context for native window subprocess

### DIFF
--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -179,7 +179,7 @@ def activate(protocol: str, host: str, port: int, title: str, width: int, height
     event_manager.start()
     args = (protocol, host, port, title, width, height, fullscreen, frameless,
             native.method_queue, native.response_queue, native.event_sender, favicon)
-    process = mp.Process(target=_open_window, args=args, daemon=True)
+    process = native.SPAWN_CONTEXT.Process(target=_open_window, args=args, daemon=True)
     process.start()
 
     Thread(target=check_shutdown, daemon=True).start()


### PR DESCRIPTION
### Motivation

Fixes #6062. `ui.run(native=True)` raises `RuntimeError: An attempt has been made to start a new process before the current process has finished its bootstrapping phase.` on Python 3.14+ Linux. The doc example reproduces it as-is.

Root cause: Python 3.14 changed the Linux multiprocessing default start method from `fork` to `forkserver` ([What's New in Python 3.14 — Deprecated](https://docs.python.org/3.14/whatsnew/3.14.html#deprecated), [gh-84559](https://github.com/python/cpython/issues/84559)). NiceGUI's native window subprocess in `nicegui/native/native_mode.py:182` was created via `mp.Process(...)` — the default context — so on 3.14+ Linux it now picks up forkserver. Forkserver re-imports the user's main module to bootstrap each worker but, unlike `spawn`, does NOT use the `--multiprocessing-fork` argv trampoline that lets `mp.freeze_support()` short-circuit. So the re-import re-runs the doc example's top-level `ui.run(native=True)`, which calls `process.start()` again, which fails inside `_check_not_importing_main()` before the user can even see their window.

### Implementation

This finishes the spawn-context migration started in #6045, which moved `Queue` / `Pipe` / `Event` to `SPAWN_CONTEXT` but left the `Process` on the default context. One-line change: use `native.SPAWN_CONTEXT.Process(...)` to match the rest of the native-mode IPC primitives. The `# match uvicorn's ChangeReload worker (#1841)` comment on `SPAWN_CONTEXT` already documents the rationale for the explicit context; the Process callsite needs no new comment for the same reason none of the other `SPAWN_CONTEXT.*()` callsites (`Queue`, `Pipe`, `Event`) carry one.

Why spawn rather than pinning `fork`: spawn's `--multiprocessing-fork` argv trampoline makes `mp.freeze_support()` work, so the doc example continues to run without requiring users to add an `if __name__ == '__main__':` guard. It also avoids the thread-safety hazards that motivated CPython's switch away from fork (`event_manager.start()` already runs a thread before the child is spawned). User customisations on `app.native.window_args` / `start_args` / `settings` still propagate because the child re-imports the user script first (setting those attributes) and then `freeze_support()` runs `_open_window` which reads them.

### Empirical verification

| Platform                          | Python   | Default ctx  | Before fix    | After fix |
| --------------------------------- | -------- | ------------ | ------------- | --------- |
| Linux x86_64 (uv cpython 3.14.5)  | 3.14.5   | `forkserver` | RuntimeError from `_check_not_importing_main` | reaches `_open_window` with `window_args={'resizable': False}`, `start_args={'debug': True}`, `settings={'ALLOW_DOWNLOADS': True}` from the parent |
| macOS arm64 (Homebrew 3.14.4)     | 3.14.4   | `spawn`      | works         | works (no behaviour change — already spawn) |

The doc example from #6062 was used verbatim. Behaviour on Linux pre-3.14: native subprocess switches from `fork` to `spawn` (slightly slower Python re-init in the child); the queues/pipe were already spawn-context after #6045, so the parent-child wire protocol is unchanged. No change on macOS/Windows (already spawn by default).

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.

---

*Drafted by Claude Code working with @evnchn — direct follow-up to #6045, completing the spawn-context migration that left `mp.Process` on the default context.*