### PR TITLE
Fix ui.skeleton animation_speed being sent as milliseconds

### DIFF
--- a/nicegui/elements/skeleton.py
+++ b/nicegui/elements/skeleton.py
@@ -62,7 +62,7 @@ class Skeleton(Element):
         self._props.set_optional('type', type if type != 'rect' else None)
         self._props.set_optional('tag', tag if tag != 'div' else None)
         self._props.set_optional('animation', animation if animation != 'wave' else None)
-        self._props.set_optional('animation-speed', animation_speed if animation_speed != 1.5 else None)
+        self._props.set_optional('animation-speed', animation_speed * 1000 if animation_speed != 1.5 else None)
         self._props.set_bool('square', square)
         self._props.set_bool('bordered', bordered)
         self._props.set_optional('size', size)


### PR DESCRIPTION
### Motivation

Fixes #6107.

`ui.skeleton`'s `animation_speed` is documented as *"animation speed in seconds (default: 1.5)"*, but the value is forwarded verbatim to Quasar's [`QSkeleton`](https://quasar.dev/vue-components/skeleton#qskeleton-api) `animation-speed` prop, which is in **milliseconds**.

The old default `1.5` only ever looked correct by coincidence: `1.5` matched the sentinel that *omits* the prop, so Quasar fell back to its own default of `1500ms` (= 1.5 s). Any explicitly passed value was sent as-is in milliseconds, so e.g. `animation_speed=2.0` rendered as `2ms` (a sub-frame, effectively invisible animation) rather than the 2 seconds the docstring implied.

### Implementation

Keep the public API in **seconds** (the documented, intended unit) and convert to milliseconds internally — matching how every other duration in NiceGUI is handled:

- `ui.notification` `timeout` — seconds, `(timeout or 0) * 1000`
- `ui.scroll_area` `duration` — seconds, `1000 * duration`
- `ui.page_scroller` `duration` — seconds, `* 1000`
- `ui.sortable` `animation` — seconds, `* 1000`

The diff is a single line: `animation_speed` → `animation_speed * 1000` when forwarding to the prop. The default (`1.5`) and the docstring (*"in seconds"*) are unchanged, so **the public API is untouched and this is a pure bugfix** — the docs were always right, the code just wasn't doing what they said.

| Caller | Before (buggy) | This PR (seconds) |
|---|---|---|
| default `1.5` | 1.5 s ✓ | 1.5 s ✓ |
| `2.0` (trusted the "seconds" docstring) | 2 ms ✗ | **2 s ✓** |
| `1500` (worked around the bug) | 1.5 s | 1500 s |

This rewards everyone who followed the documentation and only changes behavior for callers who relied on the undocumented millisecond passthrough.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been updated. (no change needed — the docstring already said "in seconds")
- [x] No breaking changes to the public API or migration steps are described above.

---

*Updated direction after [@falkoschindler's review](https://github.com/zauberzeug/nicegui/pull/6110#pullrequestreview-4497622222): switched from changing the public unit to milliseconds, to keeping seconds and converting internally for consistency with the rest of the library. Branch force-pushed (amended single commit). Earlier revisions of this description referred to the milliseconds approach.*
