### PR TITLE
Fix crash when loading STL with wireframe=True

### DIFF
--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -335,6 +335,33 @@ export default {
           undefined,
           (error) => console.error(error),
         );
+      } else if (type == "stl") {
+        const url = args[0];
+        const wireframe = args[1];
+        mesh = new THREE.Group();
+        mesh.userData.isStl = true;
+        mesh.userData.loaded = false;
+        mesh.userData.wireframe = wireframe;
+        this.stl_loader.load(
+          url,
+          (geometry) => {
+            const child = wireframe
+              ? new THREE.LineSegments(
+                  new THREE.EdgesGeometry(geometry),
+                  new THREE.LineBasicMaterial({ transparent: true }),
+                )
+              : new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({ transparent: true }));
+            mesh.add(child);
+            mesh.userData.loaded = true;
+            if (mesh.userData.pendingMaterialInfo) {
+              const { color, opacity, side } = mesh.userData.pendingMaterialInfo;
+              delete mesh.userData.pendingMaterialInfo;
+              this.material(id, color, opacity, side);
+            }
+          },
+          undefined,
+          (error) => console.error("STL load error:", error),
+        );
       } else if (type == "axes_helper") {
         mesh = new THREE.AxesHelper(args[0]);
         mesh.material.transparent = true;
@@ -365,11 +392,6 @@ export default {
           const settings = { depth: height, bevelEnabled: false };
           geometry = new THREE.ExtrudeGeometry(shape, settings);
         }
-        if (type == "stl") {
-          const url = args[0];
-          geometry = new THREE.BufferGeometry();
-          this.stl_loader.load(url, (geometry) => (mesh.geometry = geometry));
-        }
         let material;
         if (wireframe) {
           mesh = new THREE.LineSegments(
@@ -392,7 +414,7 @@ export default {
     material(object_id, color, opacity, side) {
       const object = this.objects.get(object_id);
       if (!object) return;
-      if (object.userData.isGltf && !object.userData.loaded) {
+      if ((object.userData.isGltf || object.userData.isStl) && !object.userData.loaded) {
         object.userData.pendingMaterialInfo = { color, opacity, side };
         return;
       }
@@ -408,8 +430,8 @@ export default {
           else m.side = THREE.DoubleSide;
         });
       };
-      if (object.userData.isGltf) {
-        object.traverse((child) => child.isMesh && child.material && apply(child.material));
+      if (object.userData.isGltf || object.userData.isStl) {
+        object.traverse((child) => (child.isMesh || child.isLine) && child.material && apply(child.material));
       } else if (object.material) {
         apply(object.material);
       }

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -339,7 +339,7 @@ export default {
             }
           },
           undefined,
-          (error) => console.error(error),
+          (error) => console.error("GLTF load error:", error),
         );
       } else if (type == "stl") {
         const url = args[0];

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -426,9 +426,7 @@ export default {
         });
       };
       if (object.userData.isGltf || object.userData.isStl) {
-        object.traverse(
-          (child) => (child.isMesh || (object.userData.isStl && child.isLine)) && child.material && apply(child.material),
-        );
+        object.traverse((child) => child.material && apply(child.material));
       } else if (object.material) {
         apply(object.material);
       }

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -341,7 +341,6 @@ export default {
         mesh = new THREE.Group();
         mesh.userData.isStl = true;
         mesh.userData.loaded = false;
-        mesh.userData.wireframe = wireframe;
         this.stl_loader.load(
           url,
           (geometry) => {
@@ -351,6 +350,8 @@ export default {
                   new THREE.LineBasicMaterial({ transparent: true }),
                 )
               : new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({ transparent: true }));
+            child.object_id = id; // NOTE: click intersections report the raycast-hit child, not the group
+            child.name = mesh.name;
             mesh.add(child);
             mesh.userData.loaded = true;
             if (mesh.userData.pendingMaterialInfo) {
@@ -431,7 +432,9 @@ export default {
         });
       };
       if (object.userData.isGltf || object.userData.isStl) {
-        object.traverse((child) => (child.isMesh || child.isLine) && child.material && apply(child.material));
+        object.traverse(
+          (child) => (child.isMesh || (object.userData.isStl && child.isLine)) && child.material && apply(child.material),
+        );
       } else if (object.material) {
         apply(object.material);
       }

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -402,7 +402,9 @@ export default {
     },
     name(object_id, name) {
       if (!this.objects.has(object_id)) return;
-      this.objects.get(object_id).name = name;
+      const object = this.objects.get(object_id);
+      object.name = name;
+      if (object.userData.isStl) object.children.forEach((child) => (child.name = name));
     },
     material(object_id, color, opacity, side) {
       const object = this.objects.get(object_id);

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -58,6 +58,12 @@ function texture_material(texture) {
   });
 }
 
+function mesh_from_geometry(geometry, wireframe) {
+  return wireframe
+    ? new THREE.LineSegments(new THREE.EdgesGeometry(geometry), new THREE.LineBasicMaterial({ transparent: true }))
+    : new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({ transparent: true }));
+}
+
 function set_point_cloud_data(position, color, geometry) {
   geometry.setAttribute("position", new THREE.Float32BufferAttribute(position.flat(), 3));
   if (color === null) {
@@ -344,12 +350,7 @@ export default {
         this.stl_loader.load(
           url,
           (geometry) => {
-            const child = wireframe
-              ? new THREE.LineSegments(
-                  new THREE.EdgesGeometry(geometry),
-                  new THREE.LineBasicMaterial({ transparent: true }),
-                )
-              : new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({ transparent: true }));
+            const child = mesh_from_geometry(geometry, wireframe);
             child.object_id = id; // NOTE: click intersections report the raycast-hit child, not the group
             child.name = mesh.name;
             mesh.add(child);
@@ -393,16 +394,7 @@ export default {
           const settings = { depth: height, bevelEnabled: false };
           geometry = new THREE.ExtrudeGeometry(shape, settings);
         }
-        let material;
-        if (wireframe) {
-          mesh = new THREE.LineSegments(
-            new THREE.EdgesGeometry(geometry),
-            new THREE.LineBasicMaterial({ transparent: true }),
-          );
-        } else {
-          material = new THREE.MeshPhongMaterial({ transparent: true });
-          mesh = new THREE.Mesh(geometry, material);
-        }
+        mesh = mesh_from_geometry(geometry, wireframe);
       }
       mesh.object_id = id;
       this.objects.set(id, mesh);

--- a/tests/media/cube.stl
+++ b/tests/media/cube.stl
@@ -1,0 +1,86 @@
+solid cube
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 1 1 0
+      vertex 1 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 0 1 0
+      vertex 1 1 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 1
+      vertex 1 0 1
+      vertex 1 1 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 1
+      vertex 1 1 1
+      vertex 0 1 1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 1 0 0
+      vertex 1 0 1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 1 0 1
+      vertex 0 0 1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 1 0
+      vertex 1 1 1
+      vertex 1 1 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 1 0
+      vertex 0 1 1
+      vertex 1 1 1
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 1
+      vertex 0 1 1
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 1 1
+      vertex 0 1 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 1 0 0
+      vertex 1 1 0
+      vertex 1 1 1
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 1 0 0
+      vertex 1 1 1
+      vertex 1 0 1
+    endloop
+  endfacet
+endsolid cube

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -218,7 +218,7 @@ def test_gltf(screen: Screen, set_material: bool, color: str):
 
 
 def test_stl_wireframe(screen: Screen):
-    """A wireframe STL must render as edges: a LineSegments whose geometry is EdgesGeometry."""
+    """A wireframe STL must render as edges (a LineSegments with EdgesGeometry) and follow renames after loading."""
     scene = None
     obj = None
 
@@ -228,25 +228,31 @@ def test_stl_wireframe(screen: Screen):
         app.add_static_file(local_file=TEST_DIR / 'media' / 'cube.stl', url_path='/cube.stl')
         with ui.scene() as scene:
             obj = scene.stl('/cube.stl', wireframe=True)
+        ui.button('Rename', on_click=lambda: obj.with_name('renamed'))
 
     screen.open('/')
     screen.wait_for(lambda: obj is not None and screen.selenium.execute_script(
         f'return !!window.getElement && getElement({scene.id})?.objects?.get("{obj.id}")?.children.length > 0'
     ))
-    result = screen.selenium.execute_script(
-        f'const o = getElement({scene.id}).objects.get("{obj.id}");'
-        'const child = o.children && o.children[0];'
-        'return {'
-        '  root_type: o.type,'
-        '  child_geometry: child ? child.geometry.type : null,'
-        '  edge_count: (child && child.geometry.attributes.position) ? child.geometry.attributes.position.count : 0,'
-        '  child_object_id: child ? child.object_id : null,'
-        '};'
-    )
+    result = screen.selenium.execute_script(f'''
+        const obj = getElement({scene.id}).objects.get("{obj.id}");
+        const child = obj.children && obj.children[0];
+        return {{
+            root_type: obj.type,
+            child_geometry: child ? child.geometry.type : null,
+            edge_count: (child && child.geometry.attributes.position) ? child.geometry.attributes.position.count : 0,
+            child_object_id: child ? child.object_id : null,
+        }};
+    ''')
     assert result['root_type'] == 'Group', f'expected a Group wrapper, got {result}'
     assert result['child_geometry'] == 'EdgesGeometry', f'expected EdgesGeometry child, got {result}'
     assert result['edge_count'] > 0, f'expected non-empty edges, got {result}'
     assert result['child_object_id'] == obj.id, f'expected click-hittable child with object_id, got {result}'
+
+    screen.click('Rename')  # rename AFTER the async load has completed
+    screen.wait_for(lambda: screen.selenium.execute_script(
+        f'return getElement({scene.id}).objects.get("{obj.id}").children[0].name === "renamed"'
+    ))
 
 
 def test_no_cyclic_references(screen: Screen):
@@ -279,25 +285,3 @@ def test_custom_controls(screen: Screen, control_type: Literal['map', 'trackball
     screen.open('/')
     screen.wait_for(lambda: scene is not None)
     assert screen.selenium.execute_script(f'return getElement({scene.id}).controls.constructor.name') == constructor
-
-
-def test_stl_name_after_load(screen: Screen):
-    """Renaming an STL after it has loaded must reach the raycast-hittable child (else click3d reports a stale name)."""
-    scene = None
-    obj = None
-
-    @ui.page('/')
-    def page():
-        nonlocal scene, obj
-        app.add_static_file(local_file=TEST_DIR / 'media' / 'cube.stl', url_path='/cube.stl')
-        with ui.scene() as scene:
-            obj = scene.stl('/cube.stl')
-
-    screen.open('/')
-    screen.wait_for(lambda: obj is not None and screen.selenium.execute_script(
-        f'return !!window.getElement && getElement({scene.id})?.objects?.get("{obj.id}")?.children.length > 0'
-    ))
-    obj.with_name('renamed')  # rename AFTER the async load has completed
-    screen.wait_for(lambda: screen.selenium.execute_script(
-        f'return getElement({scene.id}).objects.get("{obj.id}").children[0].name === "renamed"'
-    ))

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -279,3 +279,25 @@ def test_custom_controls(screen: Screen, control_type: Literal['map', 'trackball
     screen.open('/')
     screen.wait_for(lambda: scene is not None)
     assert screen.selenium.execute_script(f'return getElement({scene.id}).controls.constructor.name') == constructor
+
+
+def test_stl_name_after_load(screen: Screen):
+    """Renaming an STL after it has loaded must reach the raycast-hittable child (else click3d reports a stale name)."""
+    scene = None
+    obj = None
+
+    @ui.page('/')
+    def page():
+        nonlocal scene, obj
+        app.add_static_file(local_file=TEST_DIR / 'media' / 'cube.stl', url_path='/cube.stl')
+        with ui.scene() as scene:
+            obj = scene.stl('/cube.stl')
+
+    screen.open('/')
+    screen.wait_for(lambda: obj is not None and screen.selenium.execute_script(
+        f'return !!window.getElement && getElement({scene.id})?.objects?.get("{obj.id}")?.children.length > 0'
+    ))
+    obj.with_name('renamed')  # rename AFTER the async load has completed
+    screen.wait_for(lambda: screen.selenium.execute_script(
+        f'return getElement({scene.id}).objects.get("{obj.id}").children[0].name === "renamed"'
+    ))

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -217,6 +217,34 @@ def test_gltf(screen: Screen, set_material: bool, color: str):
     ) == color
 
 
+def test_stl_wireframe(screen: Screen):
+    """A wireframe STL must render as edges: a LineSegments whose geometry is EdgesGeometry."""
+    scene = None
+    obj = None
+
+    @ui.page('/')
+    def page():
+        nonlocal scene, obj
+        app.add_static_file(local_file=TEST_DIR / 'media' / 'cube.stl', url_path='/cube.stl')
+        with ui.scene() as scene:
+            obj = scene.stl('/cube.stl', wireframe=True)
+
+    screen.open('/')
+    screen.wait(1.0)
+    result = screen.selenium.execute_script(
+        f'const o = getElement({scene.id}).objects.get("{obj.id}");'
+        'const child = o.children && o.children[0];'
+        'return {'
+        '  root_type: o.type,'
+        '  child_geometry: child ? child.geometry.type : null,'
+        '  edge_count: (child && child.geometry.attributes.position) ? child.geometry.attributes.position.count : 0,'
+        '};'
+    )
+    assert result['root_type'] == 'Group', f'expected a Group wrapper, got {result}'
+    assert result['child_geometry'] == 'EdgesGeometry', f'expected EdgesGeometry child, got {result}'
+    assert result['edge_count'] > 0, f'expected non-empty edges, got {result}'
+
+
 def test_no_cyclic_references(screen: Screen):
     objects: weakref.WeakSet = weakref.WeakSet()
     scene = None

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -240,11 +240,13 @@ def test_stl_wireframe(screen: Screen):
         '  root_type: o.type,'
         '  child_geometry: child ? child.geometry.type : null,'
         '  edge_count: (child && child.geometry.attributes.position) ? child.geometry.attributes.position.count : 0,'
+        '  child_object_id: child ? child.object_id : null,'
         '};'
     )
     assert result['root_type'] == 'Group', f'expected a Group wrapper, got {result}'
     assert result['child_geometry'] == 'EdgesGeometry', f'expected EdgesGeometry child, got {result}'
     assert result['edge_count'] > 0, f'expected non-empty edges, got {result}'
+    assert result['child_object_id'] == obj.id, f'expected click-hittable child with object_id, got {result}'
 
 
 def test_no_cyclic_references(screen: Screen):

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -230,7 +230,9 @@ def test_stl_wireframe(screen: Screen):
             obj = scene.stl('/cube.stl', wireframe=True)
 
     screen.open('/')
-    screen.wait(1.0)
+    screen.wait_for(lambda: obj is not None and screen.selenium.execute_script(
+        f'return !!window.getElement && getElement({scene.id})?.objects?.get("{obj.id}")?.children.length > 0'
+    ))
     result = screen.selenium.execute_script(
         f'const o = getElement({scene.id}).objects.get("{obj.id}");'
         'const child = o.children && o.children[0];'

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -218,7 +218,7 @@ def test_gltf(screen: Screen, set_material: bool, color: str):
 
 
 def test_stl_wireframe(screen: Screen):
-    """A wireframe STL must render as edges (a LineSegments with EdgesGeometry) and follow renames after loading."""
+    """A wireframe STL must render as edges (a LineSegments with EdgesGeometry), be colorable, and follow renames."""
     scene = None
     obj = None
 
@@ -227,7 +227,7 @@ def test_stl_wireframe(screen: Screen):
         nonlocal scene, obj
         app.add_static_file(local_file=TEST_DIR / 'media' / 'cube.stl', url_path='/cube.stl')
         with ui.scene() as scene:
-            obj = scene.stl('/cube.stl', wireframe=True)
+            obj = scene.stl('/cube.stl', wireframe=True).material('#ff0000')
         ui.button('Rename', on_click=lambda: obj.with_name('renamed'))
 
     screen.open('/')
@@ -242,12 +242,14 @@ def test_stl_wireframe(screen: Screen):
             child_geometry: child ? child.geometry.type : null,
             edge_count: (child && child.geometry.attributes.position) ? child.geometry.attributes.position.count : 0,
             child_object_id: child ? child.object_id : null,
+            child_color: (child && child.material) ? child.material.color.getHexString() : null,
         }};
     ''')
     assert result['root_type'] == 'Group', f'expected a Group wrapper, got {result}'
     assert result['child_geometry'] == 'EdgesGeometry', f'expected EdgesGeometry child, got {result}'
     assert result['edge_count'] > 0, f'expected non-empty edges, got {result}'
     assert result['child_object_id'] == obj.id, f'expected click-hittable child with object_id, got {result}'
+    assert result['child_color'] == 'ff0000', f'expected material to reach the wireframe lines, got {result}'
 
     screen.click('Rename')  # rename AFTER the async load has completed
     screen.wait_for(lambda: screen.selenium.execute_script(


### PR DESCRIPTION
### Motivation

`scene.stl(url, wireframe=True)` is broken on `main`: the `stl` case in `scene.js` creates an empty `BufferGeometry` synchronously and immediately hands it to `EdgesGeometry`, which throws reading the position attribute during creation — the object is never registered — and the async load callback then throws again assigning `.geometry` to the never-created mesh. Result: two uncaught TypeErrors in the console and nothing rendered.

Full analysis with a minimal repro and before/after screenshots by @evnchn in https://github.com/zauberzeug/nicegui/pull/5989#issuecomment-4862310342. This PR splits the fix out of #5989 so it can land ahead of the feature work there, as suggested in that review.

### Implementation

The `stl` path now mirrors the `gltf` path: `scene.stl` creates a `THREE.Group` placeholder and builds the actual `LineSegments`/`EdgesGeometry` (or `Mesh`) inside the loader callback, once the real geometry exists. Material application on the not-yet-loaded group is deferred via the existing `pendingMaterialInfo` mechanism and flushed when loading completes.

Within loaded model groups (STL and glTF), `material()` now applies to every child that has a material. This is what lets wireframe STLs (`LineSegments`) receive color/opacity/side updates, and it also fixes a small related glTF bug: an explicit `material()` call previously recolored only mesh primitives, silently skipping line and point primitives. Since #6118, glTF materials are only applied when the user explicitly sets one, so model-defined materials remain untouched otherwise.

The loader callback also stamps the element's `object_id` and name on the raycast-hittable child, so STL objects keep producing `click3d` hits exactly as they did on `main` (a Group is never the intersected object, and the click handler filters hits without an `object_id`); `name()` forwards later renames to that child so hits don't report a stale name.

The regression test (based on @evnchn's ready-made test from the #5989 review, thanks!) loads a minimal 12-triangle ASCII cube fixture (`tests/media/cube.stl`) with `wireframe=True` and an explicit red material, and asserts a `Group` wrapper with a non-empty `EdgesGeometry` child carrying the element's `object_id` and the material color — it fails with the crash on `main` and passes with this fix. A button click then renames the object after the async load and the test asserts the new name reaches the raycast-hittable child.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
