### PR TITLE
Redo: Randomize test ports/dirs for parallel pytest sessions

### DIFF
--- a/nicegui/helpers/__init__.py
+++ b/nicegui/helpers/__init__.py
@@ -10,7 +10,7 @@ from .functions import (
     normalize_lifecycle_handler,
     should_await,
 )
-from .network import format_url, is_port_open, schedule_browser
+from .network import find_free_port, format_url, is_port_open, schedule_browser
 from .strings import event_type_to_camel_case, kebab_to_camel_case, remove_indentation
 from .warnings import warn_once
 
@@ -19,6 +19,7 @@ __all__ = [
     'await_with_context',
     'event_type_to_camel_case',
     'expects_arguments',
+    'find_free_port',
     'format_url',
     'hash_file_path',
     'is_coroutine_function',

--- a/nicegui/helpers/network.py
+++ b/nicegui/helpers/network.py
@@ -19,6 +19,16 @@ def is_port_open(host: str, port: int) -> bool:
         sock.close()
 
 
+def find_free_port() -> int:
+    """Find a free port usable by ui.run (which binds to all interfaces by default).
+
+    Best-effort only: another process may grab the port between this call returning and ui.run binding.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(('0.0.0.0', 0))
+        return sock.getsockname()[1]
+
+
 def format_url(protocol: str, host: str, port: int) -> str:
     """Format a URL, bracketing IPv6 hosts and omitting the port for http:80 / https:443."""
     if ':' in host and not host.startswith('['):

--- a/nicegui/testing/filelock.py
+++ b/nicegui/testing/filelock.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from pathlib import Path
+
+if sys.platform == 'win32':
+    import msvcrt  # pylint: disable=import-error
+else:
+    import fcntl
+
+
+class FileLock:
+    """Exclusive, non-blocking, advisory file lock that auto-releases on process death."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._fd: int | None = None
+
+    def acquire(self) -> bool:
+        """Acquire the lock. Return True on success, False if another process holds it."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(self.path, os.O_CREAT | os.O_RDWR)
+        try:
+            if sys.platform == 'win32':
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            else:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            os.close(fd)
+            return False
+        self._fd = fd
+        return True
+
+    def release(self) -> None:
+        """Release the lock if held by this instance."""
+        if self._fd is None:
+            return
+        if sys.platform == 'win32':
+            msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(self._fd, fcntl.LOCK_UN)
+        os.close(self._fd)
+        self._fd = None

--- a/nicegui/testing/general_fixtures.py
+++ b/nicegui/testing/general_fixtures.py
@@ -1,3 +1,5 @@
+import atexit
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -10,8 +12,6 @@ from . import general
 
 # pylint: disable=redefined-outer-name
 
-Storage.path = None  # type: ignore[assignment]  # sentinel; pytest_configure assigns a session-unique tempdir
-
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Add pytest option for main file."""
@@ -20,19 +20,13 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 def pytest_configure(config: pytest.Config) -> None:
     """Set up a session-unique storage path and register the "nicegui_main_file" marker."""
-    if Storage.path is not None:
-        return  # already configured (e.g. plugin.py + user_plugin.py both loaded)
+    if Storage.path != Path(os.environ.get('NICEGUI_STORAGE_PATH', '.nicegui')).resolve():
+        return  # already configured
+
     Storage.path = Path(tempfile.mkdtemp(prefix='nicegui-test-storage-')).resolve()
+    atexit.register(shutil.rmtree, Storage.path, ignore_errors=True)
     app.storage = Storage()  # rebuild app.storage so its FilePersistentDict picks up the new path
     config.addinivalue_line('markers', 'nicegui_main_file: specify the main file for the test')
-
-
-def pytest_unconfigure(config: pytest.Config) -> None:  # pylint: disable=unused-argument
-    """Clean up session-unique storage directory."""
-    if Storage.path is None:
-        return
-    shutil.rmtree(Storage.path, ignore_errors=True)
-    Storage.path = None  # type: ignore[assignment]
 
 
 def get_path_to_main_file(request: pytest.FixtureRequest) -> Path | None:

--- a/nicegui/testing/general_fixtures.py
+++ b/nicegui/testing/general_fixtures.py
@@ -1,5 +1,4 @@
 import atexit
-import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -12,6 +11,8 @@ from . import general
 
 # pylint: disable=redefined-outer-name
 
+_configured = False
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Add pytest option for main file."""
@@ -20,9 +21,10 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 def pytest_configure(config: pytest.Config) -> None:
     """Set up a session-unique storage path and register the "nicegui_main_file" marker."""
-    if Storage.path != Path(os.environ.get('NICEGUI_STORAGE_PATH', '.nicegui')).resolve():
-        return  # already configured
-
+    global _configured  # pylint: disable=global-statement # noqa: PLW0603
+    if _configured:
+        return
+    _configured = True
     Storage.path = Path(tempfile.mkdtemp(prefix='nicegui-test-storage-')).resolve()
     atexit.register(shutil.rmtree, Storage.path, ignore_errors=True)
     app.storage = Storage()  # rebuild app.storage so its FilePersistentDict picks up the new path

--- a/nicegui/testing/general_fixtures.py
+++ b/nicegui/testing/general_fixtures.py
@@ -1,10 +1,16 @@
+import shutil
+import tempfile
 from pathlib import Path
 
 import pytest
 
+from .. import app
+from ..storage import Storage
 from . import general
 
 # pylint: disable=redefined-outer-name
+
+Storage.path = None  # type: ignore[assignment]  # sentinel; pytest_configure assigns a session-unique tempdir
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -13,8 +19,20 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Register the "nicegui_main_file" marker."""
+    """Set up a session-unique storage path and register the "nicegui_main_file" marker."""
+    if Storage.path is not None:
+        return  # already configured (e.g. plugin.py + user_plugin.py both loaded)
+    Storage.path = Path(tempfile.mkdtemp(prefix='nicegui-test-storage-')).resolve()
+    app.storage = Storage()  # rebuild app.storage so its FilePersistentDict picks up the new path
     config.addinivalue_line('markers', 'nicegui_main_file: specify the main file for the test')
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:  # pylint: disable=unused-argument
+    """Clean up session-unique storage directory."""
+    if Storage.path is None:
+        return
+    shutil.rmtree(Storage.path, ignore_errors=True)
+    Storage.path = None  # type: ignore[assignment]
 
 
 def get_path_to_main_file(request: pytest.FixtureRequest) -> Path | None:

--- a/nicegui/testing/plugin.py
+++ b/nicegui/testing/plugin.py
@@ -1,5 +1,5 @@
 # pylint: disable=unused-import
-from .general_fixtures import nicegui_reset_globals, pytest_addoption, pytest_unconfigure  # noqa: F401
+from .general_fixtures import nicegui_reset_globals, pytest_addoption  # noqa: F401
 from .screen_plugin import (  # noqa: F401
     nicegui_chrome_options,
     nicegui_driver,

--- a/nicegui/testing/plugin.py
+++ b/nicegui/testing/plugin.py
@@ -1,9 +1,10 @@
 # pylint: disable=unused-import
-from .general_fixtures import nicegui_reset_globals, pytest_addoption, pytest_configure  # noqa: F401
+from .general_fixtures import nicegui_reset_globals, pytest_addoption, pytest_unconfigure  # noqa: F401
 from .screen_plugin import (  # noqa: F401
     nicegui_chrome_options,
     nicegui_driver,
     nicegui_remove_all_screenshots,
+    pytest_configure,  # wraps general_fixtures' to also set up Screen.PORT/SCREENSHOT_DIR/DOWNLOAD_DIR
     pytest_runtest_makereport,
     screen,
 )

--- a/nicegui/testing/screen_plugin.py
+++ b/nicegui/testing/screen_plugin.py
@@ -12,11 +12,7 @@ from selenium.webdriver.chrome.service import Service
 from nicegui import helpers
 
 from .filelock import FileLock
-from .general_fixtures import (  # noqa: F401  # pylint: disable=unused-import
-    nicegui_reset_globals,
-    pytest_addoption,
-    pytest_unconfigure,
-)
+from .general_fixtures import nicegui_reset_globals, pytest_addoption  # noqa: F401  # pylint: disable=unused-import
 from .general_fixtures import pytest_configure as _general_pytest_configure
 from .screen import Screen
 

--- a/nicegui/testing/screen_plugin.py
+++ b/nicegui/testing/screen_plugin.py
@@ -26,7 +26,7 @@ def pytest_configure(config: pytest.Config) -> None:
     _general_pytest_configure(config)
     global DOWNLOAD_DIR  # pylint: disable=global-statement # noqa: PLW0603
     Screen.PORT = helpers.find_free_port()
-    Screen.SCREENSHOT_DIR = Path('screenshots') / str(os.getpid())
+    Screen.SCREENSHOT_DIR = (Path('screenshots') / str(os.getpid())).resolve()
     DOWNLOAD_DIR = Path(tempfile.mkdtemp(prefix='nicegui-test-download-'))
     atexit.register(shutil.rmtree, DOWNLOAD_DIR, ignore_errors=True)  # safety net for aborted session
 
@@ -68,7 +68,8 @@ def nicegui_chrome_options() -> webdriver.ChromeOptions:
 @pytest.fixture(scope='session')
 def nicegui_remove_all_screenshots() -> None:
     """Prune directories of finished concurrent runs and remove screenshots from previous runs."""
-    FileLock(Screen.SCREENSHOT_DIR / '.lock').acquire()
+    # NOTE: the FileLock is intentionally not stored; the kernel fd keeps the flock until process exit.
+    assert FileLock(Screen.SCREENSHOT_DIR / '.lock').acquire(), 'should be able to lock own screenshot dir'
     if Screen.SCREENSHOT_DIR.parent.exists():
         for path in Screen.SCREENSHOT_DIR.parent.iterdir():
             if path.is_dir() and path.name.isdigit() and (probe := FileLock(path / '.lock')).acquire():

--- a/nicegui/testing/screen_plugin.py
+++ b/nicegui/testing/screen_plugin.py
@@ -1,5 +1,7 @@
+import atexit
 import os
 import shutil
+import tempfile
 from collections.abc import Generator
 from pathlib import Path
 
@@ -7,16 +9,30 @@ import pytest
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 
+from nicegui import helpers
+
+from .filelock import FileLock
 from .general_fixtures import (  # noqa: F401  # pylint: disable=unused-import
     nicegui_reset_globals,
     pytest_addoption,
-    pytest_configure,
+    pytest_unconfigure,
 )
+from .general_fixtures import pytest_configure as _general_pytest_configure
 from .screen import Screen
 
 # pylint: disable=redefined-outer-name
 
-DOWNLOAD_DIR = Path(__file__).parent / 'download'
+DOWNLOAD_DIR: Path | None = None  # set in pytest_configure()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Configure storage (delegated) and set up session-unique Screen.PORT, SCREENSHOT_DIR, DOWNLOAD_DIR."""
+    _general_pytest_configure(config)
+    global DOWNLOAD_DIR  # pylint: disable=global-statement # noqa: PLW0603
+    Screen.PORT = helpers.find_free_port()
+    Screen.SCREENSHOT_DIR = Path('screenshots') / str(os.getpid())
+    DOWNLOAD_DIR = Path(tempfile.mkdtemp(prefix='nicegui-test-download-'))
+    atexit.register(shutil.rmtree, DOWNLOAD_DIR, ignore_errors=True)  # safety net for aborted session
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -30,6 +46,7 @@ def pytest_runtest_makereport(item, call):  # pylint: disable=unused-argument
 @pytest.fixture(scope='session')
 def nicegui_chrome_options() -> webdriver.ChromeOptions:
     """Configure the Chrome options for the NiceGUI tests."""
+    assert DOWNLOAD_DIR is not None, 'pytest_configure must run before this fixture'
     chrome_options = webdriver.ChromeOptions()
     chrome_options.add_argument('disable-dev-shm-usage')
     chrome_options.add_argument('disable-search-engine-choice-screen')
@@ -54,9 +71,15 @@ def nicegui_chrome_options() -> webdriver.ChromeOptions:
 
 @pytest.fixture(scope='session')
 def nicegui_remove_all_screenshots() -> None:
-    """Remove all screenshots from the screenshot directory before the test session."""
-    for name in Screen.SCREENSHOT_DIR.glob('*.png'):
-        name.unlink()
+    """Prune directories of finished concurrent runs and remove screenshots from previous runs."""
+    FileLock(Screen.SCREENSHOT_DIR / '.lock').acquire()
+    if Screen.SCREENSHOT_DIR.parent.exists():
+        for path in Screen.SCREENSHOT_DIR.parent.iterdir():
+            if path.is_dir() and path.name.isdigit() and (probe := FileLock(path / '.lock')).acquire():
+                probe.release()
+                shutil.rmtree(path, ignore_errors=True)
+    for path in Screen.SCREENSHOT_DIR.glob('*.png'):
+        path.unlink()
 
 
 @pytest.fixture(scope='session')
@@ -85,8 +108,10 @@ def screen(nicegui_reset_globals,  # noqa: F811, pylint: disable=unused-argument
            caplog: pytest.LogCaptureFixture,
            ) -> Generator[Screen, None, None]:
     """Create a new SeleniumScreen fixture."""
+    assert DOWNLOAD_DIR is not None, 'pytest_configure must run before this fixture'
     _reset_browser_state(nicegui_driver)
     os.environ['NICEGUI_SCREEN_TEST_PORT'] = str(Screen.PORT)
+    DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
     screen_ = Screen(nicegui_driver, caplog, request)
     try:
         yield screen_
@@ -105,8 +130,7 @@ def screen(nicegui_reset_globals,  # noqa: F811, pylint: disable=unused-argument
     finally:
         os.environ.pop('NICEGUI_SCREEN_TEST_PORT', None)
         screen_.stop_server()
-        if DOWNLOAD_DIR.exists():
-            shutil.rmtree(DOWNLOAD_DIR)
+        shutil.rmtree(DOWNLOAD_DIR, ignore_errors=True)
 
 
 def _reset_browser_state(driver: webdriver.Chrome) -> None:

--- a/nicegui/testing/user_plugin.py
+++ b/nicegui/testing/user_plugin.py
@@ -12,6 +12,7 @@ from .general_fixtures import (  # noqa: F401  # pylint: disable=unused-import
     get_path_to_main_file,
     pytest_addoption,
     pytest_configure,
+    pytest_unconfigure,
 )
 from .user import User
 from .user_simulation import prepare_simulation, user_simulation

--- a/nicegui/testing/user_plugin.py
+++ b/nicegui/testing/user_plugin.py
@@ -12,7 +12,6 @@ from .general_fixtures import (  # noqa: F401  # pylint: disable=unused-import
     get_path_to_main_file,
     pytest_addoption,
     pytest_configure,
-    pytest_unconfigure,
 )
 from .user import User
 from .user_simulation import prepare_simulation, user_simulation

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,7 +1,6 @@
 import asyncio
 import copy
 import time
-from pathlib import Path
 
 import httpx
 import pytest
@@ -9,6 +8,7 @@ import pytest
 from nicegui import Client, app, background_tasks, context, core, ui
 from nicegui.app.app import prune_tab_storage, prune_user_storage
 from nicegui.persistence.file_persistent_dict import FilePersistentDict
+from nicegui.storage import Storage
 from nicegui.testing import Screen, User
 
 
@@ -98,7 +98,7 @@ def test_access_user_storage_from_fastapi(screen: Screen):
         assert response.status_code == 200
         assert response.text == '"OK"'
         time.sleep(0.5)  # wait for storage to be written
-        assert next(Path('.nicegui').glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"msg":"yes"}'
+        assert next(Storage.path.glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"msg":"yes"}'
 
 
 def test_access_user_storage_on_interaction(screen: Screen):
@@ -112,7 +112,7 @@ def test_access_user_storage_on_interaction(screen: Screen):
     screen.open('/')
     screen.click('switch')
     screen.wait(0.5)
-    assert next(Path('.nicegui').glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"test_switch":true}'
+    assert next(Storage.path.glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"test_switch":true}'
 
 
 def test_access_user_storage_from_button_click_handler(screen: Screen):
@@ -125,7 +125,7 @@ def test_access_user_storage_from_button_click_handler(screen: Screen):
     screen.click('test')
     screen.wait(1)
     assert \
-        next(Path('.nicegui').glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"inner_function":"works"}'
+        next(Storage.path.glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"inner_function":"works"}'
 
 
 def test_access_user_storage_from_background_task(screen: Screen):
@@ -142,7 +142,7 @@ def test_access_user_storage_from_background_task(screen: Screen):
     screen.ui_run_kwargs['storage_secret'] = 'just a test'
     screen.open('/')
     screen.should_contain('Done')
-    assert next(Path('.nicegui').glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"subtask":"works"}'
+    assert next(Storage.path.glob('storage-user-*.json')).read_text(encoding='utf-8') == '{"subtask":"works"}'
 
 
 def test_user_and_general_storage_is_persisted(screen: Screen):
@@ -178,7 +178,7 @@ def test_rapid_storage(screen: Screen):
     screen.open('/')
     screen.click('test')
     screen.wait(0.5)
-    assert Path('.nicegui', 'storage-general.json').read_text(encoding='utf-8') == '{"one":1,"two":2,"three":3}'
+    assert (Storage.path / 'storage-general.json').read_text(encoding='utf-8') == '{"one":1,"two":2,"three":3}'
 
 
 def test_tab_storage_is_local(screen: Screen):
@@ -283,7 +283,7 @@ def test_deepcopy(screen: Screen):
     screen.open('/')
     screen.should_contain('Loaded')
     screen.wait(0.5)
-    assert Path('.nicegui', 'storage-general.json').read_text(encoding='utf-8') == '{"a":{"b":0}}'
+    assert (Storage.path / 'storage-general.json').read_text(encoding='utf-8') == '{"a":{"b":0}}'
 
 
 def test_missing_storage_secret(screen: Screen):
@@ -362,7 +362,7 @@ async def test_user_storage_is_pruned(screen: Screen):
     assert len(Client.instances) == 1
     assert len(app.storage._users) == 1
 
-    response = httpx.get('http://localhost:3392/status')
+    response = httpx.get(f'http://localhost:{Screen.PORT}/status')
     assert response.status_code == 200
     assert response.text == '"ok"'
     assert len(Client.instances) == 1

--- a/website/documentation/content/screen_documentation.py
+++ b/website/documentation/content/screen_documentation.py
@@ -32,9 +32,10 @@ def screen_fixture():
 doc.text('Configuration', '''
     The `screen` fixture can be configured by setting the following static attributes:
 
-    - `PORT`: The port to use for the server (default: 3392).
+    - `PORT`: The port to use for the server (default: automatically determined free port).
     - `IMPLICIT_WAIT`: The implicit wait time in seconds (default: 4).
-    - `SCREENSHOT_DIR`: The directory to store the screenshots (default: "screenshots").
+    - `SCREENSHOT_DIR`: The directory to store the screenshots
+        (default: `./screenshots/<pid>`, a per-process subdirectory so parallel `pytest` invocations do not collide).
     - `CATCH_JS_ERRORS`: Whether to catch JavaScript errors (default: `True`, *added in version 3.2.0*).
 ''')
 


### PR DESCRIPTION
### Motivation

Recreate of #5960, which was merged in 3.13 and then reverted on main (commit ec74aa6d4) due to the import-time `Storage.path` clobber regression reported in #6061.

This PR restores #5960's contents *and* includes the proper fix for #6061 on top, so the change can be re-merged safely.

### Implementation

Three commits:

1. **Reapply `#5960`** (`git revert ec74aa6d4`) — restores the original implementation:
    - **`nicegui/helpers/network.py`**: new public helper `find_free_port()` binds an ephemeral `AF_INET / SOCK_STREAM` to `('0.0.0.0', 0)`.
    - **`nicegui/testing/filelock.py`** (new): small cross-platform `FileLock` (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows). Used as a process-liveness probe for screenshot pruning.
    - **`nicegui/testing/screen_plugin.py`**: `pytest_configure` sets `Screen.PORT = helpers.find_free_port()`, `Screen.SCREENSHOT_DIR = Path('screenshots') / str(os.getpid())`, and a per-session `DOWNLOAD_DIR` via `tempfile.mkdtemp`. `nicegui_remove_all_screenshots` acquires an exclusive lock per PID-dir and prunes sibling dirs whose lock can be acquired (= owner gone).
    - **`tests/test_storage.py`**: replaces `Path('.nicegui')` literals with `Storage.path` and the hardcoded `3392` with `Screen.PORT`.
    - **`website/documentation/content/screen_documentation.py`**: doc default notes updated.

2. **Fix `#6061`** — move the `Storage.path` mutation out of import time. The original PR set `Storage.path = None` at the top of `general_fixtures.py`, which ran on plain `import` (not just under pytest) and broke any code path that touched `Storage.path` before the testing plugin was active. The fix:
    - **`nicegui/testing/general_fixtures.py`**: do the `Storage.path = tempfile.mkdtemp(...)` assignment + `app.storage = Storage()` rebuild inside `pytest_configure` instead of at module top, so a plain `import nicegui.testing` no longer mutates `Storage.path`.

3. **Harden testing plugin idempotency and own-dir lock** — refine commit 2:
    - **`nicegui/testing/general_fixtures.py`**: guard `pytest_configure` with a module-level `_configured: bool` sentinel (`if _configured: return`) instead of comparing `Storage.path` against its import-time default. The value comparison conflated "we already configured" with "the user deliberately set `Storage.path` / `NICEGUI_STORAGE_PATH`", silently skipping isolation in those cases; the boolean tracks only our own configuration, so repeat in-process calls are idempotent and a user-set value no longer suppresses the override.
    - **`nicegui/testing/screen_plugin.py`**: `assert` the own-dir `FileLock` acquire in `nicegui_remove_all_screenshots` (an unchecked failure would cascade to `rmtree`-ing the active session's screenshot dir) with a `# NOTE:` documenting the deliberate fd-leak, and `.resolve()` `Screen.SCREENSHOT_DIR` at configure time so the prune sweep is `os.chdir`-safe.

### Notes on observable defaults

Three observable defaults change under the testing plugin. None are hard breaks — the idiomatic way to use each surface was always indirect — but worth calling out:

- **`Screen.PORT`** was `3392` and is now a random free port per process. Tests that hardcoded `3392` (e.g. `http://localhost:3392/...`) need to read `Screen.PORT`, which has always been the documented-public way. This PR applies that migration to NiceGUI's own `test_storage.py`.
- **`Screen.SCREENSHOT_DIR`** was `'screenshots'` and is now `'screenshots/<pid>'`. Same shape as the existing `.failed.png` convention — a subpath under the screenshots root, transparent to anyone who reads screenshots via `Screen.SCREENSHOT_DIR` rather than hardcoding the literal.
- **`Storage.path`** (when the testing plugin is loaded) now points to a session-unique tempdir instead of `.nicegui/`. Reading `.nicegui/` directly in test code was never a supported pattern — the `Storage.path` attribute is the contract. NiceGUI's own `test_storage.py` is migrated to match.

Outside the testing plugin (plain `import nicegui`), `Storage.path` is unchanged from main — that's the regression #6061 was about, and it's the explicit purpose of the second commit to keep it that way.

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation has been updated (`screen_documentation.py`).
- [x] No breaking changes to the public API — observable default values move under the testing plugin only, and the documented accessors (`Screen.PORT`, `Screen.SCREENSHOT_DIR`, `Storage.path`) are unchanged. Migration notes above.