### PR TITLE
Fix auto-prune timers being skipped in script mode

### DIFF
--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -144,11 +144,11 @@ async def _startup() -> None:
     run.setup()
     app.start()
     background_tasks.create(binding.refresh_loop(), name='refresh bindings')
-    app.timer(10, Client.prune_instances)
-    app.timer(10, Slot.prune_stacks)
-    app.timer(10, prune_tab_storage)
+    app.timer(10, Client.prune_instances, _internal=True)
+    app.timer(10, Slot.prune_stacks, _internal=True)
+    app.timer(10, prune_tab_storage, _internal=True)
     if app.storage.secret is not None:
-        app.timer(10, prune_user_storage)
+        app.timer(10, prune_user_storage, _internal=True)
     air.connect()
 
 

--- a/nicegui/timer.py
+++ b/nicegui/timer.py
@@ -18,6 +18,7 @@ class Timer:
                  active: bool = True,
                  once: bool = False,
                  immediate: bool = True,
+                 _internal: bool = False,
                  ) -> None:
         """Timer
 
@@ -37,6 +38,7 @@ class Timer:
         self.active = active
         self._is_canceled = False
         self._immediate = immediate
+        self._internal = _internal
         self._current_invocation: asyncio.Task | None = None
 
         coroutine = self._run_once if once else self._run_in_loop
@@ -49,7 +51,8 @@ class Timer:
 
     def _skip_registration(self) -> bool:
         # Global app.timer: skip on per-client re-execution; was registered on the first run.
-        return core.is_script_mode_re_execution()
+        # Internal timers (registered by NiceGUI itself from `_startup`) are exempt — they run once per process.
+        return core.is_script_mode_re_execution() and not self._internal
 
     def activate(self) -> None:
         """Activate the timer."""


### PR DESCRIPTION
### Motivation

Fixes #6072.

PR #6006 added a `_skip_registration` guard to `Timer.__init__` so user-script `app.timer(...)` calls at module level wouldn't be re-registered on every per-client re-execution in script mode. The guard returns `True` whenever `script_mode and app.is_started`.

That predicate also fires for NiceGUI's own four internal `app.timer(...)` calls in `_startup`, because they run **after** `app.start()` has set `is_started=True`. Result in script mode: `Client.prune_instances`, `Slot.prune_stacks`, `prune_tab_storage`, and (when storage secret is set) `prune_user_storage` are never scheduled. Clients, their routes, slot stacks, and tab storage accumulate without bound — see #6072 for the repro.

### Implementation

Adds a private `_internal: bool = False` kwarg to `Timer.__init__`. When set, `_skip_registration` bypasses the script-mode-re-execution check. The four internal `app.timer(...)` calls in `nicegui/nicegui.py` pass `_internal=True`.

The marker makes the distinction explicit in code: _NiceGUI-internal timers run once per process and must never be skipped_, regardless of where they appear in `_startup`. This is more robust than relying on registration order around `app.start()` (the implicit invariant that caused the regression).

The same misclassification could in principle bite the lifecycle handlers (`on_connect`, `on_disconnect`, `on_delete`, `on_startup`, `on_shutdown`, `on_exception`) — they share the identical guard. None are broken today (the two `on_shutdown(...)` calls inside `app.start()` itself work by timing accident: they run while `_state == STARTING`, before `is_started` flips). Leaving them out of this PR to keep scope tight; happy to extend if reviewers prefer.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary (script mode is not easily testable at the moment).
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.