### PR TITLE
Reserve NOTE comment markers for drawing special attention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,8 +148,9 @@ The conventions below cover both general Python style and NiceGUI-specific patte
 
   - Follow **PEP 8** with a 120 character line length
   - Use single quotes in Python, double quotes in JavaScript
-  - Use f-strings wherever possible (mark performance-critical exceptions with `# NOTE:`)
-  - Use `# NOTE:` prefix for important implementation details and non-obvious code
+  - Use f-strings wherever possible (mark performance-critical exceptions with a comment)
+  - Explain important implementation details and non-obvious code with comments
+  - Use `# NOTE:` only to draw special attention, e.g. to changes that need to be mirrored elsewhere or hidden cross-file coupling
   - No mutable defaults (`[]`, `{}`) without `# noqa: B006` and a justification — prefer `None`
   - Put high-level/interesting code at the top of files; helper functions go below their usage
   - Each sentence in documentation goes on a new line ([why](https://nick.groenen.me/notes/one-sentence-per-line/))

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -45,7 +45,7 @@ For coding rules, see [CONTRIBUTING.md](CONTRIBUTING.md); for general agent guid
 - **Cross-platform**
   - Windows path assumptions, locale/timezone hardcoding, reliance on system binaries without guards
 - **Readability**
-  - Complex logic without `# NOTE:` comments explaining intent; magic numbers
+  - Complex logic without comments explaining intent; magic numbers
 
 ## Severity vocabulary
 

--- a/deploy.py
+++ b/deploy.py
@@ -72,7 +72,7 @@ for region, count in instances.items():
     run(['fly', 'scale', 'count', f'app={count}', '--region', region, '-y'])
     time.sleep(2)
 
-# NOTE: wait for machines to become healthy before pinning
+# wait for machines to become healthy before pinning
 print('waiting for machines to become healthy...')
 HEALTH_TIMEOUT = 60
 HEALTH_INTERVAL = 5
@@ -90,7 +90,7 @@ else:
     missing = expected_regions - healthy_regions
     print(f'  timed out waiting for: {", ".join(sorted(missing))}')
 
-# NOTE: pin first machine per region to avoid cold-start latency
+# pin first machine per region to avoid cold-start latency
 print('pinning machines...')
 machines_json = run(['fly', 'machines', 'list', '--json'], capture=True)
 machines = json.loads(machines_json)

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -19,15 +19,15 @@ def get_root():
 def show():
     ui.label('Hello, NiceGUI!')
 
-    # NOTE dark mode will be persistent for each user across tabs and server restarts
+    # dark mode will be persistent for each user across tabs and server restarts
     ui.dark_mode().bind_value(app.storage.user, 'dark_mode')
     ui.checkbox('dark mode').bind_value(app.storage.user, 'dark_mode')
 
 
 ui.run_with(
     fastapi_app,
-    mount_path='/gui',  # NOTE this can be omitted if you want the paths passed to @ui.page to be at the root
-    storage_secret='pick your private secret here',  # NOTE setting a secret is optional but allows for persistent storage per user
+    mount_path='/gui',  # this can be omitted if you want the paths passed to @ui.page to be at the root
+    storage_secret='pick your private secret here',  # setting a secret is optional but allows for persistent storage per user
 )
 
 if __name__ == '__main__':

--- a/examples/fullcalendar/fullcalendar.js
+++ b/examples/fullcalendar/fullcalendar.js
@@ -7,7 +7,7 @@ export default {
     resourcePath: String,
   },
   async mounted() {
-    await this.$nextTick(); // NOTE: wait for window.path_prefix to be set
+    await this.$nextTick(); // wait for window.path_prefix to be set
     await loadResource(window.path_prefix + `${this.resourcePath}/index.global.min.js`);
     this.options.eventClick = (info) => this.$emit("click", { info });
     this.calendar = new FullCalendar.Calendar(this.$el, this.options);

--- a/examples/google_oauth2/main.py
+++ b/examples/google_oauth2/main.py
@@ -67,6 +67,6 @@ def _is_valid(user_info: dict) -> bool:
 
 
 ui.run(
-    host='localhost',  # NOTE: this ensures that you can run the app locally, accessing via http://127.0.0.1:8080 is not supported by Google OAuth2
+    host='localhost',  # this ensures that you can run the app locally, accessing via http://127.0.0.1:8080 is not supported by Google OAuth2
     storage_secret='random secret goes here',
 )

--- a/examples/google_one_tap_auth/main.py
+++ b/examples/google_one_tap_auth/main.py
@@ -64,6 +64,6 @@ def _is_valid(user_info: dict) -> bool:
 
 
 ui.run(
-    host='localhost',  # NOTE: this ensures that you can run the app locally, accessing via http://127.0.0.1:8080 is not supported by Google OAuth2
+    host='localhost',  # this ensures that you can run the app locally, accessing via http://127.0.0.1:8080 is not supported by Google OAuth2
     storage_secret='random secret goes here',
 )

--- a/examples/openai_assistant/main.py
+++ b/examples/openai_assistant/main.py
@@ -50,6 +50,6 @@ async def root():
             .classes('w-full self-center mt-4').props('hint="Ask your question" dense') \
             .on('keydown.enter', send)
         response = ui.markdown().classes('mx-4 mt-2')
-        ui.timer(0, send, once=True)  # NOTE: we send the prepared demo question immediately
+        ui.timer(0, send, once=True)  # we send the prepared demo question immediately
 
 ui.run(root=root)

--- a/examples/reaktiv/main.py
+++ b/examples/reaktiv/main.py
@@ -23,7 +23,7 @@ with ui.row():
         tax_label = ui.label()
         total_label = ui.label().classes('text-bold')
 
-        # NOTE: Effects must be assigned to variables to prevent garbage collection
+        # Effects must be assigned to variables to prevent garbage collection
         subtotal_effect = Effect(lambda: subtotal_label.set_text(f'Subtotal: ${subtotal():.2f}'))
         tax_effect = Effect(lambda: tax_label.set_text(f'Tax: ${tax():.2f}'))
         total_effect = Effect(lambda: total_label.set_text(f'Total: ${total():.2f}'))

--- a/examples/script_executor/main.py
+++ b/examples/script_executor/main.py
@@ -12,20 +12,20 @@ async def run_command(command: str) -> None:
     """Run a command in the background and display the output in the pre-created dialog."""
     dialog.open()
     result.content = ''
-    command = command.replace('python3', sys.executable)  # NOTE replace with machine-independent Python path (#1240)
+    command = command.replace('python3', sys.executable)  # replace with machine-independent Python path (#1240)
     process = await asyncio.create_subprocess_exec(
         *shlex.split(command, posix='win' not in sys.platform.lower()),
         stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
         cwd=os.path.dirname(os.path.abspath(__file__))
     )
-    # NOTE we need to read the output in chunks, otherwise the process will block
+    # we need to read the output in chunks, otherwise the process will block
     output = ''
     while True:
         new = await process.stdout.read(4096)
         if not new:
             break
         output += new.decode()
-        # NOTE the content of the markdown element is replaced every time we have new output
+        # the content of the markdown element is replaced every time we have new output
         result.content = f'```\n{output}\n```'
 
 with ui.dialog() as dialog, ui.card():
@@ -38,5 +38,5 @@ with ui.row().classes('items-center'):
         .props('no-caps')
     message = ui.input('message', value='NiceGUI')
 
-# NOTE: On Windows reload must be disabled to make asyncio.create_subprocess_exec work (see https://github.com/zauberzeug/nicegui/issues/486)
+# On Windows reload must be disabled to make asyncio.create_subprocess_exec work (see https://github.com/zauberzeug/nicegui/issues/486)
 ui.run(reload=platform.system() != 'Windows')

--- a/examples/single_page_app/custom_sub_pages.py
+++ b/examples/single_page_app/custom_sub_pages.py
@@ -33,7 +33,7 @@ class CustomSubPages(ui.sub_pages):
             ui.icon('error_outline', size='4rem').classes('text-red')
             ui.label('500 - Internal Server Error').classes('text-2xl text-red')
             ui.label(f'The page "{self._router.current_path}" produced an error.').classes('text-gray-600')
-            # NOTE: we do not recommend to show exception messages in production (security risk)
+            # we do not recommend to show exception messages in production (security risk)
             ui.label(str(error)).classes('text-gray-600')
             with ui.row().classes('mt-4'):
                 ui.button('Go Home', icon='home', on_click=lambda: ui.navigate.to('/')).props('outline')
@@ -55,7 +55,7 @@ class CustomSubPages(ui.sub_pages):
             def try_login():
                 if passphrase.value == 'spa':
                     app.storage.user['authenticated'] = True
-                    self._reset_match()  # NOTE: reset the current match to allow the page to be rendered again
+                    self._reset_match()  # reset the current match to allow the page to be rendered again
                     ui.navigate.to(intended_path)
                 else:
                     ui.notify('Incorrect passphrase', color='negative')

--- a/examples/threaded_nicegui/main.py
+++ b/examples/threaded_nicegui/main.py
@@ -11,7 +11,7 @@ class GUI:
     """
 
     def __init__(self) -> None:
-        self.message = Event[str]()  # NOTE: broadcast data to all clients currently visiting self.root
+        self.message = Event[str]()  # broadcast data to all clients currently visiting self.root
 
     def start(self) -> None:
         """Start the NiceGUI server in a separate thread."""
@@ -19,7 +19,7 @@ class GUI:
         app.on_startup(started.set)
         thread = threading.Thread(target=lambda: ui.run(self.root, reload=False), daemon=True)
         thread.start()
-        if not started.wait(timeout=3.0):  # NOTE: wait for the server to start
+        if not started.wait(timeout=3.0):  # wait for the server to start
             raise RuntimeError('NiceGUI did not start within 3 seconds.')
 
     def root(self) -> None:

--- a/examples/websockets/main.py
+++ b/examples/websockets/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Websockets example showing messages from connected clients and broadcasting via button click.
 
-NOTE: NiceGUI already handles all the communication for you, so you don't need to worry about websockets and the like normally.
+NiceGUI already handles all the communication for you, so you don't need to worry about websockets and the like normally.
 This example is only for advanced use cases where you want to allow other, non-NiceGUI clients to connect to your server.
 """
 import asyncio

--- a/fetch_sponsors.py
+++ b/fetch_sponsors.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import httpx
 
-# NOTE:
 # requires a GitHub token with the necessary permissions read:org and read:user
 # call with `GITHUB_TOKEN=ghp_XXX ./fetch_sponsors.py`
 

--- a/main.py
+++ b/main.py
@@ -137,5 +137,5 @@ def _status():
     return 'Ok'
 
 
-# NOTE: do not reload on fly.io (see https://github.com/zauberzeug/nicegui/discussions/1720#discussioncomment-7288741)
+# do not reload on fly.io (see https://github.com/zauberzeug/nicegui/discussions/1720#discussioncomment-7288741)
 ui.run(uvicorn_reload_includes='*.py, *.css, *.html', reload=not on_fly, reconnect_timeout=10.0, markdown=True)

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -74,7 +74,7 @@ class Air:
                 'content': compressed,
             }
 
-            # NOTE: chunk large responses to stay within the SocketIO limit
+            # chunk large responses to stay within the SocketIO limit
             if total_size > 1_000_000:
                 async def chunk_iterator() -> AsyncIterator[bytes]:
                     chunk_size = 512 * 1024
@@ -152,7 +152,7 @@ class Air:
         @self.relay.on('connect')
         async def _handle_connect() -> None:
             self.log.debug('connected.')
-            # NOTE: reset the warning so it can be shown again if connection breaks in the future
+            # reset the warning so it can be shown again if connection breaks in the future
             helpers.warnings._shown_warnings.discard(self._host_unreachable_warning)  # pylint: disable=protected-access
 
         @self.relay.on('disconnect')
@@ -221,7 +221,7 @@ class Air:
             return
         except socketio.exceptions.ConnectionError:
             self.log.debug('Connection error.', stack_info=True)
-        except ValueError:  # NOTE this sometimes happens when the internal socketio client is not yet ready
+        except ValueError:  # this sometimes happens when the internal socketio client is not yet ready
             self.log.debug('ValueError while connecting.', stack_info=True)
         except Exception:
             log.exception('Could not connect to NiceGUI On Air server.')

--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -232,7 +232,7 @@ class App(FastAPI):
         handler = CacheControlledStaticFiles(
             directory=local_directory, follow_symlink=follow_symlink, max_cache_age=max_cache_age)
 
-        @self.get(url_path.rstrip('/') + '/{path:path}')  # NOTE: prevent double slashes in route pattern
+        @self.get(url_path.rstrip('/') + '/{path:path}')  # prevent double slashes in route pattern
         async def static_file(request: Request, path: str = '') -> Response:
             return await handler.get_response(path, request.scope)
 
@@ -287,7 +287,7 @@ class App(FastAPI):
         :param url_path: string that starts with a slash "/" and identifies the path at which the files should be served
         :param local_directory: local folder with files to serve as media content
         """
-        @self.get(url_path.rstrip('/') + '/{filename:path}')  # NOTE: prevent double slashes in route pattern
+        @self.get(url_path.rstrip('/') + '/{filename:path}')  # prevent double slashes in route pattern
         def read_item(request: Request, filename: str, nicegui_chunk_size: int = 8192) -> Response:
             local_dir = Path(local_directory).resolve()
             filepath = (local_dir / filename).resolve()
@@ -424,7 +424,7 @@ async def prune_user_storage(*, force: bool = False) -> None:
     for session_id in list(user_storages):
         if session_id not in client_session_ids:
             age = now - user_storages[session_id].last_modified
-            if force or age > 10.0:  # NOTE: do not remove storages created by middleware and still wait for client
+            if force or age > 10.0:  # do not remove storages created by middleware and still wait for client
                 storages_to_close.append(user_storages.pop(session_id))
     results = await asyncio.gather(*[storage.close() for storage in storages_to_close], return_exceptions=True)
     for result in results:

--- a/nicegui/app/app_config.py
+++ b/nicegui/app/app_config.py
@@ -11,7 +11,7 @@ class AppConfig:
     socket_io_js_query_params: dict = field(default_factory=dict)
     socket_io_js_extra_headers: dict = field(default_factory=dict)
     socket_io_js_transports: list[Literal['websocket', 'polling']] = \
-        field(default_factory=lambda: ['websocket', 'polling'])  # NOTE: we favor websocket
+        field(default_factory=lambda: ['websocket', 'polling'])  # we favor websocket
     quasar_config: dict = \
         field(default_factory=lambda: {
             'brand': {},

--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -165,7 +165,7 @@ async def teardown() -> None:
                 continue
             task.cancel()
         if tasks:
-            await asyncio.sleep(0)  # NOTE: ensure the loop can cancel the tasks before it shuts down
+            await asyncio.sleep(0)  # ensure the loop can cancel the tasks before it shuts down
             try:
                 await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=2.0)
             except asyncio.TimeoutError:

--- a/nicegui/classes.py
+++ b/nicegui/classes.py
@@ -75,7 +75,7 @@ class Classes(ObservableList, Generic[T]):
         class_list = [c for c in class_list if c not in (remove or '').split()]
         class_list += (add or '').split()
         class_list += (replace or '').split()
-        class_list = list(dict.fromkeys(class_list))  # NOTE: remove duplicates while preserving order
+        class_list = list(dict.fromkeys(class_list))  # remove duplicates while preserving order
         if toggle is not None:
             for class_ in toggle.split():
                 if class_ in class_list:

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -395,7 +395,7 @@ class Client:
 
     def remove_elements(self, elements: Iterable[Element]) -> None:
         """Remove the given elements from the client."""
-        element_list = list(elements)  # NOTE: we need to iterate over the elements multiple times
+        element_list = list(elements)  # we need to iterate over the elements multiple times
         binding.remove(element_list)
         for element in element_list:
             element._handle_delete()  # pylint: disable=protected-access

--- a/nicegui/elements/audio.js
+++ b/nicegui/elements/audio.js
@@ -12,7 +12,7 @@ export default {
     };
   },
   mounted() {
-    setTimeout(() => this.compute_src(), 0); // NOTE: wait for window.path_prefix to be set in app.mounted()
+    setTimeout(() => this.compute_src(), 0); // wait for window.path_prefix to be set in app.mounted()
   },
   updated() {
     this.compute_src();

--- a/nicegui/elements/choice_element.py
+++ b/nicegui/elements/choice_element.py
@@ -45,7 +45,7 @@ class ChoiceElement(ValueElement[Any]):
         before_value = self.value
         self._props['options'] = [{'value': index, 'label': option} for index, option in enumerate(self._labels)]
         self._props[self.VALUE_PROP] = self._value_to_model_value(before_value)
-        if not isinstance(before_value, list):  # NOTE: no need to update value in case of multi-select
+        if not isinstance(before_value, list):  # no need to update value in case of multi-select
             self.value = before_value if before_value in self._values else None
 
     def update(self) -> None:

--- a/nicegui/elements/dialog.js
+++ b/nicegui/elements/dialog.js
@@ -6,7 +6,7 @@ export default {
   `,
   methods: {
     addClass() {
-      // NOTE: prevent the page from scrolling when the dialog is closed (#5031)
+      // prevent the page from scrolling when the dialog is closed (#5031)
       document.documentElement.classList.add("nicegui-dialog-open");
     },
     removeClass() {

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -21,7 +21,7 @@ class Dialog(ValueElement[bool], NoImplicitAwait, component='dialog.js'):
         By default it is dismissible by clicking or pressing ESC.
         To make it persistent, set `.props('persistent')` on the dialog element.
 
-        NOTE: The dialog is an element.
+        Note: The dialog is an element.
         That means it is not removed when closed, but only hidden.
         You should either create it only once and then reuse it, or remove it with `.clear()` after dismissal.
 

--- a/nicegui/elements/image.js
+++ b/nicegui/elements/image.js
@@ -17,7 +17,7 @@ export default {
     };
   },
   mounted() {
-    setTimeout(() => this.compute_src(), 0); // NOTE: wait for window.path_prefix to be set in app.mounted()
+    setTimeout(() => this.compute_src(), 0); // wait for window.path_prefix to be set in app.mounted()
   },
   updated() {
     this.compute_src();

--- a/nicegui/elements/image.py
+++ b/nicegui/elements/image.py
@@ -61,7 +61,7 @@ def pil_to_tempfile(pil_image: PIL_Image, image_format: str) -> _TempPath:
         return _TempPath(temp_file.name)
 
 
-class _TempPath(type(Path())):  # type: ignore[misc]  # NOTE: Path is not subclassable before Python 3.12
+class _TempPath(type(Path())):  # type: ignore[misc]  # Path is not subclassable before Python 3.12
     """A Path subclass that deletes itself when garbage collected."""
 
     def __del__(self) -> None:

--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -45,7 +45,7 @@ export default {
     } else {
       this.renderContent();
     }
-    setTimeout(() => this.compute_src(), 0); // NOTE: wait for window.path_prefix to be set in app.mounted()
+    setTimeout(() => this.compute_src(), 0); // wait for window.path_prefix to be set in app.mounted()
     const handle_completion = () => {
       if (this.waiting_source) {
         this.computed_src = this.waiting_source;

--- a/nicegui/elements/keep_alive.py
+++ b/nicegui/elements/keep_alive.py
@@ -47,7 +47,7 @@ class KeepAlive(Element, component='keep_alive_anchor.js'):
         self._host.__exit__(*exc)
 
     def _handle_delete(self) -> None:
-        # NOTE: the host may already be queued for deletion if the entire client is being torn down,
+        # The host may already be queued for deletion if the entire client is being torn down,
         # in which case its parent slot has already cleared it from its children list.
         host_slot = self._host.parent_slot
         if not self._host.is_deleted and host_slot is not None and self._host in host_slot.children:

--- a/nicegui/elements/knob.py
+++ b/nicegui/elements/knob.py
@@ -43,7 +43,7 @@ class Knob(ValueElement[float], DisableableElement, TextColorElement):
         self._props['min'] = min
         self._props['max'] = max
         self._props['step'] = step
-        self._props['show-value'] = True  # NOTE: enable default slot, e.g. for nested icon
+        self._props['show-value'] = True  # enable default slot, e.g. for nested icon
         self._props.set_optional('center-color', center_color)
         self._props.set_optional('track-color', track_color)
         self._props.set_optional('size', size)

--- a/nicegui/elements/leaflet/leaflet.js
+++ b/nicegui/elements/leaflet/leaflet.js
@@ -14,7 +14,7 @@ export default {
     additionalResources: Array,
   },
   async mounted() {
-    await this.$nextTick(); // NOTE: wait for window.path_prefix to be set
+    await this.$nextTick(); // wait for window.path_prefix to be set
     await loadResource(window.path_prefix + `${this.resourcePath}/leaflet/leaflet.css`);
     window.L = L;
     await Promise.all(this.additionalResources.map((resource) => loadResource(resource)));
@@ -88,7 +88,7 @@ export default {
       for (const key in L.Draw.Event) {
         const type = L.Draw.Event[key];
         this.map.on(type, async (e) => {
-          await this.$nextTick(); // NOTE: allow drawn layers to be added
+          await this.$nextTick(); // allow drawn layers to be added
           const cleanedObject = cleanObject(e, [
             "_map",
             "_events",

--- a/nicegui/elements/link.js
+++ b/nicegui/elements/link.js
@@ -1,7 +1,7 @@
 export default {
   template: `<a :href="computed_href" :target="target"><slot></slot></a>`,
   mounted() {
-    setTimeout(this.compute_href, 0); // NOTE: wait for window.path_prefix to be set in app.mounted()
+    setTimeout(this.compute_href, 0); // wait for window.path_prefix to be set in app.mounted()
   },
   updated() {
     this.compute_href();

--- a/nicegui/elements/markdown.js
+++ b/nicegui/elements/markdown.js
@@ -3,7 +3,7 @@ import { loadResource } from "../../static/utils/resources.js";
 export default {
   template: `<div></div>`,
   async mounted() {
-    await this.$nextTick(); // NOTE: wait for window.path_prefix to be set
+    await this.$nextTick(); // wait for window.path_prefix to be set
     await loadResource(window.path_prefix + `${this.dynamicResourcePath}/${this.resourceName}`);
     this.renderContent();
     if (this.useMermaid) {

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -18,7 +18,7 @@ class ValidationElement(ValueElement[ValueT]):
         self._auto_validation = True
         self._error: str | None = None
         super().__init__(**kwargs)
-        self._props['error'] = None if validation is None else False  # NOTE: reserve bottom space for error message
+        self._props['error'] = None if validation is None else False  # reserve bottom space for error message
 
     @property
     def validation(self) -> ValidationFunction | ValidationDict | None:

--- a/nicegui/elements/progress.py
+++ b/nicegui/elements/progress.py
@@ -60,7 +60,7 @@ class CircularProgress(ValueElement[float], TextColorElement):
         self._props['min'] = min
         self._props['max'] = max
         self._props['size'] = size
-        self._props['show-value'] = True  # NOTE always activate the default slot because this is expected by ui.element
+        self._props['show-value'] = True  # always activate the default slot because this is expected by ui.element
         self._props['track-color'] = 'grey-4'
 
         if show_value:

--- a/nicegui/elements/row.py
+++ b/nicegui/elements/row.py
@@ -17,7 +17,7 @@ class Row(SortableElement, default_classes='nicegui-row'):
         :param align_items: alignment of the items in the row ("start", "end", "center", "baseline", or "stretch"; default: `None`)
         """
         super().__init__('div')
-        self._classes.append('row')  # NOTE: for compatibility with Quasar's col-* classes
+        self._classes.append('row')  # for compatibility with Quasar's col-* classes
         if align_items:
             self._classes.append(f'items-{align_items}')
 

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -519,7 +519,7 @@ export default {
         )
         .onUpdate((p) => {
           this.camera.position.set(p[0], p[1], p[2]);
-          this.camera.up.set(p[3], p[4], p[5]); // NOTE: before calling lookAt
+          this.camera.up.set(p[3], p[4], p[5]); // before calling lookAt
           this.look_at.set(p[6], p[7], p[8]);
           this.camera.lookAt(p[6], p[7], p[8]);
           this.controls.target.set(p[6], p[7], p[8]);

--- a/nicegui/elements/scene/scene.py
+++ b/nicegui/elements/scene/scene.py
@@ -284,7 +284,7 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
         :param predicate: function which returns `True` for objects which should be deleted
         """
         for obj in list(self.objects.values()):
-            if predicate(obj) and obj.id in self.objects:  # NOTE: object might have been deleted already by its parent
+            if predicate(obj) and obj.id in self.objects:  # object might have been deleted already by its parent
                 obj.delete()
 
     def clear(self) -> Self:

--- a/nicegui/elements/scene/scene_view.js
+++ b/nicegui/elements/scene/scene_view.js
@@ -140,7 +140,7 @@ export default {
         )
         .onUpdate((p) => {
           this.camera.position.set(p[0], p[1], p[2]);
-          this.camera.up.set(p[3], p[4], p[5]); // NOTE: before calling lookAt
+          this.camera.up.set(p[3], p[4], p[5]); // before calling lookAt
           this.look_at.set(p[6], p[7], p[8]);
           this.camera.lookAt(p[6], p[7], p[8]);
         })

--- a/nicegui/elements/select.js
+++ b/nicegui/elements/select.js
@@ -30,7 +30,7 @@ export default {
         : this.initialOptions;
     },
     addClass() {
-      // NOTE: prevent the page from scrolling when the select popup is closed (#5031)
+      // prevent the page from scrolling when the select popup is closed (#5031)
       document.documentElement.classList.add("nicegui-select-popup-open");
     },
     async removeClass() {

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -63,7 +63,7 @@ class Select(LabelElement, ValidationElement[Any], ChoiceElement, DisableableEle
             elif not isinstance(value, list):
                 value = [value]
             else:
-                value = value[:]  # NOTE: avoid modifying the original list which could be the list of options (#3014)
+                value = value[:]  # avoid modifying the original list which could be the list of options (#3014)
         super().__init__(label=label, options=options, value=value, on_change=on_change, validation=validation)
         if isinstance(key_generator, Generator):
             next(key_generator)  # prime the key generator, prepare it to receive the first value
@@ -157,7 +157,7 @@ class Select(LabelElement, ValidationElement[Any], ChoiceElement, DisableableEle
                     self.options.remove(value)
                 else:
                     self.options.append(value)
-            # NOTE: self._labels and self._values are updated via self.options since they share the same references
+            # self._labels and self._values are updated via self.options since they share the same references
             return value
         else:
             key = value

--- a/nicegui/elements/skip_link.py
+++ b/nicegui/elements/skip_link.py
@@ -36,7 +36,7 @@ class SkipLink(TextElement, default_classes='nicegui-skip-link'):
         """
         with context.client.layout:
             super().__init__(tag='a', text=text)
-        # NOTE: move the link to the top of the layout so it is the first focusable element.
+        # Move the link to the top of the layout so it is the first focusable element.
         # If the only siblings are other skip links, the link stays where ``super().__init__`` appended it
         # (last among skip links), which is the correct creation order.
         assert self.parent_slot is not None

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -75,7 +75,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         """Display the page matching the current URL path."""
         self._rendered_path = ''
         match = self._find_matching_path()
-        # NOTE: if path and query params are the same, only update fragment without re-rendering
+        # if path and query params are the same, only update fragment without re-rendering
         if (
             match is not None and
             self._match is not None and
@@ -83,7 +83,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
             not self._required_query_params_changed(match) and
             not (self.has_404 and self._match.remaining_path == match.remaining_path)
         ):
-            # NOTE: Even though our matched path is the same, the remaining path might still require us to handle 404 (if we are the last sub pages element)
+            # Even though our matched path is the same, the remaining path might still require us to handle 404 (if we are the last sub pages element)
             if match.remaining_path and not any(isinstance(el, SubPages) for el in self.descendants()):
                 self._set_match(None)
             else:
@@ -103,7 +103,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         try:
             result = match.builder(**kwargs)
         except Exception as e:
-            self.clear()  # NOTE: clear partial content created before the exception
+            self.clear()  # clear partial content created before the exception
             self._render_error(e)
             self.client.handle_exception(e)
             return True
@@ -133,7 +133,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         """Display a 404 error message for unmatched routes."""
         Label(f'404: sub page {self._router.current_path} not found')
 
-    def _render_error(self, _: Exception) -> None:  # NOTE: exception is exposed for debugging scenarios via inheritance
+    def _render_error(self, _: Exception) -> None:  # exception is exposed for debugging scenarios via inheritance
         msg = f'sub page {self._router.current_path} produced an error'
         Label(f'500: {msg}')
         log.error(msg, exc_info=True)
@@ -209,7 +209,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
     def _handle_scrolling(self, match: RouteMatch, *, behavior: str) -> None:
         if match.fragment:
             self._scroll_to_fragment(match.fragment, behavior=behavior)
-        elif not self._router.is_initial_request:  # NOTE: the initial path has no fragment; to not interfere with later fragment scrolling, we skip scrolling to top
+        elif not self._router.is_initial_request:  # the initial path has no fragment; to not interfere with later fragment scrolling, we skip scrolling to top
             self._scroll_to_top(behavior=behavior)
 
     def _scroll_to_fragment(self, fragment: str, *, behavior: str) -> None:

--- a/nicegui/elements/table.js
+++ b/nicegui/elements/table.js
@@ -19,7 +19,7 @@ export default {
   },
   methods: {
     setFullscreenClass(isFullscreen) {
-      // NOTE: prevent the page from smooth-scrolling when the table exits fullscreen;
+      // Prevent the page from smooth-scrolling when the table exits fullscreen;
       // Quasar uses setTimeout(() => el.scrollIntoView()) in exitFullscreen,
       // so we need a setTimeout to remove the class after that scroll completes.
       if (isFullscreen) {

--- a/nicegui/elements/upload.js
+++ b/nicegui/elements/upload.js
@@ -10,7 +10,7 @@ export default {
     </q-uploader>
   `,
   mounted() {
-    setTimeout(() => this.compute_url(), 0); // NOTE: wait for window.path_prefix to be set in app.mounted()
+    setTimeout(() => this.compute_url(), 0); // wait for window.path_prefix to be set in app.mounted()
   },
   updated() {
     this.compute_url();

--- a/nicegui/elements/upload_files.py
+++ b/nicegui/elements/upload_files.py
@@ -125,7 +125,7 @@ async def create_file_upload(upload: UploadFile, *, chunk_size: int = 1024 * 102
     """
     memory_limit = (
         getattr(MultiPartParser, 'spool_max_size', 0) or
-        getattr(MultiPartParser, 'max_part_size', 0) or  # NOTE: for starlette < 0.46.0
+        getattr(MultiPartParser, 'max_part_size', 0) or  # for starlette < 0.46.0
         1024 * 1024
     )
 

--- a/nicegui/elements/video.js
+++ b/nicegui/elements/video.js
@@ -12,7 +12,7 @@ export default {
     };
   },
   mounted() {
-    setTimeout(() => this.compute_src(), 0); // NOTE: wait for window.path_prefix to be set in app.mounted()
+    setTimeout(() => this.compute_src(), 0); // wait for window.path_prefix to be set in app.mounted()
   },
   updated() {
     this.compute_src();

--- a/nicegui/elements/xterm/xterm.js
+++ b/nicegui/elements/xterm/xterm.js
@@ -17,7 +17,7 @@ export default {
         this.terminal[key]((e) => this.$emit(key.slice(2).toLowerCase(), e));
       });
 
-    // NOTE: wait for window.path_prefix to be set
+    // wait for window.path_prefix to be set
     this.$nextTick().then(() => loadResource(window.path_prefix + `${this.resourcePath}/xterm.css`));
   },
   methods: {

--- a/nicegui/event.py
+++ b/nicegui/event.py
@@ -85,7 +85,7 @@ class Event(Generic[P]):
             line=frame.f_lineno,
         )
         client: Client | None = None
-        if Slot.get_stack():  # NOTE: additional check before accessing `context.slot` which would enter script mode
+        if Slot.get_stack():  # additional check before accessing `context.slot` which would enter script mode
             callback_.slot = weakref.ref(context.slot)
             client = context.client
         if callback_.slot is None and unsubscribe_on_delete is True:

--- a/nicegui/functions/style.py
+++ b/nicegui/functions/style.py
@@ -61,10 +61,10 @@ def add_sass(content: str | Path, *, shared: bool = False) -> None:  # DEPRECATE
 def _add_javascript(code: str, *, shared: bool = False) -> None:
     script_html = f'<script>{code}</script>'
     if shared:
-        client = context.client if Slot.get_stack() else None  # NOTE: don't auto-create a client if shared=True
+        client = context.client if Slot.get_stack() else None  # don't auto-create a client if shared=True
         Client.shared_head_html += script_html + '\n'
     else:
         client = context.client
         client._head_html += script_html + '\n'
-    if client is not None and client.has_socket_connection:  # NOTE: no need to run JavaScript if there is no client yet
+    if client is not None and client.has_socket_connection:  # no need to run JavaScript if there is no client yet
         client.run_javascript(code)

--- a/nicegui/helpers/files.py
+++ b/nicegui/helpers/files.py
@@ -8,7 +8,7 @@ def is_file(path: str | Path | None) -> bool:
     if not path:
         return False
     if isinstance(path, str) and path.strip().startswith('data:'):
-        return False  # NOTE: avoid passing data URLs to Path
+        return False  # avoid passing data URLs to Path
     try:
         return Path(path).is_file()
     except OSError:

--- a/nicegui/llms.md
+++ b/nicegui/llms.md
@@ -1261,7 +1261,7 @@ These follow NiceGUI project conventions and work well for NiceGUI-based apps:
 
 - **Single quotes** for strings: `'hello'` not `"hello"` (in Python code)
 - **f-strings** preferred over `.format()` or `%`
-- **`# NOTE:`** prefix for non-obvious implementation details
+- **`# NOTE:`** only to draw special attention (e.g. changes that need to be mirrored elsewhere); plain comments otherwise
 - **No mutable defaults**: use `None` instead of `[]` or `{}`
 - **`contextlib.suppress()`** instead of `try: ... except: pass`
 - **`background_tasks.create()`** instead of `asyncio.create_task()`

--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -57,7 +57,7 @@ try:
     class WindowProxy(webview.Window):
 
         def __init__(self) -> None:  # pylint: disable=super-init-not-called
-            pass  # NOTE we don't call super().__init__ here because this is just a proxy to the actual window
+            pass  # we don't call super().__init__ here because this is just a proxy to the actual window
 
         async def get_always_on_top(self) -> bool:
             """Get whether the window is always on top."""

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -112,7 +112,7 @@ def _bind_pywebview_events(window: webview.Window, event_sender: Connection) -> 
     window.events.resized += lambda width, height: send('resized', width=width, height=height)
     window.events.moved += lambda x, y: send('moved', x=x, y=y)
     window.events.closed += lambda: send('closed')
-    # NOTE: 'closing' is not bridged yet — it requires a synchronous round-trip to support vetoing the close
+    # 'closing' is not bridged yet — it requires a synchronous round-trip to support vetoing the close
 
 
 def _start_window_method_executor(window: webview.Window,
@@ -153,7 +153,7 @@ def _start_window_method_executor(window: webview.Window,
                     else:
                         log.error(f'window.{method_name} is not callable')
             except queue.Empty:
-                time.sleep(0.016)  # NOTE: avoid issue https://github.com/zauberzeug/nicegui/issues/2482 on Windows
+                time.sleep(0.016)  # avoid issue https://github.com/zauberzeug/nicegui/issues/2482 on Windows
             except Exception:
                 log.exception(f'error in window.{method_name}')
 

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -134,7 +134,7 @@ async def _startup() -> None:
                            '   if __name__ in {"__main__", "__mp_main__"}:\n'
                            'to allow for multiprocessing.')
     await welcome.collect_urls()
-    # NOTE ping interval and timeout need to be lower than the reconnect timeout, but can't be too low
+    # ping interval and timeout need to be lower than the reconnect timeout, but can't be too low
     sio.eio.ping_interval = max(app.config.reconnect_timeout * 0.8, 4)
     sio.eio.ping_timeout = max(app.config.reconnect_timeout * 0.4, 2)
     if core.app.config.favicon:
@@ -163,8 +163,8 @@ async def _shutdown() -> None:
 async def _exception_handler_404(request: Request, exception: Exception) -> Response:
     if (endpoint := request.scope.get('endpoint')) is not None and endpoint is not app and not request.scope.get('nicegui_page_path') and isinstance(exception, StarletteHTTPException):
         # non-page endpoints raising 404 should get JSON, not our HTML error page
-        # NOTE: match Starlette's HTTPException (the base class) so e.g. auth dependencies that raise it directly are covered
-        # NOTE: when mounted via ui.run_with(), the parent's Mount sets endpoint=app even if no inner route matched — exclude that case
+        # match Starlette's HTTPException (the base class) so e.g. auth dependencies that raise it directly are covered
+        # when mounted via ui.run_with(), the parent's Mount sets endpoint=app even if no inner route matched — exclude that case
         return await http_exception_handler(request, exception)
     root = core.root
     if root is not None:

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -109,7 +109,7 @@ class page:
         return self.markdown if self.markdown is not None else core.app.config.markdown
 
     def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]:
-        core.app.remove_route(self.path)  # NOTE make sure only the latest route definition is used
+        core.app.remove_route(self.path)  # make sure only the latest route definition is used
 
         if 'include_in_schema' not in self.kwargs:
             self.kwargs['include_in_schema'] = core.app.config.endpoint_documentation in {'page', 'all'}
@@ -160,7 +160,7 @@ class page:
         @wraps(func)
         async def decorated(*dec_args, **dec_kwargs) -> Response:
             request = dec_kwargs['request']
-            # NOTE cleaning up the keyword args so the signature is consistent with "func" again
+            # cleaning up the keyword args so the signature is consistent with "func" again
             dec_kwargs = {k: v for k, v in dec_kwargs.items() if k in parameters_of_decorated_func}
             with Client(self, request=request) as client:
                 if any(p.name == 'client' for p in inspect.signature(func).parameters.values()):
@@ -205,13 +205,13 @@ class page:
                 log.warning(f'{request.url} not found')
                 return client.build_response(request, 404)
 
-            if isinstance(result, Response):  # NOTE if setup returns a response, we don't need to render the page
+            if isinstance(result, Response):  # if setup returns a response, we don't need to render the page
                 return result
             binding._refresh_step()  # pylint: disable=protected-access
             return client.build_response(request, client.status_code)
 
         parameters = [p for p in inspect.signature(func).parameters.values() if p.name != 'client']
-        # NOTE adding request as a parameter so we can pass it to the client in the decorated function
+        # adding request as a parameter so we can pass it to the client in the decorated function
         if 'request' not in {p.name for p in parameters}:
             request = inspect.Parameter('request', inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Request)
             parameters.insert(0, request)

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -54,7 +54,7 @@ def safe_callback(callback: Callable, *args, **kwargs) -> Any:
     try:
         return callback(*args, **kwargs)
     except Exception as e:
-        # NOTE: we do not want to pass the original exception because it might be unpicklable
+        # we do not want to pass the original exception because it might be unpicklable
         raise SubprocessException(type(e).__name__, str(e), traceback.format_exc()) from None
 
 

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -60,7 +60,7 @@ def set_storage_secret(storage_secret: str | None = None,
         core.app.user_middleware.append(Middleware(RequestTrackingMiddleware))
     else:
         if any(m.cls == SessionMiddleware for m in core.app.user_middleware):
-            # NOTE not using "add_middleware" because it would be the wrong order
+            # not using "add_middleware" because it would be the wrong order
             core.app.user_middleware.append(Middleware(RequestTrackingMiddleware))
         elif storage_secret is not None:
             core.app.add_middleware(RequestTrackingMiddleware)

--- a/nicegui/sub_pages_router.py
+++ b/nicegui/sub_pages_router.py
@@ -33,7 +33,7 @@ class SubPagesRouter:
                     break
             if request.url.query:
                 path += '?' + request.url.query
-            # NOTE: we do not use request.url.fragment because browsers do not send it to the server
+            # we do not use request.url.fragment because browsers do not send it to the server
             self.current_path = path
         else:
             self.current_path = '/'
@@ -62,7 +62,7 @@ class SubPagesRouter:
         await self._handle_open(self.current_path)
 
     async def _handle_open(self, path: str) -> bool:
-        # NOTE: keep a reference to the client because _show clears the slots so that context.client does not work anymore
+        # keep a reference to the client because _show clears the slots so that context.client does not work anymore
         client = context.client
         self.current_path = path
         self.is_initial_request = False
@@ -74,7 +74,7 @@ class SubPagesRouter:
         return await self._can_resolve_full_path(client)
 
     async def _handle_navigate(self, path: str) -> None:
-        # NOTE: keep a reference to the client because _handle_open clears the slots so that context.client does not work anymore
+        # keep a reference to the client because _handle_open clears the slots so that context.client does not work anymore
         client = context.client
         await self._handle_open(path)
         if (
@@ -119,7 +119,7 @@ class SubPagesRouter:
         sub_pages_elements = [el for el in client.layout.descendants() if isinstance(el, SubPages)]
         if any(el._active_tasks for el in sub_pages_elements):  # pylint: disable=protected-access
             await asyncio.sleep(0)
-            # NOTE: refresh the list to include newly created nested sub pages in async sub page builders after the event loop tick
+            # refresh the list to include newly created nested sub pages in async sub page builders after the event loop tick
             sub_pages_elements = [el for el in client.layout.descendants() if isinstance(el, SubPages)]
         for sub_pages in sub_pages_elements:
             if (

--- a/nicegui/testing/screen_plugin.py
+++ b/nicegui/testing/screen_plugin.py
@@ -68,7 +68,7 @@ def nicegui_chrome_options() -> webdriver.ChromeOptions:
 @pytest.fixture(scope='session')
 def nicegui_remove_all_screenshots() -> None:
     """Prune directories of finished concurrent runs and remove screenshots from previous runs."""
-    # NOTE: the FileLock is intentionally not stored; the kernel fd keeps the flock until process exit.
+    # The FileLock is intentionally not stored; the kernel fd keeps the flock until process exit.
     assert FileLock(Screen.SCREENSHOT_DIR / '.lock').acquire(), 'should be able to lock own screenshot dir'
     if Screen.SCREENSHOT_DIR.parent.exists():
         for path in Screen.SCREENSHOT_DIR.parent.iterdir():

--- a/nicegui/testing/user.py
+++ b/nicegui/testing/user.py
@@ -54,7 +54,7 @@ class User:
         return self._client.__exit__(exc_type, exc_val, exc_tb)
 
     def __getattribute__(self, name: str) -> Any:
-        if name not in {'notify', 'navigate', 'download'}:  # NOTE: avoid infinite recursion
+        if name not in {'notify', 'navigate', 'download'}:  # avoid infinite recursion
             ui.navigate = self.navigate
             ui.notify = self.notify
             ui.download = self.download

--- a/nicegui/testing/user_navigate.py
+++ b/nicegui/testing/user_navigate.py
@@ -21,7 +21,7 @@ class UserNavigate(Navigate):
 
     def to(self, target: Callable[..., Any] | str | ui.element, new_tab: bool = False) -> None:
         if isinstance(target, ui.element):
-            # NOTE navigation to an element does not do anything in the user simulation (the whole content is always visible)
+            # navigation to an element does not do anything in the user simulation (the whole content is always visible)
             return
         path = Client.page_routes[target] if callable(target) else target
         background_tasks.create(self._open(path, clear_forward_history=True), name=f'navigate to {path}')

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -261,7 +261,7 @@ def run(root: Callable | None = None, *,
         native = False
         show_welcome_message = False
 
-    # NOTE: We save host and port in environment variables so the subprocess started in reload mode can access them.
+    # We save host and port in environment variables so the subprocess started in reload mode can access them.
     os.environ['NICEGUI_HOST'] = host
     os.environ['NICEGUI_PORT'] = str(port)
     os.environ['NICEGUI_PROTOCOL'] = protocol
@@ -275,7 +275,7 @@ def run(root: Callable | None = None, *,
     if kwargs.get('workers', 1) > 1:
         raise ValueError('NiceGUI does not support multiple workers yet.')
 
-    # NOTE: The following lines are basically a copy of `uvicorn.run`, but keep a reference to the `server`.
+    # The following lines are basically a copy of `uvicorn.run`, but keep a reference to the `server`.
 
     config = CustomServerConfig(
         APP_IMPORT_STRING if reload else core.app,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import os
 
-os.environ.setdefault('MPLBACKEND', 'Agg')  # NOTE: force a non-GUI Matplotlib backend during tests
+os.environ.setdefault('MPLBACKEND', 'Agg')  # force a non-GUI Matplotlib backend during tests
 
 pytest_plugins = ['nicegui.testing.plugin']

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -10,7 +10,7 @@ from nicegui.testing import Screen, User
 # pylint: disable=missing-function-docstring
 
 
-# NOTE: click handlers, and system events used to wrap background_task in a background_task (see https://github.com/zauberzeug/nicegui/pull/4641#issuecomment-2837448265)
+# click handlers, and system events used to wrap background_task in a background_task (see https://github.com/zauberzeug/nicegui/pull/4641#issuecomment-2837448265)
 @pytest.mark.parametrize('strategy', ['direct', 'click', 'system'])
 async def test_awaiting_background_tasks_on_shutdown(user: User, strategy: str):
     run = set()
@@ -66,9 +66,9 @@ async def test_awaiting_background_tasks_on_shutdown(user: User, strategy: str):
         background_tasks.create(one(), name='one')
         background_tasks.create(two(), name='two')
 
-    await asyncio.sleep(0.1)  # NOTE: we need to wait for the tasks to be created
+    await asyncio.sleep(0.1)  # we need to wait for the tasks to be created
 
-    # NOTE: teardown is called on shutdown; here we call it directly to test the teardown logic while test is still running
+    # teardown is called on shutdown; here we call it directly to test the teardown logic while test is still running
     await background_tasks.teardown()
     assert cancelled == {'one', 'three'}
     assert run == {'one', 'two', 'four'}

--- a/tests/test_element_filter.py
+++ b/tests/test_element_filter.py
@@ -319,8 +319,8 @@ async def test_typing(user: User):
         ui.button('button A')
         ui.label('label A')
 
-        # NOTE we have not yet found a way to test the typing suggestions automatically
-        # to test, hover over the variable and verify that your IDE infers the correct type
+        # We have not yet found a way to test the typing suggestions automatically.
+        # To test, hover over the variable and verify that your IDE infers the correct type.
         _ = ElementFilter(kind=ui.button)  # ElementFilter[ui.button]
         _ = ElementFilter(kind=ui.label)  # ElementFilter[ui.label]
         _ = ElementFilter()  # ElementFilter[Element]

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -81,7 +81,7 @@ def test_strip_indentation(screen: Screen):
 
     screen.open('/')
     screen.should_contain('This is Markdown.')
-    screen.should_not_contain('**This is Markdown.**')  # NOTE: '**' are translated to formatting and not visible
+    screen.should_not_contain('**This is Markdown.**')  # '**' are translated to formatting and not visible
 
 
 def test_replace_markdown(screen: Screen):

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -25,7 +25,7 @@ def test_close_button(screen: Screen):
     screen.should_contain('Hi!')
     assert len(b.client.layout.default_slot.children) == 2
     screen.wait_for('Close')
-    screen.wait(0.1)  # NOTE: wait for button to become clickable
+    screen.wait(0.1)  # wait for button to become clickable
     screen.click('Close')
     screen.wait(1.5)
     screen.should_not_contain('Hi!')

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -72,7 +72,7 @@ def test_wait_for_connected(screen: Screen):
     async def load() -> None:
         assert label
         label.text = 'loading...'
-        # NOTE we can not use asyncio.create_task() here because we are on a different thread than the NiceGUI event loop
+        # we can not use asyncio.create_task() here because we are on a different thread than the NiceGUI event loop
         background_tasks.create(takes_a_while())
 
     async def takes_a_while() -> None:
@@ -351,7 +351,7 @@ def test_warning_if_response_takes_too_long(screen: Screen):
         ui.label('all done')
 
     screen.start_server()
-    # NOTE: using httpx instead of screen.open to avoid Selenium script timeout on incomplete page responses
+    # using httpx instead of screen.open to avoid Selenium script timeout on incomplete page responses
     httpx.get(f'http://localhost:{Screen.PORT}/', timeout=5)
     screen.wait(1)
     screen.assert_py_logger('WARNING', re.compile('Response for / not ready after 0.5 seconds'))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -392,7 +392,7 @@ async def test_awaiting_backup_scheduled_during_teardown(user: User, tmp_path):
     def page():
         ui.label('ok')
 
-    await user.open('/')  # NOTE: needed to ensure NiceGUI's event loop is running
+    await user.open('/')  # needed to ensure NiceGUI's event loop is running
     path = tmp_path / 'storage.json'
     d = FilePersistentDict(path, encoding='utf-8')
     d['key'] = 'value'  # schedules async backup task tagged with await_on_shutdown

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -131,7 +131,7 @@ def test_opening_sub_pages_directly(screen: Screen):
     screen.should_contain('two')
     screen.should_not_contain('one')
 
-    screen.open('/one/')  # NOTE: having a slash at the end of the path should not cause an error
+    screen.open('/one/')  # having a slash at the end of the path should not cause an error
     screen.should_contain('one')
     screen.should_not_contain('two')
 
@@ -437,7 +437,7 @@ def test_navigate_to_new_tab_fallback(screen: Screen):
     screen.should_contain('main-content')
     assert calls == {'index': 1}
 
-    # NOTE: even though this is a sub page route, new_tab=True should use normal navigation
+    # even though this is a sub page route, new_tab=True should use normal navigation
     screen.click('new tab')
     screen.wait(0.5)
     screen.switch_to(1)
@@ -482,7 +482,7 @@ def test_adding_sub_pages_after_initialization(screen: Screen):
 
     screen.click('Add sub page')
     screen.wait(0.2)
-    screen.should_contain('sub-content')  # NOTE: because browser points to /sub we see the sub page content
+    screen.should_contain('sub-content')  # because browser points to /sub we see the sub page content
     assert screen.current_path == '/sub'
 
 
@@ -685,7 +685,7 @@ def test_async_sub_pages(screen: Screen):
     screen.click('/0.1')
     screen.should_contain('after 0.1 sec')
 
-    # NOTE: below we ensure that quick page changes are not affected by the async sub page
+    # below we ensure that quick page changes are not affected by the async sub page
     screen.click('/1.0')
     screen.wait(0.1)
     screen.click('/0.1')
@@ -841,7 +841,7 @@ def test_sub_pages_with_url_fragments(screen: Screen):
         calls['main'] += 1
         ui.label('Main page')
         ui.link('Go to bottom', '/page#bottom')
-        # NOTE: extend content of main page so we can verify that scroll positions are reset when doing cross-page navigation
+        # extend content of main page so we can verify that scroll positions are reset when doing cross-page navigation
         for i in range(100):
             ui.label(f'Line {i}')
 
@@ -962,7 +962,7 @@ def test_on_path_changed_event(screen: Screen):
     screen.allowed_js_errors.append('/bad_path - Failed to load resource')
     screen.open('/')
     screen.should_contain('main page')
-    assert paths == []  # NOTE: initial path is not reported, because the path does not "change" on first load
+    assert paths == []  # initial path is not reported, because the path does not "change" on first load
     assert calls == {'index': 1, 'main': 1, 'other': 0}
 
     screen.click('Go to other')
@@ -1018,17 +1018,17 @@ def test_exception_in_page_builder(screen: Screen):
     msg_content = 'sub page /content_with_exception produced an error'
     screen.should_contain(f'500: {msg_content}')
     screen.assert_py_logger('ERROR', msg_content)
-    # NOTE: the content should not show at all, when an error occurs
+    # the content should not show at all, when an error occurs
     screen.should_not_contain('content before exception')
 
     screen.click('Go to async exception')
     msg_async = 'sub page /async produced an error'
     screen.should_not_contain(f'500: {msg_async}')
     screen.assert_py_logger('ERROR', 'async test exception')
-    # NOTE: the content should show, when an error occurs after async task is started
+    # the content should show, when an error occurs after async task is started
     screen.should_contain('async content before exception')
 
-    screen.open('/content_with_exception')  # NOTE: directly opening the page produces same error as above
+    screen.open('/content_with_exception')  # directly opening the page produces same error as above
     screen.should_contain(f'500: {msg_content}')
     screen.assert_py_logger('ERROR', msg_content)
     screen.should_not_contain('content before exception')

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -442,8 +442,8 @@ async def test_typing(user: User) -> None:
         ui.button('World!')
 
     await user.open('/')
-    # NOTE we have not yet found a way to test the typing suggestions automatically
-    # to test, hover over the variable and verify that your IDE inferres the correct type
+    # We have not yet found a way to test the typing suggestions automatically.
+    # To test, hover over the variable and verify that your IDE inferres the correct type.
     _ = user.find(kind=ui.label).elements  # Set[ui.label]
     _ = user.find(ui.label).elements  # Set[ui.label]
     _ = user.find('World').elements  # Set[ui.element]

--- a/website/documentation/code_extraction.py
+++ b/website/documentation/code_extraction.py
@@ -8,7 +8,7 @@ UNCOMMENT_PATTERN = re.compile(r'^(\s*)# ?')
 
 
 def _uncomment(text: str) -> str:
-    return UNCOMMENT_PATTERN.sub(r'\1', text)  # NOTE: non-executed lines should be shown in the code examples
+    return UNCOMMENT_PATTERN.sub(r'\1', text)  # non-executed lines should be shown in the code examples
 
 
 def get_full_code(f: Callable) -> str:

--- a/website/documentation/content/user_documentation.py
+++ b/website/documentation/content/user_documentation.py
@@ -28,7 +28,7 @@ def user_fixture():
     ''').classes('w-full')
 
     ui.markdown('''
-        **NOTE:** The `user` fixture might still miss some features.
+        **Note:** The `user` fixture might still miss some features.
         Please let us know in separate feature requests
         [over on GitHub](https://github.com/zauberzeug/nicegui/discussions/new?category=ideas-feature-requests).
     ''')

--- a/website/fly.py
+++ b/website/fly.py
@@ -16,12 +16,12 @@ def setup() -> bool:
     if 'FLY_ALLOC_ID' not in os.environ:
         return False
 
-    # NOTE In our global fly.io deployment we need to make sure that we connect back to the same instance.
+    # In our global fly.io deployment we need to make sure that we connect back to the same instance.
     fly_instance_id = os.environ.get('FLY_ALLOC_ID', 'local').split('-')[0]
     app.config.socket_io_js_extra_headers['fly-force-instance-id'] = fly_instance_id  # for HTTP long polling
     app.config.socket_io_js_query_params['fly_instance_id'] = fly_instance_id  # for websocket (FlyReplayMiddleware)
 
-    import dns.resolver  # NOTE only import on fly where we have it installed to look up if instance is still available
+    import dns.resolver  # only import on fly where we have it installed to look up if instance is still available
 
     @app.add_middleware
     class FlyReplayMiddleware(BaseHTTPMiddleware):


### PR DESCRIPTION
### Motivation

Using `NOTE:` markers is a relict from times when we used comments more sparingly and felt like we should indicate the purpose of each of them: TODO, FIXME, NOTE, HACK.
Leftover TODOs and FIXMEs in code are bad practice anyway, and a `NOTE:` prefix on a comment that merely explains the adjacent code doesn't carry any meaningful information -- what else is a comment supposed to be?

But the marker remains useful for drawing special attention, e.g. to changes that need to be mirrored elsewhere (like the duplicated dependency lists in pyproject.toml) or hidden cross-file coupling that an edit would silently break.
`HACK:` also remains a valid marker for knowingly suboptimal solutions.

### Implementation

- Strip the `NOTE:` prefix from ~115 comments and docstrings that merely explain the adjacent code, keeping their content unchanged.
- Keep `NOTE:` on the 10 attention-seeking comments, e.g. the mirrored dependency lists in pyproject.toml, the deliberately empty ROS entry point, the Selenium-only global in scene.js, and the test-ordering constraint in test_highchart.py.
- Update CONTRIBUTING.md, REVIEW.md and nicegui/llms.md to describe the new convention: plain comments by default, `NOTE:` only to draw special attention.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been updated.
- [x] No breaking changes to the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)