### PR TITLE
Fix dropped `app.native.*` args in spawned window process

### DIFF
--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -38,6 +38,7 @@ def _open_window(
     window_args: dict[str, Any] | None = None,
     settings: dict[str, Any] | None = None,
     start_args: dict[str, Any] | None = None,
+    dropped_keys: dict[str, list[str]] | None = None,
 ) -> None:
     while not helpers.is_port_open(host, port):
         time.sleep(0.1)
@@ -46,6 +47,16 @@ def _open_window(
     window_args = {**(window_args or {}), **core.app.native.window_args}
     settings = {**(settings or {}), **core.app.native.settings}
     start_args = {**(start_args or {}), **core.app.native.start_args}
+
+    # Warn only about keys the parent could not pickle AND re-import did not restore here, i.e. that are truly lost.
+    for name, merged in [('window_args', window_args), ('settings', settings), ('start_args', start_args)]:
+        for key in (dropped_keys or {}).get(name, []):
+            if key not in merged:
+                helpers.warn_once(
+                    f'Could not forward app.native.{name}["{key}"] to the native window process '
+                    'because it is not picklable, so it is ignored. '
+                    'See https://github.com/zauberzeug/nicegui/issues/6082 for details.'
+                )
 
     window_kwargs = {
         'url': helpers.format_url(protocol, host, port),
@@ -186,32 +197,31 @@ def activate(protocol: str, host: str, port: int, title: str, width: int, height
     mp.freeze_support()
     native.create_queues()
     event_manager.start()
+    window_args, dropped_window_args = _split_picklable(core.app.native.window_args)
+    settings, dropped_settings = _split_picklable(core.app.native.settings)
+    start_args, dropped_start_args = _split_picklable(core.app.native.start_args)
+    dropped_keys = {'window_args': dropped_window_args, 'settings': dropped_settings, 'start_args': dropped_start_args}
     args = (protocol, host, port, title, width, height, fullscreen, frameless,
             native.method_queue, native.response_queue, native.event_sender, favicon,
-            _picklable_subset('window_args', core.app.native.window_args),
-            _picklable_subset('settings', core.app.native.settings),
-            _picklable_subset('start_args', core.app.native.start_args))
+            window_args, settings, start_args, dropped_keys)
     process = native.SPAWN_CONTEXT.Process(target=_open_window, args=args, daemon=True)
     process.start()
 
     Thread(target=check_shutdown, daemon=True).start()
 
 
-def _picklable_subset(name: str, config: dict[str, Any]) -> dict[str, Any]:
-    """Return the picklable items of a native config dict so they can be passed to the spawned window process."""
-    result: dict[str, Any] = {}
+def _split_picklable(config: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Split a native config dict into its picklable items and the keys that cannot cross the spawn boundary."""
+    picklable: dict[str, Any] = {}
+    dropped: list[str] = []
     for key, value in config.items():
         try:
             pickle.dumps(value)
         except Exception:  # pylint: disable=broad-except
-            helpers.warn_once(
-                f'Cannot forward app.native.{name}["{key}"] to the native window process because it is not picklable. '
-                'It is ignored unless your main module gets re-imported in the spawned process. '
-                'See https://github.com/zauberzeug/nicegui/issues/6082 for details.'
-            )
-            continue
-        result[key] = value
-    return result
+            dropped.append(key)
+        else:
+            picklable[key] = value
+    return picklable, dropped
 
 
 def find_open_port(start_port: int = 8000, end_port: int = 8999) -> int:

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import _thread
 import multiprocessing as mp
+import pickle
 import queue
 import socket
 import sys
@@ -34,9 +35,17 @@ def _open_window(
     protocol: str, host: str, port: int, title: str, width: int, height: int, fullscreen: bool, frameless: bool,
     method_queue: mp.Queue, response_queue: mp.Queue, event_sender: Connection,
     favicon: str | Path | None = None,
+    window_args: dict[str, Any] | None = None,
+    settings: dict[str, Any] | None = None,
+    start_args: dict[str, Any] | None = None,
 ) -> None:
     while not helpers.is_port_open(host, port):
         time.sleep(0.1)
+
+    # Let re-imported values win over the parent's picklable subset, so previous behavior is preserved (#6082).
+    window_args = {**(window_args or {}), **core.app.native.window_args}
+    settings = {**(settings or {}), **core.app.native.settings}
+    start_args = {**(start_args or {}), **core.app.native.start_args}
 
     window_kwargs = {
         'url': helpers.format_url(protocol, host, port),
@@ -45,9 +54,9 @@ def _open_window(
         'height': height,
         'fullscreen': fullscreen,
         'frameless': frameless,
-        **core.app.native.window_args,
+        **window_args,
     }
-    webview.settings.update(**core.app.native.settings)
+    webview.settings.update(**settings)
     window = webview.create_window(**window_kwargs)
     assert window is not None
     closed = Event()
@@ -62,7 +71,7 @@ def _open_window(
 
     _start_window_method_executor(window, method_queue, response_queue, closed)
     _warn_if_esm_unsupported(window)
-    webview.start(**core.app.native.start_args)
+    webview.start(**start_args)
 
 
 def _bind_pywebview_events(window: webview.Window, event_sender: Connection) -> None:
@@ -178,11 +187,31 @@ def activate(protocol: str, host: str, port: int, title: str, width: int, height
     native.create_queues()
     event_manager.start()
     args = (protocol, host, port, title, width, height, fullscreen, frameless,
-            native.method_queue, native.response_queue, native.event_sender, favicon)
+            native.method_queue, native.response_queue, native.event_sender, favicon,
+            _picklable_subset('window_args', core.app.native.window_args),
+            _picklable_subset('settings', core.app.native.settings),
+            _picklable_subset('start_args', core.app.native.start_args))
     process = native.SPAWN_CONTEXT.Process(target=_open_window, args=args, daemon=True)
     process.start()
 
     Thread(target=check_shutdown, daemon=True).start()
+
+
+def _picklable_subset(name: str, config: dict[str, Any]) -> dict[str, Any]:
+    """Return the picklable items of a native config dict so they can be passed to the spawned window process."""
+    result: dict[str, Any] = {}
+    for key, value in config.items():
+        try:
+            pickle.dumps(value)
+        except Exception:  # pylint: disable=broad-except
+            helpers.warn_once(
+                f'Cannot forward app.native.{name}["{key}"] to the native window process because it is not picklable. '
+                'It is ignored unless your main module gets re-imported in the spawned process. '
+                'See https://github.com/zauberzeug/nicegui/issues/6082 for details.'
+            )
+            continue
+        result[key] = value
+    return result
 
 
 def find_open_port(start_port: int = 8000, end_port: int = 8999) -> int:


### PR DESCRIPTION
### Motivation

`app.native.window_args`, `app.native.settings` and `app.native.start_args` are read directly off a freshly-imported `nicegui.app` inside the spawned pywebview process. They therefore only take effect when Python's `multiprocessing` spawn can re-execute the parent's main module as `__mp_main__`.

That re-execution silently fails in several common setups, dropping the user's config with no warning:

- pip `[project.scripts]` console-scripts on Windows (the launcher binary isn't a re-runnable `.py` file) — reported in #6082
- PyInstaller / `nicegui-pack` (#4842, docs-patched in #5651)
- `python -m mypkg` without a correctly wired `__main__.py`
- Briefcase / py2exe / custom launchers

Closes #6082.

### Implementation

`activate()` now forwards the **picklable subset** of each of the three native config dicts through the spawn `args` tuple. Inside `_open_window()` these are merged with whatever the child re-imported on its own:

```python
window_args = {**(passed or {}), **core.app.native.window_args}
```

The re-imported values win where they exist, so the previously working path is unchanged; the forwarded values only fill the gap when the main module could not be re-executed in the child.

Values that cannot cross the spawn boundary (e.g. a stateful `js_api` object) are skipped via a new `_picklable_subset()` helper, which emits a one-time `warn_once` per dropped key. This replaces today's **silent** drop with an explicit, actionable warning — and such values were already lost under spawn before this change.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] No breaking changes to the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
