### PR TITLE
Fix native window close hanging when run.cpu_bound was used

### DIFF
--- a/nicegui/core.py
+++ b/nicegui/core.py
@@ -47,12 +47,14 @@ def stop_and_exit() -> None:
     connection (#5443). ``os._exit`` skips normal interpreter teardown, so ``atexit`` handlers are run explicitly first.
     Code after ``ui.run()`` (e.g. a trailing ``finally``) still does not run — a documented limitation.
     """
+    from . import run  # pylint: disable=import-outside-toplevel,cyclic-import
     if loop is not None and loop.is_running() and not app.is_stopped:  # pylint: disable=undefined-variable # noqa: F821
         try:
             future = asyncio.run_coroutine_threadsafe(app.stop(), loop)  # pylint: disable=undefined-variable # noqa: F821
             future.result(timeout=30)
         except Exception:
             log.exception('Error or timeout awaiting graceful shutdown before hard exit')
+    run.tear_down()  # kill the process/thread pools before atexit, so multiprocessing's atexit join can't block
     atexit._run_exitfuncs()  # pylint: disable=protected-access
     sys.stdout.flush()
     sys.stderr.flush()


### PR DESCRIPTION
*Drafted by Claude Code on @evnchn's behalf.*

### Motivation

Fixes #6131. The native-window-close / Windows shutdown handler `core.stop_and_exit()` hangs forever if the app ever used `run.cpu_bound()` — the same "native window close hangs the process" class that #6111 / #6106 addressed, reintroduced through a different mechanism.

`stop_and_exit()` runs `atexit._run_exitfuncs()` then `os._exit(0)`, but it bypasses the lifespan `_shutdown` (`nicegui.py`) that normally calls `run.tear_down()`. So the `ProcessPoolExecutor` workers are still alive when `atexit._run_exitfuncs()` runs. They are non-daemon and tracked in `multiprocessing._children`, so `multiprocessing.util._exit_function` (a plain `atexit` handler) `join()`s them and blocks forever; `os._exit(0)` is never reached.

### Implementation

Call `run.tear_down()` in `stop_and_exit()` before `atexit._run_exitfuncs()`, so the pools are gone before the multiprocessing atexit join runs. `tear_down()` already `p.kill()`s the workers first, so its `wait=True` join returns immediately; it is a no-op when no pool was created, and idempotent if a graceful `app.stop()` already tore down. The import is local to avoid the `run` ↔ `core` circular import.

No pytest added: there is no native-shutdown test harness today, and the path ends in `os._exit(0)` (and `run.tear_down()` is a no-op under pytest), so the fix is verified via the issue's minimal reproduction instead (below).

<details>
<summary>Verification</summary>

Reproduction from #6131 (`run.setup()` + `await run.cpu_bound(abs, -1)` then `core.stop_and_exit()`), 8 s watchdog:

- **before:** prints the pre-exit line, then still alive after 8 s (hang).
- **after this PR:** exits cleanly, `rc=0`, no orphaned workers.
- **control** (same script without `run.cpu_bound`): exits cleanly before and after — confirming the process pool was the cause.

Local gates: `pre-commit` clean, `mypy ./nicegui` clean (243 files), `pylint ./nicegui` 10.00/10, `pytest tests/test_run.py` 7/7.

Independently reproduced and the fix direction confirmed by a second reviewer (different model lineage).
</details>

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary (verified via the issue's minimal reproduction; see above).
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
