### PR TITLE
Harden against X-Forwarded-Prefix reflection and clarify security docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,14 +14,27 @@ This way you will benefit from the latest features, bug fixes, and **security fi
 ## Commonly Misreported Patterns
 
 Automated scanners and AI-assisted reviews frequently flag the patterns below.
-They are **by design or already bounded**, so please trace the data flow and check them against this list before filing — it keeps the advisory queue focused on real issues.
+They are **by design or already bounded**, so please trace the data flow and check them against this list before filing —
+it keeps the advisory queue focused on real issues.
 
-- **`| safe` in the page template** (`nicegui/templates/index.html`). Jinja auto-escaping is bypassed there intentionally; the values are escaped at the source instead (for example, element data is escaped with a table sized for the `String.raw` script context it lands in). A bare `| safe` is not itself a finding — trace where the value comes from and how it is escaped.
-- **Raw `innerHTML` in `ui.html` / `ui.markdown`** (`nicegui/elements/html.js`, `markdown.js`). The raw assignment is the `else` branch of `sanitize`: the opt-in `sanitize=False` path. The default (`sanitize=True`) sanitizes via DOMPurify. Passing untrusted input with `sanitize=False` is the caller's documented responsibility.
-- **`ui.add_head_html`, `ui.add_body_html`, `ui.run_javascript`, `ui.add_css`.** These inject raw HTML/JS/CSS by design and are documented as never-for-untrusted-input. Using them with unsanitized user data is an application bug, not a framework vulnerability.
-- **`ast.literal_eval` in the docs.** `literal_eval` only parses literals; it is the safe alternative to `eval` that the documentation demonstrates.
+- **`| safe` in the page template** (`nicegui/templates/index.html`).
+  Jinja auto-escaping is bypassed there intentionally; the values are escaped at the source instead
+  (for example, element data is escaped with a table sized for the `String.raw` script context it lands in).
+  A bare `| safe` is not itself a finding — trace where the value comes from and how it is escaped.
+- **Raw `innerHTML` in `ui.html` / `ui.markdown`** (`nicegui/elements/html.js`, `markdown.js`).
+  The raw assignment is the `else` branch of `sanitize`: the opt-in `sanitize=False` path.
+  The default (`sanitize=True`) sanitizes via DOMPurify.
+  Passing untrusted input with `sanitize=False` is the caller's documented responsibility.
+- **`ui.add_head_html`, `ui.add_body_html`, `ui.run_javascript`, `ui.add_css`.**
+  These inject raw HTML/JS/CSS by design and are documented as never-for-untrusted-input.
+  Using them with unsanitized user data is an application bug, not a framework vulnerability.
+- **`ast.literal_eval` in the docs.**
+  `literal_eval` only parses literals; it is the safe alternative to `eval` that the documentation demonstrates.
 
-If instead you have found a way **around** one of these protections — an escaping bypass, or a default `sanitize=True` path that still executes script — that is a real issue and we would very much like to hear about it. Please include a reproduction.
+If instead you have found a way **around** one of these protections —
+an escaping bypass, or a default `sanitize=True` path that still executes script —
+that is a real issue and we would very much like to hear about it.
+Please include a reproduction.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,18 @@ The latest version of NiceGUI is supported.
 You are encouraged to write tests for your application and update your NiceGUI version frequently after ensuring that your tests are passing.
 This way you will benefit from the latest features, bug fixes, and **security fixes**.
 
+## Commonly Misreported Patterns
+
+Automated scanners and AI-assisted reviews frequently flag the patterns below.
+They are **by design or already bounded**, so please trace the data flow and check them against this list before filing — it keeps the advisory queue focused on real issues.
+
+- **`| safe` in the page template** (`nicegui/templates/index.html`). Jinja auto-escaping is bypassed there intentionally; the values are escaped at the source instead (for example, element data is escaped with a table sized for the `String.raw` script context it lands in). A bare `| safe` is not itself a finding — trace where the value comes from and how it is escaped.
+- **Raw `innerHTML` in `ui.html` / `ui.markdown`** (`nicegui/elements/html.js`, `markdown.js`). The raw assignment is the `else` branch of `sanitize`: the opt-in `sanitize=False` path. The default (`sanitize=True`) sanitizes via DOMPurify. Passing untrusted input with `sanitize=False` is the caller's documented responsibility.
+- **`ui.add_head_html`, `ui.add_body_html`, `ui.run_javascript`, `ui.add_css`.** These inject raw HTML/JS/CSS by design and are documented as never-for-untrusted-input. Using them with unsanitized user data is an application bug, not a framework vulnerability.
+- **`ast.literal_eval` in the docs.** `literal_eval` only parses literals; it is the safe alternative to `eval` that the documentation demonstrates.
+
+If instead you have found a way **around** one of these protections — an escaping bypass, or a default `sanitize=True` path that still executes script — that is a real issue and we would very much like to hear about it. Please include a reproduction.
+
 ## Reporting a Vulnerability
 
 If you think you found a vulnerability, and even if you are not sure about it, please report it right away

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -58,10 +58,13 @@ HTML_ESCAPE_TABLE = str.maketrans({
     '$': '&#36;',
 })
 
-# RFC 3986 path-legal characters (sub-delims + ":" "@" "/"), plus "%" to avoid double-encoding an already-encoded
-# prefix. quote() also leaves the unreserved set (A-Za-z0-9-._~) untouched, so encoding with this safe set only
-# touches characters that are illegal in a URL path anyway (e.g. `"` `<` `>` `\` `` ` `` space) — a no-op for any
-# well-formed prefix while neutralizing reflected-header injection.
+# RFC 3986 path-legal characters (sub-delims + ":" "@" "/"), plus "%" so an already-encoded prefix is not
+# double-encoded. A literal "%xx" therefore passes through unchanged, which is safe: no sink URL-decodes the value
+# back into a markup/JS context, so it stays inert. quote() also leaves the unreserved set (A-Za-z0-9-._~) untouched,
+# so this only encodes characters illegal in a URL path anyway (e.g. `"` `<` `>` `\` `` ` `` space) — a no-op for any
+# well-formed ASCII path prefix while neutralizing reflected-header injection. Non-ASCII is the exception: it is
+# always percent-encoded (never reflected raw) but cannot round-trip cleanly, since HTTP headers are latin-1 and the
+# proxy's byte encoding decides the result.
 FORWARDED_PREFIX_SAFE_CHARS = "/:@!$&'()*+,;=%"
 
 HEADWIND_CONTENT = (Path(__file__).parent / 'static' / 'headwind.css').read_text().strip()

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -58,15 +58,6 @@ HTML_ESCAPE_TABLE = str.maketrans({
     '$': '&#36;',
 })
 
-# RFC 3986 path-legal characters (sub-delims + ":" "@" "/"), plus "%" so an already-encoded prefix is not
-# double-encoded. A literal "%xx" therefore passes through unchanged, which is safe: no sink URL-decodes the value
-# back into a markup/JS context, so it stays inert. quote() also leaves the unreserved set (A-Za-z0-9-._~) untouched,
-# so this only encodes characters illegal in a URL path anyway (e.g. `"` `<` `>` `\` `` ` `` space) — a no-op for any
-# well-formed ASCII path prefix while neutralizing reflected-header injection. Non-ASCII is the exception: it is
-# always percent-encoded (never reflected raw) but cannot round-trip cleanly, since HTTP headers are latin-1 and the
-# proxy's byte encoding decides the result.
-FORWARDED_PREFIX_SAFE_CHARS = "/:@!$&'()*+,;=%"
-
 HEADWIND_CONTENT = (Path(__file__).parent / 'static' / 'headwind.css').read_text().strip()
 
 
@@ -199,9 +190,12 @@ class Client:
         self.outbox.updates.clear()
         # Defense in depth: `prefix` is reflected into the page (importmap, <script src>, JS `prefix:`, CSS @import)
         # via `| safe`, and the X-Forwarded-Prefix part is client-controllable on a directly-exposed app or a
-        # pass-through proxy. Percent-encode it so no structural character can break out of any sink; a legitimate
-        # URL-path prefix only contains characters this leaves untouched (see FORWARDED_PREFIX_SAFE_CHARS).
-        prefix = quote(request.headers.get('X-Forwarded-Prefix', ''), safe=FORWARDED_PREFIX_SAFE_CHARS) \
+        # pass-through proxy. Percent-encode it with the RFC 3986 path-legal characters as the safe set (unreserved +
+        # sub-delims + ":" "@" "/", plus "%" so an already-encoded prefix isn't double-encoded): quote() then only
+        # touches characters illegal in a URL path (`"` `<` `>` `\` space, non-ASCII), so nothing can break out of a
+        # sink, yet it's a no-op for any well-formed ASCII prefix. Non-ASCII is always encoded (never raw) but can't
+        # round-trip cleanly, since headers are latin-1.
+        prefix = quote(request.headers.get('X-Forwarded-Prefix', ''), safe="/:@!$&'()*+,;=%") \
             + request.scope.get('root_path', '')
         elements = json.dumps({
             id: element._to_dict() for id, element in self.elements.items()  # pylint: disable=protected-access

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast
+from urllib.parse import quote
 
 from fastapi import Request
 from fastapi.responses import Response
@@ -56,6 +57,12 @@ HTML_ESCAPE_TABLE = str.maketrans({
     '`': '&#96;',
     '$': '&#36;',
 })
+
+# RFC 3986 path-legal characters (sub-delims + ":" "@" "/"), plus "%" to avoid double-encoding an already-encoded
+# prefix. quote() also leaves the unreserved set (A-Za-z0-9-._~) untouched, so encoding with this safe set only
+# touches characters that are illegal in a URL path anyway (e.g. `"` `<` `>` `\` `` ` `` space) — a no-op for any
+# well-formed prefix while neutralizing reflected-header injection.
+FORWARDED_PREFIX_SAFE_CHARS = "/:@!$&'()*+,;=%"
 
 HEADWIND_CONTENT = (Path(__file__).parent / 'static' / 'headwind.css').read_text().strip()
 
@@ -187,7 +194,12 @@ class Client:
                 background=BackgroundTask(self.delete),
             )
         self.outbox.updates.clear()
-        prefix = request.headers.get('X-Forwarded-Prefix', '') + request.scope.get('root_path', '')
+        # Defense in depth: `prefix` is reflected into the page (importmap, <script src>, JS `prefix:`, CSS @import)
+        # via `| safe`, and the X-Forwarded-Prefix part is client-controllable on a directly-exposed app or a
+        # pass-through proxy. Percent-encode it so no structural character can break out of any sink; a legitimate
+        # URL-path prefix only contains characters this leaves untouched (see FORWARDED_PREFIX_SAFE_CHARS).
+        prefix = quote(request.headers.get('X-Forwarded-Prefix', ''), safe=FORWARDED_PREFIX_SAFE_CHARS) \
+            + request.scope.get('root_path', '')
         elements = json.dumps({
             id: element._to_dict() for id, element in self.elements.items()  # pylint: disable=protected-access
         })

--- a/tests/test_forwarded_prefix.py
+++ b/tests/test_forwarded_prefix.py
@@ -9,41 +9,27 @@ async def test_forwarded_prefix_injection_is_neutralized(user: User):
     def page():
         ui.label('Hello')
 
-    payload = '"></script><script>PWNED</script>'
-    response = await user.http_client.get('/', headers={'X-Forwarded-Prefix': payload})
-    assert payload not in response.text, 'X-Forwarded-Prefix must not be reflected raw into the page'
-    assert '<script>PWNED' not in response.text, 'the injected tag must not survive in executable form'
-    assert '%3Cscript%3EPWNED' in response.text, 'dangerous characters should be percent-encoded'
+    response = await user.http_client.get('/', headers={'X-Forwarded-Prefix': '"></script><script>XSS</script>'})
+    assert '<script>XSS' not in response.text, 'the injected tag must not survive in executable form'
+    assert '%3Cscript%3EXSS' in response.text, 'dangerous characters should be percent-encoded'
 
 
-@pytest.mark.parametrize('prefix', [
-    '/app',
-    '/api/v1',
-    '/team-name_2',
-    '/MyApp.v2',
-    '/a+b,c=d&e(f)',  # RFC 3986 path-legal sub-delims must pass through unchanged
+@pytest.mark.parametrize('sent, expected', [
+    # well-formed path prefixes pass through byte-for-byte (incl. RFC 3986 sub-delims)
+    (b'/api/v1', '/api/v1'),
+    (b'/team-name_2.MyApp', '/team-name_2.MyApp'),
+    (b'/a+b,c=d&e(f)', '/a+b,c=d&e(f)'),
+    # non-ASCII can't round-trip cleanly (headers are latin-1, so the proxy's byte encoding decides the result)
+    # but is always percent-encoded, never reflected raw
+    ('/café'.encode(), '/caf%C3%83%C2%A9'),  # codespell:ignore
+    ('/café'.encode('latin-1'), '/caf%C3%A9'),  # codespell:ignore
 ])
-async def test_forwarded_prefix_valid_path_is_unchanged(user: User, prefix: str):
+async def test_forwarded_prefix_is_reflected_in_safe_form(user: User, sent: bytes, expected: str):
     @ui.page('/')
     def page():
         ui.label('Hello')
 
-    response = await user.http_client.get('/', headers={'X-Forwarded-Prefix': prefix})
-    assert f'{prefix}/_nicegui/' in response.text, 'a legitimate URL-path prefix must pass through byte-for-byte'
-
-
-@pytest.mark.parametrize('raw_bytes, expected', [
-    ('/café'.encode(), '/caf%C3%83%C2%A9'),  # UTF-8 proxy: latin-1-decoded first -> mojibake. codespell:ignore
-    ('/café'.encode('latin-1'), '/caf%C3%A9'),  # latin-1 proxy: decodes cleanly. codespell:ignore
-])
-async def test_forwarded_prefix_non_ascii_is_encoded_never_raw(user: User, raw_bytes: bytes, expected: str):
-    """A non-ASCII prefix never round-trips cleanly (HTTP headers are latin-1 by spec, so the byte encoding the
-    proxy uses decides the result) — but it is always percent-encoded and never reflected as raw, executable text.
-    """
-    @ui.page('/')
-    def page():
-        ui.label('Hello')
-
-    response = await user.http_client.get('/', headers={'X-Forwarded-Prefix': raw_bytes})
+    response = await user.http_client.get('/', headers={b'X-Forwarded-Prefix': sent})
     assert f'{expected}/_nicegui/' in response.text
-    assert '/café/_nicegui' not in response.text, 'must never be reflected as raw non-ASCII'
+    if (raw := sent.decode('latin-1')) != expected:
+        assert raw not in response.text, 'a non-passthrough prefix must never appear raw in any sink'

--- a/tests/test_forwarded_prefix.py
+++ b/tests/test_forwarded_prefix.py
@@ -1,0 +1,49 @@
+import pytest
+
+from nicegui import ui
+from nicegui.testing import User
+
+
+async def test_forwarded_prefix_injection_is_neutralized(user: User):
+    @ui.page('/')
+    def page():
+        ui.label('Hello')
+
+    payload = '"></script><script>PWNED</script>'
+    response = await user.http_client.get('/', headers={'X-Forwarded-Prefix': payload})
+    assert payload not in response.text, 'X-Forwarded-Prefix must not be reflected raw into the page'
+    assert '<script>PWNED' not in response.text, 'the injected tag must not survive in executable form'
+    assert '%3Cscript%3EPWNED' in response.text, 'dangerous characters should be percent-encoded'
+
+
+@pytest.mark.parametrize('prefix', [
+    '/app',
+    '/api/v1',
+    '/team-name_2',
+    '/MyApp.v2',
+    '/a+b,c=d&e(f)',  # RFC 3986 path-legal sub-delims must pass through unchanged
+])
+async def test_forwarded_prefix_valid_path_is_unchanged(user: User, prefix: str):
+    @ui.page('/')
+    def page():
+        ui.label('Hello')
+
+    response = await user.http_client.get('/', headers={'X-Forwarded-Prefix': prefix})
+    assert f'{prefix}/_nicegui/' in response.text, 'a legitimate URL-path prefix must pass through byte-for-byte'
+
+
+@pytest.mark.parametrize('raw_bytes, expected', [
+    ('/café'.encode(), '/caf%C3%83%C2%A9'),  # UTF-8 proxy: latin-1-decoded first -> mojibake. codespell:ignore
+    ('/café'.encode('latin-1'), '/caf%C3%A9'),  # latin-1 proxy: decodes cleanly. codespell:ignore
+])
+async def test_forwarded_prefix_non_ascii_is_encoded_never_raw(user: User, raw_bytes: bytes, expected: str):
+    """A non-ASCII prefix never round-trips cleanly (HTTP headers are latin-1 by spec, so the byte encoding the
+    proxy uses decides the result) — but it is always percent-encoded and never reflected as raw, executable text.
+    """
+    @ui.page('/')
+    def page():
+        ui.label('Hello')
+
+    response = await user.http_client.get('/', headers={'X-Forwarded-Prefix': raw_bytes})
+    assert f'{expected}/_nicegui/' in response.text
+    assert '/café/_nicegui' not in response.text, 'must never be reflected as raw non-ASCII'

--- a/website/documentation/content/section_security.py
+++ b/website/documentation/content/section_security.py
@@ -186,13 +186,16 @@ doc.text('Client-Side Secrets', '''
     **To protect client sessions:**
 
     - **Serve pages over HTTPS** in production to prevent traffic sniffing.
-    - **Never let a shared cache store page responses.** Each page embeds a fresh `client_id`, so a CDN,
-      reverse-proxy cache, or any other intermediary that caches the HTML breaks the security model two ways:
-      it hands one visitor's session token to everyone who hits that cache entry, and it turns any reflected input
-      into a cache-poisoning vector — a single malicious request can store attacker-controlled HTML (XSS, phishing,
-      defacement) that is then served to every subsequent visitor. NiceGUI sends `Cache-Control: no-store` on pages
-      for exactly this reason — do not override or strip it (e.g. a blanket "cache everything" rule). This is the
-      shared-cache counterpart to the private browser-cache leak noted above.
+    - **Never let a shared cache store page responses.**
+      Each page embeds a fresh `client_id`,
+      so a CDN, reverse-proxy cache, or any other intermediary that caches the HTML breaks the security model two ways:
+      it hands one visitor's session token to everyone who hits that cache entry,
+      and it turns any reflected input into a cache-poisoning vector —
+      a single malicious request can store attacker-controlled HTML (XSS, phishing, defacement)
+      that is then served to every subsequent visitor.
+      NiceGUI sends `Cache-Control: no-store` on pages for exactly this reason —
+      do not override or strip it (e.g. a blanket "cache everything" rule).
+      This is the shared-cache counterpart to the private browser-cache leak noted above.
     - **Do not serve untrusted content** from the same origin
       (e.g. serving user-uploaded HTML files could leak secrets via JavaScript).
     - **Do not expose `client_id`** in logs, URLs, or API responses visible to other users.

--- a/website/documentation/content/section_security.py
+++ b/website/documentation/content/section_security.py
@@ -186,6 +186,13 @@ doc.text('Client-Side Secrets', '''
     **To protect client sessions:**
 
     - **Serve pages over HTTPS** in production to prevent traffic sniffing.
+    - **Never let a shared cache store page responses.** Each page embeds a fresh `client_id`, so a CDN,
+      reverse-proxy cache, or any other intermediary that caches the HTML breaks the security model two ways:
+      it hands one visitor's session token to everyone who hits that cache entry, and it turns any reflected input
+      into a cache-poisoning vector — a single malicious request can store attacker-controlled HTML (XSS, phishing,
+      defacement) that is then served to every subsequent visitor. NiceGUI sends `Cache-Control: no-store` on pages
+      for exactly this reason — do not override or strip it (e.g. a blanket "cache everything" rule). This is the
+      shared-cache counterpart to the private browser-cache leak noted above.
     - **Do not serve untrusted content** from the same origin
       (e.g. serving user-uploaded HTML files could leak secrets via JavaScript).
     - **Do not expose `client_id`** in logs, URLs, or API responses visible to other users.


### PR DESCRIPTION
### Motivation

We keep receiving GHSA reports about the unsanitized page template (`| safe` sinks, `innerHTML`, `X-Forwarded-Prefix` reflection). They are almost all duplicates of patterns that are either by-design or already bounded. This PR hardens the one place that is genuinely client-controllable and documents the rest, so future reports of the same shape become non-events.

It consolidates three of the "brick" PRs reviewed on the fork (#185 + #186 + #187); #184 and #188 were dropped as redundant.

### Implementation

**1. Percent-encode `X-Forwarded-Prefix` at the source** (`client.py`) — the only behavior change.

`prefix` is reflected into the page (importmap, `<script src>`, JS `prefix:`, CSS `@import`) via `| safe`, and the `X-Forwarded-Prefix` part is client-controllable on a directly-exposed app or a pass-through proxy. We `quote()` it with a safe set equal to the RFC 3986 path-legal characters (`/:@!$&'()*+,;=` plus `%` to avoid double-encoding). So encoding is a **no-op for any well-formed URL-path prefix** but neutralizes every structural break-out character (`"` `<` `>` `\`, space, non-ASCII). Encoding at the source — not the template — also covers `generate_resources`, not just the importmap.

Regression tests cover an injection payload, a parametrized set of valid prefixes (asserted byte-for-byte unchanged), and non-ASCII header behavior (always percent-encoded, never reflected raw).

**2 & 3. Documentation** (no behavior change):

- **Shared-cache invariant** (`section_security.py`): each page embeds a fresh `client_id`, so a CDN / reverse-proxy cache that stores the HTML both leaks one visitor's session token to everyone and turns reflected input into a cache-poisoning vector. NiceGUI sends `Cache-Control: no-store` for exactly this reason — don't strip it.
- **Commonly Misreported Patterns** (`SECURITY.md`): a short section listing the by-design patterns (`| safe`, `sanitize=False` `innerHTML`, `add_head_html` / `run_javascript` / `add_css`, `ast.literal_eval` in docs) so reporters trace the data flow before filing — while explicitly still inviting reports that find a way *around* these protections.

Out of scope: the open-redirect surface in `middlewares.py` (GHSA-6fp9) — percent-encoding doesn't address it and the team judged it non-exploitable; defense-in-depth path-validation there can be a separate change if wanted.

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] Pytests have been added (`tests/test_forwarded_prefix.py`, 8 cases).
- [x] Documentation has been added/updated.
- [x] No breaking changes — encoding is a no-op for every well-formed prefix.
