### PR TITLE
Fix selection error when changing `ui.select` options in an "input-value" handler

### DIFF
--- a/nicegui/elements/select.js
+++ b/nicegui/elements/select.js
@@ -7,24 +7,33 @@ export default {
       @filter="filterFn"
       @popup-show="addClass"
       @popup-hide="removeClass"
-      @input-value="deferInputValue"
+      @input-value="forwardInputValue"
+      @update:model-value="forwardModelValue"
     >
       <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
         <slot :name="slot" v-bind="slotProps || {}" />
       </template>
     </q-select>
   `,
-  emits: ["input-value"],
+  emits: ["input-value", "update:model-value"],
   data() {
     return {
       initialOptions: this.options,
       filteredOptions: this.options,
+      modelValueChanged: false,
     };
   },
   methods: {
-    async deferInputValue(value) {
-      await this.$nextTick(); // emit one tick later to process selection-induced "update:model-value" first (#4420)
-      this.$emit("input-value", value);
+    forwardModelValue(...args) {
+      this.modelValueChanged = true;
+      this.$emit("update:model-value", ...args);
+    },
+    async forwardInputValue(value) {
+      this.modelValueChanged = false;
+      await this.$nextTick(); // wait for a possible "update:model-value" event indicating a selection
+      if (!this.modelValueChanged) {
+        this.$emit("input-value", value); // suppress selection-induced events which would re-trigger filtering (#4420)
+      }
     },
     filterFn(val, update, abort) {
       update(() => (this.filteredOptions = val ? this.findFilteredOptions() : this.initialOptions));

--- a/nicegui/elements/select.js
+++ b/nicegui/elements/select.js
@@ -7,12 +7,14 @@ export default {
       @filter="filterFn"
       @popup-show="addClass"
       @popup-hide="removeClass"
+      @input-value="deferInputValue"
     >
       <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
         <slot :name="slot" v-bind="slotProps || {}" />
       </template>
     </q-select>
   `,
+  emits: ["input-value"],
   data() {
     return {
       initialOptions: this.options,
@@ -20,6 +22,10 @@ export default {
     };
   },
   methods: {
+    async deferInputValue(value) {
+      await this.$nextTick(); // emit one tick later to process selection-induced "update:model-value" first (#4420)
+      this.$emit("input-value", value);
+    },
     filterFn(val, update, abort) {
       update(() => (this.filteredOptions = val ? this.findFilteredOptions() : this.initialOptions));
     },

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -200,6 +200,19 @@ def test_keep_filtered_options(multiple: bool, screen: Screen):
         screen.should_contain('B2')
 
 
+def test_changing_options_in_input_value_handler(screen: Screen):
+    @ui.page('/')
+    def page():
+        select = ui.select([], with_input=True) \
+            .on('input-value', lambda e: select.set_options([o for o in ['A1', 'A2'] if str(e.args) in o]))
+        ui.label().bind_text_from(select, 'value', lambda v: f'value = {v}')
+
+    screen.open('/')
+    screen.find_by_tag('input').send_keys('A')
+    screen.click('A2')
+    screen.should_contain('value = A2')
+
+
 @pytest.mark.parametrize('auto_validation', [True, False])
 def test_select_validation(auto_validation: bool, screen: Screen):
     @ui.page('/')

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -200,16 +200,20 @@ def test_keep_filtered_options(multiple: bool, screen: Screen):
         screen.should_contain('B2')
 
 
-def test_changing_options_in_input_value_handler(screen: Screen):
+@pytest.mark.parametrize('option_dict', [False, True])
+def test_changing_options_in_input_value_handler(option_dict: bool, screen: Screen):
     @ui.page('/')
     def page():
-        select = ui.select([], with_input=True) \
-            .on('input-value', lambda e: select.set_options([o for o in ['A1', 'A2'] if str(e.args) in o]))
+        def handle_input(e):
+            keys = [o for o in ['A1', 'A2'] if str(e.args) in o]
+            select.set_options({o: f'Option {o}' for o in keys} if option_dict else keys)
+        select = ui.select({} if option_dict else [], with_input=True).on('input-value', handle_input)
         ui.label().bind_text_from(select, 'value', lambda v: f'value = {v}')
 
     screen.open('/')
     screen.find_by_tag('input').send_keys('A')
-    screen.click('A2')
+    screen.click('Option A2' if option_dict else 'A2')
+    screen.wait(0.5)  # wait for a potential deferred "input-value" event clearing the value
     screen.should_contain('value = A2')
 
 


### PR DESCRIPTION
### Motivation

Fixes #4420.

When a `ui.select` with `with_input=True` changes its options inside an "input-value" handler (e.g. for server-side filtering of large option lists), selecting an option raises "list index out of range":

```py
ui.select([], with_input=True) \
    .on('input-value', lambda e: e.sender.set_options([o for o in ['A1', 'A2'] if str(e.args) in o]))
```

Selecting an option fires two events nearly simultaneously: due to `fill-input`, the new input text triggers "input-value", and the selection itself triggers "update:model-value" with the option's index. QSelect emits "input-value" first, so the server refilters the options before processing the selection -- and the transmitted index no longer matches the new options list. Depending on how the options changed, this either raises an `IndexError` or silently resolves to the wrong value.

### Implementation

select.js intercepts both events (declaring them in `emits` so the server-registered listeners no longer fall through to the inner QSelect) and forwards "input-value" one tick later -- unless an "update:model-value" event was emitted during the same tick. In other words: the "input-value" event accompanying a selection is suppressed entirely, so a selection never re-triggers the app's filtering, and "input-value" comes to mean "the user typed". For regular typing, nothing else is emitted in the same tick and the one-tick deferral is imperceptible.

The "update:model-value" interception has to re-emit synchronously rather than just observe: a plain template listener would shadow the server-registered fallthrough listener, because Vue resolves the camelCase handler key first and only calls that one.

Decisions and trade-offs (see also the discussion in #4420, #5682 and the review below):

- A first iteration merely re-ordered the two events. The review showed that this converts the loud `IndexError` into a *silent* value reset whenever the refilter cannot re-match the fill-input text, which carries the *label* (most notably dict options filtered by key). Suppression eliminates both failure modes: the options the user selected from stay untouched until they actually type again.
- No server-side index guard or label-based fallback: labels are not unique for dict options, and a stale-but-valid index is indistinguishable from a correct one. The residual race -- options changed by a timer or another user while a selection is in flight -- still fails loudly with `IndexError` rather than being half-masked.
- Behavioral change: "input-value" no longer reaches handlers when an option is selected (or cleared, if QSelect resets the input text in the same tick) -- only on actual input changes. Known workarounds for #4420 (sleeping in the handler, checking `is_showing_popup`) keep working; verified in a live browser along with the original example, the reviewer's dict reproduction, and a worst-case filter that removes the selected option.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytest has been added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
