### PR TITLE
Fix Event.emitted() dropping the emitted arguments

### DIFF
--- a/nicegui/event.py
+++ b/nicegui/event.py
@@ -56,6 +56,7 @@ class Event(Generic[P]):
         self.instances.add(self)
 
     def subscribe(self, callback: Callable[P, Any] | Callable[[], Any], *,
+                  expect_args: bool | None = None,
                   unsubscribe_on_delete: bool | None = None) -> None:
         """Subscribe to the event.
 
@@ -65,6 +66,8 @@ class Event(Generic[P]):
         to prevent memory leaks.
 
         :param callback: the callback which will be called when the event is fired
+        :param expect_args: whether to forward the event's arguments to the callback
+            (default: ``None`` meaning auto-detected from the callback's signature, *added in version 3.13.0*)
         :param unsubscribe_on_delete: whether to unsubscribe the callback when the current client is deleted
             (default: ``None`` meaning the callback is automatically unsubscribed if subscribed from within a UI context)
         """
@@ -77,7 +80,7 @@ class Event(Generic[P]):
             expect_args=helpers.expects_arguments(callback) or (
                 isinstance(getattr(callback, '__self__', None), Event) and
                 getattr(callback, '__name__', None) in {'emit', 'call'}
-            ),
+            ) if expect_args is None else expect_args,
             filepath=frame.f_code.co_filename,
             line=frame.f_lineno,
         )
@@ -119,7 +122,7 @@ class Event(Generic[P]):
             if not future.done():
                 future.set_result(args[0] if len(args) == 1 else args if args else None)
 
-        self.subscribe(callback)
+        self.subscribe(callback, expect_args=True)
         try:
             return await asyncio.wait_for(future, timeout)
         except TimeoutError as error:

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -86,6 +86,19 @@ async def test_exception_during_emit(user: User, caplog: pytest.LogCaptureFixtur
     caplog.records.pop(0)
 
 
+async def test_await_emitted(user: User):
+    event = Event()
+    app.timer(0.1, lambda: event.emit(42))
+
+    @ui.page('/')
+    async def page():
+        number = await event.emitted()
+        ui.label(f'Emitted number: {number}')
+
+    await user.open('/')
+    await user.should_see('Emitted number: 42')
+
+
 async def test_exception_during_call(user: User):
     event = Event()
     event.subscribe(lambda: print(1 / 0))


### PR DESCRIPTION
### Motivation

`Event.emitted()` is documented as _"Wait for an event to be fired and return its arguments"_, but it currently returns `None` for any event whose `emit()` is called with arguments.

Reproducer:

```python
import asyncio
from nicegui import Event

async def main():
    e: Event[int] = Event()

    async def waiter():
        return await e.emitted(timeout=1)

    task = asyncio.create_task(waiter())
    await asyncio.sleep(0)
    e.emit(42)
    print('expected 42, got', await task)  # -> got None

asyncio.run(main())
```

Internally, `Event.emitted()` registers a `def callback(*args, **kwargs)` receiver and waits on a future that the receiver is supposed to fill. The receiver is dispatched through `Callback.run`, which only forwards arguments when `expect_args` is true. `expect_args` is auto-detected via `helpers.expects_arguments`, which returns `False` for purely variadic signatures — by design, since for a UI handler "no required parameters" correctly means "don't forward anything". So the receiver runs with `args=()` and stores `None` on the future.

The helper is right: a `*args, **kwargs` wrapper doesn't _expect_ arguments, it _accepts_ them. The missing piece is a way for the caller to opt into forwarding when it knows its wrapper is intentionally permissive.

### Implementation

- Add an `expect_args: bool | None = None` keyword argument to `Event.subscribe()`. When `None` (the default), behavior is identical to before — same auto-detection, including the existing special case for bound `Event.emit` / `Event.call` chaining. When set explicitly, the caller's choice wins.
- Use `self.subscribe(callback, expect_args=True)` inside `Event.emitted()` so its variadic internal receiver actually receives the emitted arguments and writes them to the future.
- Add a `test_await_emitted` regression test.

No public-API changes for existing callers; the new parameter is opt-in.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary (internal behavior fix; existing `Event.emitted()` docstring already describes the intended contract).
- [x] No breaking changes to the public API.