### PR TITLE
Fix infinite reload loop when async page build exceeds `response_timeout`

### DIFF
--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -11,6 +11,7 @@ from fastapi import Request, Response
 
 from . import background_tasks, binding, core, helpers
 from .client import Client, ClientConnectionTimeout
+from .error import error_content
 from .favicon import create_favicon_route
 from .language import Language
 from .logging import log
@@ -194,6 +195,12 @@ class page:
                     task.cancel()
                     log.warning(f'Response for {client.page.path} not ready after {self.response_timeout} seconds')
                     client.delete()
+                    # The client is gone, so serving the normal page would only handshake-fail and reload-loop (#6126).
+                    # Serve a terminal error page through a fresh, alive client whose handshake succeeds.
+                    with Client(page(''), request=request) as error_client:
+                        error_content(500, f'The page took longer than the response_timeout of {self.response_timeout} seconds to build. '
+                                      'Await ui.context.client.connected() before long-running setup or increase response_timeout.')
+                    return error_client.build_response(request, 500)
                 if not task_wait_for_connection.done():
                     task_wait_for_connection.cancel()
                 if task.done():

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -386,10 +386,11 @@ def test_warning_if_response_takes_too_long(screen: Screen):
         await asyncio.sleep(1)
         ui.label('all done')
 
-    screen.start_server()
-    # using httpx instead of screen.open to avoid Selenium script timeout on incomplete page responses
-    httpx.get(f'http://localhost:{Screen.PORT}/', timeout=5)
-    screen.wait(1)
+    screen.allowed_js_errors.append('/ - Failed to load resource')
+    screen.open('/')
+    screen.should_contain('500')
+    screen.should_contain('Server error')
+    screen.should_contain('The page took longer than the response_timeout of 0.5 seconds to build.')
     screen.assert_py_logger('WARNING', re.compile('Response for / not ready after 0.5 seconds'))
 
 


### PR DESCRIPTION
### Motivation

Closes #6126.

When an async page builder takes longer than `response_timeout`, the page enters an **infinite reload loop**: the browser logs `reloading because implicit handshake failed for clientId …` with a fresh clientId every cycle, and the page content never renders. The server logs `Response for <path> not ready after N seconds` once per cycle.

```python
@ui.page('/test', response_timeout=3)
async def _():
    await asyncio.sleep(5)   # any async work longer than response_timeout
    ui.label('test')
```

The underlying user mistake is real (long work should come _after_ `await ui.context.client.connected()`), but NiceGUI surfaced it as an uninterpretable loop that looks like a framework bug instead of a clear, terminal error.

**Why it loops:** on timeout, `page.py` cancels the build and calls `client.delete()` — but execution still fell through to `client.build_response(...)`, serving a normal page for a client that no longer exists in `Client.instances`. That page connects with `implicit_handshake=true`; `_on_handshake` can't find the deleted client and raises `ConnectionRefusedError('Implicit handshake failed')`; `nicegui.js` reacts with an unconditional `window.location.reload()`. The reload re-builds, times out again → loop. (Regression traced in the issue to #5116, which added the real `client.delete()` on timeout.)

### Implementation

On timeout, instead of falling through to a page that is guaranteed to handshake-fail, serve a **terminal error page through a fresh, alive client** whose handshake succeeds (reusing the same `error_content` + `build_response` pattern as the existing 404/500 error pages), so the user gets NiceGUI's styled error page (status 500) with an actionable message.

Notes on the design:

- **A fresh client is the key.** The loop was never about the page template — it was that the _deleted_ client's id couldn't handshake. A new client stays in `Client.instances`, so its handshake succeeds and the page is terminal. (The HTML branch of `build_response` does not schedule `BackgroundTask(self.delete)` — only the markdown branch does — so the error client survives long enough to handshake.)
- **No prefetch special-casing needed.** We still `client.delete()` on timeout (preserving #5116's speculative-load cleanup), and the error response is `Cache-Control: no-store`, so a prefetch can never reuse it for the real navigation. A _prerender_ (which connects and would otherwise loop) now gets the terminal page too. The existing `test_speculative_loading.py` tests still pass.
- **A timeout is a config mistake, not a crash**, so it is rendered directly rather than routed through `create_500_error_page` / the exception handler chain — the latter re-raises when no `on_page_exception` handler is registered (the default), dumping a misleading multi-hundred-line ASGI traceback to the server log.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated or are not necessary.
- [x] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.
