### PR TITLE
Fix ui.select(with_input) dropping its html_id (breaks tooltips)

### DIFF
--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -79,6 +79,7 @@ class Select(LabelElement, ValidationElement[Any], ChoiceElement, DisableableEle
             self._props.set_bool('hide-selected', not multiple)
             self._props['fill-input'] = True
             self._props['input-debounce'] = 0
+            self._props['for'] = self.html_id  # keep html_id on the input so tooltips/ui.query can anchor (#6114)
         self._props.set_bool('multiple', multiple)
         self._props.set_bool('clearable', clearable)
 

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -471,6 +471,7 @@ def test_even_special_elements_have_an_html_id(screen: Screen):
             ui.time_input(),
             ui.color_input(),
             ui.select([]),
+            ui.select([], with_input=True),  # #6114: with_input select dropped its html_id
             ui.input_chips(),
             ui.toggle([]),
             ui.radio([]),

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -326,18 +326,3 @@ def test_popup_scroll_behavior(screen: Screen):
     screen.type(Keys.ESCAPE)
     screen.wait(0.2)
     assert screen.selenium.execute_script('return window.scrollY') == position
-
-
-def test_with_input_select_exposes_html_id(screen: Screen):
-    """A `with_input` select must keep its html_id on a DOM element so tooltips and ui.query can anchor to it (#6114)."""
-    box = {}
-
-    @ui.page('/')
-    def page():
-        select = ui.select(['A', 'B', 'C'], with_input=True).tooltip('hello')
-        box['html_id'] = select.html_id
-
-    screen.open('/')
-    screen.wait(0.5)
-    found = screen.selenium.execute_script('return !!document.getElementById(arguments[0]);', box['html_id'])
-    assert found, f'with_input select html_id {box["html_id"]!r} is missing from the DOM (#6114)'

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -326,3 +326,18 @@ def test_popup_scroll_behavior(screen: Screen):
     screen.type(Keys.ESCAPE)
     screen.wait(0.2)
     assert screen.selenium.execute_script('return window.scrollY') == position
+
+
+def test_with_input_select_exposes_html_id(screen: Screen):
+    """A `with_input` select must keep its html_id on a DOM element so tooltips and ui.query can anchor to it (#6114)."""
+    box = {}
+
+    @ui.page('/')
+    def page():
+        select = ui.select(['A', 'B', 'C'], with_input=True).tooltip('hello')
+        box['html_id'] = select.html_id
+
+    screen.open('/')
+    screen.wait(0.5)
+    found = screen.selenium.execute_script('return !!document.getElementById(arguments[0]);', box['html_id'])
+    assert found, f'with_input select html_id {box["html_id"]!r} is missing from the DOM (#6114)'


### PR DESCRIPTION
*Posted by Claude Code on @evnchn's behalf.*

### Motivation

Fixes #6114.

`ui.select(with_input=True)` doesn't show a tooltip added via `.tooltip()`. The browser console shows `Anchor: target "#cN" not found`, and `ui.query(f'#{select.html_id}')` can't target the element either.

**Root cause:** `.tooltip()` anchors its `QTooltip` with `target="#{html_id}"`, relying on the element's `id` landing on a DOM node. In `use-input` mode, Quasar's `QSelect` assigns the inner `<input>` a generated id (its `targetUid`, e.g. `f_<uuid>`), which displaces NiceGUI's fall-through `id`. As a result no DOM element carries `cN`, so the tooltip anchor (and `ui.query('#...')`) resolve to nothing.

Verified against the rendered DOM: a plain `ui.select` keeps its id on the persistent `q-field__native` div, and `ui.input` / `ui.number` / `ui.textarea` are unaffected — **only `with_input` selects** drop the id.

### Implementation

Set Quasar's `for` prop to the element's `html_id` in the `with_input` branch. `for` is Quasar's documented way to set the inner control's id, so the input's id becomes `html_id` again and the anchor target exists:

```python
self._props['for'] = self.html_id
```

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added (`test_with_input_select_exposes_html_id`, a `Screen` test asserting the html_id is present in the DOM).
- [x] Documentation has been added/updated or is not necessary. (bug fix — no doc change)
- [x] No breaking changes to the public API or migration steps are described above.

---

Thanks to @rolfn for the clear report and to @python-and-novella for pinpointing the lost id and the `for`-prop workaround this builds on.
