### PR TITLE
Fix bad CLS on documentation homepage

### DIFF
--- a/website/components/examples_section.py
+++ b/website/components/examples_section.py
@@ -24,7 +24,7 @@ def create() -> None:
 def example_card(example: Example) -> None:
     """Render a single example card with screenshot, title, and description."""
     with ui.link(target=example.url).classes(
-        'rounded-2xl overflow-hidden transition-all duration-200 hover:-translate-y-0.5'
+        'rounded-2xl overflow-hidden transition-[transform,box-shadow] duration-200 hover:-translate-y-0.5'
         f' {d.BG_SURFACE} {d.BORDER} hover:{d.SHADOW_CARD}'
     ):
         with ui.element().classes(f'overflow-hidden aspect-video bg-white p-4 dark:brightness-[0.85] {d.BORDER_B}'):

--- a/website/components/features_section.py
+++ b/website/components/features_section.py
@@ -57,7 +57,7 @@ def create() -> None:
 
 def _card(icon: str, title: str, items: list[str]) -> None:
     """Render a single feature card with icon, title, and bullet list."""
-    with ui.column().classes(f'relative rounded-2xl p-7 gap-0 group transition-all duration-200 cursor-default hover:-translate-y-0.5 {d.BG_SURFACE} {d.BORDER}'):
+    with ui.column().classes(f'relative rounded-2xl p-7 gap-0 group transition-transform duration-200 cursor-default hover:-translate-y-0.5 {d.BG_SURFACE} {d.BORDER}'):
         ui.label('ui.card()') \
             .classes(f'absolute top-2.5 right-3 font-mono {d.TEXT_13PX} {d.TEXT_BLUE} opacity-0 group-hover:opacity-30 transition-opacity duration-300 pointer-events-none')
         phosphor_icon(icon) \

--- a/website/components/shared.py
+++ b/website/components/shared.py
@@ -45,7 +45,7 @@ def cta_button(
     """Styled CTA button with optional Phosphor icons."""
     with ui.button(on_click=on_click) \
             .props('unelevated no-caps rounded size=1rem') \
-            .classes('px-7 py-2.5 transition-all duration-150 hover:-translate-y-px') as button:
+            .classes('px-7 py-2.5 transition-transform duration-150 hover:-translate-y-px') as button:
         with ui.row(align_items='center').classes('gap-2'):
             if left_icon:
                 phosphor_icon(left_icon)

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -160,7 +160,7 @@ def create_tiles():
     for documentation, description in tiles:
         page = doc.get_page(documentation)
         with ui.link(target=f'/documentation/{page.name}').classes(
-            f'rounded-xl p-5 transition-all duration-200 cursor-pointer hover:-translate-y-0.5 {d.BG_SURFACE} {d.BORDER}'
+            f'rounded-xl p-5 transition-transform duration-200 cursor-pointer hover:-translate-y-0.5 {d.BG_SURFACE} {d.BORDER}'
         ):
             if page.title:
                 ui.label(page.title.replace('*', '')).classes(f'{d.TEXT_19PX} font-semibold mb-1')

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -156,7 +156,7 @@ def create_tiles():
     with ui.row(align_items='center').classes('mx-auto gap-y-1'):
         ui.label('Do you like NiceGUI? Become a')
         ui.html('<iframe src="https://github.com/sponsors/zauberzeug/button" title="Sponsor zauberzeug" height="32" width="114"'
-                ' class="border-0 outline-[1px] outline-offset-[-1px] outline-[#d1d9e0] dark:outline-[#3d444d] rounded-xl"></iframe>', sanitize=False)
+                ' class="border-0 outline-[1px] outline-offset-[-1px] outline-[#d1d9e0] dark:outline-[#3d444d] rounded"></iframe>', sanitize=False)
     for documentation, description in tiles:
         page = doc.get_page(documentation)
         with ui.link(target=f'/documentation/{page.name}').classes(

--- a/website/documentation/content/overview.py
+++ b/website/documentation/content/overview.py
@@ -156,7 +156,7 @@ def create_tiles():
     with ui.row(align_items='center').classes('mx-auto gap-y-1'):
         ui.label('Do you like NiceGUI? Become a')
         ui.html('<iframe src="https://github.com/sponsors/zauberzeug/button" title="Sponsor zauberzeug" height="32" width="114"'
-                ' class="border-0 outline-[1px] outline-offset-[-1px] outline-[#d1d9e0] dark:outline-[#3d444d] rounded"></iframe>', sanitize=False)
+                ' class="border-0 outline-[1px] outline-offset-[-1px] outline-[#d1d9e0] dark:outline-[#3d444d] rounded-xl"></iframe>', sanitize=False)
     for documentation, description in tiles:
         page = doc.get_page(documentation)
         with ui.link(target=f'/documentation/{page.name}').classes(

--- a/website/header.py
+++ b/website/header.py
@@ -145,7 +145,7 @@ def _github_badge() -> None:
     with ui.link(target='https://github.com/zauberzeug/nicegui/') \
             .classes(f'rounded-full px-3.5 py-[0.4em] {d.TEXT_13PX} {SM_UP} '
                      f'{d.BORDER} {d.BORDER_ACCENT}! dark:{d.BORDER_ACCENT}/50! '
-                     f'hover:{d.BG_ACCENT}/10 duration-150'):
+                     f'hover:{d.BG_ACCENT}/10 transition-[background-color] duration-150'):
         with ui.row().classes(f'gap-2 items-center {d.TEXT_ACCENT}'):
             phosphor_icon('ph-github-logo').classes('text-base')
             ui.label().bind_text_from(github_stars.stars, 'string').classes(MD_UP)


### PR DESCRIPTION
### Motivation

The NiceGUI documentation homepage suffers from bad Cumulative Layout Shift (CLS): on the first frame the tiles render in their unstyled state and then visibly morph into the final design over ~200ms. Closes #6087.

The cards and CTA buttons use `transition-all`. Because NiceGUI applies the Tailwind classes via JavaScript _after_ the element first paints, `transition-all` animates _every_ property when the styled state is applied — including layout-affecting ones like `padding` and `border-radius`. That reflow is the morph captured in the issue's screenshot and what Chrome measures as CLS.

### Implementation

Scope each transition to only the properties that actually animate on hover. `transform` and `box-shadow` are composited and never trigger layout reflow, so the hover lift stays smooth while the layout-shifting animation is gone:

- `overview.py` (doc homepage tiles), `features_section.py`, `shared.py` (CTA button): `transition-all` → `transition-transform` (hover only does `-translate-y`).
- `examples_section.py`: `transition-all` → `transition-[transform,box-shadow]` (hover does `-translate-y` plus a shadow).

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.
