### PR TITLE
Simplify spool size lookup now that Starlette >= 1.0.1 is required

### DIFF
--- a/nicegui/elements/upload_files.py
+++ b/nicegui/elements/upload_files.py
@@ -123,19 +123,13 @@ async def create_file_upload(upload: UploadFile, *, chunk_size: int = 1024 * 102
     :param upload: the Starlette UploadFile to create a file upload from
     :param chunk_size: the size of each chunk to read in bytes (default: 1 MB)
     """
-    memory_limit = (
-        getattr(MultiPartParser, 'spool_max_size', 0) or
-        getattr(MultiPartParser, 'max_part_size', 0) or  # NOTE: for starlette < 0.46.0
-        1024 * 1024
-    )
-
     buffer = BytesIO()
     buffer_size = 0
     temp_file: aiofiles.threadpool.binary.AsyncBufferedIOBase | None = None
 
     try:
         while (chunk := await upload.read(chunk_size)):
-            if not temp_file and buffer_size + len(chunk) > memory_limit:
+            if not temp_file and buffer_size + len(chunk) > MultiPartParser.spool_max_size:
                 temp_file = await aiofiles.tempfile.NamedTemporaryFile('wb', delete=False)
                 await temp_file.write(buffer.getvalue())
                 buffer = BytesIO()  # release memory


### PR DESCRIPTION
### Motivation

Since we require `starlette>=1.0.1`, the fallback chain for determining the multipart spool size in `create_file_upload` is obsolete:
`MultiPartParser.spool_max_size` is guaranteed to exist as a class attribute (introduced in Starlette 0.46.0).

Fun fact: The `max_part_size` fallback (annotated "for starlette < 0.46.0") never worked as intended anyway.
In Starlette < 0.46.0, `max_part_size` was only an `__init__` parameter, not a class attribute, so the `getattr` always returned 0 there — the pre-0.46 spool threshold was actually named `max_file_size`.

### Implementation

Replace the `getattr(...) or getattr(...) or 1024 * 1024` chain with a direct access to `MultiPartParser.spool_max_size`, which is also the attribute our documentation recommends overriding for large uploads.

Minor behavioral improvement: If a user sets `MultiPartParser.spool_max_size = 0` to force spooling to disk, the old `or` chain silently replaced that with 1 MB; now it is respected.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.