### PR TITLE
Fix ui.sub_pages wildcard re-rendering and reject unsupported route patterns (#6090)

### DIFF
--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -30,6 +30,8 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         Provides URL-based navigation between different views to build single page applications (SPAs).
         Routes are defined as path patterns mapping to page builder functions.
         Path parameters like "/user/{id}" are extracted and passed to the builder function.
+        Only single-segment "{name}" parameters are supported (not Starlette-style converters like "{name:path}");
+        for wildcard routing use ``show_404=False`` and read ``PageArguments.remaining_path``.
 
         *Added in version 2.22.0*
 
@@ -42,6 +44,8 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         super().__init__()
         self._router = context.client.sub_pages_router
         self._routes = routes or {}
+        for path in self._routes:
+            self._validate_route(path)
         parent_sub_pages_element = next((el for el in self.ancestors() if isinstance(el, SubPages)), None)
         self._rendered_path = ''
         self._root_path = parent_sub_pages_element._rendered_path if parent_sub_pages_element else root_path
@@ -59,6 +63,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         :param page: function to call when this path is accessed
         :return: self for method chaining
         """
+        self._validate_route(path)
         self._routes[path] = page
         self._show()
         return self
@@ -75,16 +80,19 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         """Display the page matching the current URL path."""
         self._rendered_path = ''
         match = self._find_matching_path()
+        has_nested_sub_pages = any(isinstance(el, SubPages) for el in self.descendants())
         # NOTE: if path and query params are the same, only update fragment without re-rendering
         if (
+            # pylint: disable=too-many-boolean-expressions
             match is not None and
             self._match is not None and
             match.path == self._match.path and
+            (self._match.remaining_path == match.remaining_path or has_nested_sub_pages) and
             not self._required_query_params_changed(match) and
             not (self.has_404 and self._match.remaining_path == match.remaining_path)
         ):
             # NOTE: Even though our matched path is the same, the remaining path might still require us to handle 404 (if we are the last sub pages element)
-            if match.remaining_path and not any(isinstance(el, SubPages) for el in self.descendants()):
+            if match.remaining_path and not has_nested_sub_pages:
                 self._set_match(None)
             else:
                 self._handle_scrolling(match, behavior='smooth')
@@ -186,6 +194,18 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
                     fragment=fragment,
                 ), query_params
         return None, query_params
+
+    @staticmethod
+    def _validate_route(path: str) -> None:
+        for parameter in re.findall(r'\{(.*?)\}', path):
+            if not re.fullmatch(r'\w+', parameter):
+                raise ValueError(
+                    f'Invalid route "{path}": the parameter "{{{parameter}}}" is not supported. '
+                    'ui.sub_pages only supports single-segment "{name}" parameters, '
+                    'not Starlette-style converters like "{name:path}". '
+                    'For wildcard routing, use show_404=False and read PageArguments.remaining_path '
+                    '(see https://nicegui.io/documentation/sub_pages).'
+                )
 
     @staticmethod
     def _match_path(pattern: str, path: str) -> dict[str, str] | None:

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -88,8 +88,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
             self._match is not None and
             match.path == self._match.path and
             (self._match.remaining_path == match.remaining_path or has_nested_sub_pages or self._404_enabled) and
-            not self._required_query_params_changed(match) and
-            not (self.has_404 and self._match.remaining_path == match.remaining_path)
+            not self._required_query_params_changed(match)
         ):
             # Even though our matched path is the same, the remaining path might still require us to handle 404 (if we are the last sub pages element)
             if match.remaining_path and not has_nested_sub_pages:

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -87,7 +87,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
             match is not None and
             self._match is not None and
             match.path == self._match.path and
-            (self._match.remaining_path == match.remaining_path or has_nested_sub_pages) and
+            (self._match.remaining_path == match.remaining_path or has_nested_sub_pages or self._404_enabled) and
             not self._required_query_params_changed(match) and
             not (self.has_404 and self._match.remaining_path == match.remaining_path)
         ):

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -1292,13 +1292,21 @@ def test_remaining_path_for_wildcard_routing(screen: Screen):
         ui.sub_pages({'/sub': sub_page}, show_404=False)
 
     def sub_page(args: PageArguments):
-        ui.label(f'remaining={args.remaining_path}')
+        ui.label(f'remaining={args.remaining_path!r}')
+        ui.link('deeper', '/sub/x/2/a')
+        ui.link('shallow', '/sub')
 
     screen.open('/sub')
-    screen.should_contain('remaining=')
+    screen.should_contain("remaining=''")
 
     screen.open('/sub/x/2/a')
-    screen.should_contain('remaining=/x/2/a')
+    screen.should_contain("remaining='/x/2/a'")
+
+    # NOTE: client-side navigation between paths matching the same route must re-render with the new remaining_path (#6090)
+    screen.click('shallow')
+    screen.should_contain("remaining=''")
+    screen.click('deeper')  # navigating deeper from an exact match is the regression trigger
+    screen.should_contain("remaining='/x/2/a'")
 
 
 def test_query_parameters_wildcard_routing(screen: Screen):

--- a/tests/test_sub_pages_match_path.py
+++ b/tests/test_sub_pages_match_path.py
@@ -165,6 +165,19 @@ def test_invalid_parameter_names():
     assert ui.sub_pages._match_path('/path{param.name}', '/path{other.name}') is None
 
 
+def test_validate_route_accepts_supported_patterns():
+    """Single-segment {name} parameters and plain paths are valid route patterns."""
+    for pattern in ['/', '/item', '/user/{id}', '/{a}/{b}', '/{user_id}', '/blog/{year}/{month}/{slug}']:
+        ui.sub_pages._validate_route(pattern)  # should not raise
+
+
+def test_validate_route_rejects_unsupported_patterns():
+    """Starlette-style converters and other non-{name} parameters are rejected at registration time."""
+    for pattern in ['/{_:path}', '/{name:path}', '/{id:int}', '/{}', '/item/{a-b}']:
+        with pytest.raises(ValueError, match='not supported'):
+            ui.sub_pages._validate_route(pattern)
+
+
 def test_adjacent_parameters():
     """Test patterns with parameters that are adjacent (no static separators)."""
     # This is an edge case - adjacent parameters without separators


### PR DESCRIPTION
### Motivation

Fixes #6090.

Two issues surfaced from the same report:

1. **Wildcard sub pages did not re-render on client-side navigation.** When navigating between two URLs that match the _same_ route but differ in `remaining_path` (e.g. `/` → `/item`, both matching route `/`), `ui.sub_pages` kept the stale content and never called the builder again with the new `remaining_path`. With `show_404=False` this silently showed nothing new. The existing wildcard tests only used full-page `screen.open()` reloads, so they never exercised client-side navigation and missed this.

2. **Starlette-style convertor patterns failed silently.** Route patterns like `'/{_:path}'` are not supported by `ui.sub_pages` (only single-segment `'{name}'` parameters are). Such a pattern was treated as a literal route that no URL ever matches, so the route just never fired — with no error or warning.

### Implementation

1. **Re-render fix** (`_show`): the "path unchanged" fast-path that skips re-rendering now also requires that `remaining_path` is unchanged _or_ that a nested `ui.sub_pages` is present to absorb the change. A leaf sub pages whose `remaining_path` changed now falls through to a full re-render so the builder sees the new value. The nested case keeps the optimization (the parent is not rebuilt when only the child's segment changes).

2. **Unsupported patterns now raise** a `ValueError` at registration time (`__init__` and `add`) via a new `_validate_route`, pointing users to `show_404=False` + `PageArguments.remaining_path` for wildcard routing. The runtime matcher (`_match_path`) is unchanged.

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation has been added (docstring note on the parameter limitation).
- [x] **Minor breaking change:**

Route patterns that previously failed silently (e.g. `'/{_:path}'`, `'/{name:path}'`) now raise `ValueError` at `ui.sub_pages(...)` / `.add(...)`. These never matched anything before, so only already-broken routes are affected; the fix is to use `show_404=False` + `remaining_path`.
