### PR TITLE
Don't inject sad-face error_content when ui.sub_pages handles 404 (fixes #6069)

### DIFF
--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -202,8 +202,6 @@ class page:
                     task.add_done_callback(check_for_late_return_value)
 
             if not await client.sub_pages_router._can_resolve_full_path(client):  # pylint: disable=protected-access
-                # The SubPages element renders its own 404 label inside the page; don't inject
-                # a sibling sad-face block on top of user-supplied chrome. Just return 404 status.
                 log.warning(f'{request.url} not found')
                 return client.build_response(request, 404)
 

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -7,11 +7,10 @@ from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from fastapi import HTTPException, Request, Response
+from fastapi import Request, Response
 
 from . import background_tasks, binding, core, helpers
 from .client import Client, ClientConnectionTimeout
-from .error import error_content
 from .favicon import create_favicon_route
 from .language import Language
 from .logging import log
@@ -203,10 +202,9 @@ class page:
                     task.add_done_callback(check_for_late_return_value)
 
             if not await client.sub_pages_router._can_resolve_full_path(client):  # pylint: disable=protected-access
-                # Handle 404 gracefully without re-raising exception (similar to 404 handler when no root function)
+                # The SubPages element renders its own 404 label inside the page; don't inject
+                # a sibling sad-face block on top of user-supplied chrome. Just return 404 status.
                 log.warning(f'{request.url} not found')
-                with client:
-                    error_content(404, HTTPException(404, f'{client.sub_pages_router.current_path} not found'))
                 return client.build_response(request, 404)
 
             if isinstance(result, Response):  # NOTE if setup returns a response, we don't need to render the page

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -976,7 +976,7 @@ def test_on_path_changed_event(screen: Screen):
     assert calls == {'index': 2, 'main': 1, 'other': 2}
 
     screen.open('/bad_path')
-    screen.should_contain('HTTPException: 404: /bad_path not found')
+    screen.should_contain('404: sub page /bad_path not found')
     assert paths == ['/other']
     assert calls == {'index': 3, 'main': 2, 'other': 2}
 
@@ -1089,6 +1089,25 @@ def test_navigate_from_404_to_root_path(screen: Screen):
     screen.should_contain('main page')
 
 
+def test_navigate_from_initial_404_does_not_leak_sad_face(screen: Screen):
+    # Regression test for https://github.com/zauberzeug/nicegui/issues/6069
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index():
+        ui.link('Go to home', '/')
+        ui.sub_pages({'/': lambda: ui.label('main page')})
+
+    screen.allowed_js_errors.append('/bad_path - Failed to load resource')
+    screen.open('/bad_path')
+    screen.should_contain('404: sub page /bad_path not found')
+    screen.should_not_contain("This page doesn't exist.")
+
+    screen.click('Go to home')
+    screen.should_contain('main page')
+    screen.should_not_contain('404: sub page /bad_path not found')
+    screen.should_not_contain("This page doesn't exist.")
+
+
 def test_http_404_on_initial_request(screen: Screen):
     @ui.page('/')
     @ui.page('/{_:path}')
@@ -1107,7 +1126,7 @@ def test_http_404_on_initial_request(screen: Screen):
     screen.should_contain('main page')
 
     screen.open('/bad_path')
-    screen.should_contain('HTTPException: 404: /bad_path not found')
+    screen.should_contain('404: sub page /bad_path not found')
 
 
 def test_http_404_on_initial_request_with_async_page_builder(screen: Screen):
@@ -1128,7 +1147,7 @@ def test_http_404_on_initial_request_with_async_page_builder(screen: Screen):
     screen.should_contain('main page')
 
     screen.open('/bad_path')
-    screen.should_contain('HTTPException: 404: /bad_path not found')
+    screen.should_contain('404: sub page /bad_path not found')
 
 
 def test_http_404_on_initial_request_with_async_sub_page_builder(screen: Screen):
@@ -1160,7 +1179,7 @@ def test_http_404_on_initial_request_with_async_sub_page_builder(screen: Screen)
     screen.should_contain('sub sub page')
 
     screen.open('/bad_path')
-    screen.should_contain('HTTPException: 404: /bad_path not found')
+    screen.should_contain('404: sub page /bad_path not found')
 
 
 def test_http_404_with_root_function_and_sub_pages(screen: Screen):

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -1090,7 +1090,7 @@ def test_navigate_from_404_to_root_path(screen: Screen):
 
 
 def test_navigate_from_initial_404_does_not_leak_sad_face(screen: Screen):
-    # Regression test for https://github.com/zauberzeug/nicegui/issues/6069
+    # regression test for #6069
     @ui.page('/')
     @ui.page('/{_:path}')
     def index():


### PR DESCRIPTION
### Motivation

Fixes #6069.

When a page handler returns a 404 because `ui.sub_pages` cannot resolve the path, `nicegui/page.py` was injecting `error_content` (the sad-face block) as a sibling of the user's `root()` chrome. Client-side navigation via `sub_pages_router._handle_open` only re-renders `SubPages` elements, so the sibling sad-face leaked past the recovered navigation — that's the bug in #6069.

### Implementation

This PR implements Falko's "fix 1" proposal from the issue: delete the `error_content` injection in `page.py` and let `SubPages` continue to render its own inline `404: sub page X not found` label inside its own slot. Because that label lives inside the slot, `_show()` naturally cleans it up on SPA navigation. HTTP 404 status is unchanged.

Changes:
- `nicegui/page.py`: drop the `with client: error_content(...)` block and the now-unused `HTTPException` / `error_content` imports.
- `tests/test_sub_pages.py`:
  - 4 existing assertions updated from `'HTTPException: 404: /bad_path not found'` (sad-face text) to `'404: sub page /bad_path not found'` (inline label).
  - New `test_navigate_from_initial_404_does_not_leak_sad_face` regression test for #6069.

Test plan:
- CI on my fork is green (mypy, pre-commit, pylint, quick-test/3.10/pytest 20m44s): https://github.com/evnchn/nicegui/pull/159
- Manually confirm the original repro from #6069: direct-URL `/bad_path` shows only the inline label inside chrome, and clicking the `Go to home` link leaves only home content (no stale 404 text).

Note: this is a user-visible behavior change — apps that relied on the styled sad-face overlay appearing on `ui.sub_pages` 404s will now see only the inline label inside their own chrome. HTTP status and the `show_404=False` escape hatch are unchanged. See the trade-off discussion below.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.

---

## Note to @falkoschindler

A couple of things I'd like your call on before merging:

**Milestone — 3.12.1 patch or 3.13?**

I'd lean 3.13. The fix changes user-visible behavior (apps relying on the sad-face overlay on sub_pages 404 will stop seeing it), so it doesn't feel right for a patch release even though it closes a bug. A minor release with an explicit changelog note feels safer.

**Does fix 1 really sit well with you?**

You proposed two directions in the issue. I went with fix 1 because, framing-wise, when `root()` contains `ui.sub_pages` the surrounding UI is user chrome and the framework arguably shouldn't be drawing a styled 404 page on top of it. But there's a real trade-off and I want to flag it rather than just advocate.

### Neutral review of fix 1

**Pros**
- Smallest possible patch (2 imports + 3 lines deleted in `page.py`).
- Respects user chrome: once you opt into `ui.sub_pages`, you've taken responsibility for the page surface.
- Closes #6069 by construction — there's no sibling element to leak past SPA nav, so no router cleanup needed now or later.
- Preserves HTTP 404 status; bookmarks / SEO / `curl` outputs unchanged.
- Consistent with the existing `show_404=False` escape hatch, which already treats the sub_pages 404 as user-controlled.

**Cons / things to consider**
- The inline `SubPages` 404 is currently a plain `Label('404: sub page X not found')` — debug-quality, leaks framework-speak ('sub page'). Apps that were quietly relying on the sad-face overlay as their 404 UI lose that polish and just see a small line of text inside their chrome.
- There's no customization hook yet. Users who want a pretty 404 today have to either `show_404=False` plus a conditional render in `root()`, or wait for a follow-up (e.g. `not_found_builder=` callback on `ui.sub_pages`, or a `'*'` wildcard route). Worth tracking as a separate issue regardless of which fix you pick.
- 4 existing tests in `test_sub_pages.py` asserted on the sad-face text; that's evidence that downstream code/snippets/demos may also assume the overlay is present. The changelog entry should call this out so users aren't surprised.
- Scope check: this PR only touches the sub_pages-aware 404 path. Direct `HTTPException(404)` raises and FastAPI-level 404s (no matching route, no root) still render `error_content` via `nicegui/nicegui.py`. That's intentional — the framework still owns those surfaces — but worth noting.

**Trade-off framing**
- Fix 1 says: framework should not own UX inside user chrome.
- Fix 2 (track sibling + cleanup on resolve) says: framework provides a polished default 404, but is SPA-aware.
- Both close #6069. The decision is framework philosophy more than engineering. I'm comfortable with either; just flagging that fix 2 wouldn't be wrong, only different.

If you'd rather go with fix 2, happy to rework — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
