### PR TITLE
Fix interactive_image coordinates when stream changes resolution

### DIFF
--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -106,8 +106,8 @@ export default {
       }
     },
     refreshImageDimensions() {
-      // Sync cached dimensions with the live <img> in case the source changed size without firing "load"
-      // (e.g. a multipart/x-mixed-replace stream switching resolution); see #6122.
+      // Re-sync cached dimensions with the live <img> when the stream changed size without firing "load" (#6122).
+      // No event fires for an in-place naturalWidth change, so this only catches up on the next interaction.
       const img = this.$refs.img;
       if (
         this.src &&
@@ -118,7 +118,7 @@ export default {
         this.loaded_image_width = img.naturalWidth;
         this.loaded_image_height = img.naturalHeight;
         this.updateViewbox(this.loaded_image_width, this.loaded_image_height);
-        this.$emit("loaded", { width: this.loaded_image_width, height: this.loaded_image_height, source: img.currentSrc });
+        this.$emit("loaded", { width: this.loaded_image_width, height: this.loaded_image_height, source: img.src });
       }
     },
     updateCrossHair(e) {

--- a/nicegui/elements/interactive_image.js
+++ b/nicegui/elements/interactive_image.js
@@ -105,7 +105,24 @@ export default {
         this.updateViewbox(this.size[0], this.size[1]);
       }
     },
+    refreshImageDimensions() {
+      // Sync cached dimensions with the live <img> in case the source changed size without firing "load"
+      // (e.g. a multipart/x-mixed-replace stream switching resolution); see #6122.
+      const img = this.$refs.img;
+      if (
+        this.src &&
+        img.naturalWidth &&
+        img.naturalHeight &&
+        (img.naturalWidth !== this.loaded_image_width || img.naturalHeight !== this.loaded_image_height)
+      ) {
+        this.loaded_image_width = img.naturalWidth;
+        this.loaded_image_height = img.naturalHeight;
+        this.updateViewbox(this.loaded_image_width, this.loaded_image_height);
+        this.$emit("loaded", { width: this.loaded_image_width, height: this.loaded_image_height, source: img.currentSrc });
+      }
+    },
     updateCrossHair(e) {
+      this.refreshImageDimensions();
       const width = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
       const height = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
       this.x = (e.offsetX * width) / e.target.clientWidth;
@@ -118,6 +135,7 @@ export default {
       this.$emit("loaded", { width: this.loaded_image_width, height: this.loaded_image_height, source: e.target.src });
     },
     onMouseEvent(type, e) {
+      this.refreshImageDimensions();
       const imageWidth = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
       const imageHeight = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
       this.$emit("mouse", {
@@ -133,6 +151,7 @@ export default {
       });
     },
     onPointerEvent(type, e) {
+      this.refreshImageDimensions();
       const imageWidth = this.src ? this.loaded_image_width : this.size ? this.size[0] : 1;
       const imageHeight = this.src ? this.loaded_image_height : this.size ? this.size[1] : 1;
       this.$emit(`svg:${type}`, {

--- a/tests/test_interactive_image.py
+++ b/tests/test_interactive_image.py
@@ -133,7 +133,8 @@ def test_resync_on_stream_resolution_change(screen: Screen):
         buffer = io.BytesIO()
         Image.new('RGB', (width, height)).save(buffer, format='JPEG')
         data = buffer.getvalue()
-        # pad to force instant paint
+        # Browsers won't paint a multipart frame until enough bytes have arrived, so a tiny JPEG can stall.
+        # Bulk it up by inserting a JPEG comment segment (0xFFFE marker + 2-byte length) padded with spaces after the SOI marker.
         return data[:2] + b'\xff\xfe' + struct.pack('>H', 40_002) + b' ' * 40_000 + data[2:]
 
     frame = {'data': jpeg(300, 200)}

--- a/tests/test_interactive_image.py
+++ b/tests/test_interactive_image.py
@@ -121,6 +121,56 @@ def test_add_layer(screen: Screen):
         assert len(screen.find_all_by_tag('circle')) == 1
 
 
+def test_resync_on_stream_resolution_change(screen: Screen):
+    """https://github.com/zauberzeug/nicegui/issues/6122"""
+    import asyncio
+    import io
+    import struct
+    from collections.abc import AsyncGenerator
+
+    from fastapi.responses import StreamingResponse
+    from PIL import Image
+
+    def jpeg(width: int, height: int) -> bytes:
+        buffer = io.BytesIO()
+        Image.new('RGB', (width, height)).save(buffer, format='JPEG')
+        data = buffer.getvalue()
+        # pad to force instant paint
+        return data[:2] + b'\xff\xfe' + struct.pack('>H', 40_002) + b' ' * 40_000 + data[2:]
+
+    frame = {'data': jpeg(300, 200)}
+    clicks = []
+
+    async def generate() -> AsyncGenerator[bytes, None]:
+        for _ in range(600):
+            yield b'--frame\r\nContent-Type: image/jpeg\r\n\r\n' + frame['data'] + b'\r\n'
+            await asyncio.sleep(0.05)
+
+    @app.get('/stream')
+    def stream():
+        return StreamingResponse(generate(), media_type='multipart/x-mixed-replace; boundary=frame')
+
+    @ui.page('/')
+    def page():
+        ui.interactive_image('/stream', events=['mousedown'], on_mouse=lambda e: clicks.append((e.image_x, e.image_y)))
+        ui.button('Change', on_click=lambda: frame.update(data=jpeg(600, 400)))
+
+    screen.open('/')
+
+    def click_when_width(width: int):
+        for _ in range(100):
+            if screen.selenium.execute_script('return document.querySelector("img").naturalWidth') == width:
+                break
+            screen.wait(0.1)
+        ActionChains(screen.selenium).move_to_element(screen.find_by_tag('img')).click().perform()
+        screen.wait(0.5)
+        return clicks[-1]
+
+    assert click_when_width(300) == pytest.approx((150, 100), abs=2)
+    screen.click('Change')  # the <img> resolution changes in place, without firing a new "load" event
+    assert click_when_width(600) == pytest.approx((300, 200), abs=2)
+
+
 def test_xss_sanitization(screen: Screen):
     @ui.page('/')
     def page():

--- a/tests/test_interactive_image.py
+++ b/tests/test_interactive_image.py
@@ -1,6 +1,12 @@
+import asyncio
+import io
+import struct
+from collections.abc import AsyncGenerator
 from pathlib import Path
 
 import pytest
+from fastapi.responses import StreamingResponse
+from PIL import Image
 from selenium.webdriver.common.action_chains import ActionChains
 
 from nicegui import app, ui
@@ -123,14 +129,6 @@ def test_add_layer(screen: Screen):
 
 def test_resync_on_stream_resolution_change(screen: Screen):
     """https://github.com/zauberzeug/nicegui/issues/6122"""
-    import asyncio
-    import io
-    import struct
-    from collections.abc import AsyncGenerator
-
-    from fastapi.responses import StreamingResponse
-    from PIL import Image
-
     def jpeg(width: int, height: int) -> bytes:
         buffer = io.BytesIO()
         Image.new('RGB', (width, height)).save(buffer, format='JPEG')


### PR DESCRIPTION
### Motivation

Fixes #6122. When an `interactive_image` shows a `multipart/x-mixed-replace` stream (e.g. an MJPEG decoder) and the streamed resolution changes — the reported pattern: a fixed-size placeholder later replaced by the real, differently-sized stream — mouse/pointer coordinates and the SVG overlay keep using the *old* dimensions until a full page reload.

Root cause: the component caches image dimensions only from the `<img>` `load` event. A multipart stream swaps frames in place — `naturalWidth`/`naturalHeight` change but `load` never re-fires — so `loaded_image_width`/`loaded_image_height`, the SVG `viewBox`, and the `loaded` event stay frozen at the first-seen size.

### Implementation

Add `refreshImageDimensions()`, which reads the live `naturalWidth`/`naturalHeight` at event time and, **only when they differ** from the cache, resyncs the cache + `viewBox` and emits `loaded`. It is called at the top of `onMouseEvent`, `onPointerEvent`, and `updateCrossHair`.

- Guarded by change-detection → it is a no-op (and emits nothing) on the normal `load` path, so no duplicate `loaded` events.
- Only the `src`-present branch is touched; the `size`-only (sourceless canvas) mode is unchanged.
- Emitting `loaded` on a real size change keeps `add_layer()` layers and server-side `on('loaded')` handlers consistent too.

The resync is **event-time only**: there is no event for an in-place `naturalWidth` change (and `ResizeObserver` watches the rendered box, not natural size), so `viewBox`/`aspectRatio`/`loaded` catch up on the next pointer/mouse interaction. Coordinates — the reported bug — are always correct because they are computed at event time.

`test_resync_on_stream_resolution_change` serves a padded multipart MJPEG, swaps its resolution in place, and asserts the click coordinates follow the new size (fails on `main`, passes with the fix).

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
