### PR TITLE
Detach removed items from ObservableCollection and reference containers weakly

### DIFF
--- a/nicegui/observables.py
+++ b/nicegui/observables.py
@@ -33,9 +33,8 @@ class ObservableCollection(abc.ABC):  # noqa: B024
 
     @_parent.setter
     def _parent(self, parent: ObservableCollection | None) -> None:
-        # NOTE: the reference is weak so that items don't keep discarded parent collections alive
-        self._parent_ref: weakref.ref[ObservableCollection] | None = \
-            weakref.ref(parent) if parent is not None else None
+        # the reference is weak so that items don't keep discarded parent collections alive
+        self._parent_ref = weakref.ref(parent) if parent is not None else None
 
     @property
     def change_handlers(self) -> list[Callable]:
@@ -44,8 +43,7 @@ class ObservableCollection(abc.ABC):  # noqa: B024
 
     @property
     def _change_handlers_with_args(self) -> list[tuple[Callable, bool]]:
-        """Return all change handlers and their pre-resolved `expect_args` flag,
-        including those of parents and observers."""
+        """Return change handlers with pre-resolved ``expect_args`` flag, including those of parents and observers."""
         change_handlers = self._change_handlers[:]
         observers = [ref() for ref in self._observer_refs]
         change_handlers.extend((observer._handle_change, False)  # pylint: disable=protected-access
@@ -65,12 +63,7 @@ class ObservableCollection(abc.ABC):  # noqa: B024
             self._change_handlers.append((handler, helpers.expects_arguments(handler)))
 
     def _register_observer(self, observer: ObservableCollection) -> None:
-        """Register a collection which contains this collection and should be notified about changes.
-
-        Registrations are idempotent: a collection which already observes this collection
-        (directly or as its parent) is not registered again.
-        The observer is referenced weakly so that it can be garbage-collected when it is discarded.
-        """
+        """Register a collection which contains this collection and should be notified about changes."""
         if observer is self or observer is self._parent:
             return
         alive_refs = [ref for ref in self._observer_refs if ref() is not None]
@@ -97,7 +90,6 @@ class ObservableCollection(abc.ABC):  # noqa: B024
         return data
 
     def _unobserve(self, *items: Any) -> None:
-        """Detach removed items so that they no longer notify this collection about changes."""
         removed = [item for item in items if isinstance(item, ObservableCollection)]
         if not removed:
             return
@@ -126,8 +118,8 @@ class ObservableCollection(abc.ABC):  # noqa: B024
         raise NotImplementedError(f'ObservableCollection.__deepcopy__ not implemented for {type(self)}')
 
     def __reduce__(self) -> tuple[Any, tuple]:
-        # NOTE: reconstruct from plain contents so that the observer wiring (weak references, which are not
-        # picklable) is rebuilt by __init__ instead of being pickled; a freshly loaded tree has no observers yet.
+        # reconstruct from plain contents so that the observer wiring (weak references, which are not picklable)
+        # is rebuilt by __init__ instead of being pickled; a freshly loaded tree has no observers yet.
         if isinstance(self, dict):
             return ObservableDict, (dict(self),)
         if isinstance(self, list):
@@ -197,11 +189,7 @@ class ObservableDict(ObservableCollection, dict):
         return super().__or__(other)
 
     def __ior__(self, other: Any) -> Any:
-        new_items = dict(other)
-        old_values = [self[key] for key in new_items if key in self]
-        super().__ior__({key: self._observe(value) for key, value in new_items.items()})
-        self._unobserve(*old_values)
-        self._handle_change()
+        self.update(other)
         return self
 
 
@@ -230,9 +218,7 @@ class ObservableList(ObservableCollection, list):
         self._handle_change()
 
     def remove(self, value: Any) -> None:
-        item = super().pop(super().index(value))
-        self._unobserve(item)
-        self._handle_change()
+        self.pop(super().index(value))
 
     def pop(self, index: SupportsIndex = -1) -> Any:
         item = super().pop(index)
@@ -275,8 +261,7 @@ class ObservableList(ObservableCollection, list):
         return super().__add__(other)
 
     def __iadd__(self, other: Any) -> Any:
-        super().__iadd__([self._observe(item) for item in other])
-        self._handle_change()
+        self.extend(other)
         return self
 
     def __mul__(self, other: Any) -> Any:
@@ -329,8 +314,7 @@ class ObservableSet(ObservableCollection, set):
         self._handle_change()
 
     def update(self, *s: Iterable[Any]) -> None:
-        items: set = set(*s)
-        super().update({self._observe(item) for item in items})
+        super().update({self._observe(item) for item in set().union(*s)})
         self._handle_change()
 
     def intersection_update(self, *s: Iterable[Any]) -> None:
@@ -347,8 +331,7 @@ class ObservableSet(ObservableCollection, set):
 
     def symmetric_difference_update(self, *s: Iterable[Any]) -> None:
         old_items = list(self)
-        items: set = set(*s)
-        super().symmetric_difference_update({self._observe(item) for item in items})
+        super().symmetric_difference_update({self._observe(item) for item in set().union(*s)})
         self._unobserve(*old_items)
         self._handle_change()
 
@@ -356,36 +339,26 @@ class ObservableSet(ObservableCollection, set):
         return super().__or__(other)
 
     def __ior__(self, other: Any) -> Any:
-        super().__ior__({self._observe(item) for item in other})
-        self._handle_change()
+        self.update(other)
         return self
 
     def __and__(self, other: Any) -> set:
         return super().__and__(other)
 
     def __iand__(self, other: Any) -> Any:
-        old_items = list(self)
-        super().__iand__(other)
-        self._unobserve(*old_items)
-        self._handle_change()
+        self.intersection_update(other)
         return self
 
     def __sub__(self, other: Any) -> set:
         return super().__sub__(other)
 
     def __isub__(self, other: Any) -> Any:
-        old_items = list(self)
-        super().__isub__(other)
-        self._unobserve(*old_items)
-        self._handle_change()
+        self.difference_update(other)
         return self
 
     def __xor__(self, other: Any) -> set:
         return super().__xor__(other)
 
     def __ixor__(self, other: Any) -> Any:
-        old_items = list(self)
-        super().__ixor__({self._observe(item) for item in other})
-        self._unobserve(*old_items)
-        self._handle_change()
+        self.symmetric_difference_update(other)
         return self

--- a/nicegui/observables.py
+++ b/nicegui/observables.py
@@ -279,6 +279,16 @@ class ObservableList(ObservableCollection, list):
         self._handle_change()
         return self
 
+    def __mul__(self, other: Any) -> Any:
+        return super().__mul__(other)
+
+    def __imul__(self, other: Any) -> Any:
+        old_items = list(self)
+        super().__imul__(other)
+        self._unobserve(*old_items)
+        self._handle_change()
+        return self
+
 
 class ObservableSet(ObservableCollection, set):
 

--- a/nicegui/observables.py
+++ b/nicegui/observables.py
@@ -118,6 +118,17 @@ class ObservableCollection(abc.ABC):  # noqa: B024
             return ObservableSet({deepcopy(item) for item in self}, _parent=self._parent)
         raise NotImplementedError(f'ObservableCollection.__deepcopy__ not implemented for {type(self)}')
 
+    def __reduce__(self) -> tuple[Any, tuple]:
+        # NOTE: reconstruct from plain contents so that the observer wiring (weak references, which are not
+        # picklable) is rebuilt by __init__ instead of being pickled; a freshly loaded tree has no observers yet.
+        if isinstance(self, dict):
+            return ObservableDict, (dict(self),)
+        if isinstance(self, list):
+            return ObservableList, (list(self),)
+        if isinstance(self, set):
+            return ObservableSet, (set(self),)
+        raise NotImplementedError(f'ObservableCollection.__reduce__ not implemented for {type(self)}')
+
 
 class ObservableDict(ObservableCollection, dict):
 

--- a/nicegui/observables.py
+++ b/nicegui/observables.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import abc
 import time
+import weakref
 from collections.abc import Callable, Collection, Iterable
 from copy import deepcopy
-from typing import Any, SupportsIndex
+from typing import Any, SupportsIndex, cast
 
 from typing_extensions import Self
 
@@ -23,11 +24,25 @@ class ObservableCollection(abc.ABC):  # noqa: B024
         self._parent = _parent
         self.last_modified = time.time()
         self._change_handlers: list[Callable] = [on_change] if on_change else []
+        self._observer_refs: list[weakref.ref[ObservableCollection]] = []
+
+    @property
+    def _parent(self) -> ObservableCollection | None:
+        return self._parent_ref() if self._parent_ref is not None else None
+
+    @_parent.setter
+    def _parent(self, parent: ObservableCollection | None) -> None:
+        # NOTE: the reference is weak so that items don't keep discarded parent collections alive
+        self._parent_ref: weakref.ref[ObservableCollection] | None = \
+            weakref.ref(parent) if parent is not None else None
 
     @property
     def change_handlers(self) -> list[Callable]:
-        """Return a list of all change handlers registered on this collection and its parents."""
+        """Return a list of all change handlers registered on this collection and its parents and observers."""
         change_handlers = self._change_handlers[:]
+        observers = [ref() for ref in self._observer_refs]
+        change_handlers.extend(observer._handle_change  # pylint: disable=protected-access
+                               for observer in observers if observer is not None)
         if self._parent is not None:
             change_handlers.extend(self._parent.change_handlers)
         return change_handlers
@@ -42,9 +57,29 @@ class ObservableCollection(abc.ABC):  # noqa: B024
         if handler != self._handle_change:  # pylint: disable=comparison-with-callable
             self._change_handlers.append(handler)
 
+    def _register_observer(self, observer: ObservableCollection) -> None:
+        """Register a collection which contains this collection and should be notified about changes.
+
+        Registrations are idempotent: a collection which already observes this collection
+        (directly or as its parent) is not registered again.
+        The observer is referenced weakly so that it can be garbage-collected when it is discarded.
+        """
+        if observer is self or observer is self._parent:
+            return
+        alive_refs = [ref for ref in self._observer_refs if ref() is not None]
+        if any(ref() is observer for ref in alive_refs):
+            return
+        self._observer_refs = [*alive_refs, weakref.ref(observer)]
+
+    def _unregister_observer(self, observer: ObservableCollection) -> None:
+        """Unregister a collection so that it is no longer notified about changes."""
+        if self._parent is observer:
+            self._parent = None
+        self._observer_refs = [ref for ref in self._observer_refs if ref() is not None and ref() is not observer]
+
     def _observe(self, data: Any) -> Any:
         if isinstance(data, ObservableCollection):
-            data.on_change(self._handle_change)
+            data._register_observer(self)  # pylint: disable=protected-access
             return data
         if isinstance(data, dict):
             return ObservableDict(data, _parent=self)
@@ -53,6 +88,17 @@ class ObservableCollection(abc.ABC):  # noqa: B024
         if isinstance(data, set):
             return ObservableSet(data, _parent=self)
         return data
+
+    def _unobserve(self, *items: Any) -> None:
+        """Detach removed items so that they no longer notify this collection about changes."""
+        removed = [item for item in items if isinstance(item, ObservableCollection)]
+        if not removed:
+            return
+        values: Iterable = self.values() if isinstance(self, dict) else cast(Iterable, self)
+        contained_ids = {id(value) for value in values if isinstance(value, ObservableCollection)}
+        for item in removed:
+            if id(item) not in contained_ids:
+                item._unregister_observer(self)  # pylint: disable=protected-access
 
     def __copy__(self) -> Self:
         if isinstance(self, dict):
@@ -87,41 +133,56 @@ class ObservableDict(ObservableCollection, dict):
 
     def pop(self, k: Any, d: Any = None) -> Any:
         item = super().pop(k, d)
+        self._unobserve(item)
         self._handle_change()
         return item
 
     def popitem(self) -> Any:
         item = super().popitem()
+        self._unobserve(item[1])
         self._handle_change()
         return item
 
     def update(self, *args: Any, **kwargs: Any) -> None:
-        super().update(self._observe(dict(*args, **kwargs)))
+        new_items = dict(*args, **kwargs)
+        old_values = [self[key] for key in new_items if key in self]
+        super().update({key: self._observe(value) for key, value in new_items.items()})
+        self._unobserve(*old_values)
         self._handle_change()
 
     def clear(self) -> None:
+        values = list(self.values())
         super().clear()
+        self._unobserve(*values)
         self._handle_change()
 
     def setdefault(self, __key: Any, __default: Any = None) -> Any:
-        item = super().setdefault(__key, self._observe(__default))
+        if __key not in self:
+            __default = self._observe(__default)
+        item = super().setdefault(__key, __default)
         self._handle_change()
         return item
 
     def __setitem__(self, __key: Any, __value: Any) -> None:
+        old_value = self.get(__key)
         super().__setitem__(__key, self._observe(__value))
+        self._unobserve(old_value)
         self._handle_change()
 
     def __delitem__(self, __key: Any) -> None:
+        item = self[__key]
         super().__delitem__(__key)
+        self._unobserve(item)
         self._handle_change()
 
     def __or__(self, other: Any) -> Any:
         return super().__or__(other)
 
     def __ior__(self, other: Any) -> Any:
-        other_dict = self._observe(dict(other))
-        super().__ior__(other_dict)
+        new_items = dict(other)
+        old_values = [self[key] for key in new_items if key in self]
+        super().__ior__({key: self._observe(value) for key, value in new_items.items()})
+        self._unobserve(*old_values)
         self._handle_change()
         return self
 
@@ -143,7 +204,7 @@ class ObservableList(ObservableCollection, list):
         self._handle_change()
 
     def extend(self, iterable: Iterable) -> None:
-        super().extend(self._observe(list(iterable)))
+        super().extend([self._observe(item) for item in iterable])
         self._handle_change()
 
     def insert(self, index: SupportsIndex, obj: Any) -> None:
@@ -151,16 +212,20 @@ class ObservableList(ObservableCollection, list):
         self._handle_change()
 
     def remove(self, value: Any) -> None:
-        super().remove(value)
+        item = super().pop(super().index(value))
+        self._unobserve(item)
         self._handle_change()
 
     def pop(self, index: SupportsIndex = -1) -> Any:
         item = super().pop(index)
+        self._unobserve(item)
         self._handle_change()
         return item
 
     def clear(self) -> None:
+        items = list(self)
         super().clear()
+        self._unobserve(*items)
         self._handle_change()
 
     def sort(self, **kwargs: Any) -> None:
@@ -172,18 +237,27 @@ class ObservableList(ObservableCollection, list):
         self._handle_change()
 
     def __delitem__(self, key: SupportsIndex | slice) -> None:
+        items = self[key] if isinstance(key, slice) else [self[key]]
         super().__delitem__(key)
+        self._unobserve(*items)
         self._handle_change()
 
     def __setitem__(self, key: SupportsIndex | slice, value: Any) -> None:
-        super().__setitem__(key, self._observe(value))
+        if isinstance(key, slice):
+            old_items = self[key]
+            super().__setitem__(key, [self._observe(item) for item in value])
+            self._unobserve(*old_items)
+        else:
+            old_item = self[key]
+            super().__setitem__(key, self._observe(value))
+            self._unobserve(old_item)
         self._handle_change()
 
     def __add__(self, other: Any) -> Any:
         return super().__add__(other)
 
     def __iadd__(self, other: Any) -> Any:
-        super().__iadd__(self._observe(other))
+        super().__iadd__([self._observe(item) for item in other])
         self._handle_change()
         return self
 
@@ -206,42 +280,55 @@ class ObservableSet(ObservableCollection, set):
 
     def remove(self, item: Any) -> None:
         super().remove(item)
+        self._unobserve(item)
         self._handle_change()
 
     def discard(self, item: Any) -> None:
         super().discard(item)
+        self._unobserve(item)
         self._handle_change()
 
     def pop(self) -> Any:
         item = super().pop()
+        self._unobserve(item)
         self._handle_change()
         return item
 
     def clear(self) -> None:
+        items = list(self)
         super().clear()
+        self._unobserve(*items)
         self._handle_change()
 
     def update(self, *s: Iterable[Any]) -> None:
-        super().update(self._observe(set(*s)))
+        items: set = set(*s)
+        super().update({self._observe(item) for item in items})
         self._handle_change()
 
     def intersection_update(self, *s: Iterable[Any]) -> None:
+        old_items = list(self)
         super().intersection_update(*s)
+        self._unobserve(*old_items)
         self._handle_change()
 
     def difference_update(self, *s: Iterable[Any]) -> None:
+        old_items = list(self)
         super().difference_update(*s)
+        self._unobserve(*old_items)
         self._handle_change()
 
     def symmetric_difference_update(self, *s: Iterable[Any]) -> None:
-        super().symmetric_difference_update(*s)
+        old_items = list(self)
+        items: set = set(*s)
+        super().symmetric_difference_update({self._observe(item) for item in items})
+        self._unobserve(*old_items)
         self._handle_change()
 
     def __or__(self, other: Any) -> Any:
         return super().__or__(other)
 
     def __ior__(self, other: Any) -> Any:
-        super().__ior__(self._observe(other))
+        super().__ior__({self._observe(item) for item in other})
         self._handle_change()
         return self
 
@@ -249,7 +336,9 @@ class ObservableSet(ObservableCollection, set):
         return super().__and__(other)
 
     def __iand__(self, other: Any) -> Any:
-        super().__iand__(self._observe(other))
+        old_items = list(self)
+        super().__iand__(other)
+        self._unobserve(*old_items)
         self._handle_change()
         return self
 
@@ -257,7 +346,9 @@ class ObservableSet(ObservableCollection, set):
         return super().__sub__(other)
 
     def __isub__(self, other: Any) -> Any:
-        super().__isub__(self._observe(other))
+        old_items = list(self)
+        super().__isub__(other)
+        self._unobserve(*old_items)
         self._handle_change()
         return self
 
@@ -265,6 +356,8 @@ class ObservableSet(ObservableCollection, set):
         return super().__xor__(other)
 
     def __ixor__(self, other: Any) -> Any:
-        super().__ixor__(self._observe(other))
+        old_items = list(self)
+        super().__ixor__({self._observe(item) for item in other})
+        self._unobserve(*old_items)
         self._handle_change()
         return self

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import gc
+import pickle
 import weakref
 
 from nicegui import ui
@@ -274,3 +275,16 @@ def test_discarded_collections_are_garbage_collected():
     gc.collect()
     assert [ref() for ref in refs] == [None, None, None, None], 'discarded collections should be garbage-collected'
     assert child == {}
+
+
+def test_nested_observables_are_picklable():
+    reset_counter()
+    data = ObservableList([{'id': 1, 'tags': ['a', 'b']}, {'id': 2}])
+    restored = pickle.loads(pickle.dumps(data))
+    assert restored == [{'id': 1, 'tags': ['a', 'b']}, {'id': 2}]
+    assert isinstance(restored, ObservableList)
+    assert isinstance(restored[0], ObservableDict)
+    assert isinstance(restored[0]['tags'], ObservableList)
+    root = ObservableList(restored, on_change=increment_counter)
+    root[0]['x'] = 1
+    assert count == 1, 'a restored tree should wire up freshly and notify exactly once'

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -218,6 +218,10 @@ def test_removed_dict_values_are_detached():
     assert count == n, 'detached items should not fire change events anymore'
     data['c']['x'] = 1
     assert count == n + 1, 'items which are still contained should fire change events'
+    item = data['c']
+    data.clear()
+    item['y'] = 2
+    assert count == n + 2, 'items removed by clearing the dict should not fire change events anymore'
 
 
 def test_removed_list_items_are_detached():

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -235,6 +235,20 @@ def test_removed_list_items_are_detached():
     assert count == n, 'detached items should not fire change events anymore'
 
 
+def test_multiplying_list_in_place():
+    reset_counter()
+    data = ObservableList([{}], on_change=increment_counter)
+    item = data[0]
+    data *= 2
+    assert count == 1
+    item['x'] = 1
+    assert count == 2, 'items contained multiple times should fire only one change event'
+    data *= 0
+    assert count == 3
+    item['y'] = 2
+    assert count == 3, 'items removed by multiplying with zero should not fire change events anymore'
+
+
 def test_items_contained_multiple_times_are_detached_on_last_removal():
     reset_counter()
     data = ObservableList(on_change=increment_counter)

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -1,5 +1,7 @@
 import asyncio
 import copy
+import gc
+import weakref
 
 from nicegui import ui
 from nicegui.observables import ObservableDict, ObservableList, ObservableSet
@@ -178,3 +180,97 @@ async def test_no_infinite_recursion(user: User):
 
     await user.open('/')
     await user.should_see('[1, 2, 3, 1, 2, 3]')
+
+
+def test_rebuilding_list_in_place_does_not_accumulate_handlers():
+    reset_counter()
+    data = ObservableList([{}], on_change=increment_counter)
+    for _ in range(3):
+        data[:] = list(data)
+    assert count == 3
+    data[0]['x'] = 1
+    assert count == 4, 'mutating a surviving item should fire exactly one change event'
+
+
+def test_replacing_list_does_not_accumulate_handlers():
+    reset_counter()
+    data = ObservableDict({'items': [{}]}, on_change=increment_counter)
+    for _ in range(3):
+        data['items'] = list(data['items'])
+    assert count == 3
+    data['items'][0]['x'] = 1
+    assert count == 4, 'mutating a surviving item should fire exactly one change event'
+
+
+def test_removed_dict_values_are_detached():
+    reset_counter()
+    data = ObservableDict({'a': {}, 'b': {}, 'c': {}, 'd': {}}, on_change=increment_counter)
+    detached = [data.pop('a'), data.popitem()[1], data['b'], data['c']]
+    del data['b']
+    data['c'] = {'new': True}
+    data.update(e={})
+    detached.append(data['e'])
+    data.update(e={})
+    n = count
+    for item in detached:
+        item['x'] = 1
+    assert count == n, 'detached items should not fire change events anymore'
+    data['c']['x'] = 1
+    assert count == n + 1, 'items which are still contained should fire change events'
+
+
+def test_removed_list_items_are_detached():
+    reset_counter()
+    data = ObservableList([{}, {}, {}, {}, {}, {}, {}], on_change=increment_counter)
+    detached = [data.pop(), data[0], data[1], data[2], *data[3:5]]
+    data.remove(data[0])
+    del data[0]
+    data[0] = {'new': True}
+    del data[1:3]
+    data.clear()
+    n = count
+    for item in detached:
+        item['x'] = 1
+    assert count == n, 'detached items should not fire change events anymore'
+
+
+def test_items_contained_multiple_times_are_detached_on_last_removal():
+    reset_counter()
+    data = ObservableList(on_change=increment_counter)
+    item = ObservableDict()
+    data.append(item)
+    data.append(item)
+    item['x'] = 1
+    assert count == 3, 'items contained multiple times should fire only one change event'
+    data.pop()
+    item['y'] = 2
+    assert count == 5, 'items which are still contained once should fire change events'
+    data.pop()
+    item['z'] = 3
+    assert count == 6, 'items removed completely should not fire change events anymore'
+
+
+def test_items_shared_between_collections():
+    counts = {'a': 0, 'b': 0}
+    item = ObservableDict()
+    a = ObservableList([item], on_change=lambda: counts.update(a=counts['a'] + 1))
+    b = ObservableList([item], on_change=lambda: counts.update(b=counts['b'] + 1))
+    item['x'] = 1
+    assert counts == {'a': 1, 'b': 1}
+    a.clear()
+    item['y'] = 2
+    assert counts == {'a': 2, 'b': 2}, 'item should only notify the collection which still contains it'
+    assert b == [item]
+
+
+def test_discarded_collections_are_garbage_collected():
+    data = ObservableDict({'items': [{}]})
+    refs = [weakref.ref(data['items'])]
+    for _ in range(3):
+        data['items'] = list(data['items'])
+        refs.append(weakref.ref(data['items']))
+    child = data['items'][0]
+    del data
+    gc.collect()
+    assert [ref() for ref in refs] == [None, None, None, None], 'discarded collections should be garbage-collected'
+    assert child == {}


### PR DESCRIPTION
### Motivation

Fixes #6139: `ObservableCollection._observe` registered the container's `_handle_change` on observable items, but no removal or replacement operation ever deregistered it. Handlers accumulated on every rebuild (`lst[:] = [...]`, `options['series'] = [...]`), so after N rebuilds a single item mutation fired N+1 change events, and discarded containers could never be garbage-collected. Re-inserting an item into a collection it already belonged to registered a duplicate handler.

### Implementation

The item→container bookkeeping is reworked in four ways:

1. **Weak references from items to their containers.** Instead of registering strong bound-method handlers on items, observing containers are tracked in a new `_observer_refs` list of weak references, and `_parent` is now backed by a weak reference as well. A discarded container is garbage-collected and its registrations vanish with it. (Rationale: an item cannot know whether a container that still holds it has been discarded — only weak references make discarded containers collectable, which is what the reassignment pattern `options['series'] = [...]` requires.)
2. **Idempotent observation.** `_register_observer` skips containers that already observe the item (directly or as its parent), fixing the duplicate-handler wart on re-insertion.
3. **Per-item observation for bulk inserts.** `extend`, `update`, slice assignment, `|=`, `+=` etc. now observe each incoming item individually instead of wrapping the whole incoming collection in a temporary observable — previously that temporary stayed reachable via the handlers it left on surviving items.
4. **Explicit detach on removal.** Every removal/replacement operation calls the new `_unobserve`, which detaches items that are no longer contained (identity-based check, so items contained multiple times or shared between collections stay attached as long as one occurrence remains). `setdefault` also no longer observes the default value when the key already exists.

Both mechanisms are needed: explicit deregistration alone cannot fix the reassignment pattern (the discarded old wrapper still *contains* the surviving items, so no removal-based bookkeeping ever detaches it), and weak references alone cannot fix removal correctness (`item = data.pop('x'); item['y'] = 1` must not notify the still-alive `data`).

Behavioral notes:

- Mutating an item that was removed from a collection no longer notifies that collection — this is the issue's expected behavior, but technically a semantic change.
- If user code holds only a nested item while the root collection is discarded, the root is now garbage-collected and its handlers stop firing (previously the item kept the whole chain alive). Within NiceGUI, roots (props, storage, bindings) are always independently referenced.
- Nested observables are no longer picklable (weakrefs aren't picklable). Pickling was never a supported path — storage serializes to JSON, and `__copy__`/`__deepcopy__` are implemented explicitly.

Open questions for reviewers:

- **Fully weak vs. weak observers only:** Keeping `_parent` *strong* would restore picklability of plain nested trees and preserve the old "a held child keeps its discarded root alive and notifying" behavior, while still fixing the unbounded per-rebuild growth. The cost: the original wrapper of each surviving item stays alive forever (bounded at one dead container per item). This PR goes fully weak for consistency and to satisfy "discarded containers can be collected" verbatim — but the strong-`_parent` middle ground is a defensible alternative.
- **`ObservableSet` symmetry:** The `_unobserve`/per-item changes in `ObservableSet` are dead code in practice, since observables are unhashable and can never be set members. They are included for symmetry but could be dropped to shrink the diff.
- A fire-time containment check (notify only observers that still contain the sender) was considered as a smaller alternative that would leave all mutation methods untouched, but was rejected because it puts an O(container size) identity scan on every change event instead of a cost on the much rarer removal operations.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API; subtle behavioral changes are described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
