### PR TITLE
Add docs on how to fix non-working aggrid events

### DIFF
--- a/website/documentation/content/aggrid_documentation.py
+++ b/website/documentation/content/aggrid_documentation.py
@@ -218,16 +218,16 @@ def aggrid_respond_to_event():
 
 
 doc.text('', '''
-    **Note:** Certain events, e. g. `rowClicked` don't seem to work.
+    **Note:** Certain events, e.g. `rowClicked`, don't seem to work.
     This is because some event arguments include cyclic references.
-    For these seemingly non-working events you'll see an error on the developer console in your browser.
+    For these seemingly non-working events you'll see a serialization error on the developer console in your browser.
 
     To inspect the event arguments and find the values you are interested in,
     you can replace the event registration with the following JavaScript handler:
     ```
     .on('rowClicked', js_handler='console.log')
     ```
-    Then limit the event arguments to the necessary ones, e. g. `data`, thus excluding the cycles:
+    Then limit the event arguments to the necessary ones, e.g. `data`, thus excluding the cycles:
     ```
     .on('rowClicked', lambda event: ui.notify(f'Row: {event.args}'), ['data'])
     ```

--- a/website/documentation/content/aggrid_documentation.py
+++ b/website/documentation/content/aggrid_documentation.py
@@ -202,6 +202,22 @@ def aggrid_with_html_columns():
 @doc.demo('Respond to an AG Grid event', '''
     All AG Grid events are passed through to NiceGUI via the AG Grid global listener.
     These events can be subscribed to using the `.on()` method.
+
+    Note: Certain events, e. g. `rowClicked` don't seem to work. This is because some
+    event arguments include cyclic references. For these seemingly non-working events
+    you'll see an error on the developer console in your browser.
+
+    To inspect the event arguments and find the values you are interested in, you can
+    replace the event registration with the following JavaScript handler:
+    ```
+    .on('rowClicked', js_handler='console.log')
+    ```
+    Then limit the event arguments to the necessary ones, e. g. `data`, thus
+    excluding the cycles:
+    ```
+    .on('rowClicked', lambda event: ui.notify(f'Row: {event.args}'), ['data'])
+    ```
+    This selection can be serialized safely and will work correctly.
 ''')
 def aggrid_respond_to_event():
     ui.aggrid({

--- a/website/documentation/content/aggrid_documentation.py
+++ b/website/documentation/content/aggrid_documentation.py
@@ -202,22 +202,6 @@ def aggrid_with_html_columns():
 @doc.demo('Respond to an AG Grid event', '''
     All AG Grid events are passed through to NiceGUI via the AG Grid global listener.
     These events can be subscribed to using the `.on()` method.
-
-    Note: Certain events, e. g. `rowClicked` don't seem to work. This is because some
-    event arguments include cyclic references. For these seemingly non-working events
-    you'll see an error on the developer console in your browser.
-
-    To inspect the event arguments and find the values you are interested in, you can
-    replace the event registration with the following JavaScript handler:
-    ```
-    .on('rowClicked', js_handler='console.log')
-    ```
-    Then limit the event arguments to the necessary ones, e. g. `data`, thus
-    excluding the cycles:
-    ```
-    .on('rowClicked', lambda event: ui.notify(f'Row: {event.args}'), ['data'])
-    ```
-    This selection can be serialized safely and will work correctly.
 ''')
 def aggrid_respond_to_event():
     ui.aggrid({
@@ -231,6 +215,24 @@ def aggrid_respond_to_event():
             {'name': 'Carol', 'age': 42},
         ],
     }).on('cellClicked', lambda event: ui.notify(f'Cell value: {event.args["value"]}'))
+
+
+doc.text('', '''
+    **Note:** Certain events, e. g. `rowClicked` don't seem to work.
+    This is because some event arguments include cyclic references.
+    For these seemingly non-working events you'll see an error on the developer console in your browser.
+
+    To inspect the event arguments and find the values you are interested in,
+    you can replace the event registration with the following JavaScript handler:
+    ```
+    .on('rowClicked', js_handler='console.log')
+    ```
+    Then limit the event arguments to the necessary ones, e. g. `data`, thus excluding the cycles:
+    ```
+    .on('rowClicked', lambda event: ui.notify(f'Row: {event.args}'), ['data'])
+    ```
+    This selection can be serialized safely and will work correctly.
+''')
 
 
 @doc.demo('AG Grid with complex objects', '''


### PR DESCRIPTION
### Motivation

In https://github.com/zauberzeug/nicegui/discussions/2878 we encountered non-obvious behaviour regarding certain `aggrid` events. I also stumbled on this now, so there seems to be a need to make this more beginner-friendly. To directly provide a solution without searching we mention how to proceed in the docs.

### Implementation

Just add some paragraphs to the docs.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests are not necessary. <!--Remove the option that does not apply.-->
- [x] Documentation has been added. <!--Remove the option that does not apply.-->
- [x] No breaking changes to the public API or migration steps are described above. <!--Remove the option that does not apply.-->
