### PR TITLE
Fix #5684: serve no-op stub modules to worker subprocesses

### DIFF
--- a/nicegui/__init__.py
+++ b/nicegui/__init__.py
@@ -1,13 +1,38 @@
-from . import binding, elements, html, run, storage, ui
-from .api_router import APIRouter
-from .app.app import App
-from .client import Client
-from .context import context
-from .element_filter import ElementFilter
-from .event import Event
-from .nicegui import app
-from .page_arguments import PageArguments
-from .version import __version__
+import sys
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+from . import _lazy
+
+_LAZY_IMPORTS = {
+    'APIRouter': ('.api_router', 'APIRouter'),
+    'App': ('.app.app', 'App'),
+    'Client': ('.client', 'Client'),
+    'ElementFilter': ('.element_filter', 'ElementFilter'),
+    'Event': ('.event', 'Event'),
+    'PageArguments': ('.page_arguments', 'PageArguments'),
+    '__version__': ('.version', '__version__'),
+    'app': ('.nicegui', 'app'),
+    'binding': ('.binding', ''),
+    'context': ('.context', 'context'),
+    'elements': ('.elements', ''),
+    'html': ('.html', ''),
+    'run': ('.run', ''),
+    'storage': ('.storage', ''),
+    'ui': ('.ui', ''),
+}
+
+if TYPE_CHECKING:
+    from . import binding, elements, html, run, storage, ui
+    from .api_router import APIRouter
+    from .app.app import App
+    from .client import Client
+    from .context import context
+    from .element_filter import ElementFilter
+    from .event import Event
+    from .nicegui import app
+    from .page_arguments import PageArguments
+    from .version import __version__
 
 __all__ = [
     'APIRouter',
@@ -26,3 +51,31 @@ __all__ = [
     'storage',
     'ui',
 ]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def __getattr__(name: str) -> object:
+    return _lazy.resolve(__name__, 'nicegui', _LAZY_IMPORTS, name)
+
+
+class _PackageModule(ModuleType):
+    """Class for the nicegui package module itself.
+
+    The attributes ``app`` and ``context`` collide with the submodules ``nicegui.app`` and ``nicegui.context``:
+    whenever the import machinery loads those submodules, it binds them as package attributes,
+    shadowing the ``App`` and ``Context`` instances which ``__getattr__`` provides.
+    (The eager package init used to win this race by assignment order.)
+    Ignoring module bindings for these two names keeps them resolvable via ``__getattr__``,
+    while non-module assignments (e.g. ``mock.patch``) still work as plain instance attributes.
+    """
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name in {'app', 'context'} and isinstance(value, ModuleType):
+            return  # absorb the import machinery's submodule binding (see class docstring)
+        super().__setattr__(name, value)
+
+
+sys.modules[__name__].__class__ = _PackageModule

--- a/nicegui/__init__.py
+++ b/nicegui/__init__.py
@@ -1,8 +1,15 @@
+import os
 import sys
 from types import ModuleType
 from typing import TYPE_CHECKING
 
 from . import _lazy
+
+if os.environ.get('NICEGUI_WORKER_STUBS') == '1':
+    import multiprocessing  # cheap here: already imported by the spawn bootstrap in any real worker
+    if multiprocessing.current_process().name != 'MainProcess':
+        from . import _worker_stubs
+        _worker_stubs.install()
 
 _LAZY_IMPORTS = {
     'APIRouter': ('.api_router', 'APIRouter'),

--- a/nicegui/_lazy.py
+++ b/nicegui/_lazy.py
@@ -1,0 +1,20 @@
+"""Shared machinery for lazily importing module attributes via a PEP 562 module ``__getattr__``."""
+import importlib
+import sys
+from collections.abc import Mapping
+
+
+def resolve(module_name: str, package: str, lazy_imports: Mapping[str, tuple[str, str | None]], name: str) -> object:
+    """Import the attribute ``name`` as declared in ``lazy_imports`` and cache it on module ``module_name``.
+
+    Each entry in ``lazy_imports`` maps an attribute name to a ``(module path, attribute name)`` tuple,
+    where the module path is resolved relative to ``package``.
+    An empty attribute name yields the module itself.
+    """
+    if name not in lazy_imports:
+        raise AttributeError(f'module {module_name!r} has no attribute {name!r}')
+    module_path, attr_name = lazy_imports[name]
+    module = importlib.import_module(module_path, package=package)
+    value = getattr(module, attr_name) if attr_name else module
+    setattr(sys.modules[module_name], name, value)
+    return value

--- a/nicegui/_worker_stubs.py
+++ b/nicegui/_worker_stubs.py
@@ -1,0 +1,118 @@
+"""Stub modules for worker subprocesses (see https://github.com/zauberzeug/nicegui/issues/5684).
+
+When a NiceGUI app spawns worker subprocesses (``run.cpu_bound``, ``multiprocessing.Pool``, ``Manager()``, ...),
+each worker re-imports the user's main module and thereby the nicegui package.
+Workers don't serve UI, so UI-related modules are replaced with no-op stubs which makes the re-import
+practically free and turns module-level UI code (``ui.label(...)``, ``ui.run(...)``) into harmless no-ops.
+
+Modules listed in ``REAL_MODULES`` are NOT stubbed:
+
+- ``run`` must be real because unpickling a ``run.cpu_bound`` payload imports it in the worker
+- ``native`` must be real because the native-mode window subprocess executes its entry point
+- data-bearing modules (``binding``, ``dataclasses``, ``events``, ``observables``, ...) must be real so that
+  classes derived from them (e.g. via ``@binding.bindable_dataclass``) keep working in workers,
+  including unpickling ``run.cpu_bound`` payloads that reference such classes
+- the set is closed under imports (enforced by ``tests/test_worker_stubs.py``):
+  a real module must never import from a stubbed one, or it would bind no-op values
+
+Known limitations (by design — workers should not consume UI state):
+
+- worker code that READS values from stubbed modules gets ``WHATEVER`` objects: equality comparisons,
+  truthiness and containment are ``False``, iteration is empty — conditions silently take the negative branch
+- operations that are not stubbed (``len()``, ``int()``, ``+`` with a real left operand, format specs)
+  raise loudly, which is preferable to silent corruption
+- ``import nicegui.elements.button``-style submodule imports and ``from nicegui import App``-style lazy
+  attributes of stubbed submodules raise ``ModuleNotFoundError`` in stub mode (``from nicegui import ui`` works)
+- ``nicegui.testing`` is stubbed, which is fine: the pytest plugin loads in pytest's main process, never in workers
+- ``fork``-started children (Linux <= 3.13 default) inherit the parent's real modules, so stubs never engage
+  there — no benefit, but also no cost, since fork does not re-import anything
+"""
+import os
+import pkgutil
+import sys
+from types import ModuleType
+from typing import Literal
+
+REAL_MODULES = {
+    'awaitable_response',
+    'background_tasks',
+    'binding',
+    'context',
+    'core',
+    'dataclasses',
+    'events',
+    'helpers',
+    'json',
+    'logging',
+    'native',
+    'observables',
+    'optional_features',
+    'run',
+    'slot',
+    'version',
+}
+
+
+class Whatever:
+    """A universal no-op object: every operation yields the no-op singleton ``WHATEVER``.
+
+    Truthiness is ``False``, iteration is empty and containment checks are ``False``,
+    so conditions and loops over stub values silently take the empty/negative branch.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass  # accept any arguments so that user classes subclassing a stub (via __mro_entries__) can instantiate
+
+    def __getattr__(self, name: str) -> 'Whatever':
+        return WHATEVER
+
+    def __call__(self, *args, **kwargs) -> 'Whatever':
+        return WHATEVER
+
+    def __mro_entries__(self, *args, **kwargs) -> tuple:  # pylint: disable=unused-argument
+        return (Whatever,)  # so module-level `class X(ui.element)` survives class creation
+
+    def __enter__(self) -> 'Whatever':
+        return WHATEVER  # so module-level `with ui.row():` no-ops (e.g. examples/menu_and_tabs)
+
+    def __exit__(self, *args) -> Literal[False]:
+        return False
+
+    def __getitem__(self, item) -> 'Whatever':
+        return WHATEVER  # e.g. generic subscription like Handler[X] in annotations evaluated at class definition
+
+    def __eq__(self, other: object) -> bool:
+        return False  # two unrelated stub values must not compare equal just because they share the singleton
+
+    __hash__ = object.__hash__  # would be unset by defining __eq__; identity hashing keeps stubs usable as dict keys
+
+    def __bool__(self) -> bool:
+        return False  # so module-level `if app.storage...:` and the like take the negative branch
+
+    def __iter__(self):
+        return iter(())  # without this, `__getitem__` would make the legacy sequence protocol iterate forever
+
+    def __contains__(self, item) -> bool:
+        return False
+
+    def __repr__(self) -> str:
+        return '<nicegui worker stub>'
+
+
+WHATEVER = Whatever()
+
+
+class WhateverModule(ModuleType):
+    """A module whose every attribute is the ``WHATEVER`` no-op object."""
+
+    def __getattr__(self, name: str) -> Whatever:
+        return WHATEVER
+
+
+def install() -> None:
+    """Pre-fill ``sys.modules`` with stubs for all non-essential top-level nicegui modules."""
+    for module_info in pkgutil.iter_modules([os.path.dirname(__file__)]):
+        name = module_info.name
+        if name.startswith('_') or name in REAL_MODULES:
+            continue
+        sys.modules[f'nicegui.{name}'] = WhateverModule(f'nicegui.{name}')

--- a/nicegui/core.py
+++ b/nicegui/core.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import importlib
 import os
 import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from socketio import AsyncServer
-
 from .logging import log
 
 if TYPE_CHECKING:
+    from socketio import AsyncServer
+
     from .air import Air
     from .app import App
     from .client import Client
@@ -23,6 +24,17 @@ air: Air | None = None
 root: Callable | None = None
 script_mode: bool = False
 script_client: Client | None = None
+
+
+def __getattr__(name: str) -> object:
+    if name in {'app', 'sio'}:
+        # lazily build the App and AsyncServer on first access by importing the nicegui module which assigns them
+        module = importlib.import_module('.nicegui', package='nicegui')
+        if name in globals():
+            return globals()[name]
+        # a genuine circular import raises AttributeError with Python's standard "partially initialized" hint
+        return getattr(module, name)
+    raise AttributeError(f"module 'nicegui.core' has no attribute {name!r}")
 
 
 def is_loop_running() -> bool:

--- a/nicegui/helpers/__init__.py
+++ b/nicegui/helpers/__init__.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os
 
 from .elements import require_top_level_layout
@@ -24,6 +25,7 @@ __all__ = [
     'hash_file_path',
     'is_coroutine_function',
     'is_file',
+    'is_main_process',
     'is_port_open',
     'is_pytest',
     'is_user_simulation',
@@ -35,6 +37,11 @@ __all__ = [
     'should_await',
     'warn_once',
 ]
+
+
+def is_main_process() -> bool:
+    """Check if the code is running in the main process (as opposed to a spawned subprocess)."""
+    return multiprocessing.current_process().name == 'MainProcess'
 
 
 def is_pytest() -> bool:

--- a/nicegui/json/__init__.py
+++ b/nicegui/json/__init__.py
@@ -8,14 +8,31 @@ in socketio.AsyncServer, which expects a module as parameter
 to override Python's default json module.
 """
 
+from typing import TYPE_CHECKING
+
+from .. import _lazy
+
 try:
-    from .orjson_wrapper import NiceGUIJSONResponse, dumps, loads
+    from .orjson_wrapper import dumps, loads, render
 except ImportError:
-    from .builtin_wrapper import NiceGUIJSONResponse, dumps, loads  # type: ignore
+    from .builtin_wrapper import dumps, loads, render  # type: ignore
+
+# deferred so that `import nicegui.json` does not pull in FastAPI
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    'NiceGUIJSONResponse': ('.response', 'NiceGUIJSONResponse'),
+}
+
+if TYPE_CHECKING:
+    from .response import NiceGUIJSONResponse
 
 
 __all__ = [
     'NiceGUIJSONResponse',
     'dumps',
     'loads',
+    'render',
 ]
+
+
+def __getattr__(name: str) -> object:
+    return _lazy.resolve(__name__, __name__, _LAZY_IMPORTS, name)

--- a/nicegui/json/builtin_wrapper.py
+++ b/nicegui/json/builtin_wrapper.py
@@ -3,8 +3,6 @@ import json
 from datetime import date, datetime
 from typing import Any
 
-from fastapi.responses import JSONResponse
-
 try:
     HAS_NUMPY = importlib.util.find_spec('numpy') is not None
 except (ModuleNotFoundError, ValueError):
@@ -39,11 +37,12 @@ def loads(value: str) -> Any:
     return json.loads(value)
 
 
-class NiceGUIJSONResponse(JSONResponse):
-    """FastAPI response class to support our custom json serializer implementation."""
+def render(obj: Any) -> bytes:
+    """Serialize a Python object directly to JSON-encoded bytes.
 
-    def render(self, content: Any) -> bytes:
-        return dumps(content).encode('utf-8')
+    Uses Python's default json module internally.
+    """
+    return dumps(obj).encode('utf-8')
 
 
 class NumpyJsonEncoder(json.JSONEncoder):

--- a/nicegui/json/orjson_wrapper.py
+++ b/nicegui/json/orjson_wrapper.py
@@ -4,7 +4,6 @@ from typing import Any
 
 # pylint: disable=no-member
 import orjson
-from fastapi.responses import JSONResponse
 
 try:
     HAS_NUMPY = importlib.util.find_spec('numpy') is not None
@@ -51,6 +50,14 @@ def loads(value: str) -> Any:
     return orjson.loads(value)
 
 
+def render(obj: Any) -> bytes:
+    """Serialize a Python object directly to JSON-encoded bytes.
+
+    Uses package `orjson` internally.
+    """
+    return orjson.dumps(obj, option=ORJSON_OPTS, default=_orjson_converter)
+
+
 def _orjson_converter(obj):
     """Custom serializer/converter, e.g. for NumPy object arrays."""
     if HAS_NUMPY:
@@ -60,13 +67,3 @@ def _orjson_converter(obj):
     if isinstance(obj, Decimal):
         return float(obj)
     raise TypeError(f'Object of type {obj.__class__.__name__} is not JSON serializable')
-
-
-class NiceGUIJSONResponse(JSONResponse):
-    """FastAPI response class to support our custom json serializer implementation.
-
-    Uses package `orjson` internally.
-    """
-
-    def render(self, content: Any) -> bytes:
-        return orjson.dumps(content, option=ORJSON_OPTS, default=_orjson_converter)

--- a/nicegui/json/response.py
+++ b/nicegui/json/response.py
@@ -1,0 +1,12 @@
+from typing import Any
+
+from fastapi.responses import JSONResponse
+
+from . import render as _render
+
+
+class NiceGUIJSONResponse(JSONResponse):
+    """FastAPI response class to support our custom json serializer implementation."""
+
+    def render(self, content: Any) -> bytes:
+        return _render(content)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -1,7 +1,6 @@
 import asyncio
 import inspect
 import mimetypes
-import multiprocessing
 import sys
 import urllib.parse
 from contextlib import asynccontextmanager
@@ -123,7 +122,7 @@ async def _startup() -> None:
     if not app.config.has_run_config:
         argv0 = Path(sys.argv[0]) if sys.argv else Path()
         is_dash_m_package = argv0.name == '__main__.py' and (argv0.parent / '__init__.py').is_file()
-        if multiprocessing.current_process().name != 'MainProcess' and is_dash_m_package:
+        if not helpers.is_main_process() and is_dash_m_package:
             raise RuntimeError('\n\nAuto-reload is not supported when running a package with `python -m`.\n'
                                'Pass `reload=False` to ui.run() to start the server.')
         raise RuntimeError('\n\n'

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -1,9 +1,10 @@
 import builtins
 import importlib
 import importlib.util
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from . import _lazy
 
 _LAZY_IMPORTS = {
     'context': ('.context', 'context'),
@@ -437,13 +438,7 @@ def __dir__() -> builtins.list[str]:
 
 
 def __getattr__(name: str) -> object:
-    if name not in _LAZY_IMPORTS:
-        raise AttributeError(f"module 'nicegui.ui' has no attribute {name!r}")
-    module_path, attr_name = _LAZY_IMPORTS[name]
-    module = importlib.import_module(module_path, package='nicegui')
-    value = getattr(module, attr_name) if attr_name else module
-    setattr(sys.modules[__name__], name, value)
-    return value
+    return _lazy.resolve(__name__, 'nicegui', _LAZY_IMPORTS, name)
 
 
 # Eagerly import element packages with 'dist' dirs so their __init__.py registers ESM modules in the importmap.

--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import os
 import runpy
 import sys
@@ -218,7 +217,10 @@ def run(root: Callable | None = None, *,
     if on_air:
         core.air = Air('' if on_air is True else on_air)
 
-    if multiprocessing.current_process().name != 'MainProcess':
+    if not helpers.is_main_process():
+        # this is the reload server child (or a worker re-running user code): mark the environment so that
+        # subprocesses spawned from here on get worker stubs (see _worker_stubs.py and #5684)
+        os.environ['NICEGUI_WORKER_STUBS'] = '1'
         return
 
     is_repl = bool(getattr(sys, 'ps1', sys.flags.interactive))
@@ -267,6 +269,13 @@ def run(root: Callable | None = None, *,
     os.environ['NICEGUI_PORT'] = str(port)
     os.environ['NICEGUI_PROTOCOL'] = protocol
 
+    # While the server is running, child processes (cpu_bound workers, user-created processes, ...) are workers
+    # which should import nicegui as cheap no-op stubs (see _worker_stubs.py and #5684). The native webview window
+    # child is spawned above WITHOUT this marker because it needs the real package (it reads core.app.native.*),
+    # the marker is removed again below before the reload supervisor spawns the server child for the same reason,
+    # and it is popped once the server has stopped so that its purpose ends with the server (e.g. between tests).
+    os.environ['NICEGUI_WORKER_STUBS'] = '1'
+
     if show:
         helpers.schedule_browser(protocol, host, port, show if isinstance(show, str) else '/')
 
@@ -302,13 +311,18 @@ def run(root: Callable | None = None, *,
         sys.exit(1)
 
     if config.should_reload:
+        os.environ.pop('NICEGUI_WORKER_STUBS', None)  # the spawned server child needs the real nicegui package
         sock = config.bind_socket()
         ChangeReload(config, target=Server.instance.run, sockets=[sock]).run()
     elif config.workers > 1:
+        os.environ.pop('NICEGUI_WORKER_STUBS', None)  # spawned server workers need the real nicegui package
         sock = config.bind_socket()
         Multiprocess(config, target=Server.instance.run, sockets=[sock]).run()
     else:
-        Server.instance.run()
+        try:
+            Server.instance.run()
+        finally:
+            os.environ.pop('NICEGUI_WORKER_STUBS', None)  # the marker's purpose ends with the server
     if config.uds:
         os.remove(config.uds)  # pragma: py-win32
 

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,13 +1,71 @@
 import subprocess
+import sys
 from textwrap import dedent
 
 import pytest
 
+import nicegui
 from nicegui import ui
 
 
 def test_lazy_imports_match_all():
     assert set(ui._LAZY_IMPORTS) == set(ui.__all__)  # pylint: disable=protected-access
+
+
+def test_package_lazy_imports_match_all():
+    assert set(nicegui._LAZY_IMPORTS) == set(nicegui.__all__)  # pylint: disable=protected-access
+
+
+def test_package_all_names_resolve():
+    for name in nicegui.__all__:
+        obj = getattr(nicegui, name)
+        assert obj is not None, f'nicegui.{name} should not be None'
+
+
+def test_package_app_is_the_app_instance():
+    from nicegui.app.app import App
+    assert isinstance(nicegui.app, App), 'nicegui.app must be the App instance, not the nicegui.app subpackage'
+
+
+def test_package_app_and_context_can_be_monkeypatched():
+    from unittest import mock
+    original = nicegui.app
+    with mock.patch.object(nicegui, 'app') as fake:
+        assert nicegui.app is fake
+    assert nicegui.app is original
+
+
+def test_lazy_objects_win_over_submodule_shadowing():
+    result = subprocess.run([sys.executable, '-c', dedent('''\
+        import nicegui.context  # import submodules FIRST so the import machinery sets the package attributes...
+        import nicegui.nicegui
+        from nicegui import app, context  # ...which must NOT shadow the actual objects
+        assert type(context).__name__ == 'Context', f'expected Context instance, got {type(context)}'
+        assert type(app).__name__ == 'App', f'expected App instance, got {type(app)}'
+    ''')], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_package_import_does_not_import_web_framework():
+    result = subprocess.run([sys.executable, '-c', dedent('''\
+        import sys
+        import nicegui
+        heavy = {'fastapi', 'starlette', 'socketio', 'engineio', 'uvicorn', 'matplotlib', 'httpx'}
+        loaded = heavy & set(sys.modules)
+        sys.exit(f'unexpectedly imported: {loaded}' if loaded else 0)
+    ''')], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_ui_import_does_not_import_web_framework():
+    result = subprocess.run([sys.executable, '-c', dedent('''\
+        import sys
+        from nicegui import ui
+        heavy = {'fastapi', 'starlette', 'socketio', 'engineio', 'uvicorn', 'matplotlib', 'httpx'}
+        loaded = heavy & set(sys.modules)
+        sys.exit(f'unexpectedly imported: {loaded}' if loaded else 0)
+    ''')], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_all_names_resolve():

--- a/tests/test_worker_stubs.py
+++ b/tests/test_worker_stubs.py
@@ -1,0 +1,177 @@
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+EXAMPLES = Path(__file__).resolve().parent.parent / 'examples'
+
+WORKER_CODE = dedent('''\
+    import os, sys
+    os.environ['NICEGUI_WORKER_STUBS'] = '1'
+    import multiprocessing as mp
+
+    def child(queue):
+        import nicegui
+        from nicegui import ui, app
+        from nicegui import run, core  # what unpickling a cpu_bound payload triggers; must be the REAL modules
+        label = ui.label('hello')          # must be a no-op
+        with ui.row():                     # context manager must work
+            ui.button('x')
+        ui.run()                           # must be a no-op
+        queue.put({
+            'ui_is_stub': type(sys.modules['nicegui.ui']).__name__ == 'WhateverModule',
+            'run_is_real': type(sys.modules['nicegui.run']).__name__ != 'WhateverModule',
+            'cpu_bound_callable': callable(run.cpu_bound) and run.cpu_bound.__name__ == 'cpu_bound',
+            'fastapi_loaded': 'fastapi' in sys.modules,
+            'stub_is_falsy': not label,
+            'stub_iterates_empty': list(label) == [],
+            'stub_contains_nothing': 'key' not in label,
+            'stubs_never_equal': not (label == ui.button('y')),  # unrelated stub values share one singleton
+            'stub_hashable': isinstance(hash(label), int),  # so stub values can be dict keys
+            'is_stopping_is_falsy': not core.app.is_stopping,  # so run.io_bound works in workers
+        })
+
+    if __name__ == '__main__':
+        ctx = mp.get_context('spawn')
+        q = ctx.Queue()
+        p = ctx.Process(target=child, args=(q,))
+        p.start()
+        result = q.get(timeout=30)
+        p.join()
+        print(result)
+        assert result['ui_is_stub'], 'ui must be stubbed in worker'
+        assert result['run_is_real'], 'run must be the real module in worker'
+        assert result['cpu_bound_callable'], 'run.cpu_bound must be the real function in worker'
+        assert not result['fastapi_loaded'], 'fastapi must not load in worker'
+        assert result['stub_is_falsy'], 'stub values must be falsy'
+        assert result['stub_iterates_empty'], 'stub values must iterate empty'
+        assert result['stub_contains_nothing'], 'stub containment checks must be False'
+        assert result['stubs_never_equal'], 'stub values must not compare equal to each other'
+        assert result['stub_hashable'], 'stub values must remain hashable'
+        assert result['is_stopping_is_falsy'], 'core.app.is_stopping must be falsy in stub mode'
+''')
+
+
+def test_worker_gets_stubs(tmp_path):
+    script = tmp_path / 'worker_app.py'
+    script.write_text(WORKER_CODE)
+    result = subprocess.run([sys.executable, str(script)], capture_output=True, text=True, timeout=60, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+# The goal function (#5684): when an official example spawns a worker, re-importing the example module must NOT
+# pull in the web framework. 'progress' defines its UI inside @ui.page; 'menu_and_tabs' defines it at module level
+# with `with ui.x():` blocks — between them they cover both idiomatic shapes, each ending in a bare ui.run().
+@pytest.mark.parametrize('example', ['progress', 'menu_and_tabs'])
+def test_official_example_worker_reimport_is_framework_free(example, tmp_path):
+    example_main = EXAMPLES / example / 'main.py'
+    assert example_main.is_file(), f'missing example: {example_main}'
+    driver = tmp_path / 'driver.py'
+    driver.write_text(dedent(f'''\
+        import contextlib, os, sys, runpy, multiprocessing as mp
+        os.environ['NICEGUI_WORKER_STUBS'] = '1'
+
+        def worker(q):
+            with contextlib.suppress(SystemExit):
+                runpy.run_path({str(example_main)!r}, run_name='__mp_main__')  # what mp.spawn does to the user's main
+            q.put({{'fastapi': 'fastapi' in sys.modules,
+                    'ui_is_stub': type(sys.modules.get('nicegui.ui')).__name__ == 'WhateverModule'}})
+
+        if __name__ == '__main__':
+            ctx = mp.get_context('spawn')
+            q = ctx.Queue()
+            p = ctx.Process(target=worker, args=(q,))
+            p.start(); print(q.get(timeout=60)); p.join()
+    '''))
+    result = subprocess.run([sys.executable, str(driver)], capture_output=True, text=True, timeout=90, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+    out = eval(result.stdout.strip().splitlines()[-1])  # pylint: disable=eval-used
+    assert out['ui_is_stub'], f'{example}: ui must be stubbed in the worker'
+    assert not out['fastapi'], f'{example}: re-importing the example in a worker must not import fastapi'
+
+
+def test_bindable_dataclass_survives_worker_roundtrip(tmp_path):
+    # Regression test for stub mode breaking pickling contracts: a class built from a data-bearing module
+    # (here `binding`) must stay real in the worker, so that resolving the pickled class reference against
+    # the re-imported main module yields the actual class instead of a stub.
+    script = tmp_path / 'bindable_app.py'
+    script.write_text(dedent('''\
+        import multiprocessing as mp
+        import os
+        os.environ['NICEGUI_WORKER_STUBS'] = '1'
+        from nicegui import binding
+
+        @binding.bindable_dataclass
+        class Point:
+            x: int = 0
+            y: int = 0
+
+        def child(queue, point_cls):
+            queue.put((isinstance(point_cls, type), point_cls(x=1, y=2).x))
+
+        if __name__ == '__main__':
+            ctx = mp.get_context('spawn')
+            q = ctx.Queue()
+            p = ctx.Process(target=child, args=(q, Point))
+            p.start()
+            assert q.get(timeout=30) == (True, 1)
+            p.join()
+    '''))
+    result = subprocess.run([sys.executable, str(script)], capture_output=True, text=True, timeout=60, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_real_modules_are_closed_under_imports():
+    # A module in REAL_MODULES must never (transitively) import a stubbed module,
+    # or it would bind no-op values instead of the classes and functions it expects.
+    code = dedent('''\
+        import importlib, sys
+        from nicegui._worker_stubs import REAL_MODULES
+        importlib.import_module('nicegui.run')  # import the heaviest real module first to dodge import-order cycles
+        for name in sorted(REAL_MODULES):
+            importlib.import_module(f'nicegui.{name}')
+        loaded = {m.split('.')[1] for m in sys.modules if m.startswith('nicegui.')}
+        extras = {m for m in loaded if not m.startswith('_')} - REAL_MODULES
+        assert not extras, f'real modules transitively import modules which would be stubbed: {sorted(extras)}'
+    ''')
+    result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_fresh_main_process_never_stubbed():
+    code = dedent('''\
+        import os, sys
+        os.environ['NICEGUI_WORKER_STUBS'] = '1'  # even with the marker present...
+        import nicegui                              # ...a fresh MainProcess must get the real package
+        from nicegui import ui
+        assert type(sys.modules['nicegui.ui']).__name__ != 'WhateverModule'
+        assert ui.label.__name__ == 'Label'
+    ''')
+    result = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_marker_not_set_means_real_import_in_child(tmp_path):
+    script = tmp_path / 'no_marker_app.py'
+    script.write_text(dedent('''\
+        import multiprocessing as mp
+        import os
+        import sys
+        os.environ.pop('NICEGUI_WORKER_STUBS', None)  # the surrounding pytest process may have it set
+
+        def child(queue):
+            import nicegui
+            queue.put(type(sys.modules.get('nicegui.ui', None)).__name__ if 'nicegui.ui' in sys.modules else 'unloaded')
+
+        if __name__ == '__main__':
+            ctx = mp.get_context('spawn')
+            q = ctx.Queue()
+            p = ctx.Process(target=child, args=(q,))
+            p.start()
+            assert q.get(timeout=30) != 'WhateverModule'
+            p.join()
+    '''))
+    result = subprocess.run([sys.executable, str(script)], capture_output=True, text=True, timeout=60, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
*Drafted with Claude Code (assisting @evnchn). Reworked 2026-07-06 per the review — this PR is now the **stubs-only** half; the lazy-package-import enabler was split out per the direction-check answer and is staged at evnchn#195 before going upstream separately. The first commit here is that enabler and will drop out once it lands.*

### Motivation

Follow-up to #5684 and the merged #5303: every spawned worker subprocess (`run.cpu_bound`, `multiprocessing.Pool`, `Manager()`) re-imports the user's main module and re-pays the NiceGUI import. With lazy imports alone this is still ~300–500 ms per worker for the official examples, because a trailing `ui.run()` or module-level UI re-materializes the app.

### Implementation

While the server is running, `ui.run()` marks the environment (`NICEGUI_WORKER_STUBS=1`); spawn workers then pre-fill `sys.modules` with no-op stubs for UI modules, making the re-import practically free: `examples/progress` worker re-import 495 → ~25 ms, `menu_and_tabs` 328 → ~4.5 ms — matching loky-style pool reuse (#5574) with zero new dependencies.

Failure semantics per the review of the first draft (details in the review reply below):

- **data-bearing modules stay real in workers** (`binding`, `observables`, `events`, `dataclasses`, `awaitable_response` + transitive closure) — classes built from them keep working and pickled references resolve to actual classes; closure is enforced by a test (findings 3, 5)
- **the `Whatever` no-op is falsy, iterates empty, contains nothing, and never compares equal** (`__bool__`/`__iter__`/`__contains__`/`__eq__` defined; without `__iter__` the legacy sequence protocol iterated forever); unsupported operations still raise loudly (findings 1, 2)
- **the marker is scoped to the server's lifetime** (set at server start, popped in a `try/finally` at stop); the pytest carve-out is gone, so stub behavior is testable under the `Screen` fixture (finding 4 — see the reply for why the pool-initializer variant can't work for spawn)

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [ ] The implementation is complete. (Draft until the split-out enabler lands and this rebases onto it.)
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation has been added/updated (module docstring documents worker semantics and known limitations).
- [x] No breaking changes to the public API. (Behavior note: in stub workers, `from nicegui import App`-style access to stubbed submodules now raises `ModuleNotFoundError` loudly instead of hanging.)
