### PR TITLE
Fix auto-prune timers being skipped in script mode

### DIFF
--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -1,7 +1,9 @@
+import asyncio
 import inspect
 import os
 import platform
 import signal
+import time
 import urllib
 from collections.abc import Callable, Iterator
 from enum import Enum
@@ -10,7 +12,7 @@ from pathlib import Path
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import FileResponse
 
-from .. import background_tasks, core, helpers
+from .. import background_tasks, binding, core, helpers
 from ..client import Client
 from ..context import context
 from ..elements.mixins.color_elements import QUASAR_COLORS
@@ -18,8 +20,9 @@ from ..logging import log
 from ..native import NativeConfig
 from ..observables import ObservableSet
 from ..server import Server
+from ..slot import Slot
 from ..staticfiles import CacheControlledStaticFiles
-from ..storage import Storage
+from ..storage import PersistentDict, Storage
 from .app_config import AppConfig
 from .range_response import get_range_response
 
@@ -79,6 +82,12 @@ class App(FastAPI):
             self.safe_invoke(t)
         self.on_shutdown(self.storage.on_shutdown)
         self.on_shutdown(background_tasks.teardown)
+        background_tasks.create(binding.refresh_loop(), name='refresh bindings')
+        self.timer(10, Client.prune_instances)
+        self.timer(10, Slot.prune_stacks)
+        self.timer(10, prune_tab_storage)
+        if self.storage.secret is not None:
+            self.timer(10, prune_user_storage)
         self._state = State.STARTED
 
     async def stop(self) -> None:
@@ -393,3 +402,31 @@ class App(FastAPI):
         for client in Client.instances.values():
             if path is None or client.page.path == path:
                 yield client
+
+
+async def prune_tab_storage(*, force: bool = False) -> None:
+    """Prune tab storage that is older than the configured ``max_tab_storage_age``."""
+    tab_storages = core.app.storage._tabs  # pylint: disable=protected-access
+    for tab_id, tab in list(tab_storages.items()):
+        if force or time.time() > tab.last_modified + core.app.storage.max_tab_storage_age:
+            tab.clear()
+            if isinstance(tab, PersistentDict):
+                await tab.close()
+            del tab_storages[tab_id]
+
+
+async def prune_user_storage(*, force: bool = False) -> None:
+    """Remove user storage objects without a client session."""
+    client_session_ids = {client.request.session['id'] for client in Client.instances.values()}
+    storages_to_close: list[PersistentDict] = []
+    now = time.time()
+    user_storages = core.app.storage._users  # pylint: disable=protected-access
+    for session_id in list(user_storages):
+        if session_id not in client_session_ids:
+            age = now - user_storages[session_id].last_modified
+            if force or age > 10.0:  # NOTE: do not remove storages created by middleware and still wait for client
+                storages_to_close.append(user_storages.pop(session_id))
+    results = await asyncio.gather(*[storage.close() for storage in storages_to_close], return_exceptions=True)
+    for result in results:
+        if isinstance(result, Exception):
+            log.exception(result)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -1,7 +1,6 @@
 import asyncio
 import inspect
 import mimetypes
-import time
 import urllib.parse
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -13,7 +12,7 @@ from fastapi.exception_handlers import http_exception_handler
 from fastapi.responses import FileResponse, Response
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from . import air, background_tasks, binding, core, favicon, helpers, json, run, welcome
+from . import air, core, favicon, helpers, json, run, welcome
 from .app import App
 from .client import Client
 from .dependencies import dynamic_resources, esm_modules, js_components, libraries, resources, vue_components
@@ -22,8 +21,6 @@ from .json import NiceGUIJSONResponse
 from .logging import log
 from .page import page
 from .page_arguments import PageArguments
-from .persistence import PersistentDict
-from .slot import Slot
 from .staticfiles import CacheControlledStaticFiles
 from .version import __version__
 
@@ -143,12 +140,6 @@ async def _startup() -> None:
     core.loop = asyncio.get_running_loop()
     run.setup()
     app.start()
-    background_tasks.create(binding.refresh_loop(), name='refresh bindings')
-    app.timer(10, Client.prune_instances)
-    app.timer(10, Slot.prune_stacks)
-    app.timer(10, prune_tab_storage)
-    if app.storage.secret is not None:
-        app.timer(10, prune_user_storage)
     air.connect()
 
 
@@ -256,31 +247,3 @@ def _on_ack(_: str, msg: dict) -> None:
 def _on_log(_: str, msg: dict) -> None:
     if client := Client.instances.get(msg['client_id']):
         client.handle_log_message(msg)
-
-
-async def prune_tab_storage(*, force: bool = False) -> None:
-    """Prune tab storage that is older than the configured ``max_tab_storage_age``."""
-    tab_storages = core.app.storage._tabs  # pylint: disable=protected-access
-    for tab_id, tab in list(tab_storages.items()):
-        if force or time.time() > tab.last_modified + core.app.storage.max_tab_storage_age:
-            tab.clear()
-            if isinstance(tab, PersistentDict):
-                await tab.close()
-            del tab_storages[tab_id]
-
-
-async def prune_user_storage(*, force: bool = False) -> None:
-    """Remove user storage objects without a client session."""
-    client_session_ids = {client.request.session['id'] for client in Client.instances.values()}
-    storages_to_close: list[PersistentDict] = []
-    now = time.time()
-    user_storages = core.app.storage._users  # pylint: disable=protected-access
-    for session_id in list(user_storages):
-        if session_id not in client_session_ids:
-            age = now - user_storages[session_id].last_modified
-            if force or age > 10.0:  # NOTE: do not remove storages created by middleware and still wait for client
-                storages_to_close.append(user_storages.pop(session_id))
-    results = await asyncio.gather(*[storage.close() for storage in storages_to_close], return_exceptions=True)
-    for result in results:
-        if isinstance(result, Exception):
-            log.exception(result)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,7 +6,8 @@ from pathlib import Path
 import httpx
 import pytest
 
-from nicegui import Client, app, background_tasks, context, core, nicegui, ui
+from nicegui import Client, app, background_tasks, context, core, ui
+from nicegui.app.app import prune_tab_storage, prune_user_storage
 from nicegui.persistence.file_persistent_dict import FilePersistentDict
 from nicegui.testing import Screen, User
 
@@ -213,7 +214,7 @@ def test_tab_storage_is_auto_removed(screen: Screen):
     screen.open('/')
     screen.should_contain('2')
 
-    background_tasks.create(nicegui.prune_tab_storage(force=True))
+    background_tasks.create(prune_tab_storage(force=True))
     screen.wait(0.1)
     screen.open('/')
     screen.should_contain('1')
@@ -369,7 +370,7 @@ async def test_user_storage_is_pruned(screen: Screen):
 
     screen.close()
     screen.wait(5)  # more than 3 seconds
-    await nicegui.prune_user_storage(force=True)
+    await prune_user_storage(force=True)
     assert len(Client.instances) == 0
     assert len(app.storage._users) == 0
 


### PR DESCRIPTION
### Motivation

Fixes #6072.

PR #6006 added a `_skip_registration` guard to `Timer.__init__` so user-script `app.timer(...)` calls at module level wouldn't be re-registered on every per-client re-execution in script mode. The guard returns `True` whenever `script_mode and app.is_started`.

That predicate also fires for NiceGUI's own four internal `app.timer(...)` calls in `_startup`, because they ran **after** `app.start()` had set `is_started=True`. Result in script mode: `Client.prune_instances`, `Slot.prune_stacks`, `prune_tab_storage`, and (when storage secret is set) `prune_user_storage` were never scheduled. Clients, their routes, slot stacks, and tab storage accumulated without bound — see #6072 for the repro.

### Implementation

Move the internal startup wiring into `App.start()` itself, before the `_state = State.STARTED` flip:

- The four `app.timer(10, …)` registrations for the prune helpers.
- The `background_tasks.create(binding.refresh_loop(), …)` task (not affected by the bug, but moved for symmetry — it's part of the same "start NiceGUI internals" wiring).

The two helpers `prune_tab_storage` / `prune_user_storage` are moved alongside, from `nicegui/nicegui.py` into `nicegui/app/app.py`, since they manipulate `app.storage` internals and now live next to their only registration site.

Because the timers register while `_state == STARTING` (so `is_started == False`), `_skip_registration()` no longer matches them. The ordering invariant — *internal timers must register before `STARTED` is set* — is now physically inside the method that owns the state machine, which makes accidental re-regression much less likely than when the registrations lived in `_startup` separated from `app.start()` by other code.

Test update: `tests/test_storage.py` was importing the prune helpers via `nicegui.prune_tab_storage` / `nicegui.prune_user_storage` (the `nicegui.nicegui` module); switched to importing them from `nicegui.app.app` to follow the move. The helpers aren't referenced anywhere user-facing (website, examples, README), so no compatibility shim is provided.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary (script mode is not easily testable at the moment).
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.