### PR TITLE
Fix blank ui.aggrid when flex columns use the infinite row model

### DIFF
--- a/nicegui/elements/aggrid/aggrid.py
+++ b/nicegui/elements/aggrid/aggrid.py
@@ -49,7 +49,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         super().__init__()
 
         col_defs = [options.get('defaultColDef', {}), *options.get('columnDefs', [])]
-        uses_flex = any(col.get('flex') is not None or ':flex' in col for col in col_defs)
+        uses_flex = any(col.get('flex') or ':flex' in col for col in col_defs)
         if auto_size_columns is None:
             auto_size_columns = not uses_flex  # auto: flex columns size themselves
         elif auto_size_columns and uses_flex:

--- a/nicegui/elements/aggrid/aggrid.py
+++ b/nicegui/elements/aggrid/aggrid.py
@@ -188,6 +188,8 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
     @options.setter
     def options(self, value: dict) -> None:
         self._props['options'] = value
+        if self.auto_size_columns and self._uses_flex(value):
+            helpers.warn_once('AG Grid: "flex" is ignored when auto_size_columns=True. Grid may render blank.')
 
     @property
     def html_columns(self) -> list[int]:

--- a/nicegui/elements/aggrid/aggrid.py
+++ b/nicegui/elements/aggrid/aggrid.py
@@ -48,11 +48,9 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
 
         super().__init__()
 
-        col_defs = [options.get('defaultColDef', {}), *options.get('columnDefs', [])]
-        uses_flex = any(col.get('flex') or ':flex' in col for col in col_defs)
         if auto_size_columns is None:
-            auto_size_columns = not uses_flex  # auto: flex columns size themselves
-        elif auto_size_columns and uses_flex:
+            auto_size_columns = not self._uses_flex(options)
+        elif auto_size_columns and self._uses_flex(options):
             helpers.warn_once('AG Grid: "flex" is ignored when auto_size_columns=True. Grid may render blank.')
 
         self._props['options'] = {
@@ -65,6 +63,11 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         self._props['modules'] = modules[:]
 
         self._props.add_rename('html_columns', 'html-columns')  # DEPRECATED: remove in NiceGUI 4.0
+
+    @staticmethod
+    def _uses_flex(options: dict) -> bool:
+        col_defs = [options.get('defaultColDef', {}), *options.get('columnDefs', [])]
+        return any(col.get('flex') or ':flex' in col for col in col_defs)
 
     @staticmethod
     def _migrate_deprecated_checkbox_renderer(options: dict) -> None:
@@ -212,6 +215,8 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
     @auto_size_columns.setter
     def auto_size_columns(self, value: bool) -> None:
         if value and not self.auto_size_columns:
+            if self._uses_flex(self._props['options']):
+                helpers.warn_once('AG Grid: "flex" is ignored when auto_size_columns=True. Grid may render blank.')
             self._props['options']['autoSizeStrategy'] = {'type': 'fitGridWidth'}
         if not value and self.auto_size_columns:
             self._props['options'].pop('autoSizeStrategy')

--- a/nicegui/elements/aggrid/aggrid.py
+++ b/nicegui/elements/aggrid/aggrid.py
@@ -47,14 +47,14 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         self._migrate_deprecated_checkbox_renderer(options)  # DEPRECATED: remove in NiceGUI 4.0
 
         super().__init__()
+
+        col_defs = [options.get('defaultColDef', {}), *options.get('columnDefs', [])]
+        uses_flex = any(col.get('flex') is not None or ':flex' in col for col in col_defs)
         if auto_size_columns is None:
-            auto_size_columns = not self._uses_flex(options)  # auto: flex columns size themselves
-        elif auto_size_columns and self._uses_flex(options):
-            helpers.warn_once(
-                'AG Grid: auto_size_columns=True is incompatible with columns using "flex" '
-                '(AG Grid ignores flex when autoSizeStrategy is set, and the grid may render blank).\n'
-                'Use either flex or auto_size_columns, not both.'
-            )
+            auto_size_columns = not uses_flex  # auto: flex columns size themselves
+        elif auto_size_columns and uses_flex:
+            helpers.warn_once('AG Grid: "flex" is ignored when auto_size_columns=True. Grid may render blank.')
+
         self._props['options'] = {
             'theme': theme or 'quartz',
             **({'autoSizeStrategy': {'type': 'fitGridWidth'}} if auto_size_columns else {}),
@@ -86,16 +86,6 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
                 "    'editable': True,\n"
                 'Please migrate ASAP as the backwards-compatibility will be removed in NiceGUI 4.0.'
             )
-
-    @staticmethod
-    def _uses_flex(options: dict) -> bool:
-        """Whether any column requests flex sizing (mutually exclusive with autoSizeStrategy).
-
-        Detects both the literal ``flex`` key and the dynamic ``:flex`` property form,
-        which NiceGUI converts to ``flex`` on the client (see #5087).
-        """
-        return any(col.get('flex') is not None or ':flex' in col
-                   for col in [options.get('defaultColDef', {}), *options.get('columnDefs', [])])
 
     @classmethod
     def from_pandas(cls,

--- a/nicegui/elements/aggrid/aggrid.py
+++ b/nicegui/elements/aggrid/aggrid.py
@@ -25,7 +25,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
                  options: dict, *,
                  html_columns: list[int] = DEFAULT_PROP | [],
                  theme: Literal['quartz', 'balham', 'material', 'alpine'] | None = None,
-                 auto_size_columns: bool = True,
+                 auto_size_columns: bool | None = None,
                  modules: Literal['community', 'enterprise'] | list[str] = 'community',
                  ) -> None:
         """AG Grid
@@ -38,7 +38,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         :param options: dictionary of AG Grid options
         :param html_columns: list of columns that should be rendered as HTML (default: ``[]``)
         :param theme: AG Grid theme "quartz", "balham", "material", or "alpine" (default: ``options['theme']`` or "quartz")
-        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``True``)
+        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``None``, i.e. fit to width unless columns use ``flex``)
         :param modules: either "community", "enterprise", or a list of `AG Grid Modules <https://www.ag-grid.com/javascript-data-grid/modules/>`_ (default: "community")
         """
         if not isinstance(modules, list):
@@ -47,6 +47,14 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         self._migrate_deprecated_checkbox_renderer(options)  # DEPRECATED: remove in NiceGUI 4.0
 
         super().__init__()
+        if auto_size_columns is None:
+            auto_size_columns = not self._uses_flex(options)  # auto: flex columns size themselves
+        elif auto_size_columns and self._uses_flex(options):
+            helpers.warn_once(
+                'AG Grid: auto_size_columns=True is incompatible with columns using "flex" '
+                '(AG Grid ignores flex when autoSizeStrategy is set, and the grid may render blank).\n'
+                'Use either flex or auto_size_columns, not both.'
+            )
         self._props['options'] = {
             'theme': theme or 'quartz',
             **({'autoSizeStrategy': {'type': 'fitGridWidth'}} if auto_size_columns else {}),
@@ -79,12 +87,22 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
                 'Please migrate ASAP as the backwards-compatibility will be removed in NiceGUI 4.0.'
             )
 
+    @staticmethod
+    def _uses_flex(options: dict) -> bool:
+        """Whether any column requests flex sizing (mutually exclusive with autoSizeStrategy).
+
+        Detects both the literal ``flex`` key and the dynamic ``:flex`` property form,
+        which NiceGUI converts to ``flex`` on the client (see #5087).
+        """
+        return any(col.get('flex') is not None or ':flex' in col
+                   for col in [options.get('defaultColDef', {}), *options.get('columnDefs', [])])
+
     @classmethod
     def from_pandas(cls,
                     df: 'pd.DataFrame', *,
                     html_columns: list[int] = [],  # noqa: B006
                     theme: Literal['quartz', 'balham', 'material', 'alpine'] | None = None,
-                    auto_size_columns: bool = True,
+                    auto_size_columns: bool | None = None,
                     options: dict = {},  # noqa: B006
                     modules: Literal['community', 'enterprise'] | list[str] = 'community',
                     ) -> Self:
@@ -103,7 +121,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         :param df: Pandas DataFrame
         :param html_columns: list of columns that should be rendered as HTML (default: ``[]``, *added in version 2.19.0*)
         :param theme: AG Grid theme "quartz", "balham", "material", or "alpine" (default: ``options['theme']`` or "quartz")
-        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``True``)
+        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``None``, i.e. fit to width unless columns use ``flex``)
         :param options: dictionary of additional AG Grid options
         :param modules: either "community", "enterprise", or a list of `AG Grid Modules <https://www.ag-grid.com/javascript-data-grid/modules/>`_ (default: "community")
         :return: AG Grid element
@@ -142,7 +160,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
                     df: 'pl.DataFrame', *,
                     html_columns: list[int] = [],  # noqa: B006
                     theme: Literal['quartz', 'balham', 'material', 'alpine'] | None = None,
-                    auto_size_columns: bool = True,
+                    auto_size_columns: bool | None = None,
                     options: dict = {},  # noqa: B006
                     modules: Literal['community', 'enterprise'] | list[str] = 'community',
                     ) -> Self:
@@ -156,7 +174,7 @@ class AgGrid(Element, component='aggrid.js', esm={'nicegui-aggrid': 'dist'}, def
         :param df: Polars DataFrame
         :param html_columns: list of columns that should be rendered as HTML (default: ``[]``, *added in version 2.19.0*)
         :param theme: AG Grid theme "quartz", "balham", "material", or "alpine" (default: ``options['theme']`` or "quartz")
-        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``True``)
+        :param auto_size_columns: whether to automatically resize columns to fit the grid width (default: ``None``, i.e. fit to width unless columns use ``flex``)
         :param options: dictionary of additional AG Grid options
         :param modules: either "community", "enterprise", or a list of `AG Grid Modules <https://www.ag-grid.com/javascript-data-grid/modules/>`_ (default: "community")
         :return: AG Grid element

--- a/tests/test_aggrid.py
+++ b/tests/test_aggrid.py
@@ -11,7 +11,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 
 from nicegui import Event, app, ui
-from nicegui.testing import Screen
+from nicegui.testing import Screen, User
 
 
 def test_update_table(screen: Screen):
@@ -380,3 +380,23 @@ def test_pandas_with_index(screen: Screen, index: Any, expected: list[str], unex
         screen.should_contain(item)
     for item in unexpected:
         screen.should_not_contain(item)
+
+
+async def test_auto_size_columns_vs_flex(user: User):
+    """auto_size_columns=None must skip autoSizeStrategy for flex columns, but respect explicit values (#5087)."""
+    grids: dict = {}
+
+    @ui.page('/')
+    def page():
+        grids['default'] = ui.aggrid({'columnDefs': [{'field': 'a'}]})
+        grids['flex'] = ui.aggrid({'defaultColDef': {'flex': 1}, 'columnDefs': [{'field': 'a'}]})
+        grids['dynamic_flex'] = ui.aggrid({'columnDefs': [{'field': 'a', ':flex': '1'}]})
+        grids['forced'] = ui.aggrid({'defaultColDef': {'flex': 1}}, auto_size_columns=True)
+        grids['off'] = ui.aggrid({'columnDefs': [{'field': 'a'}]}, auto_size_columns=False)
+
+    await user.open('/')
+    assert 'autoSizeStrategy' in grids['default'].options, 'None default without flex should fit-to-width'
+    assert 'autoSizeStrategy' not in grids['flex'].options, 'None default with flex should skip autoSizeStrategy (#5087)'
+    assert 'autoSizeStrategy' not in grids['dynamic_flex'].options, 'dynamic :flex should also skip autoSizeStrategy'
+    assert 'autoSizeStrategy' in grids['forced'].options, 'explicit auto_size_columns=True must be respected'
+    assert 'autoSizeStrategy' not in grids['off'].options, 'explicit auto_size_columns=False must be respected'

--- a/tests/test_aggrid.py
+++ b/tests/test_aggrid.py
@@ -396,7 +396,8 @@ async def test_auto_size_columns_vs_flex(user: User):
 
     await user.open('/')
     assert 'autoSizeStrategy' in grids['default'].options, 'None default without flex should fit-to-width'
-    assert 'autoSizeStrategy' not in grids['flex'].options, 'None default with flex should skip autoSizeStrategy (#5087)'
+    assert 'autoSizeStrategy' not in grids[
+        'flex'].options, 'None default with flex should skip autoSizeStrategy (#5087)'
     assert 'autoSizeStrategy' not in grids['dynamic_flex'].options, 'dynamic :flex should also skip autoSizeStrategy'
     assert 'autoSizeStrategy' in grids['forced'].options, 'explicit auto_size_columns=True must be respected'
     assert 'autoSizeStrategy' not in grids['off'].options, 'explicit auto_size_columns=False must be respected'

--- a/tests/test_aggrid.py
+++ b/tests/test_aggrid.py
@@ -382,22 +382,17 @@ def test_pandas_with_index(screen: Screen, index: Any, expected: list[str], unex
         screen.should_not_contain(item)
 
 
-async def test_auto_size_columns_vs_flex(user: User):
-    """auto_size_columns=None must skip autoSizeStrategy for flex columns, but respect explicit values (#5087)."""
-    grids: dict = {}
-
+@pytest.mark.parametrize('args,auto_size_strategy_expected', [
+    ({'options': {'columnDefs': [{'field': 'a'}]}}, True),
+    ({'options': {'columnDefs': [{'field': 'a'}], 'defaultColDef': {'flex': 1}}}, False),
+    ({'options': {'columnDefs': [{'field': 'a', ':flex': '1'}]}}, False),
+    ({'options': {'columnDefs': [{'field': 'a'}]}, 'auto_size_columns': False}, False),
+    ({'options': {'defaultColDef': {'flex': 1}}, 'auto_size_columns': True}, True),
+])
+async def test_auto_size_columns_vs_flex(user: User, args: dict[str, Any], auto_size_strategy_expected: bool):
     @ui.page('/')
     def page():
-        grids['default'] = ui.aggrid({'columnDefs': [{'field': 'a'}]})
-        grids['flex'] = ui.aggrid({'defaultColDef': {'flex': 1}, 'columnDefs': [{'field': 'a'}]})
-        grids['dynamic_flex'] = ui.aggrid({'columnDefs': [{'field': 'a', ':flex': '1'}]})
-        grids['forced'] = ui.aggrid({'defaultColDef': {'flex': 1}}, auto_size_columns=True)
-        grids['off'] = ui.aggrid({'columnDefs': [{'field': 'a'}]}, auto_size_columns=False)
+        grid = ui.aggrid(**args)
+        assert ('autoSizeStrategy' in grid.options) == auto_size_strategy_expected
 
     await user.open('/')
-    assert 'autoSizeStrategy' in grids['default'].options, 'None default without flex should fit-to-width'
-    assert 'autoSizeStrategy' not in grids[
-        'flex'].options, 'None default with flex should skip autoSizeStrategy (#5087)'
-    assert 'autoSizeStrategy' not in grids['dynamic_flex'].options, 'dynamic :flex should also skip autoSizeStrategy'
-    assert 'autoSizeStrategy' in grids['forced'].options, 'explicit auto_size_columns=True must be respected'
-    assert 'autoSizeStrategy' not in grids['off'].options, 'explicit auto_size_columns=False must be respected'

--- a/tests/test_aggrid.py
+++ b/tests/test_aggrid.py
@@ -385,6 +385,7 @@ def test_pandas_with_index(screen: Screen, index: Any, expected: list[str], unex
 @pytest.mark.parametrize('args,auto_size_strategy_expected', [
     ({'options': {'columnDefs': [{'field': 'a'}]}}, True),
     ({'options': {'columnDefs': [{'field': 'a'}], 'defaultColDef': {'flex': 1}}}, False),
+    ({'options': {'columnDefs': [{'field': 'a', 'flex': 0}]}}, True),
     ({'options': {'columnDefs': [{'field': 'a', ':flex': '1'}]}}, False),
     ({'options': {'columnDefs': [{'field': 'a'}]}, 'auto_size_columns': False}, False),
     ({'options': {'defaultColDef': {'flex': 1}}, 'auto_size_columns': True}, True),


### PR DESCRIPTION
### Motivation

`ui.aggrid` renders a **blank** grid when columns use `flex` together with the **infinite row model**. The data loads (rows and headers are in the DOM), but every cell ends up `visibility: hidden`, so the user sees nothing. Reported in the comments of #5087; minimal repro:

```python
from nicegui import ui

ui.aggrid({
    'defaultColDef': {'flex': 1},
    'columnDefs': [{'field': 'athlete'}, {'field': 'age'}, {'field': 'country'}],
    'rowData': None,
    'rowModelType': 'infinite',
    ':onGridReady': '''(params) => params.api.setGridOption("datasource", {
        getRows: (p) => p.successCallback([{athlete: "A", age: 1, country: "X"}], 1),
    })''',
})

ui.run()
```

Root cause: `auto_size_columns=True` (the default) injects `autoSizeStrategy: {'type': 'fitGridWidth'}`, and AG Grid treats `flex` and `autoSizeStrategy` as mutually exclusive — it logs `colDef.flex is not supported with gridOptions.autoSizeStrategy` and, under the infinite row model, never paints the cells.

This is the same family as #5276 ("render failed when `flex=1` after upgrade to 3.0"), which #5277 fixed for the **client-side** row model by switching from `sizeColumnsToFit()` to `autoSizeStrategy`. That fixed client-side + flex, but the **infinite row model + flex** case is still blank on 3.12.

I'm aware #5277 originally drafted "ignore `auto_size_columns` when a column has `flex`" and then moved away from it (the struck-through line in its description) in favour of `autoSizeStrategy`. This PR revisits a *refined* version of that idea, because `autoSizeStrategy` is fundamentally incompatible with `flex` (per AG Grid's own warning), so it can't be the auto-sizing mechanism when flex is in play.

### Implementation

Make `auto_size_columns` a tri-state `bool | None = None`:

- **`None`** (new default): fit-to-width **unless** columns use `flex` — then skip `autoSizeStrategy` and let flex size the columns.
- **`True`**: always inject `autoSizeStrategy` (explicit intent respected), with a `warn_once` when it conflicts with `flex`.
- **`False`**: never inject (unchanged).

`_uses_flex(options)` detects flex in `defaultColDef`/`columnDefs`, including the dynamic `:flex` property form (which NiceGUI converts to `flex` client-side). The `auto_size_columns` property getter is unchanged and stays truthful.

Why the tri-state rather than #5277's struck-through unconditional skip: it keeps an explicit escape hatch (`auto_size_columns=True` still forces `autoSizeStrategy`), so users who deliberately want fit-to-width with flex aren't silently overridden — only the unopinionated default becomes flex-aware.

Verified locally (AG Grid 34.2.0):
- #5276 repro (flex, **client-side**) — still renders correctly (no regression of #5277).
- #5087 repro (flex, **infinite**) — now renders (was blank).
- `ruff` + `mypy ./nicegui` + `pylint ./nicegui` (10.00/10) clean.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated. (Browser-free `user`-fixture test asserting `autoSizeStrategy` presence/absence across `None`/`True`/`False` × flex / no-flex / `:flex`.)
- [x] Documentation has been added/updated or is not necessary. (Docstrings updated; glad to add an aggrid flex demo if preferred.)
- [x] No breaking changes to the public API or migration steps are described above. (Default `True`→`None`; behavior unchanged for non-flex grids and for explicit `True`/`False`; flex grids change from *blank* to *working*. Type widens `bool`→`bool | None`, backward-compatible.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
