### PR TITLE
Optimize binding cleanup with reverse index

### DIFF
--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -30,8 +30,7 @@ bindings: defaultdict[BindingKey, list[Binding]] = defaultdict(list)
 bindable_properties: weakref.WeakValueDictionary[BindingKey, Any] = weakref.WeakValueDictionary()
 active_links: list[ActiveLink] = []
 _active_links_added = asyncio.Event()
-# Maps object IDs to binding keys that reference them, so remove() avoids scanning all bindings.
-_binding_keys_by_object: dict[int, set[BindingKey]] = {}
+_binding_keys_by_object: defaultdict[int, set[BindingKey]] = defaultdict(set)
 
 TC = TypeVar('TC', bound=type)
 T = TypeVar('T')
@@ -39,16 +38,8 @@ T = TypeVar('T')
 _MISSING = object()
 
 
-def _index_binding(source_obj: Any, target_obj: Any, binding_key: BindingKey) -> None:
-    """Index both endpoints so remove() can find affected binding lists without a full scan."""
-    _binding_keys_by_object.setdefault(id(source_obj), set()).add(binding_key)
-    _binding_keys_by_object.setdefault(id(target_obj), set()).add(binding_key)
-
-
 def _discard_binding_key_from_object_index(obj_id: int, binding_key: BindingKey) -> None:
-    indexed_binding_keys = _binding_keys_by_object.get(obj_id)
-    if indexed_binding_keys is None:
-        return
+    indexed_binding_keys = _binding_keys_by_object[obj_id]
     indexed_binding_keys.discard(binding_key)
     if not indexed_binding_keys:
         del _binding_keys_by_object[obj_id]
@@ -59,7 +50,8 @@ def _bind_one_way(source_obj: Any, source_name: tuple[str, ...], target_obj: Any
     """Register a one-way binding and run its initial propagation."""
     binding_key = (id(source_obj), source_name)
     bindings[binding_key].append((source_obj, target_obj, target_name, transform))
-    _index_binding(source_obj, target_obj, binding_key)
+    _binding_keys_by_object[id(source_obj)].add(binding_key)
+    _binding_keys_by_object[id(target_obj)].add(binding_key)
     if binding_key not in bindable_properties:
         active_links.append((source_obj, source_name, target_obj, target_name, transform))
         _active_links_added.set()

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -6,9 +6,9 @@ import dataclasses
 import time
 import weakref
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Mapping, MutableMapping
+from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 from typing_extensions import dataclass_transform
 
@@ -18,23 +18,177 @@ from .logging import log
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance, IdentityFunction
 
+ObjectId = int
+NamePath = tuple[str, ...]
+NameBucket = NamePath | set[NamePath]
+BindingKey = tuple[ObjectId, NamePath]
+BindingKeyBucket = BindingKey | set[BindingKey]
+Transform = Callable[[Any], Any] | None
+Binding = tuple[Any, Any, NamePath, Transform]
+ActiveLink = tuple[Any, NamePath, Any, NamePath, Transform]
+BindableEntry = tuple[weakref.ref[Any], NameBucket]
+
+
+class _BindablePropertyRegistry:
+    """Weak bindable-property registry keyed by object ID with name-path buckets.
+
+    Most bindable objects expose one bindable property, so the common case stores a single name path and upgrades to a
+    set only when the same object has multiple bindable properties.
+    """
+
+    def __init__(self) -> None:
+        self._entries_by_object_id: dict[ObjectId, BindableEntry] = {}
+
+    def _discard_object_id(self, obj_id: ObjectId) -> None:
+        self._entries_by_object_id.pop(obj_id, None)
+
+    def __setitem__(self, key: BindingKey, obj: Any) -> None:
+        obj_id, name_path = key
+        entry = self._entries_by_object_id.get(obj_id)
+        if entry is None:
+            def discard(_: weakref.ref[Any], obj_id: ObjectId = obj_id) -> None:
+                self._discard_object_id(obj_id)
+            self._entries_by_object_id[obj_id] = (weakref.ref(obj, discard), name_path)
+            return
+        ref, name_bucket = entry
+        if isinstance(name_bucket, set):
+            name_bucket.add(name_path)
+        elif name_bucket != name_path:
+            self._entries_by_object_id[obj_id] = (ref, {name_bucket, name_path})
+
+    def contains_key(self, key: BindingKey) -> bool:
+        """Return whether a validated binding key is registered."""
+        obj_id, name_path = key
+        entry = self._entries_by_object_id.get(obj_id)
+        if entry is None:
+            return False
+        ref, name_bucket = entry
+        if ref() is None:
+            self._discard_object_id(obj_id)
+            return False
+        return name_path in name_bucket if isinstance(name_bucket, set) else name_bucket == name_path
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, tuple) or len(key) != 2:
+            return False
+        obj_id, name_path = key
+        if not isinstance(obj_id, int) or not isinstance(name_path, tuple):
+            return False
+        return self.contains_key((obj_id, cast(NamePath, name_path)))
+
+    def __iter__(self) -> Iterator[BindingKey]:
+        # Copy before iterating because weakref callbacks can mutate this dictionary.
+        for obj_id, (ref, name_bucket) in list(self._entries_by_object_id.items()):
+            if ref() is None:
+                self._discard_object_id(obj_id)
+                continue
+            if isinstance(name_bucket, set):
+                for name_path in name_bucket:
+                    yield obj_id, name_path
+            else:
+                yield obj_id, name_bucket
+
+    def clear(self) -> None:
+        """Remove all registered bindable-property entries."""
+        self._entries_by_object_id.clear()
+
+    def discard_object_ids(self, object_ids: Iterable[int]) -> None:
+        """Remove registered bindable-property entries for the given object IDs."""
+        pop = self._entries_by_object_id.pop
+        for obj_id in object_ids:
+            pop(obj_id, None)
+
+
 MAX_PROPAGATION_TIME = 0.01
 
-propagation_visited: ContextVar[set[tuple[int, tuple[str, ...]]] | None] = \
+propagation_visited: ContextVar[set[BindingKey] | None] = \
     ContextVar('propagation_visited', default=None)
 
 bindings: defaultdict[
-    tuple[int, tuple[str, ...]],
-    list[tuple[Any, Any, tuple[str, ...], Callable[[Any], Any] | None]]
+    BindingKey,
+    list[Binding]
 ] = defaultdict(list)
-bindable_properties: weakref.WeakValueDictionary[tuple[int, tuple[str, ...]], Any] = weakref.WeakValueDictionary()
-active_links: list[tuple[Any, tuple[str, ...], Any, tuple[str, ...], Callable[[Any], Any] | None]] = []
+bindable_properties: _BindablePropertyRegistry = _BindablePropertyRegistry()
+active_links: list[ActiveLink] = []
 _active_links_added = asyncio.Event()
+# Maps object IDs to binding keys that reference them, so remove() avoids scanning all bindings.
+_binding_keys_by_object: dict[ObjectId, BindingKeyBucket] = {}
 
 TC = TypeVar('TC', bound=type)
 T = TypeVar('T')
 
 _MISSING = object()
+
+
+def _discard_binding_key_from_object_index(obj_id: ObjectId, binding_key: BindingKey) -> None:
+    """Remove one binding key from the reverse index used by remove()."""
+    bucket = _binding_keys_by_object.get(obj_id)
+    if bucket is None:
+        return
+    if not isinstance(bucket, set):
+        if bucket == binding_key:
+            del _binding_keys_by_object[obj_id]
+        return
+    bucket.discard(binding_key)
+    if not bucket:
+        del _binding_keys_by_object[obj_id]
+
+
+def _add_binding_key_to_object_index(obj_id: ObjectId, binding_key: BindingKey) -> None:
+    """Add one endpoint reference to the reverse index used by remove()."""
+    bucket = _binding_keys_by_object.get(obj_id)
+    if bucket is None:
+        _binding_keys_by_object[obj_id] = binding_key
+    elif isinstance(bucket, set):
+        bucket.add(binding_key)
+    elif bucket != binding_key:
+        _binding_keys_by_object[obj_id] = {bucket, binding_key}
+
+
+def _index_binding(source_obj: Any, target_obj: Any, binding_key: BindingKey) -> None:
+    """Index both endpoints so remove() can find affected binding lists without a full scan."""
+    _add_binding_key_to_object_index(id(source_obj), binding_key)
+    _add_binding_key_to_object_index(id(target_obj), binding_key)
+
+
+def _bind_one_way(source_obj: Any, source_name: NamePath, target_obj: Any, target_name: NamePath,
+                  transform: Transform) -> None:
+    """Register a one-way binding and run its initial propagation."""
+    binding_key = (id(source_obj), source_name)
+    bindings[binding_key].append((source_obj, target_obj, target_name, transform))
+    _index_binding(source_obj, target_obj, binding_key)
+    if not bindable_properties.contains_key(binding_key):
+        active_links.append((source_obj, source_name, target_obj, target_name, transform))
+        _active_links_added.set()
+    _propagate(source_obj, source_name)
+
+
+def _collect_binding_keys_for_objects(object_ids: Iterable[ObjectId]) -> set[BindingKey] | None:
+    """Return binding keys whose source or target may reference the given objects."""
+    # Stay at None until the first hit so remove() calls for objects with no active
+    # bindings ("ghost removals") skip the set allocation and traversal entirely.
+    binding_keys: set[BindingKey] | None = None
+    get_object_binding_keys = _binding_keys_by_object.get
+    for obj_id in object_ids:
+        bucket = get_object_binding_keys(obj_id)
+        if bucket is None:
+            continue
+        if binding_keys is None:
+            binding_keys = set()
+        if isinstance(bucket, set):
+            binding_keys.update(bucket)
+        else:
+            binding_keys.add(bucket)
+    return binding_keys
+
+
+def _remove_active_links_for_objects(removed_object_ids: set[ObjectId]) -> None:
+    """Drop polling fallback links that reference any removed object."""
+    active_links[:] = [
+        (source_obj, source_name, target_obj, target_name, transform)
+        for source_obj, source_name, target_obj, target_name, transform in active_links
+        if id(source_obj) not in removed_object_ids and id(target_obj) not in removed_object_ids
+    ]
 
 
 def _get_attribute(obj: object | Mapping, name: tuple[str, ...]) -> Any:
@@ -173,11 +327,7 @@ def bind_to(self_obj: Any, self_name: str | tuple[str, ...], other_obj: Any, oth
     self_name_tuple = _normalize_name(self_name)
     other_name_tuple = _normalize_name(other_name)
     _check_self_and_other_attribute(self_obj, self_name_tuple, other_obj, other_name_tuple, self_strict, other_strict)
-    bindings[(id(self_obj), self_name_tuple)].append((self_obj, other_obj, other_name_tuple, forward))
-    if (id(self_obj), self_name_tuple) not in bindable_properties:
-        active_links.append((self_obj, self_name_tuple, other_obj, other_name_tuple, forward))
-        _active_links_added.set()
-    _propagate(self_obj, self_name_tuple)
+    _bind_one_way(self_obj, self_name_tuple, other_obj, other_name_tuple, forward)
 
 
 def bind_from(self_obj: Any, self_name: str | tuple[str, ...], other_obj: Any, other_name: str | tuple[str, ...],
@@ -202,11 +352,7 @@ def bind_from(self_obj: Any, self_name: str | tuple[str, ...], other_obj: Any, o
     self_name_tuple = _normalize_name(self_name)
     other_name_tuple = _normalize_name(other_name)
     _check_self_and_other_attribute(self_obj, self_name_tuple, other_obj, other_name_tuple, self_strict, other_strict)
-    bindings[(id(other_obj), other_name_tuple)].append((other_obj, self_obj, self_name_tuple, backward))
-    if (id(other_obj), other_name_tuple) not in bindable_properties:
-        active_links.append((other_obj, other_name_tuple, self_obj, self_name_tuple, backward))
-        _active_links_added.set()
-    _propagate(other_obj, other_name_tuple)
+    _bind_one_way(other_obj, other_name_tuple, self_obj, self_name_tuple, backward)
 
 
 def bind(self_obj: Any, self_name: str | tuple[str, ...], other_obj: Any, other_name: str | tuple[str, ...], *,
@@ -290,23 +436,47 @@ def remove(objects: Iterable[Any]) -> None:
 
     :param objects: The objects to remove.
     """
-    object_ids = set(map(id, objects))
-    active_links[:] = [
-        (source_obj, source_name, target_obj, target_name, transform)
-        for source_obj, source_name, target_obj, target_name, transform in active_links
-        if id(source_obj) not in object_ids and id(target_obj) not in object_ids
-    ]
-    for key, binding_list in list(bindings.items()):
-        binding_list[:] = [
-            (source_obj, target_obj, target_name, transform)
-            for source_obj, target_obj, target_name, transform in binding_list
-            if id(source_obj) not in object_ids and id(target_obj) not in object_ids
-        ]
-        if not binding_list:
+    # Keep IDs as a list until membership checks are needed; ghost removals only do dict pop/get by ID.
+    removed_object_ids = [id(obj) for obj in objects]
+    if not removed_object_ids:
+        return
+
+    bindable_properties.discard_object_ids(removed_object_ids)
+
+    affected_binding_keys = _collect_binding_keys_for_objects(removed_object_ids)
+    if not affected_binding_keys:
+        return
+
+    removed_object_id_set = set(removed_object_ids)
+    _remove_active_links_for_objects(removed_object_id_set)
+
+    for key in affected_binding_keys:
+        binding_list = bindings.get(key)
+        if binding_list is None:
+            continue
+        source_obj_id = key[0]
+        # Binding keys are source IDs; target-only removals only prune entries from the binding list.
+        if source_obj_id in removed_object_id_set:
+            for _, target_obj, _, _ in binding_list:
+                target_obj_id = id(target_obj)
+                if target_obj_id not in removed_object_id_set:
+                    _discard_binding_key_from_object_index(target_obj_id, key)
             del bindings[key]
-    for obj_id, name in list(bindable_properties):
-        if obj_id in object_ids:
-            del bindable_properties[(obj_id, name)]
+            continue
+        if len(binding_list) == 1:
+            if id(binding_list[0][1]) in removed_object_id_set:
+                del bindings[key]
+                _discard_binding_key_from_object_index(source_obj_id, key)
+            continue
+        remaining_bindings = [binding for binding in binding_list if id(binding[1]) not in removed_object_id_set]
+        if remaining_bindings:
+            binding_list[:] = remaining_bindings
+        else:
+            del bindings[key]
+            _discard_binding_key_from_object_index(source_obj_id, key)
+
+    for obj_id in removed_object_ids:
+        _binding_keys_by_object.pop(obj_id, None)
 
 
 def reset() -> None:
@@ -317,6 +487,7 @@ def reset() -> None:
     bindings.clear()
     bindable_properties.clear()
     active_links.clear()
+    _binding_keys_by_object.clear()
 
 
 @dataclass_transform()

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -38,36 +38,6 @@ T = TypeVar('T')
 _MISSING = object()
 
 
-def _discard_binding_key_from_object_index(obj_id: int, binding_key: BindingKey) -> None:
-    indexed_binding_keys = _binding_keys_by_object[obj_id]
-    indexed_binding_keys.discard(binding_key)
-    if not indexed_binding_keys:
-        del _binding_keys_by_object[obj_id]
-
-
-def _bind_one_way(source_obj: Any, source_name: tuple[str, ...], target_obj: Any, target_name: tuple[str, ...],
-                  transform: Callable[[Any], Any] | None) -> None:
-    """Register a one-way binding and run its initial propagation."""
-    binding_key = (id(source_obj), source_name)
-    bindings[binding_key].append((source_obj, target_obj, target_name, transform))
-    _binding_keys_by_object[id(source_obj)].add(binding_key)
-    _binding_keys_by_object[id(target_obj)].add(binding_key)
-    if binding_key not in bindable_properties:
-        active_links.append((source_obj, source_name, target_obj, target_name, transform))
-        _active_links_added.set()
-    _propagate(source_obj, source_name)
-
-
-def _pop_binding_keys_for_objects(object_ids: Iterable[int]) -> set[BindingKey]:
-    """Pop and return binding keys whose source or target may reference the given objects."""
-    binding_keys: set[BindingKey] = set()
-    for obj_id in object_ids:
-        indexed_binding_keys = _binding_keys_by_object.pop(obj_id, None)
-        if indexed_binding_keys is not None:
-            binding_keys.update(indexed_binding_keys)
-    return binding_keys
-
-
 def _get_attribute(obj: object | Mapping, name: tuple[str, ...]) -> Any:
     try:
         for key in name:
@@ -180,6 +150,19 @@ def _check_self_and_other_attribute(self_obj: Any, self_name: tuple[str, ...], o
         _check_attribute_exists(self_obj, self_name, role='self')
     if other_strict or (other_strict is None and not _path_contains_dict(other_obj, other_name)):
         _check_attribute_exists(other_obj, other_name, role='other')
+
+
+def _bind_one_way(source_obj: Any, source_name: tuple[str, ...], target_obj: Any, target_name: tuple[str, ...],
+                  transform: Callable[[Any], Any] | None) -> None:
+    """Register a one-way binding and run its initial propagation."""
+    binding_key = (id(source_obj), source_name)
+    bindings[binding_key].append((source_obj, target_obj, target_name, transform))
+    _binding_keys_by_object[id(source_obj)].add(binding_key)
+    _binding_keys_by_object[id(target_obj)].add(binding_key)
+    if binding_key not in bindable_properties:
+        active_links.append((source_obj, source_name, target_obj, target_name, transform))
+        _active_links_added.set()
+    _propagate(source_obj, source_name)
 
 
 def bind_to(self_obj: Any, self_name: str | tuple[str, ...], other_obj: Any, other_name: str | tuple[str, ...],
@@ -308,16 +291,22 @@ class BindableProperty:
             self._change_handler(owner, value)
 
 
+def _discard_binding_key_from_object_index(obj_id: int, binding_key: BindingKey) -> None:
+    keys = _binding_keys_by_object[obj_id]
+    keys.discard(binding_key)
+    if not keys:
+        del _binding_keys_by_object[obj_id]
+
+
 def remove(objects: Iterable[Any]) -> None:
     """Remove all bindings that involve the given objects.
 
     :param objects: The objects to remove.
     """
     object_ids = set(map(id, objects))
-    affected_binding_keys = _pop_binding_keys_for_objects(object_ids)
+    affected_binding_keys = {key for obj_id in object_ids for key in _binding_keys_by_object.pop(obj_id, ())}
     if not affected_binding_keys:
-        # remove() only deletes binding links; weak bindable-property markers expire when their objects are collected.
-        return
+        return  # only delete binding links; weak bindable-property markers expire when their objects are collected
 
     active_links[:] = [
         (source_obj, source_name, target_obj, target_name, transform)

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -18,28 +18,20 @@ from .logging import log
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance, IdentityFunction
 
-ObjectId = int
-NamePath = tuple[str, ...]
-BindingKey = tuple[ObjectId, NamePath]
-Transform = Callable[[Any], Any] | None
-Binding = tuple[Any, Any, NamePath, Transform]
-ActiveLink = tuple[Any, NamePath, Any, NamePath, Transform]
-
-
 MAX_PROPAGATION_TIME = 0.01
 
-propagation_visited: ContextVar[set[BindingKey] | None] = \
-    ContextVar('propagation_visited', default=None)
+BindingKey = tuple[int, tuple[str, ...]]
+Binding = tuple[Any, Any, tuple[str, ...], Callable[[Any], Any] | None]
+ActiveLink = tuple[Any, tuple[str, ...], Any, tuple[str, ...], Callable[[Any], Any] | None]
 
-bindings: defaultdict[
-    BindingKey,
-    list[Binding]
-] = defaultdict(list)
+propagation_visited: ContextVar[set[BindingKey] | None] = ContextVar('propagation_visited', default=None)
+
+bindings: defaultdict[BindingKey, list[Binding]] = defaultdict(list)
 bindable_properties: weakref.WeakValueDictionary[BindingKey, Any] = weakref.WeakValueDictionary()
 active_links: list[ActiveLink] = []
 _active_links_added = asyncio.Event()
 # Maps object IDs to binding keys that reference them, so remove() avoids scanning all bindings.
-_binding_keys_by_object: dict[ObjectId, set[BindingKey]] = {}
+_binding_keys_by_object: dict[int, set[BindingKey]] = {}
 
 TC = TypeVar('TC', bound=type)
 T = TypeVar('T')
@@ -53,7 +45,7 @@ def _index_binding(source_obj: Any, target_obj: Any, binding_key: BindingKey) ->
     _binding_keys_by_object.setdefault(id(target_obj), set()).add(binding_key)
 
 
-def _discard_binding_key_from_object_index(obj_id: ObjectId, binding_key: BindingKey) -> None:
+def _discard_binding_key_from_object_index(obj_id: int, binding_key: BindingKey) -> None:
     indexed_binding_keys = _binding_keys_by_object.get(obj_id)
     if indexed_binding_keys is None:
         return
@@ -62,8 +54,8 @@ def _discard_binding_key_from_object_index(obj_id: ObjectId, binding_key: Bindin
         del _binding_keys_by_object[obj_id]
 
 
-def _bind_one_way(source_obj: Any, source_name: NamePath, target_obj: Any, target_name: NamePath,
-                  transform: Transform) -> None:
+def _bind_one_way(source_obj: Any, source_name: tuple[str, ...], target_obj: Any, target_name: tuple[str, ...],
+                  transform: Callable[[Any], Any] | None) -> None:
     """Register a one-way binding and run its initial propagation."""
     binding_key = (id(source_obj), source_name)
     bindings[binding_key].append((source_obj, target_obj, target_name, transform))
@@ -74,7 +66,7 @@ def _bind_one_way(source_obj: Any, source_name: NamePath, target_obj: Any, targe
     _propagate(source_obj, source_name)
 
 
-def _pop_binding_keys_for_objects(object_ids: Iterable[ObjectId]) -> set[BindingKey]:
+def _pop_binding_keys_for_objects(object_ids: Iterable[int]) -> set[BindingKey]:
     """Pop and return binding keys whose source or target may reference the given objects."""
     binding_keys: set[BindingKey] = set()
     for obj_id in object_ids:
@@ -84,7 +76,7 @@ def _pop_binding_keys_for_objects(object_ids: Iterable[ObjectId]) -> set[Binding
     return binding_keys
 
 
-def _remove_active_links_for_objects(removed_object_ids: set[ObjectId]) -> None:
+def _remove_active_links_for_objects(removed_object_ids: set[int]) -> None:
     """Drop polling fallback links that reference any removed object."""
     active_links[:] = [
         (source_obj, source_name, target_obj, target_name, transform)

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -29,7 +29,7 @@ ActiveLink = tuple[Any, NamePath, Any, NamePath, Transform]
 BindableEntry = tuple[weakref.ref[Any], NameBucket]
 
 
-class _BindablePropertyRegistry:
+class _BindablePropertyRegistry(MutableMapping[BindingKey, Any]):
     """Weak bindable-property registry keyed by object ID with name-path buckets.
 
     Most bindable objects expose one bindable property, so the common case stores a single name path and upgrades to a
@@ -39,34 +39,81 @@ class _BindablePropertyRegistry:
     def __init__(self) -> None:
         self._entries_by_object_id: dict[ObjectId, BindableEntry] = {}
 
-    def _discard_object_id(self, obj_id: ObjectId) -> None:
-        self._entries_by_object_id.pop(obj_id, None)
+    def _discard_object_id(self, object_id: ObjectId) -> None:
+        self._entries_by_object_id.pop(object_id, None)
+
+    @staticmethod
+    def _key_or_raise(key: object) -> tuple[ObjectId, tuple[Any, ...]]:
+        if not isinstance(key, tuple) or len(key) != 2:
+            raise KeyError(key)
+        requested_object_id, requested_name_path = key
+        if not isinstance(requested_object_id, int) or not isinstance(requested_name_path, tuple):
+            raise KeyError(key)
+        return requested_object_id, requested_name_path
 
     def __setitem__(self, key: BindingKey, obj: Any) -> None:
-        obj_id, name_path = key
-        entry = self._entries_by_object_id.get(obj_id)
+        object_id, name_path = key
+        entry = self._entries_by_object_id.get(object_id)
         if entry is None:
-            def discard(_: weakref.ref[Any], obj_id: ObjectId = obj_id) -> None:
-                self._discard_object_id(obj_id)
-            self._entries_by_object_id[obj_id] = (weakref.ref(obj, discard), name_path)
+            def discard(discarded_ref: weakref.ref[Any], object_id: ObjectId = object_id) -> None:
+                self._discard_object_id(object_id)
+            self._entries_by_object_id[object_id] = (weakref.ref(obj, discard), name_path)
             return
-        ref, name_bucket = entry
-        if isinstance(name_bucket, set):
-            name_bucket.add(name_path)
-        elif name_bucket != name_path:
-            self._entries_by_object_id[obj_id] = (ref, {name_bucket, name_path})
+        object_ref, registered_name_paths = entry
+        if isinstance(registered_name_paths, set):
+            registered_name_paths.add(name_path)
+        elif registered_name_paths != name_path:
+            self._entries_by_object_id[object_id] = (object_ref, {registered_name_paths, name_path})
+
+    def __getitem__(self, key: object) -> Any:
+        requested_object_id, requested_name_path = self._key_or_raise(key)
+        entry = self._entries_by_object_id.get(requested_object_id)
+        if entry is None:
+            raise KeyError(key)
+        object_ref, registered_name_paths = entry
+        registered_object = object_ref()
+        if registered_object is None:
+            self._discard_object_id(requested_object_id)
+            raise KeyError(key)
+        if (requested_name_path in registered_name_paths
+                if isinstance(registered_name_paths, set)
+                else registered_name_paths == requested_name_path):
+            return registered_object
+        raise KeyError(key)
+
+    def __delitem__(self, key: object) -> None:
+        requested_object_id, requested_name_path = self._key_or_raise(key)
+        entry = self._entries_by_object_id.get(requested_object_id)
+        if entry is None:
+            raise KeyError(key)
+        _object_ref, registered_name_paths = entry
+        if isinstance(registered_name_paths, set):
+            if requested_name_path not in registered_name_paths:
+                raise KeyError(key)
+            registered_name_paths.discard(requested_name_path)
+            if not registered_name_paths:
+                self._discard_object_id(requested_object_id)
+            return
+        if registered_name_paths != requested_name_path:
+            raise KeyError(key)
+        self._discard_object_id(requested_object_id)
+
+    def __len__(self) -> int:
+        return sum(1 for key in self)
 
     def contains_key(self, key: BindingKey) -> bool:
         """Return whether a validated binding key is registered."""
-        obj_id, name_path = key
-        entry = self._entries_by_object_id.get(obj_id)
+        object_id, name_path = key
+        entry = self._entries_by_object_id.get(object_id)
         if entry is None:
             return False
-        ref, name_bucket = entry
-        if ref() is None:
-            self._discard_object_id(obj_id)
+        object_ref, registered_name_paths = entry
+        if object_ref() is None:
+            self._discard_object_id(object_id)
             return False
-        return name_path in name_bucket if isinstance(name_bucket, set) else name_bucket == name_path
+        return (name_path in registered_name_paths
+                if isinstance(registered_name_paths, set)
+                else registered_name_paths == name_path)
 
     def __contains__(self, key: object) -> bool:
         if not isinstance(key, tuple) or len(key) != 2:
@@ -75,15 +122,15 @@ class _BindablePropertyRegistry:
 
     def __iter__(self) -> Iterator[BindingKey]:
         # Copy before iterating because weakref callbacks can mutate this dictionary.
-        for obj_id, (ref, name_bucket) in list(self._entries_by_object_id.items()):
-            if ref() is None:
-                self._discard_object_id(obj_id)
+        for object_id, (object_ref, registered_name_paths) in list(self._entries_by_object_id.items()):
+            if object_ref() is None:
+                self._discard_object_id(object_id)
                 continue
-            if isinstance(name_bucket, set):
-                for name_path in name_bucket:
-                    yield obj_id, name_path
+            if isinstance(registered_name_paths, set):
+                for name_path in registered_name_paths:
+                    yield object_id, name_path
             else:
-                yield obj_id, name_bucket
+                yield object_id, registered_name_paths
 
     def clear(self) -> None:
         """Remove all registered bindable-property entries."""
@@ -92,8 +139,8 @@ class _BindablePropertyRegistry:
     def discard_object_ids(self, object_ids: Iterable[int]) -> None:
         """Remove registered bindable-property entries for the given object IDs."""
         pop = self._entries_by_object_id.pop
-        for obj_id in object_ids:
-            pop(obj_id, None)
+        for object_id in object_ids:
+            pop(object_id, None)
 
 
 MAX_PROPAGATION_TIME = 0.01

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -314,9 +314,7 @@ def remove(objects: Iterable[Any]) -> None:
         if id(source_obj) not in object_ids and id(target_obj) not in object_ids
     ]
     for binding_key in affected_binding_keys:
-        binding_list = bindings.get(binding_key)
-        if binding_list is None:
-            continue
+        binding_list = bindings[binding_key]
         source_obj_id = binding_key[0]
         # Binding keys are source IDs; target-only removals only prune entries from the binding list.
         if source_obj_id in object_ids:

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -8,7 +8,7 @@ import weakref
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from typing_extensions import dataclass_transform
 
@@ -71,10 +71,7 @@ class _BindablePropertyRegistry:
     def __contains__(self, key: object) -> bool:
         if not isinstance(key, tuple) or len(key) != 2:
             return False
-        obj_id, name_path = key
-        if not isinstance(obj_id, int) or not isinstance(name_path, tuple):
-            return False
-        return self.contains_key((obj_id, cast(NamePath, name_path)))
+        return self.contains_key(key)  # type: ignore[arg-type]
 
     def __iter__(self) -> Iterator[BindingKey]:
         # Copy before iterating because weakref callbacks can mutate this dictionary.
@@ -120,29 +117,43 @@ T = TypeVar('T')
 _MISSING = object()
 
 
-def _discard_binding_key_from_object_index(obj_id: ObjectId, binding_key: BindingKey) -> None:
-    """Remove one binding key from the reverse index used by remove()."""
-    bucket = _binding_keys_by_object.get(obj_id)
+def _bucket_add(bucket_dict: dict[Any, Any], key: Any, value: Any) -> None:
+    """Add value to a scalar-or-set bucket in a dict.
+
+    Most objects have a single entry, so the common case stores a bare value
+    and upgrades to a set only when a second distinct value is added.
+    """
+    bucket = bucket_dict.get(key)
+    if bucket is None:
+        bucket_dict[key] = value
+    elif isinstance(bucket, set):
+        bucket.add(value)
+    elif bucket != value:
+        bucket_dict[key] = {bucket, value}
+
+
+def _bucket_discard(bucket_dict: dict[Any, Any], key: Any, value: Any) -> None:
+    """Remove value from a scalar-or-set bucket in a dict; delete bucket if empty."""
+    bucket = bucket_dict.get(key)
     if bucket is None:
         return
     if not isinstance(bucket, set):
-        if bucket == binding_key:
-            del _binding_keys_by_object[obj_id]
+        if bucket == value:
+            del bucket_dict[key]
         return
-    bucket.discard(binding_key)
+    bucket.discard(value)
     if not bucket:
-        del _binding_keys_by_object[obj_id]
+        del bucket_dict[key]
+
+
+def _discard_binding_key_from_object_index(obj_id: ObjectId, binding_key: BindingKey) -> None:
+    """Remove one binding key from the reverse index used by remove()."""
+    _bucket_discard(_binding_keys_by_object, obj_id, binding_key)
 
 
 def _add_binding_key_to_object_index(obj_id: ObjectId, binding_key: BindingKey) -> None:
     """Add one endpoint reference to the reverse index used by remove()."""
-    bucket = _binding_keys_by_object.get(obj_id)
-    if bucket is None:
-        _binding_keys_by_object[obj_id] = binding_key
-    elif isinstance(bucket, set):
-        bucket.add(binding_key)
-    elif bucket != binding_key:
-        _binding_keys_by_object[obj_id] = {bucket, binding_key}
+    _bucket_add(_binding_keys_by_object, obj_id, binding_key)
 
 
 def _index_binding(source_obj: Any, target_obj: Any, binding_key: BindingKey) -> None:

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -55,7 +55,7 @@ class _BindablePropertyRegistry(MutableMapping[BindingKey, Any]):
         object_id, name_path = key
         entry = self._entries_by_object_id.get(object_id)
         if entry is None:
-            def discard(discarded_ref: weakref.ref[Any], object_id: ObjectId = object_id) -> None:
+            def discard(_discarded_ref: weakref.ref[Any], object_id: ObjectId = object_id) -> None:
                 self._discard_object_id(object_id)
             self._entries_by_object_id[object_id] = (weakref.ref(obj, discard), name_path)
             return

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -74,18 +74,13 @@ def _bind_one_way(source_obj: Any, source_name: NamePath, target_obj: Any, targe
     _propagate(source_obj, source_name)
 
 
-def _pop_binding_keys_for_objects(object_ids: Iterable[ObjectId]) -> set[BindingKey] | None:
+def _pop_binding_keys_for_objects(object_ids: Iterable[ObjectId]) -> set[BindingKey]:
     """Pop and return binding keys whose source or target may reference the given objects."""
-    # Stay at None until the first hit so remove() calls for objects with no active
-    # bindings ("ghost removals") skip the set allocation and traversal entirely.
-    binding_keys: set[BindingKey] | None = None
+    binding_keys: set[BindingKey] = set()
     for obj_id in object_ids:
         indexed_binding_keys = _binding_keys_by_object.pop(obj_id, None)
-        if indexed_binding_keys is None:
-            continue
-        if binding_keys is None:
-            binding_keys = set()
-        binding_keys.update(indexed_binding_keys)
+        if indexed_binding_keys is not None:
+            binding_keys.update(indexed_binding_keys)
     return binding_keys
 
 
@@ -343,18 +338,13 @@ def remove(objects: Iterable[Any]) -> None:
 
     :param objects: The objects to remove.
     """
-    # Keep IDs as a list until membership checks are needed; ghost removals only do dict pop/get by ID.
-    removed_object_ids = [id(obj) for obj in objects]
-    if not removed_object_ids:
-        return
-
+    removed_object_ids = set(map(id, objects))
     affected_binding_keys = _pop_binding_keys_for_objects(removed_object_ids)
     if not affected_binding_keys:
         # remove() only deletes binding links; weak bindable-property markers expire when their objects are collected.
         return
 
-    removed_object_id_set = set(removed_object_ids)
-    _remove_active_links_for_objects(removed_object_id_set)
+    _remove_active_links_for_objects(removed_object_ids)
 
     for binding_key in affected_binding_keys:
         binding_list = bindings.get(binding_key)
@@ -362,14 +352,14 @@ def remove(objects: Iterable[Any]) -> None:
             continue
         source_obj_id = binding_key[0]
         # Binding keys are source IDs; target-only removals only prune entries from the binding list.
-        if source_obj_id in removed_object_id_set:
+        if source_obj_id in removed_object_ids:
             for _source_obj, target_obj, _target_name, _transform in binding_list:
                 target_obj_id = id(target_obj)
-                if target_obj_id not in removed_object_id_set:
+                if target_obj_id not in removed_object_ids:
                     _discard_binding_key_from_object_index(target_obj_id, binding_key)
             del bindings[binding_key]
             continue
-        remaining_bindings = [binding for binding in binding_list if id(binding[1]) not in removed_object_id_set]
+        remaining_bindings = [binding for binding in binding_list if id(binding[1]) not in removed_object_ids]
         if remaining_bindings:
             binding_list[:] = remaining_bindings
         else:

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -499,11 +499,11 @@ def remove(objects: Iterable[Any]) -> None:
     if not removed_object_ids:
         return
 
-    bindable_properties.discard_object_ids(removed_object_ids)
-
     affected_binding_keys = _collect_binding_keys_for_objects(removed_object_ids)
     if not affected_binding_keys:
         return
+
+    bindable_properties.discard_object_ids(removed_object_ids)
 
     removed_object_id_set = set(removed_object_ids)
     _remove_active_links_for_objects(removed_object_id_set)

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -6,7 +6,7 @@ import dataclasses
 import time
 import weakref
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
@@ -24,102 +24,6 @@ BindingKey = tuple[ObjectId, NamePath]
 Transform = Callable[[Any], Any] | None
 Binding = tuple[Any, Any, NamePath, Transform]
 ActiveLink = tuple[Any, NamePath, Any, NamePath, Transform]
-BindableEntry = tuple[weakref.ref[Any], set[NamePath]]
-
-
-class _BindablePropertyRegistry(MutableMapping[BindingKey, Any]):
-    """Weak bindable-property registry keyed by object ID with name-path buckets."""
-
-    def __init__(self) -> None:
-        self._entries_by_object_id: dict[ObjectId, BindableEntry] = {}
-
-    def _discard_object_id(self, object_id: ObjectId) -> None:
-        self._entries_by_object_id.pop(object_id, None)
-
-    @staticmethod
-    def _key_or_raise(key: object) -> tuple[ObjectId, tuple[Any, ...]]:
-        if not isinstance(key, tuple) or len(key) != 2:
-            raise KeyError(key)
-        requested_object_id, requested_name_path = key
-        if not isinstance(requested_object_id, int) or not isinstance(requested_name_path, tuple):
-            raise KeyError(key)
-        return requested_object_id, requested_name_path
-
-    def __setitem__(self, key: BindingKey, obj: Any) -> None:
-        object_id, name_path = key
-        bindable_entry = self._entries_by_object_id.get(object_id)
-        if bindable_entry is None:
-            def discard(_discarded_ref: weakref.ref[Any], object_id: ObjectId = object_id) -> None:
-                self._discard_object_id(object_id)
-            self._entries_by_object_id[object_id] = (weakref.ref(obj, discard), {name_path})
-            return
-        registered_name_paths = bindable_entry[1]
-        registered_name_paths.add(name_path)
-
-    def __getitem__(self, key: object) -> Any:
-        requested_object_id, requested_name_path = self._key_or_raise(key)
-        bindable_entry = self._entries_by_object_id.get(requested_object_id)
-        if bindable_entry is None:
-            raise KeyError(key)
-        object_ref, registered_name_paths = bindable_entry
-        registered_object = object_ref()
-        if registered_object is None:
-            self._discard_object_id(requested_object_id)
-            raise KeyError(key)
-        if requested_name_path in registered_name_paths:
-            return registered_object
-        raise KeyError(key)
-
-    def __delitem__(self, key: object) -> None:
-        requested_object_id, requested_name_path = self._key_or_raise(key)
-        bindable_entry = self._entries_by_object_id.get(requested_object_id)
-        if bindable_entry is None:
-            raise KeyError(key)
-        registered_name_paths = bindable_entry[1]
-        if requested_name_path not in registered_name_paths:
-            raise KeyError(key)
-        registered_name_paths.discard(requested_name_path)
-        if not registered_name_paths:
-            self._discard_object_id(requested_object_id)
-
-    def __len__(self) -> int:
-        return sum(1 for key in self)
-
-    def contains_key(self, key: BindingKey) -> bool:
-        """Return whether a validated binding key is registered."""
-        object_id, name_path = key
-        bindable_entry = self._entries_by_object_id.get(object_id)
-        if bindable_entry is None:
-            return False
-        object_ref, registered_name_paths = bindable_entry
-        if object_ref() is None:
-            self._discard_object_id(object_id)
-            return False
-        return name_path in registered_name_paths
-
-    def __contains__(self, key: object) -> bool:
-        if not isinstance(key, tuple) or len(key) != 2:
-            return False
-        return self.contains_key(key)  # type: ignore[arg-type]
-
-    def __iter__(self) -> Iterator[BindingKey]:
-        # Copy before iterating because weakref callbacks can mutate this dictionary.
-        for object_id, (object_ref, registered_name_paths) in list(self._entries_by_object_id.items()):
-            if object_ref() is None:
-                self._discard_object_id(object_id)
-                continue
-            for name_path in registered_name_paths:
-                yield object_id, name_path
-
-    def clear(self) -> None:
-        """Remove all registered bindable-property entries."""
-        self._entries_by_object_id.clear()
-
-    def discard_object_ids(self, object_ids: Iterable[int]) -> None:
-        """Remove registered bindable-property entries for the given object IDs."""
-        pop = self._entries_by_object_id.pop
-        for object_id in object_ids:
-            pop(object_id, None)
 
 
 MAX_PROPAGATION_TIME = 0.01
@@ -131,7 +35,7 @@ bindings: defaultdict[
     BindingKey,
     list[Binding]
 ] = defaultdict(list)
-bindable_properties: _BindablePropertyRegistry = _BindablePropertyRegistry()
+bindable_properties: weakref.WeakValueDictionary[BindingKey, Any] = weakref.WeakValueDictionary()
 active_links: list[ActiveLink] = []
 _active_links_added = asyncio.Event()
 # Maps object IDs to binding keys that reference them, so remove() avoids scanning all bindings.
@@ -164,20 +68,19 @@ def _bind_one_way(source_obj: Any, source_name: NamePath, target_obj: Any, targe
     binding_key = (id(source_obj), source_name)
     bindings[binding_key].append((source_obj, target_obj, target_name, transform))
     _index_binding(source_obj, target_obj, binding_key)
-    if not bindable_properties.contains_key(binding_key):
+    if binding_key not in bindable_properties:
         active_links.append((source_obj, source_name, target_obj, target_name, transform))
         _active_links_added.set()
     _propagate(source_obj, source_name)
 
 
-def _collect_binding_keys_for_objects(object_ids: Iterable[ObjectId]) -> set[BindingKey] | None:
-    """Return binding keys whose source or target may reference the given objects."""
+def _pop_binding_keys_for_objects(object_ids: Iterable[ObjectId]) -> set[BindingKey] | None:
+    """Pop and return binding keys whose source or target may reference the given objects."""
     # Stay at None until the first hit so remove() calls for objects with no active
     # bindings ("ghost removals") skip the set allocation and traversal entirely.
     binding_keys: set[BindingKey] | None = None
-    get_object_binding_keys = _binding_keys_by_object.get
     for obj_id in object_ids:
-        indexed_binding_keys = get_object_binding_keys(obj_id)
+        indexed_binding_keys = _binding_keys_by_object.pop(obj_id, None)
         if indexed_binding_keys is None:
             continue
         if binding_keys is None:
@@ -445,11 +348,10 @@ def remove(objects: Iterable[Any]) -> None:
     if not removed_object_ids:
         return
 
-    affected_binding_keys = _collect_binding_keys_for_objects(removed_object_ids)
+    affected_binding_keys = _pop_binding_keys_for_objects(removed_object_ids)
     if not affected_binding_keys:
+        # remove() only deletes binding links; weak bindable-property markers expire when their objects are collected.
         return
-
-    bindable_properties.discard_object_ids(removed_object_ids)
 
     removed_object_id_set = set(removed_object_ids)
     _remove_active_links_for_objects(removed_object_id_set)
@@ -467,20 +369,12 @@ def remove(objects: Iterable[Any]) -> None:
                     _discard_binding_key_from_object_index(target_obj_id, binding_key)
             del bindings[binding_key]
             continue
-        if len(binding_list) == 1:
-            if id(binding_list[0][1]) in removed_object_id_set:
-                del bindings[binding_key]
-                _discard_binding_key_from_object_index(source_obj_id, binding_key)
-            continue
         remaining_bindings = [binding for binding in binding_list if id(binding[1]) not in removed_object_id_set]
         if remaining_bindings:
             binding_list[:] = remaining_bindings
         else:
             del bindings[binding_key]
             _discard_binding_key_from_object_index(source_obj_id, binding_key)
-
-    for obj_id in removed_object_ids:
-        _binding_keys_by_object.pop(obj_id, None)
 
 
 def reset() -> None:

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -301,12 +301,14 @@ def _discard_binding_key_from_object_index(obj_id: int, binding_key: BindingKey)
 def remove(objects: Iterable[Any]) -> None:
     """Remove all bindings that involve the given objects.
 
+    This only deletes binding links; weak bindable-property markers expire when their objects are garbage-collected.
+
     :param objects: The objects to remove.
     """
     object_ids = set(map(id, objects))
     affected_binding_keys = {key for obj_id in object_ids for key in _binding_keys_by_object.pop(obj_id, ())}
     if not affected_binding_keys:
-        return  # only delete binding links; weak bindable-property markers expire when their objects are collected
+        return
 
     active_links[:] = [
         (source_obj, source_name, target_obj, target_name, transform)

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -318,10 +318,8 @@ def remove(objects: Iterable[Any]) -> None:
         source_obj_id = binding_key[0]
         # Binding keys are source IDs; target-only removals only prune entries from the binding list.
         if source_obj_id in object_ids:
-            for _source_obj, target_obj, _target_name, _transform in binding_list:
-                target_obj_id = id(target_obj)
-                if target_obj_id not in object_ids:
-                    _discard_binding_key_from_object_index(target_obj_id, binding_key)
+            for target_obj_id in {id(target_obj) for _, target_obj, _, _ in binding_list} - object_ids:
+                _discard_binding_key_from_object_index(target_obj_id, binding_key)
             del bindings[binding_key]
             continue
         remaining_bindings = [binding for binding in binding_list if id(binding[1]) not in object_ids]

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -168,7 +168,7 @@ def _propagate_recursively(source_obj: Any, source_name: tuple[str, ...]) -> Non
     if (source_value := _get_attribute(source_obj, source_name)) is _MISSING:
         return
 
-    for _source_obj, target_obj, target_name, transform in bindings.get((source_obj_id, source_name), []):
+    for _, target_obj, target_name, transform in bindings.get((source_obj_id, source_name), []):
         if (id(target_obj), target_name) in visited:
             continue
 
@@ -313,10 +313,10 @@ class BindableProperty:
     def __init__(self, on_change: Callable[..., Any] | None = None) -> None:
         self._change_handler = on_change
 
-    def __set_name__(self, _owner_type: type[Any], name: str) -> None:
+    def __set_name__(self, _, name: str) -> None:
         self.name = name  # pylint: disable=attribute-defined-outside-init
 
-    def __get__(self, owner: Any, _owner_type: type[Any] | None = None) -> Any:
+    def __get__(self, owner: Any, _=None) -> Any:
         return getattr(owner, '___' + self.name)
 
     def __set__(self, owner: Any, value: Any) -> None:

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -20,21 +20,15 @@ if TYPE_CHECKING:
 
 ObjectId = int
 NamePath = tuple[str, ...]
-NameBucket = NamePath | set[NamePath]
 BindingKey = tuple[ObjectId, NamePath]
-BindingKeyBucket = BindingKey | set[BindingKey]
 Transform = Callable[[Any], Any] | None
 Binding = tuple[Any, Any, NamePath, Transform]
 ActiveLink = tuple[Any, NamePath, Any, NamePath, Transform]
-BindableEntry = tuple[weakref.ref[Any], NameBucket]
+BindableEntry = tuple[weakref.ref[Any], set[NamePath]]
 
 
 class _BindablePropertyRegistry(MutableMapping[BindingKey, Any]):
-    """Weak bindable-property registry keyed by object ID with name-path buckets.
-
-    Most bindable objects expose one bindable property, so the common case stores a single name path and upgrades to a
-    set only when the same object has multiple bindable properties.
-    """
+    """Weak bindable-property registry keyed by object ID with name-path buckets."""
 
     def __init__(self) -> None:
         self._entries_by_object_id: dict[ObjectId, BindableEntry] = {}
@@ -53,50 +47,40 @@ class _BindablePropertyRegistry(MutableMapping[BindingKey, Any]):
 
     def __setitem__(self, key: BindingKey, obj: Any) -> None:
         object_id, name_path = key
-        entry = self._entries_by_object_id.get(object_id)
-        if entry is None:
+        bindable_entry = self._entries_by_object_id.get(object_id)
+        if bindable_entry is None:
             def discard(_discarded_ref: weakref.ref[Any], object_id: ObjectId = object_id) -> None:
                 self._discard_object_id(object_id)
-            self._entries_by_object_id[object_id] = (weakref.ref(obj, discard), name_path)
+            self._entries_by_object_id[object_id] = (weakref.ref(obj, discard), {name_path})
             return
-        object_ref, registered_name_paths = entry
-        if isinstance(registered_name_paths, set):
-            registered_name_paths.add(name_path)
-        elif registered_name_paths != name_path:
-            self._entries_by_object_id[object_id] = (object_ref, {registered_name_paths, name_path})
+        registered_name_paths = bindable_entry[1]
+        registered_name_paths.add(name_path)
 
     def __getitem__(self, key: object) -> Any:
         requested_object_id, requested_name_path = self._key_or_raise(key)
-        entry = self._entries_by_object_id.get(requested_object_id)
-        if entry is None:
+        bindable_entry = self._entries_by_object_id.get(requested_object_id)
+        if bindable_entry is None:
             raise KeyError(key)
-        object_ref, registered_name_paths = entry
+        object_ref, registered_name_paths = bindable_entry
         registered_object = object_ref()
         if registered_object is None:
             self._discard_object_id(requested_object_id)
             raise KeyError(key)
-        if (requested_name_path in registered_name_paths
-                if isinstance(registered_name_paths, set)
-                else registered_name_paths == requested_name_path):
+        if requested_name_path in registered_name_paths:
             return registered_object
         raise KeyError(key)
 
     def __delitem__(self, key: object) -> None:
         requested_object_id, requested_name_path = self._key_or_raise(key)
-        entry = self._entries_by_object_id.get(requested_object_id)
-        if entry is None:
+        bindable_entry = self._entries_by_object_id.get(requested_object_id)
+        if bindable_entry is None:
             raise KeyError(key)
-        _object_ref, registered_name_paths = entry
-        if isinstance(registered_name_paths, set):
-            if requested_name_path not in registered_name_paths:
-                raise KeyError(key)
-            registered_name_paths.discard(requested_name_path)
-            if not registered_name_paths:
-                self._discard_object_id(requested_object_id)
-            return
-        if registered_name_paths != requested_name_path:
+        registered_name_paths = bindable_entry[1]
+        if requested_name_path not in registered_name_paths:
             raise KeyError(key)
-        self._discard_object_id(requested_object_id)
+        registered_name_paths.discard(requested_name_path)
+        if not registered_name_paths:
+            self._discard_object_id(requested_object_id)
 
     def __len__(self) -> int:
         return sum(1 for key in self)
@@ -104,16 +88,14 @@ class _BindablePropertyRegistry(MutableMapping[BindingKey, Any]):
     def contains_key(self, key: BindingKey) -> bool:
         """Return whether a validated binding key is registered."""
         object_id, name_path = key
-        entry = self._entries_by_object_id.get(object_id)
-        if entry is None:
+        bindable_entry = self._entries_by_object_id.get(object_id)
+        if bindable_entry is None:
             return False
-        object_ref, registered_name_paths = entry
+        object_ref, registered_name_paths = bindable_entry
         if object_ref() is None:
             self._discard_object_id(object_id)
             return False
-        return (name_path in registered_name_paths
-                if isinstance(registered_name_paths, set)
-                else registered_name_paths == name_path)
+        return name_path in registered_name_paths
 
     def __contains__(self, key: object) -> bool:
         if not isinstance(key, tuple) or len(key) != 2:
@@ -126,11 +108,8 @@ class _BindablePropertyRegistry(MutableMapping[BindingKey, Any]):
             if object_ref() is None:
                 self._discard_object_id(object_id)
                 continue
-            if isinstance(registered_name_paths, set):
-                for name_path in registered_name_paths:
-                    yield object_id, name_path
-            else:
-                yield object_id, registered_name_paths
+            for name_path in registered_name_paths:
+                yield object_id, name_path
 
     def clear(self) -> None:
         """Remove all registered bindable-property entries."""
@@ -156,7 +135,7 @@ bindable_properties: _BindablePropertyRegistry = _BindablePropertyRegistry()
 active_links: list[ActiveLink] = []
 _active_links_added = asyncio.Event()
 # Maps object IDs to binding keys that reference them, so remove() avoids scanning all bindings.
-_binding_keys_by_object: dict[ObjectId, BindingKeyBucket] = {}
+_binding_keys_by_object: dict[ObjectId, set[BindingKey]] = {}
 
 TC = TypeVar('TC', bound=type)
 T = TypeVar('T')
@@ -164,49 +143,19 @@ T = TypeVar('T')
 _MISSING = object()
 
 
-def _bucket_add(bucket_dict: dict[Any, Any], key: Any, value: Any) -> None:
-    """Add value to a scalar-or-set bucket in a dict.
-
-    Most objects have a single entry, so the common case stores a bare value
-    and upgrades to a set only when a second distinct value is added.
-    """
-    bucket = bucket_dict.get(key)
-    if bucket is None:
-        bucket_dict[key] = value
-    elif isinstance(bucket, set):
-        bucket.add(value)
-    elif bucket != value:
-        bucket_dict[key] = {bucket, value}
-
-
-def _bucket_discard(bucket_dict: dict[Any, Any], key: Any, value: Any) -> None:
-    """Remove value from a scalar-or-set bucket in a dict; delete bucket if empty."""
-    bucket = bucket_dict.get(key)
-    if bucket is None:
-        return
-    if not isinstance(bucket, set):
-        if bucket == value:
-            del bucket_dict[key]
-        return
-    bucket.discard(value)
-    if not bucket:
-        del bucket_dict[key]
+def _index_binding(source_obj: Any, target_obj: Any, binding_key: BindingKey) -> None:
+    """Index both endpoints so remove() can find affected binding lists without a full scan."""
+    _binding_keys_by_object.setdefault(id(source_obj), set()).add(binding_key)
+    _binding_keys_by_object.setdefault(id(target_obj), set()).add(binding_key)
 
 
 def _discard_binding_key_from_object_index(obj_id: ObjectId, binding_key: BindingKey) -> None:
-    """Remove one binding key from the reverse index used by remove()."""
-    _bucket_discard(_binding_keys_by_object, obj_id, binding_key)
-
-
-def _add_binding_key_to_object_index(obj_id: ObjectId, binding_key: BindingKey) -> None:
-    """Add one endpoint reference to the reverse index used by remove()."""
-    _bucket_add(_binding_keys_by_object, obj_id, binding_key)
-
-
-def _index_binding(source_obj: Any, target_obj: Any, binding_key: BindingKey) -> None:
-    """Index both endpoints so remove() can find affected binding lists without a full scan."""
-    _add_binding_key_to_object_index(id(source_obj), binding_key)
-    _add_binding_key_to_object_index(id(target_obj), binding_key)
+    indexed_binding_keys = _binding_keys_by_object.get(obj_id)
+    if indexed_binding_keys is None:
+        return
+    indexed_binding_keys.discard(binding_key)
+    if not indexed_binding_keys:
+        del _binding_keys_by_object[obj_id]
 
 
 def _bind_one_way(source_obj: Any, source_name: NamePath, target_obj: Any, target_name: NamePath,
@@ -228,15 +177,12 @@ def _collect_binding_keys_for_objects(object_ids: Iterable[ObjectId]) -> set[Bin
     binding_keys: set[BindingKey] | None = None
     get_object_binding_keys = _binding_keys_by_object.get
     for obj_id in object_ids:
-        bucket = get_object_binding_keys(obj_id)
-        if bucket is None:
+        indexed_binding_keys = get_object_binding_keys(obj_id)
+        if indexed_binding_keys is None:
             continue
         if binding_keys is None:
             binding_keys = set()
-        if isinstance(bucket, set):
-            binding_keys.update(bucket)
-        else:
-            binding_keys.add(bucket)
+        binding_keys.update(indexed_binding_keys)
     return binding_keys
 
 
@@ -324,7 +270,7 @@ def _propagate_recursively(source_obj: Any, source_name: tuple[str, ...]) -> Non
     if (source_value := _get_attribute(source_obj, source_name)) is _MISSING:
         return
 
-    for _, target_obj, target_name, transform in bindings.get((source_obj_id, source_name), []):
+    for _source_obj, target_obj, target_name, transform in bindings.get((source_obj_id, source_name), []):
         if (id(target_obj), target_name) in visited:
             continue
 
@@ -469,10 +415,10 @@ class BindableProperty:
     def __init__(self, on_change: Callable[..., Any] | None = None) -> None:
         self._change_handler = on_change
 
-    def __set_name__(self, _, name: str) -> None:
+    def __set_name__(self, _owner_type: type[Any], name: str) -> None:
         self.name = name  # pylint: disable=attribute-defined-outside-init
 
-    def __get__(self, owner: Any, _=None) -> Any:
+    def __get__(self, owner: Any, _owner_type: type[Any] | None = None) -> Any:
         return getattr(owner, '___' + self.name)
 
     def __set__(self, owner: Any, value: Any) -> None:
@@ -508,30 +454,30 @@ def remove(objects: Iterable[Any]) -> None:
     removed_object_id_set = set(removed_object_ids)
     _remove_active_links_for_objects(removed_object_id_set)
 
-    for key in affected_binding_keys:
-        binding_list = bindings.get(key)
+    for binding_key in affected_binding_keys:
+        binding_list = bindings.get(binding_key)
         if binding_list is None:
             continue
-        source_obj_id = key[0]
+        source_obj_id = binding_key[0]
         # Binding keys are source IDs; target-only removals only prune entries from the binding list.
         if source_obj_id in removed_object_id_set:
-            for _, target_obj, _, _ in binding_list:
+            for _source_obj, target_obj, _target_name, _transform in binding_list:
                 target_obj_id = id(target_obj)
                 if target_obj_id not in removed_object_id_set:
-                    _discard_binding_key_from_object_index(target_obj_id, key)
-            del bindings[key]
+                    _discard_binding_key_from_object_index(target_obj_id, binding_key)
+            del bindings[binding_key]
             continue
         if len(binding_list) == 1:
             if id(binding_list[0][1]) in removed_object_id_set:
-                del bindings[key]
-                _discard_binding_key_from_object_index(source_obj_id, key)
+                del bindings[binding_key]
+                _discard_binding_key_from_object_index(source_obj_id, binding_key)
             continue
         remaining_bindings = [binding for binding in binding_list if id(binding[1]) not in removed_object_id_set]
         if remaining_bindings:
             binding_list[:] = remaining_bindings
         else:
-            del bindings[key]
-            _discard_binding_key_from_object_index(source_obj_id, key)
+            del bindings[binding_key]
+            _discard_binding_key_from_object_index(source_obj_id, binding_key)
 
     for obj_id in removed_object_ids:
         _binding_keys_by_object.pop(obj_id, None)

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -76,15 +76,6 @@ def _pop_binding_keys_for_objects(object_ids: Iterable[int]) -> set[BindingKey]:
     return binding_keys
 
 
-def _remove_active_links_for_objects(removed_object_ids: set[int]) -> None:
-    """Drop polling fallback links that reference any removed object."""
-    active_links[:] = [
-        (source_obj, source_name, target_obj, target_name, transform)
-        for source_obj, source_name, target_obj, target_name, transform in active_links
-        if id(source_obj) not in removed_object_ids and id(target_obj) not in removed_object_ids
-    ]
-
-
 def _get_attribute(obj: object | Mapping, name: tuple[str, ...]) -> Any:
     try:
         for key in name:
@@ -330,28 +321,31 @@ def remove(objects: Iterable[Any]) -> None:
 
     :param objects: The objects to remove.
     """
-    removed_object_ids = set(map(id, objects))
-    affected_binding_keys = _pop_binding_keys_for_objects(removed_object_ids)
+    object_ids = set(map(id, objects))
+    affected_binding_keys = _pop_binding_keys_for_objects(object_ids)
     if not affected_binding_keys:
         # remove() only deletes binding links; weak bindable-property markers expire when their objects are collected.
         return
 
-    _remove_active_links_for_objects(removed_object_ids)
-
+    active_links[:] = [
+        (source_obj, source_name, target_obj, target_name, transform)
+        for source_obj, source_name, target_obj, target_name, transform in active_links
+        if id(source_obj) not in object_ids and id(target_obj) not in object_ids
+    ]
     for binding_key in affected_binding_keys:
         binding_list = bindings.get(binding_key)
         if binding_list is None:
             continue
         source_obj_id = binding_key[0]
         # Binding keys are source IDs; target-only removals only prune entries from the binding list.
-        if source_obj_id in removed_object_ids:
+        if source_obj_id in object_ids:
             for _source_obj, target_obj, _target_name, _transform in binding_list:
                 target_obj_id = id(target_obj)
-                if target_obj_id not in removed_object_ids:
+                if target_obj_id not in object_ids:
                     _discard_binding_key_from_object_index(target_obj_id, binding_key)
             del bindings[binding_key]
             continue
-        remaining_bindings = [binding for binding in binding_list if id(binding[1]) not in removed_object_ids]
+        remaining_bindings = [binding for binding in binding_list if id(binding[1]) not in object_ids]
         if remaining_bindings:
             binding_list[:] = remaining_bindings
         else:

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -232,7 +232,8 @@ def test_remove_prunes_indexed_target_binding(nicegui_reset_globals: Any) -> Non
 
     assert binding.bindings[source_key] == [(source, target2, ('text',), None)]
     assert id(target1) not in binding._binding_keys_by_object  # pylint: disable=protected-access
-    binding_keys = binding._collect_binding_keys_for_objects([id(source), id(target2)])  # pylint: disable=protected-access
+    binding_keys = binding._collect_binding_keys_for_objects(
+        [id(source), id(target2)])  # pylint: disable=protected-access
     assert binding_keys is not None
     assert source_key in binding_keys
 

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -213,6 +213,50 @@ def test_automatic_cleanup(screen: Screen):
     assert is_alive(ref2) and has_bindable_property(model_id2)
 
 
+def test_remove_prunes_indexed_target_binding(nicegui_reset_globals: Any) -> None:  # pylint: disable=unused-argument
+    class Source:
+        value = 'initial'
+
+    class Target:
+        text = ''
+
+    source = Source()
+    target1 = Target()
+    target2 = Target()
+
+    binding.bind_to(source, 'value', target1, 'text')
+    binding.bind_to(source, 'value', target2, 'text')
+    source_key = (id(source), ('value',))
+
+    binding.remove([target1])
+
+    assert binding.bindings[source_key] == [(source, target2, ('text',), None)]
+    assert id(target1) not in binding._binding_keys_by_object  # pylint: disable=protected-access
+    binding_keys = binding._collect_binding_keys_for_objects([id(source), id(target2)])  # pylint: disable=protected-access
+    assert binding_keys is not None
+    assert source_key in binding_keys
+
+
+def test_remove_clears_index_for_source_binding(nicegui_reset_globals: Any) -> None:  # pylint: disable=unused-argument
+    class Source:
+        value = 'initial'
+
+    class Target:
+        text = ''
+
+    source = Source()
+    target = Target()
+
+    binding.bind_to(source, 'value', target, 'text')
+    source_key = (id(source), ('value',))
+
+    binding.remove([source])
+
+    assert source_key not in binding.bindings
+    assert id(source) not in binding._binding_keys_by_object  # pylint: disable=protected-access
+    assert id(target) not in binding._binding_keys_by_object  # pylint: disable=protected-access
+
+
 async def test_nested_propagation(user: User):
     class Demo:
         a = binding.BindableProperty()

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -258,6 +258,35 @@ def test_remove_clears_index_for_source_binding(nicegui_reset_globals: Any) -> N
     assert id(target) not in binding._binding_keys_by_object  # pylint: disable=protected-access
 
 
+def test_bindable_properties_keeps_dict_compatible_surface(nicegui_reset_globals: Any) -> None:  # pylint: disable=unused-argument
+    class Model:
+        value = binding.BindableProperty()
+        text = binding.BindableProperty()
+
+        def __init__(self) -> None:
+            self.value = 1
+            self.text = 'hello'
+
+    model = Model()
+    value_key = (id(model), ('value',))
+    text_key = (id(model), ('text',))
+
+    assert len(binding.bindable_properties) == 2
+    assert binding.bindable_properties[value_key] is model
+    assert binding.bindable_properties.get(value_key) is model
+    assert binding.bindable_properties.get((id(model), ('missing',)), 'fallback') == 'fallback'
+    assert binding.bindable_properties.get('missing', 'fallback') == 'fallback'
+    assert set(binding.bindable_properties.keys()) == {value_key, text_key}
+    assert set(binding.bindable_properties.items()) == {(value_key, model), (text_key, model)}
+    assert list(binding.bindable_properties.values()) == [model, model]
+
+    assert binding.bindable_properties.pop('missing', 'fallback') == 'fallback'
+    assert binding.bindable_properties.pop(value_key) is model
+    assert value_key not in binding.bindable_properties
+    del binding.bindable_properties[text_key]
+    assert len(binding.bindable_properties) == 0
+
+
 async def test_nested_propagation(user: User):
     class Demo:
         a = binding.BindableProperty()

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -213,7 +213,7 @@ def test_automatic_cleanup(screen: Screen):
     assert is_alive(ref2) and has_bindable_property(model_id2)
 
 
-def test_remove_prunes_indexed_target_binding(nicegui_reset_globals: Any) -> None:  # pylint: disable=unused-argument
+def test_remove_prunes_indexed_target_binding(nicegui_reset_globals) -> None:
     class Source:
         value = 'initial'
 
@@ -236,7 +236,7 @@ def test_remove_prunes_indexed_target_binding(nicegui_reset_globals: Any) -> Non
     assert source_key in binding._binding_keys_by_object[id(target2)]  # pylint: disable=protected-access
 
 
-def test_remove_clears_index_for_source_binding(nicegui_reset_globals: Any) -> None:  # pylint: disable=unused-argument
+def test_remove_clears_index_for_source_binding(nicegui_reset_globals) -> None:
     class Source:
         value = 'initial'
 
@@ -256,9 +256,7 @@ def test_remove_clears_index_for_source_binding(nicegui_reset_globals: Any) -> N
     assert id(target) not in binding._binding_keys_by_object  # pylint: disable=protected-access
 
 
-def test_bindable_properties_keeps_useful_mapping_operations(  # pylint: disable=unused-argument
-    nicegui_reset_globals: Any,
-) -> None:
+def test_bindable_properties_keeps_useful_mapping_operations(nicegui_reset_globals) -> None:
     class Model:
         value = binding.BindableProperty()
         text = binding.BindableProperty()
@@ -278,9 +276,7 @@ def test_bindable_properties_keeps_useful_mapping_operations(  # pylint: disable
     assert set(binding.bindable_properties.items()) == {(text_key, model)}
 
 
-def test_remove_rebind_preserves_bindable_property_semantics(  # pylint: disable=unused-argument
-    nicegui_reset_globals: Any,
-) -> None:
+def test_remove_rebind_preserves_bindable_property_semantics(nicegui_reset_globals) -> None:
     class Model:
         value = binding.BindableProperty()
 

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -256,26 +256,6 @@ def test_remove_clears_index_for_source_binding(nicegui_reset_globals) -> None:
     assert id(target) not in binding._binding_keys_by_object  # pylint: disable=protected-access
 
 
-def test_bindable_properties_keeps_useful_mapping_operations(nicegui_reset_globals) -> None:
-    class Model:
-        value = binding.BindableProperty()
-        text = binding.BindableProperty()
-
-        def __init__(self) -> None:
-            self.value = 1
-            self.text = 'hello'
-
-    model = Model()
-    value_key = (id(model), ('value',))
-    text_key = (id(model), ('text',))
-
-    assert len(binding.bindable_properties) == 2
-    assert set(binding.bindable_properties.items()) == {(value_key, model), (text_key, model)}
-    del binding.bindable_properties[value_key]
-    assert len(binding.bindable_properties) == 1
-    assert set(binding.bindable_properties.items()) == {(text_key, model)}
-
-
 def test_remove_rebind_preserves_bindable_property_semantics(nicegui_reset_globals) -> None:
     class Model:
         value = binding.BindableProperty()

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -213,47 +213,51 @@ def test_automatic_cleanup(screen: Screen):
     assert is_alive(ref2) and has_bindable_property(model_id2)
 
 
-def test_remove_prunes_indexed_target_binding(nicegui_reset_globals) -> None:
-    class Source:
-        value = 'initial'
+def test_remove_target_keeps_remaining_target_bound(nicegui_reset_globals) -> None:
+    class Model:
+        value = binding.BindableProperty()
+
+        def __init__(self) -> None:
+            self.value = 'initial'
 
     class Target:
         text = ''
 
-    source = Source()
+    source = Model()
     target1 = Target()
     target2 = Target()
 
     binding.bind_to(source, 'value', target1, 'text')
     binding.bind_to(source, 'value', target2, 'text')
-    source_key = (id(source), ('value',))
 
     binding.remove([target1])
+    source.value = 'changed'
 
-    assert binding.bindings[source_key] == [(source, target2, ('text',), None)]
-    assert id(target1) not in binding._binding_keys_by_object  # pylint: disable=protected-access
-    assert source_key in binding._binding_keys_by_object[id(source)]  # pylint: disable=protected-access
-    assert source_key in binding._binding_keys_by_object[id(target2)]  # pylint: disable=protected-access
+    assert target1.text == 'initial'
+    assert target2.text == 'changed'
 
 
-def test_remove_clears_index_for_source_binding(nicegui_reset_globals) -> None:
-    class Source:
-        value = 'initial'
+def test_remove_source_unbinds_all_targets(nicegui_reset_globals) -> None:
+    class Model:
+        value = binding.BindableProperty()
+
+        def __init__(self) -> None:
+            self.value = 'initial'
 
     class Target:
         text = ''
 
-    source = Source()
+    source = Model()
     target = Target()
 
     binding.bind_to(source, 'value', target, 'text')
-    source_key = (id(source), ('value',))
 
     binding.remove([source])
+    source.value = 'changed'
 
-    assert source_key not in binding.bindings
-    assert id(source) not in binding._binding_keys_by_object  # pylint: disable=protected-access
-    assert id(target) not in binding._binding_keys_by_object  # pylint: disable=protected-access
+    assert target.text == 'initial'
+    assert not binding.bindings
+    assert not binding._binding_keys_by_object  # pylint: disable=protected-access
 
 
 def test_remove_rebind_preserves_bindable_property_semantics(nicegui_reset_globals) -> None:

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -232,10 +232,8 @@ def test_remove_prunes_indexed_target_binding(nicegui_reset_globals: Any) -> Non
 
     assert binding.bindings[source_key] == [(source, target2, ('text',), None)]
     assert id(target1) not in binding._binding_keys_by_object  # pylint: disable=protected-access
-    binding_keys = binding._collect_binding_keys_for_objects(
-        [id(source), id(target2)])  # pylint: disable=protected-access
-    assert binding_keys is not None
-    assert source_key in binding_keys
+    assert source_key in binding._binding_keys_by_object[id(source)]  # pylint: disable=protected-access
+    assert source_key in binding._binding_keys_by_object[id(target2)]  # pylint: disable=protected-access
 
 
 def test_remove_clears_index_for_source_binding(nicegui_reset_globals: Any) -> None:  # pylint: disable=unused-argument
@@ -258,7 +256,9 @@ def test_remove_clears_index_for_source_binding(nicegui_reset_globals: Any) -> N
     assert id(target) not in binding._binding_keys_by_object  # pylint: disable=protected-access
 
 
-def test_bindable_properties_keeps_dict_compatible_surface(nicegui_reset_globals: Any) -> None:  # pylint: disable=unused-argument
+def test_bindable_properties_keeps_useful_mapping_operations(  # pylint: disable=unused-argument
+    nicegui_reset_globals: Any,
+) -> None:
     class Model:
         value = binding.BindableProperty()
         text = binding.BindableProperty()
@@ -272,19 +272,41 @@ def test_bindable_properties_keeps_dict_compatible_surface(nicegui_reset_globals
     text_key = (id(model), ('text',))
 
     assert len(binding.bindable_properties) == 2
-    assert binding.bindable_properties[value_key] is model
-    assert binding.bindable_properties.get(value_key) is model
-    assert binding.bindable_properties.get((id(model), ('missing',)), 'fallback') == 'fallback'
-    assert binding.bindable_properties.get('missing', 'fallback') == 'fallback'
-    assert set(binding.bindable_properties.keys()) == {value_key, text_key}
     assert set(binding.bindable_properties.items()) == {(value_key, model), (text_key, model)}
-    assert list(binding.bindable_properties.values()) == [model, model]
+    del binding.bindable_properties[value_key]
+    assert len(binding.bindable_properties) == 1
+    assert set(binding.bindable_properties.items()) == {(text_key, model)}
 
-    assert binding.bindable_properties.pop('missing', 'fallback') == 'fallback'
-    assert binding.bindable_properties.pop(value_key) is model
-    assert value_key not in binding.bindable_properties
-    del binding.bindable_properties[text_key]
-    assert len(binding.bindable_properties) == 0
+
+def test_remove_rebind_preserves_bindable_property_semantics(  # pylint: disable=unused-argument
+    nicegui_reset_globals: Any,
+) -> None:
+    class Model:
+        value = binding.BindableProperty()
+
+        def __init__(self, value: list[int]) -> None:
+            self.value = value
+
+    class Target:
+        value: list[int] | None = None
+
+    source = Model([1])
+    target = Target()
+    source_key = (id(source), ('value',))
+
+    binding.bind_to(source, 'value', target, 'value', forward=list)
+    assert len(binding.active_links) == 0
+    assert target.value == [1]
+
+    binding.remove([source])
+    assert source_key in binding.bindable_properties
+
+    binding.bind_to(source, 'value', target, 'value', forward=list)
+    source.value.append(2)
+    binding._refresh_step()  # pylint: disable=protected-access
+
+    assert len(binding.active_links) == 0
+    assert target.value == [1]
 
 
 async def test_nested_propagation(user: User):


### PR DESCRIPTION
### Motivation

`binding.remove()` used to scan all binding lists and all bindable-property keys for every removal. That makes cleanup scale with unrelated global binding state, which is expensive during dynamic UI rebuilds or repeated element deletion. Most NiceGUI app shapes use callbacks rather than bindings, so deleting unbound elements paid the full scan cost without ever having had a binding. This PR makes removal proportional to the removed objects' own bindings — O(1) for objects without any.

This PR focuses on the binding cleanup path only.

### Implementation

Add `_binding_keys_by_object`, a reverse index mapping each endpoint's object ID to the binding keys that may reference it. New bindings register both endpoints through the shared `_bind_one_way()` helper (deduplicated from `bind_to()`/`bind_from()`), which appends to `bindings`, indexes both endpoints, and maintains `active_links`.

`remove()` pops the removed objects' reverse-index entries, prunes or deletes only the affected binding lists, and discards stale index entries for deleted objects. Objects without any bindings take an early return without touching the rest of the global binding state.

`bindable_properties` remains a stdlib `WeakValueDictionary`, and `remove()` no longer deletes its entries — the weak markers expire when their objects are garbage-collected. This intentionally changes one edge case: re-binding a removed-but-still-alive bindable object no longer creates a polling active link, since its property descriptor still propagates on assignment (pinned down by `test_remove_rebind_preserves_bindable_property_semantics`).

Benchmarks (baseline `034db3b7a`, candidate `50bf6f287`, Python 3.11.7, median of 9 samples per case, GC disabled during each timed sample, timing only the `remove()` calls):

| case                                                                                         |      before |     after |      delta |
| -------------------------------------------------------------------------------------------- | ----------: | --------: | ---------: |
| remove 300 of 10,000 unlinked bindable objects, one `remove()` call each                     | `112.95 ms` | `0.07 ms` |   `-99.9%` |
| remove 1,000 bound targets of one source in a single call                                    |   `0.13 ms` | `0.27 ms` | `+0.14 ms` |
| remove 1,000 never-registered objects in a single call, with 15,000 bindable objects present |   `0.67 ms` | `0.06 ms` |     `-92%` |

The bound-target batch case pays for maintaining and consulting the reverse index; the absolute cost is about `0.14 ms` per 1,000 bound targets and does not grow with unrelated binding state, while the scan-dominated cases collapse to near-constant time.

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
