### PR TITLE
Bound the connection drain when the native window closes (#5443)

### DIFF
--- a/nicegui/server.py
+++ b/nicegui/server.py
@@ -38,10 +38,8 @@ class Server(uvicorn.Server):
             if (event := self.config.shutdown_event) is not None:
                 def monitor_shutdown_event() -> None:
                     event.wait()
-                    # NOTE: The window is closed, so there is no client left to wait for.
-                    # Bound the connection drain, which otherwise hangs forever on stale connection bookkeeping
-                    # on Windows (#5443); app.on_shutdown callbacks still run to completion afterwards,
-                    # because uvicorn's lifespan shutdown follows the drain and is not affected by this timeout.
+                    # The window is closed, so bound the connection drain, which can hang forever on Windows (#5443).
+                    # Lifespan shutdown (with app.on_shutdown callbacks) follows the drain, unaffected by this timeout.
                     self.config.timeout_graceful_shutdown = 1
                     self.should_exit = True
                 threading.Thread(target=monitor_shutdown_event, daemon=True).start()

--- a/nicegui/server.py
+++ b/nicegui/server.py
@@ -38,6 +38,11 @@ class Server(uvicorn.Server):
             if (event := self.config.shutdown_event) is not None:
                 def monitor_shutdown_event() -> None:
                     event.wait()
+                    # NOTE: The window is closed, so there is no client left to wait for.
+                    # Bound the connection drain, which otherwise hangs forever on stale connection bookkeeping
+                    # on Windows (#5443); app.on_shutdown callbacks still run to completion afterwards,
+                    # because uvicorn's lifespan shutdown follows the drain and is not affected by this timeout.
+                    self.config.timeout_graceful_shutdown = 1
                     self.should_exit = True
                 threading.Thread(target=monitor_shutdown_event, daemon=True).start()
 


### PR DESCRIPTION
*Drafted by Claude Code on Evan's behalf.*

### Motivation

Fixes #5443.

Implements the direction @falkoschindler proposed in https://github.com/zauberzeug/nicegui/issues/5443#issuecomment-4509935595: when the native window closes, the user is done — exit promptly without imposing anything on non-native users or truncating `app.on_shutdown` work. Supersedes #5706 (now draft), which set `timeout_graceful_shutdown=10` globally.

### One correction to the proposal's trace, which changes the implementation

The sketch assumed lifespan shutdown runs *before* the connection drain, so "wait for lifespan, then `os._exit(0)`" would be safe. In uvicorn (verified on 0.22.0, our floor, through 0.40.0, current), the order in `Server.shutdown()` is the reverse: **drain first, lifespan last**. In the hang scenario the ghost connection blocks the drain forever, so lifespan never starts — waiting on it would deadlock exactly like the original bug, and `on_shutdown` callbacks would never run.

The good news: the intent survives with uvicorn's own mechanism, no `os._exit` needed. `timeout_graceful_shutdown` is read live at shutdown time and bounds **only the drain** — on timeout, uvicorn cancels the drain and still runs lifespan shutdown. So the existing `monitor_shutdown_event` thread (which fires precisely at window close, native mode only) just sets `timeout_graceful_shutdown = 1` before `should_exit`.

### Behavior (empirical, macOS, app with a 2-second `on_shutdown` handler)

| | total wall | `on_shutdown` completed? |
|---|---|---|
| main (baseline) | 6 s | ✓ |
| `timeout = 0` (hard cancel) | **13 s** — abrupt task cancellation costs ~7 s of teardown | ✓ |
| **`timeout = 1` (this PR)** | **6 s** — drain finishes naturally in <1 s once the window is gone; the cancel path never executes | ✓ |

So on healthy platforms this is empirically a no-op; the Windows ghost-connection case gets a bounded 1-second escape with `on_shutdown` still running to completion. Non-native mode is untouched (the monitor thread only exists in native mode).

**Pending:** Windows verification against the #4970/#5443 repro — @evnchn will run this across his Windows machines before this leaves draft. @falkoschindler: does this match your intent?

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [ ] The implementation is complete. (Draft — pending Windows fleet verification and @falkoschindler's confirmation of intent.)
- [x] This PR does not address a security issue.
- [ ] Pytests have been added. (The hang is Windows-native-GUI-bound; empirical manual protocol documented above. Open to suggestions for a CI-able test.)
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

