### PR TITLE
Remove redundant CI Gate run on push to main

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,9 +1,6 @@
 name: CI Gate
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
   workflow_dispatch:


### PR DESCRIPTION
### Motivation

Every commit that lands on `main` goes through the merge queue, where the `merge_group` event runs the full test matrix (5 Python versions × pytest + startup) on the exact commit that will become `main`'s new HEAD. The subsequent `push: main` event then re-runs CI Gate again — but only as `quick-test` (Python 3.10, pytest), a strict subset of what the merge queue just validated on the identical tree. This second run consumes CI minutes without adding coverage. Nothing depends on its result: `publish.yml` triggers on tags, and there is no CI badge keyed to it.

Beyond the wasted minutes, this run actively slows down releases: after merging the last feature for a release, we have to wait ~20 min for the redundant push-to-main run to finish before cutting the release — even though the merge queue already validated that exact commit moments earlier.

### Implementation

Drop the `push: branches: [main]` trigger from `ci-gate.yml`. CI Gate now runs on `pull_request`, `merge_group`, and `workflow_dispatch` only. The merge queue remains the gate for everything that reaches `main`.

Trade-off: a commit pushed directly to `main` — bypassing the merge queue via an admin override — would no longer trigger CI Gate. Since merges go through the required merge queue, this path should not occur in normal operation, and the old push run only ran `quick-test` anyway (so it would have missed e.g. a Python 3.14-only or startup-only regression regardless).

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
