### PR TITLE
Fix native window close not shutting down the app after hot reload

### DIFF
--- a/nicegui/server.py
+++ b/nicegui/server.py
@@ -38,9 +38,8 @@ class Server(uvicorn.Server):
             native.response_queue = self.config.response_queue
             if (event := self.config.shutdown_event) is not None:
                 def monitor_shutdown_event() -> None:
-                    # Poll instead of `event.wait()`: a blocking wait would register this thread as a waiter
-                    # on the event's internal condition variable. When the auto-reloader kills the process
-                    # mid-wait, the stale registration makes a later `event.set()` block forever (#5845).
+                    # Poll instead of `event.wait()`: a blocking wait leaves a stale waiter if the reloader
+                    # kills the process mid-wait, making a later `event.set()` hang forever (#5845).
                     while not event.is_set():
                         time.sleep(0.1)
                     self.should_exit = True

--- a/nicegui/server.py
+++ b/nicegui/server.py
@@ -4,6 +4,7 @@ import multiprocessing
 import multiprocessing.synchronize
 import socket
 import threading
+import time
 from typing import Any
 
 import uvicorn
@@ -37,7 +38,11 @@ class Server(uvicorn.Server):
             native.response_queue = self.config.response_queue
             if (event := self.config.shutdown_event) is not None:
                 def monitor_shutdown_event() -> None:
-                    event.wait()
+                    # Poll instead of `event.wait()`: a blocking wait would register this thread as a waiter
+                    # on the event's internal condition variable. When the auto-reloader kills the process
+                    # mid-wait, the stale registration makes a later `event.set()` block forever (#5845).
+                    while not event.is_set():
+                        time.sleep(0.1)
                     self.should_exit = True
                 threading.Thread(target=monitor_shutdown_event, daemon=True).start()
 


### PR DESCRIPTION
*Authored by Claude Code (Claude Fable 5) on behalf of @evnchn; analysis and fix empirically verified as described in the comment below.*

### Motivation

Fixes #5845: with `ui.run(native=True, reload=True)`, closing the native window stops shutting down the app as soon as one hot reload has happened. The window disappears, but the supervisor and the worker process linger forever (the issue's "console is still in the app's process" symptom, on macOS and in principle on every platform).

> [!NOTE]
> This PR does **not** implement the SIGINT workaround sketched in [the analysis comment on the issue](https://github.com/zauberzeug/nicegui/issues/5845#issuecomment-3981993953). Empirical verification refuted that comment's root-cause claim — the webview process exits just fine after window close. This PR fixes the actual, instrumentation-proven root cause below.

The real root cause:

1. The worker's `monitor_shutdown_event` thread blocks in `shutdown_event.wait()`, which registers it as a sleeper on the `multiprocessing.Event`'s internal `Condition`.
2. A hot reload makes uvicorn's `ChangeReload` kill that worker mid-wait. The dead sleeper's registration on the shared semaphores is never cleaned up.
3. When the window is later closed, `check_shutdown()` in the supervisor calls `shutdown_event.set()`, and `Condition.notify_all()` blocks forever in `_woken_count.acquire()`, waiting for an acknowledgment the dead worker can never send.
4. Blocked `set()` means: no `should_exit` in the new worker, no `_thread.interrupt_main()` in the supervisor — nothing shuts down. (`app.shutdown()` still works because it bypasses the event and signals the supervisor directly.)

### Implementation

The worker's monitor thread now polls `event.is_set()` at 0.1 s instead of blocking in `event.wait()`. `is_set()` never registers as a Condition sleeper, so a worker killed by the reloader leaves no poisonous state behind and the supervisor's `set()` returns immediately. The 0.1 s poll matches the existing style in `check_shutdown()`.

Notes:

- `event.wait(timeout)` in a loop would **not** fix this — a timed wait still registers as a sleeper for ~100% of wall time (confirmed against CPython's `multiprocessing/synchronize.py`).
- Residual race, for the record: `is_set()` holds the Condition's lock for a few microseconds per 100 ms poll, and POSIX semaphores are not robust against owner death. A worker killed in exactly that window would still poison the event, but the probability drops from ~100% (old code: parked as a sleeper essentially all the time) to roughly lock-held-time/poll-interval ≈ 10⁻⁵ per reload, which is the practical floor without abandoning `multiprocessing.Event` entirely.
- No automated test: a faithful regression test needs a real pywebview window, a real `ChangeReload` file-touch reload and a window close, which CI cannot do. Full empirical verification (repro harness, instrumented runs, before/after matrix on macOS) is documented in the comment below.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary (not CI-able; empirical verification documented below).
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
