### PR TITLE
Update nicegui-highcharts to 3.3 and document dynamic series updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ matplotlib = [
     "fonttools>=4.60.2",  # https://github.com/zauberzeug/nicegui/security/dependabot/68, for matplotlib
     "pillow>=12.2.0",  # https://github.com/zauberzeug/nicegui/security/dependabot/245, for matplotlib
 ]
-highcharts = ["nicegui-highcharts>=3.2.1,<4"]
+highcharts = ["nicegui-highcharts>=3.3.0,<4"]
 redis = ["redis>=4.0.0"]
 
 [dependency-groups]
@@ -85,7 +85,7 @@ dev = [
     "matplotlib>=3.5.0,<4",  # extra: matplotlib
     "fonttools>=4.60.2",  # https://github.com/zauberzeug/nicegui/security/dependabot/68, for matplotlib
     "pillow>=12.2.0",  # https://github.com/zauberzeug/nicegui/security/dependabot/245, for matplotlib
-    "nicegui-highcharts>=3.2.1,<4",  # extra: highcharts
+    "nicegui-highcharts>=3.3.0,<4",  # extra: highcharts
     "redis>=4.0.0",  # extra: redis
     {include-group = "types"},
     {include-group = "website"},

--- a/uv.lock
+++ b/uv.lock
@@ -2240,7 +2240,7 @@ requires-dist = [
     { name = "lxml-html-clean", specifier = ">=0.4.4" },
     { name = "markdown2", specifier = ">=2.4.7,!=2.4.11" },
     { name = "matplotlib", marker = "extra == 'matplotlib'", specifier = ">=3.5.0,<4" },
-    { name = "nicegui-highcharts", marker = "extra == 'highcharts'", specifier = ">=3.2.1,<4" },
+    { name = "nicegui-highcharts", marker = "extra == 'highcharts'", specifier = ">=3.3.0,<4" },
     { name = "orjson", marker = "platform_machine != 'i386' and platform_machine != 'i686' and platform_python_implementation != 'PyPy'", specifier = ">=3.11.5" },
     { name = "pillow", marker = "extra == 'matplotlib'", specifier = ">=12.2.0" },
     { name = "plotly", marker = "extra == 'plotly'", specifier = ">=5.13,<7.0" },
@@ -2275,7 +2275,7 @@ dev = [
     { name = "latex2mathml", specifier = ">=3.78.1,<4.0.0" },
     { name = "matplotlib", specifier = ">=3.5.0,<4" },
     { name = "mypy", specifier = ">=1.13.0,<2" },
-    { name = "nicegui-highcharts", specifier = ">=3.2.1,<4" },
+    { name = "nicegui-highcharts", specifier = ">=3.3.0,<4" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "pandas", marker = "python_full_version < '3.13'", specifier = ">=2.0.0,<3" },
     { name = "pandas", marker = "python_full_version == '3.13.*'", specifier = ">=2.2.3,<3" },
@@ -2334,14 +2334,14 @@ website = [
 
 [[package]]
 name = "nicegui-highcharts"
-version = "3.2.1"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nicegui" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/49/e5b2fc4df76cea0356c76360fa11cdfe160e1af2b885019fb50aec3550bc/nicegui_highcharts-3.2.1.tar.gz", hash = "sha256:ab2d634b399c4a23a63209bdc459300193b9cd3c5a0d35119d92e3f67c537ac0", size = 2073203, upload-time = "2026-03-10T09:36:58.06Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/87/4495760fed63f113361e5ff52507460fbb39d7ab63375b1dce72b47e33e1/nicegui_highcharts-3.3.0.tar.gz", hash = "sha256:84848fe15c54bd7a8ff491a96f4627cf0db1b44a2da89611100237046337125d", size = 2073111, upload-time = "2026-07-04T16:31:40.385Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/4b/dbe3bd3a323b621891af8bdcc0c046e59abed6b7f285a6351e3c3cf75078/nicegui_highcharts-3.2.1-py3-none-any.whl", hash = "sha256:bf5af947dc456ef6387a5a59ca3da30fa46a4aca050708a593b5d4757b40b094", size = 2189887, upload-time = "2026-03-10T09:36:59.766Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4a/a0525c4bf3d8361cbb6fbe5c2d7b446cc6734dd9a0e7040e846c4961b79a/nicegui_highcharts-3.3.0-py3-none-any.whl", hash = "sha256:13fb5865f441efd200c874b1d40ae5679425fd732ea09ae634c6e5f930e2d920", size = 2189802, upload-time = "2026-07-04T16:31:39.011Z" },
 ]
 
 [[package]]

--- a/website/documentation/content/highchart_documentation.py
+++ b/website/documentation/content/highchart_documentation.py
@@ -23,6 +23,37 @@ def main_demo() -> None:
     ui.button('Update', on_click=update)
 
 
+@doc.demo('Adding and removing series', '''
+    The ``options`` dictionary is the single source of truth for the chart:
+    when it changes, series and axes are added, updated and removed so that the chart always matches the options.
+    State added on the client, e.g. via JavaScript, does not survive updates.
+
+    When adding and removing series dynamically, it is recommended to give each series an explicit ``id``.
+    Otherwise series are matched by position and user state like legend-click visibility
+    can end up attached to the wrong series.
+
+    *Note: Server updates while a user is drilled into a chart (``extras=['drilldown']``) reset the drill view.*
+''')
+def dynamic_series() -> None:
+    from random import random
+
+    chart = ui.highchart({
+        'title': False,
+        'chart': {'type': 'line'},
+        'series': [],
+    }).classes('w-full h-64')
+
+    def toggle(name: str, value: bool) -> None:
+        if value:
+            chart.options['series'].append({'id': name, 'name': name, 'data': [random() for _ in range(5)]})
+        else:
+            chart.options['series'][:] = [s for s in chart.options['series'] if s['id'] != name]
+
+    with ui.row():
+        ui.switch('Alpha', on_change=lambda e: toggle('Alpha', e.value))
+        ui.switch('Beta', on_change=lambda e: toggle('Beta', e.value))
+
+
 @doc.demo('Chart with extra dependencies', '''
     To use a chart type that is not included in the default dependencies, you can specify extra dependencies.
     This demo shows a solid gauge chart.

--- a/website/documentation/content/highchart_documentation.py
+++ b/website/documentation/content/highchart_documentation.py
@@ -25,21 +25,20 @@ def main_demo() -> None:
 
 @doc.demo('Adding and removing series', '''
     The ``options`` dictionary is the single source of truth for the chart:
-    when it changes, series and axes are added, updated and removed so that the chart always matches the options.
+    when it changes, series and axes are added, updated and removed so that these always match the options.
     State added on the client, e.g. via JavaScript, does not survive updates.
 
     When adding and removing series dynamically, it is recommended to give each series an explicit ``id``.
     Otherwise series are matched by position and user state like legend-click visibility
     can end up attached to the wrong series.
 
-    *Note: Server updates while a user is drilled into a chart (``extras=['drilldown']``) reset the drill view.*
+    **Note:** Server updates while a user is drilled into a chart (``extras=['drilldown']``) reset the drill view.
 ''')
 def dynamic_series() -> None:
     from random import random
 
     chart = ui.highchart({
         'title': False,
-        'chart': {'type': 'line'},
         'series': [],
     }).classes('w-full h-64')
 

--- a/website/documentation/content/highchart_documentation.py
+++ b/website/documentation/content/highchart_documentation.py
@@ -43,10 +43,11 @@ def dynamic_series() -> None:
     }).classes('w-full h-64')
 
     def toggle(name: str, value: bool) -> None:
+        series = chart.options['series']
         if value:
-            chart.options['series'].append({'id': name, 'name': name, 'data': [random() for _ in range(5)]})
+            series.append({'id': name, 'name': name, 'data': [random() for _ in range(5)]})
         else:
-            chart.options['series'][:] = [s for s in chart.options['series'] if s['id'] != name]
+            series.remove(next(s for s in series if s['id'] == name))
 
     with ui.row():
         ui.switch('Alpha', on_change=lambda e: toggle('Alpha', e.value))


### PR DESCRIPTION
### Motivation

nicegui-highcharts 3.3.0 fixes adding and removing chart series (zauberzeug/nicegui-highcharts#1, zauberzeug/nicegui-highcharts#28) by switching to Highcharts' [one-to-one updating](https://api.highcharts.com/class-reference/Highcharts.Chart#update). Bumping the dependency lets the website and the `highcharts` extra pick up the new version.

### Implementation

- Raise both `nicegui-highcharts` pins in `pyproject.toml` from `>=3.2.1,<4` to `>=3.3.0,<4`.
- Since the fix makes the `options` dictionary the single source of truth for series and axes, add a documentation demo "Adding and removing series" covering the new contract: series and axes are synchronized declaratively, explicit series `id`s are recommended for dynamic add/remove, and server updates during drilldown reset the drill view (known limitation).

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been added/updated.
- [x] No breaking changes to the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
