### PR TITLE
Add a note about large datasets to the ui.plotly docs

### DIFF
--- a/website/documentation/content/plotly_documentation.py
+++ b/website/documentation/content/plotly_documentation.py
@@ -103,8 +103,9 @@ def plot_events():
     When plotting a large number of data points, pass NumPy arrays (or pandas Series) to Plotly rather than Python lists,
     and avoid converting them back with `.tolist()`.
     For NumPy arrays, Plotly uses a compact binary encoding (base64-encoded typed arrays)
-    that the browser can render much more efficiently than parsing millions of numbers from a plain JSON array,
-    which can otherwise freeze the UI.
+    that makes the payload roughly half the size — far less data to transfer, parse and keep in memory —
+    which is what avoids freezing the UI on large updates.
+    This requires Plotly 6.0 or newer, where the binary encoding is the default.
 ''')
 def large_datasets():
     import numpy as np

--- a/website/documentation/content/plotly_documentation.py
+++ b/website/documentation/content/plotly_documentation.py
@@ -99,4 +99,22 @@ def plot_events():
     plot.on('plotly_click', ui.notify)
 
 
+@doc.demo('Large datasets', '''
+    When plotting a large number of data points, pass NumPy arrays (or pandas Series) to Plotly rather than Python lists,
+    and avoid converting them back with `.tolist()`.
+    For NumPy arrays, Plotly uses a compact binary encoding (base64-encoded typed arrays)
+    that the browser can render much more efficiently than parsing millions of numbers from a plain JSON array,
+    which can otherwise freeze the UI.
+''')
+def large_datasets():
+    import numpy as np
+    import plotly.graph_objects as go
+
+    x = np.linspace(0, 10, 100_000)
+    y = np.sin(x) + np.random.normal(0, 0.1, x.size)
+    fig = go.Figure(go.Scattergl(x=x, y=y, mode='markers', marker=dict(size=2)))
+    fig.update_layout(margin=dict(l=0, r=0, t=0, b=0))
+    ui.plotly(fig).classes('w-full h-40')
+
+
 doc.reference(ui.plotly)


### PR DESCRIPTION
### Motivation

Issue #3340 reports that updating a `ui.plotly` chart with a large dataset can freeze the UI.
After investigation it turned out the difference between a hanging and a smooth UI comes down to the data type handed to Plotly:

- A **Python list** is kept by Plotly as a plain JSON array of numbers, which the browser has to parse number-by-number — freezing the UI for large datasets.
- A **NumPy array** (or pandas Series) is encoded by Plotly as a compact base64 typed-array (`bdata`), which the browser renders far more efficiently.

This is entirely Plotly behavior (not NiceGUI's transport), so the practical takeaway is worth documenting.

### Implementation

Added a "Large datasets" demo to the `ui.plotly` documentation explaining the recommendation
(pass NumPy arrays / pandas Series, avoid `.tolist()`) with a runnable 100k-point `go.Scattergl` example.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been added.
- [x] No breaking changes to the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
