### PR TITLE
Prototype: reactive computed()/effect() on BindableProperty (RFC for #4758)

### DIFF
--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -275,6 +275,8 @@ class BindableProperty:
         self.name = name  # pylint: disable=attribute-defined-outside-init
 
     def __get__(self, owner: Any, _=None) -> Any:
+        if owner is not None:
+            _track_read(owner, (self.name,))  # PROTOTYPE: dependency capture for computed()/effect()
         return getattr(owner, '___' + self.name)
 
     def __set__(self, owner: Any, value: Any) -> None:
@@ -287,8 +289,115 @@ class BindableProperty:
         setattr(owner, '___' + self.name, value)
         bindable_properties[(id(owner), (self.name,))] = owner
         _propagate(owner, (self.name,))
+        _notify_subscribers(owner, (self.name,))  # PROTOTYPE: wake computed()/effect() that read this
         if value_changed and self._change_handler is not None:
             self._change_handler(owner, value)
+
+
+# =============================================================================
+# PROTOTYPE: reactive layer (computed / effect) on top of BindableProperty
+# -----------------------------------------------------------------------------
+# This is a proof-of-concept for zauberzeug/nicegui#4758, NOT a finished API.
+# It shows that `Computed` and `Effect` can be built directly on the existing
+# BindableProperty read/write hooks, with automatic dependency tracking, and no
+# 0.1 s refresh loop. Known open questions are documented in the discussion.
+# =============================================================================
+
+Dependency = tuple[int, tuple[str, ...]]
+
+_active_computation: ContextVar[_Computation | None] = ContextVar('active_computation', default=None)
+_subscribers: defaultdict[Dependency, weakref.WeakSet[_Computation]] = defaultdict(weakref.WeakSet)
+
+
+def _track_read(owner: Any, name: tuple[str, ...]) -> None:
+    """Record that the currently-running computation read this bindable property."""
+    computation = _active_computation.get()
+    if computation is not None:
+        computation._collecting.add((id(owner), name))  # pylint: disable=protected-access
+
+
+def _notify_subscribers(owner: Any, name: tuple[str, ...]) -> None:
+    """Re-run every computation that depends on the property that just changed."""
+    for computation in list(_subscribers.get((id(owner), name), ())):
+        computation._run()  # pylint: disable=protected-access
+
+
+class _Computation:
+    """Runs a function while recording which bindable properties it reads, then re-runs on change.
+
+    Dependencies are re-captured on every run, so branching reactive code subscribes only to the
+    properties it actually touched this time (dynamic dependency tracking).
+    """
+
+    def __init__(self, fn: Callable[[], Any]) -> None:
+        self._fn = fn
+        self._deps: set[Dependency] = set()
+        self._collecting: set[Dependency] = set()
+        self._run()
+
+    def _run(self) -> Any:
+        self._collecting = set()
+        token = _active_computation.set(self)
+        try:
+            result = self._fn()
+        finally:
+            _active_computation.reset(token)
+        for stale in self._deps - self._collecting:
+            _subscribers[stale].discard(self)
+        for fresh in self._collecting - self._deps:
+            _subscribers[fresh].add(self)
+        self._deps = self._collecting
+        return result
+
+    def dispose(self) -> None:
+        """Unsubscribe from all dependencies so this computation stops re-running."""
+        for dep in self._deps:
+            _subscribers[dep].discard(self)
+        self._deps = set()
+
+
+class Computed:
+    """A derived value that recomputes automatically when any bindable property it reads changes.
+
+    The result is exposed as a bindable ``value``, so it plugs straight into ``bind_*`` and elements::
+
+        total = binding.computed(lambda: state.price * state.qty)
+        ui.label().bind_text_from(total, 'value')
+    """
+    value = BindableProperty()
+
+    def __init__(self, fn: Callable[[], Any]) -> None:
+        self._fn = fn
+        self._computation = _Computation(lambda: setattr(self, 'value', self._fn()))
+
+    def dispose(self) -> None:
+        """Stop recomputing (dispose the underlying computation)."""
+        self._computation.dispose()
+
+
+class Effect:
+    """Runs a side-effecting function whenever any bindable property it reads changes.
+
+    Keep a reference to the returned ``Effect`` for as long as you need it; call ``dispose()``
+    (e.g. on client disconnect) to stop it and release its subscriptions.
+    """
+
+    def __init__(self, fn: Callable[[], Any]) -> None:
+        self._computation = _Computation(fn)
+
+    def dispose(self) -> None:
+        """Stop running and release all dependency subscriptions."""
+        self._computation.dispose()
+
+
+def computed(fn: Callable[[], T]) -> Computed:
+    """Create a `Computed` derived value from a function of other bindable properties (*PROTOTYPE*)."""
+    return Computed(fn)
+
+
+def effect(fn: Callable[[], Any]) -> Effect:
+    """Create an `Effect` that re-runs whenever the bindable properties it reads change (*PROTOTYPE*)."""
+    return Effect(fn)
 
 
 def _discard_binding_key_from_object_index(obj_id: int, binding_key: BindingKey) -> None:
@@ -341,6 +450,7 @@ def reset() -> None:
     bindable_properties.clear()
     active_links.clear()
     _binding_keys_by_object.clear()
+    _subscribers.clear()  # PROTOTYPE: also drop reactive computed()/effect() subscriptions
 
 
 @dataclass_transform()

--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -6,7 +6,8 @@ import dataclasses
 import time
 import weakref
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Mapping, MutableMapping
+from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
+from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
@@ -275,8 +276,21 @@ class BindableProperty:
         self.name = name  # pylint: disable=attribute-defined-outside-init
 
     def __get__(self, owner: Any, _=None) -> Any:
-        if owner is not None:
-            _track_read(owner, (self.name,))  # PROTOTYPE: dependency capture for computed()/effect()
+        # PROTOTYPE: reactive read hook. Skip while propagating (those reads are the binding system's
+        # own bookkeeping, not user dependencies) and when no computation is collecting.
+        if owner is not None and propagation_visited.get() is None:
+            computation = _active_computation.get()
+            if computation is not None:
+                name = (self.name,)
+                dep = (id(owner), name)
+                producer = _producers.get(dep)
+                if producer is not None and producer is not computation:
+                    _pull_readers.append((computation, dep))  # our fresh read of exactly this dep is in flight
+                    try:
+                        _ensure_current(producer)  # pull a dirty producer up-to-date before it is read
+                    finally:
+                        _pull_readers.pop()
+                _track_read(owner, name)  # dependency capture for computed()/effect()
         return getattr(owner, '___' + self.name)
 
     def __set__(self, owner: Any, value: Any) -> None:
@@ -288,8 +302,8 @@ class BindableProperty:
             return
         setattr(owner, '___' + self.name, value)
         bindable_properties[(id(owner), (self.name,))] = owner
-        _propagate(owner, (self.name,))
-        _notify_subscribers(owner, (self.name,))  # PROTOTYPE: wake computed()/effect() that read this
+        _notify_subscribers(owner, (self.name,))  # PROTOTYPE: settle reactive computed()/effect() first,
+        _propagate(owner, (self.name,))  # so legacy bindings that read a derived value propagate it fresh
         if value_changed and self._change_handler is not None:
             self._change_handler(owner, value)
 
@@ -305,21 +319,65 @@ class BindableProperty:
 
 Dependency = tuple[int, tuple[str, ...]]
 
+_MAX_FLUSH_ITERATIONS = 1000
+
 _active_computation: ContextVar[_Computation | None] = ContextVar('active_computation', default=None)
 _subscribers: defaultdict[Dependency, weakref.WeakSet[_Computation]] = defaultdict(weakref.WeakSet)
+_producers: weakref.WeakValueDictionary[Dependency, _Computation] = weakref.WeakValueDictionary()
+_pending: set[_Computation] = set()
+# (computation, dep) pairs currently pulling that exact producer up-to-date as a fresh read:
+_pull_readers: list[tuple[_Computation, Dependency]] = []
+_batch_depth = 0
+_flushing = False
 
 
 def _track_read(owner: Any, name: tuple[str, ...]) -> None:
-    """Record that the currently-running computation read this bindable property."""
+    """Record that the currently-running computation read this bindable property, and subscribe now.
+
+    Subscribing at read time (not at end of run) means a write to a dependency *during* the same run
+    -- e.g. an effect that writes state it just read -- still notifies the computation.
+    """
     computation = _active_computation.get()
     if computation is not None:
-        computation._collecting.add((id(owner), name))  # pylint: disable=protected-access
+        dep = (id(owner), name)
+        computation._collecting.add(dep)  # pylint: disable=protected-access
+        _subscribers[dep].add(computation)
 
 
 def _notify_subscribers(owner: Any, name: tuple[str, ...]) -> None:
-    """Re-run every computation that depends on the property that just changed."""
-    for computation in list(_subscribers.get((id(owner), name), ())):
-        computation._run()  # pylint: disable=protected-access
+    """Mark every computation that read this property dirty, then flush.
+
+    Marking is cheap and synchronous; actual recomputation is deferred to :func:`_flush` so a single
+    logical change settles the whole graph once, in dependency order -- rather than re-running
+    dependents eagerly and depth-first, which double-runs diamonds and lets effects observe
+    half-updated state.
+    """
+    dep = (id(owner), name)
+    subscribers = _subscribers.get(dep)
+    if not subscribers:
+        if subscribers is not None:
+            del _subscribers[dep]  # reap a key left empty by a garbage-collected computation
+        return
+    for computation in list(subscribers):
+        if (computation, dep) in _pull_readers:
+            continue  # it is pulling THIS dep as a fresh read in this very run: no re-enqueue needed
+        computation._dirty = True  # pylint: disable=protected-access
+        _pending.add(computation)
+    _flush()
+
+
+def _unsubscribe(dep: Dependency, computation: _Computation) -> None:
+    """Drop a computation's subscription, pruning the entry entirely when its last subscriber leaves.
+
+    (This keeps churn -- re-subscription on every run, plus ``dispose()`` -- from growing
+    ``_subscribers`` without bound. Computations garbage-collected *without* ``dispose()`` still leave
+    an empty entry behind; reaping those is part of the lifecycle work a production version must add.)
+    """
+    subscribers = _subscribers.get(dep)
+    if subscribers is not None:
+        subscribers.discard(computation)
+        if not subscribers:
+            del _subscribers[dep]
 
 
 class _Computation:
@@ -333,27 +391,93 @@ class _Computation:
         self._fn = fn
         self._deps: set[Dependency] = set()
         self._collecting: set[Dependency] = set()
+        self._dirty = False
+        self._running = False
         self._run()
 
     def _run(self) -> Any:
         self._collecting = set()
+        self._dirty = False
+        self._running = True
         token = _active_computation.set(self)
         try:
             result = self._fn()
         finally:
             _active_computation.reset(token)
-        for stale in self._deps - self._collecting:
-            _subscribers[stale].discard(self)
-        for fresh in self._collecting - self._deps:
-            _subscribers[fresh].add(self)
-        self._deps = self._collecting
+            self._running = False
+            # Reconcile deps even if fn() raised, so dispose() can unsubscribe what was read before the error
+            # (fresh deps are subscribed incrementally in _track_read; drop ones not read this run).
+            for stale in self._deps - self._collecting:
+                _unsubscribe(stale, self)
+            self._deps = self._collecting
+        if self._dirty:  # re-invalidated during our own run (e.g. we wrote a dependency we had read)
+            _pending.add(self)
+            _flush()  # converge; a genuinely unbounded feedback loop trips the _flush cycle guard
         return result
 
     def dispose(self) -> None:
         """Unsubscribe from all dependencies so this computation stops re-running."""
         for dep in self._deps:
-            _subscribers[dep].discard(self)
+            _unsubscribe(dep, self)
         self._deps = set()
+        self._dirty = False
+        _pending.discard(self)
+
+
+def _ensure_current(computation: _Computation) -> None:
+    """Recompute a dirty computation now. Used by the flush loop and by pull-on-read in ``__get__``."""
+    _pending.discard(computation)
+    if computation._dirty and not computation._running:  # pylint: disable=protected-access
+        computation._run()  # pylint: disable=protected-access
+
+
+def _flush() -> None:
+    """Recompute all pending computations, once each, in dependency order.
+
+    Ordering falls out of two mechanisms rather than an explicit topological sort: recomputing a
+    producer re-enters :func:`_notify_subscribers`, enqueueing its dependents; and a dependent that
+    happens to run first pulls any still-dirty producer it reads up-to-date via
+    :meth:`BindableProperty.__get__` before using it. So a diamond's sink recomputes exactly once,
+    after both sources have settled -- never on a half-updated intermediate.
+    """
+    global _flushing  # pylint: disable=global-statement # noqa: PLW0603
+    if _flushing or _batch_depth:
+        return
+    _flushing = True
+    try:
+        iterations = 0
+        while _pending:
+            iterations += 1
+            if iterations > _MAX_FLUSH_ITERATIONS:
+                _pending.clear()  # drop the poisoned graph state so a later unrelated write isn't re-poisoned
+                raise RuntimeError('Reactive cycle detected: the computed()/effect() graph did not '
+                                   'settle. A computation likely depends (transitively) on its own output.')
+            _ensure_current(next(iter(_pending)))
+    finally:
+        _flushing = False
+
+
+@contextmanager
+def batch() -> Iterator[None]:
+    """Coalesce multiple bindable-property writes into a single reactive flush (*PROTOTYPE*).
+
+    Without a batch, every write settles the reactive graph immediately, so reads see fresh values
+    synchronously. Inside a batch, writes only mark dependents dirty; the flush runs once when the
+    outermost batch exits, so a dependent recomputes at most once regardless of how many of its
+    sources changed::
+
+        with binding.batch():
+            order.price = 5
+            order.quantity = 9   # a subtotal computed from both recomputes once, not twice
+    """
+    global _batch_depth  # pylint: disable=global-statement # noqa: PLW0603
+    _batch_depth += 1
+    try:
+        yield
+    finally:
+        _batch_depth -= 1
+        if _batch_depth == 0:
+            _flush()
 
 
 class Computed:
@@ -369,9 +493,11 @@ class Computed:
     def __init__(self, fn: Callable[[], Any]) -> None:
         self._fn = fn
         self._computation = _Computation(lambda: setattr(self, 'value', self._fn()))
+        _producers[(id(self), ('value',))] = self._computation  # so dependents can pull us up-to-date
 
     def dispose(self) -> None:
         """Stop recomputing (dispose the underlying computation)."""
+        _producers.pop((id(self), ('value',)), None)
         self._computation.dispose()
 
 
@@ -446,11 +572,17 @@ def reset() -> None:
 
     This function is intended for testing purposes only.
     """
+    global _batch_depth, _flushing  # pylint: disable=global-statement # noqa: PLW0603
     bindings.clear()
     bindable_properties.clear()
     active_links.clear()
     _binding_keys_by_object.clear()
-    _subscribers.clear()  # PROTOTYPE: also drop reactive computed()/effect() subscriptions
+    _subscribers.clear()  # PROTOTYPE: also drop reactive computed()/effect() state
+    _producers.clear()
+    _pending.clear()
+    _pull_readers.clear()
+    _batch_depth = 0
+    _flushing = False
 
 
 @dataclass_transform()

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -480,3 +480,189 @@ def test_effect_dependencies_are_dynamic():
     handle.dispose()
     t.b = 123  # disposed -> no re-run
     assert seen == [1, 99, 7]
+
+
+@binding.bindable_dataclass
+class _Num:
+    n: int = 1
+
+
+def test_diamond_effect_runs_once_glitch_free():
+    """A single source change must update a diamond's sink exactly once, never on half-updated state.
+
+    S -> A, S -> B, (A, B) -> effect. On one write to S, the effect must observe only fully-settled
+    (A, B) and fire once for the change -- no intermediate (A=new, B=old) glitch, no double-run.
+    """
+    binding.reset()
+    src = _Num(n=1)
+    a = binding.computed(lambda: src.n + 1)   # 2
+    b = binding.computed(lambda: src.n + 10)  # 11
+    seen: list[tuple[int, int]] = []
+    handle = binding.effect(lambda: seen.append((a.value, b.value)))
+    assert seen == [(2, 11)]
+    src.n = 2
+    assert seen == [(2, 11), (3, 12)]  # ONE consistent update; not [..., (3, 11), (3, 12)]
+    handle.dispose()
+
+
+def test_diamond_computed_on_computed_runs_once():
+    """A computed sink over a diamond recomputes once with consistent inputs on a single source write."""
+    binding.reset()
+    src = _Num(n=1)
+    a = binding.computed(lambda: src.n + 1)   # 2
+    b = binding.computed(lambda: src.n + 10)  # 11
+    runs: list[float] = []
+
+    def total_fn() -> float:
+        runs.append(1)
+        return a.value + b.value
+
+    total = binding.computed(total_fn)
+    assert total.value == 13  # 2 + 11
+    runs_before = len(runs)
+    src.n = 2
+    assert total.value == 15  # 3 + 12
+    assert len(runs) == runs_before + 1  # recomputed exactly once for the change, not twice
+
+
+def test_batch_coalesces_writes():
+    """Multiple writes inside binding.batch() collapse into one flush -> one effect re-run."""
+    binding.reset()
+    order = _Order()  # price=10.0, quantity=2
+    runs: list[float] = []
+    handle = binding.effect(lambda: runs.append(order.price + order.quantity))
+    assert runs == [12.0]
+    with binding.batch():
+        order.price = 5
+        order.quantity = 9
+    assert runs == [12.0, 14.0]  # coalesced: initial + ONE, not initial + two
+    handle.dispose()
+
+
+def test_no_batch_reruns_per_write():
+    """Without batch(), each write flushes synchronously (read-after-write stays synchronous)."""
+    binding.reset()
+    order = _Order()
+    runs: list[float] = []
+    handle = binding.effect(lambda: runs.append(order.price + order.quantity))
+    assert runs == [12.0]
+    order.price = 5      # -> 7.0
+    order.quantity = 9   # -> 14.0
+    assert runs == [12.0, 7.0, 14.0]
+    handle.dispose()
+
+
+def test_equality_cutoff_stops_propagation():
+    """An unchanged write (or a computed that recomputes to the same value) must not re-run dependents."""
+    binding.reset()
+    order = _Order()
+    runs: list[float] = []
+    doubled = binding.computed(lambda: order.price * 2)
+    handle = binding.effect(lambda: runs.append(doubled.value))
+    assert runs == [20.0]
+    order.price = 10  # 10 == 10.0 -> no change -> no re-run
+    assert runs == [20.0]
+    handle.dispose()
+
+
+def test_effect_writing_its_own_dependency_converges():
+    """An effect that writes a signal it reads must run to convergence, not stop after one run.
+
+    Regression guard: the earlier "skip currently-running subscribers" heuristic silently dropped
+    this re-invalidation. The fix only skips a subscriber that is pulling the just-changed producer
+    as a fresh read (the diamond case), so a genuine post-read write still schedules a re-run.
+    """
+    binding.reset()
+    state = _Num(n=0)
+    seen: list[int] = []
+
+    def fn() -> None:
+        seen.append(state.n)
+        if state.n < 3:
+            state.n = state.n + 1
+
+    handle = binding.effect(fn)
+    assert seen == [0, 1, 2, 3]  # converged, not [0]
+    assert state.n == 3
+    handle.dispose()
+
+
+def test_disposed_subscriptions_are_pruned():
+    """Re-running/disposing computations must not leave empty subscriber entries behind (churn leak)."""
+    binding.reset()
+    state = _Num(n=0)
+    handles = [binding.effect(lambda: state.n) for _ in range(50)]
+    assert len(binding._subscribers) >= 1
+    for handle in handles:
+        handle.dispose()
+    assert len(binding._subscribers) == 0  # every emptied entry pruned
+
+
+@binding.bindable_dataclass
+class _DiamondState:
+    s: int = 1
+
+
+async def test_computed_drives_bound_ui_label(user: User):
+    """A real ui.label bound to computed() updates on a source change -- zero new element API.
+
+    Exercises the diamond end-to-end: the label binds to C = A + B, both derived from S.
+    """
+    state = _DiamondState(s=1)
+    a = binding.computed(lambda: state.s + 1)
+    b = binding.computed(lambda: state.s + 10)
+    total = binding.computed(lambda: a.value + b.value)  # C = A + B = 13 at s=1
+
+    @ui.page('/')
+    def page():
+        ui.label().bind_text_from(total, 'value', backward=lambda v: f'total={v}')
+
+    await user.open('/')
+    await user.should_see('total=13')
+    state.s = 2  # A=3, B=12 -> C=15
+    await user.should_see('total=15')
+
+
+@binding.bindable_dataclass
+class _Branch:
+    flag: bool = False
+    a: int = 0
+    b: int = 0
+
+
+def test_dispose_unsubscribes_even_when_effect_raised():
+    """Deps read before an exception must still be unsubscribed by dispose() (no zombie re-runs)."""
+    binding.reset()
+    br = _Branch()
+    runs: list[bool] = []
+
+    def fn() -> None:
+        runs.append(br.flag)
+        if br.flag:
+            _ = br.a  # newly-read dependency...
+            raise ValueError('boom')  # ...then raise before the run completes
+        _ = br.b
+
+    handle = binding.effect(fn)
+    with pytest.raises(ValueError, match='boom'):
+        br.flag = True  # triggers the raising run
+    handle.dispose()
+    runs.clear()
+    br.a = 1  # must NOT resurrect the disposed effect
+    assert runs == []
+
+
+def test_cycle_error_does_not_poison_later_writes():
+    """After a cycle RuntimeError, the scheduler must recover for unrelated reactive work."""
+    binding.reset()
+    loop = _Num(n=0)
+    with pytest.raises(RuntimeError, match='cycle'):
+        binding.effect(lambda: setattr(loop, 'n', loop.n + 1))  # unbounded feedback
+    assert binding._pending == set()  # poisoned state cleared
+
+    other = _Num(n=0)
+    seen: list[int] = []
+    handle = binding.effect(lambda: seen.append(other.n))  # retain: effects are held weakly
+    other.n = 5  # unrelated write must work normally, not re-raise the old cycle
+    assert seen == [0, 5]
+    handle.dispose()

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -409,3 +409,74 @@ async def test_nested_binding(data_type: str, initialize: bool, user: User):
             assert data['config'].volume == 50
         else:
             assert data == {'config': {'volume': 50}}
+
+
+# --- PROTOTYPE: reactive computed()/effect() on top of BindableProperty (see discussion #4758) ---
+
+@binding.bindable_dataclass
+class _Order:
+    price: float = 10.0
+    quantity: int = 2
+    tax_rate: float = 0.0
+
+
+def test_computed_derives_and_updates():
+    binding.reset()
+    order = _Order()
+    subtotal = binding.computed(lambda: order.price * order.quantity)
+    assert subtotal.value == 20
+    order.price = 15
+    assert subtotal.value == 30
+    order.quantity = 4
+    assert subtotal.value == 60
+    assert binding.active_links == []  # no 0.1s refresh loop involved
+
+
+def test_computed_chains_on_other_computed():
+    binding.reset()
+    order = _Order(tax_rate=0.1)
+    subtotal = binding.computed(lambda: order.price * order.quantity)
+    total = binding.computed(lambda: subtotal.value * (1 + order.tax_rate))
+    assert total.value == 22
+    order.price = 20
+    assert subtotal.value == 40
+    assert total.value == 44
+
+
+def test_effect_runs_on_dependency_change_and_disposes():
+    binding.reset()
+    order = _Order()
+    seen: list[float] = []
+    handle = binding.effect(lambda: seen.append(order.price))
+    assert seen == [10.0]
+    order.price = 12
+    assert seen == [10.0, 12.0]
+    handle.dispose()
+    order.price = 99
+    assert seen == [10.0, 12.0]  # no longer reacting
+
+
+@binding.bindable_dataclass
+class _Toggle:
+    on: bool = True
+    a: int = 1
+    b: int = 2
+
+
+def test_effect_dependencies_are_dynamic():
+    binding.reset()
+    t = _Toggle()
+    seen: list[int] = []
+    handle = binding.effect(lambda: seen.append(t.a if t.on else t.b))  # retain: effects must be kept alive
+    assert seen == [1]  # first run reads t.on and t.a (not t.b)
+    t.b = 99  # t.b is not a dependency yet -> no re-run
+    assert seen == [1]
+    t.on = False  # re-run; now reads t.on and t.b -> switches dependency set
+    assert seen == [1, 99]
+    t.a = 5  # t.a is no longer a dependency -> no re-run
+    assert seen == [1, 99]
+    t.b = 7  # t.b is a dependency now -> re-run
+    assert seen == [1, 99, 7]
+    handle.dispose()
+    t.b = 123  # disposed -> no re-run
+    assert seen == [1, 99, 7]


### PR DESCRIPTION
> ⚠️ **Draft / RFC — not a merge request.** This is a proof-of-concept to make the design discussion in #4758 concrete. I want feedback on the *shape*, not to land it as-is.

### Motivation

#4758 ("Managing state") keeps circling one question: should NiceGUI grow a first-class reactive layer, or is the ecosystem (reaktiv, ex4nicegui) the right home? Several people in that thread converged on the same concrete idea: *"NiceGUI's `BindableProperty` is already essentially a signal; what's missing is `Computed` and `Effect` on top of it."*

Talk is cheap, so here's what that would actually look like. The point is to turn "wouldn't it be nice" into something you can run and criticise.

The pain it targets is visible in our own [`examples/reaktiv`](https://github.com/zauberzeug/nicegui/tree/main/examples/reaktiv) — the pure-`bindable_dataclass` version needs **two** manual `bind_to` calls just to express `subtotal = price * quantity`:

```python
binding.bind_to(self, 'price',    self, 'subtotal', lambda price:    price * self.quantity)
binding.bind_to(self, 'quantity', self, 'subtotal', lambda quantity: self.price * quantity)
```

With derived state this becomes one line, and it composes:

```python
subtotal = binding.computed(lambda: order.price * order.quantity)
```

### Implementation

Two small hooks on the existing `BindableProperty`, and a thin reactive layer — all inside `binding.py`, ~110 lines:

- `__get__` → `_track_read`: while a computation runs, any bindable property it reads is recorded as a dependency (automatic, dynamic — re-captured every run, so branching code only subscribes to what it actually touched).
- `__set__` → `_notify_subscribers`: on write (next to the existing `_propagate`), wake the computations that read that property.
- `binding.computed(fn)` → a `Computed` whose result is itself a bindable `value`, so it plugs straight into `bind_*` and elements (`ui.label().bind_text_from(total, 'value')`).
- `binding.effect(fn)` → an `Effect` that re-runs on change; `dispose()` on both to unsubscribe.

Crucially there is **no polling** — it's read-tracking (`__get__`) plus write-notify (`__set__`) on the same write-detection the binding system already does, so `binding.active_links` stays empty (no 0.1s `refresh_loop` tick involved).

### Known limitations (this is a brick — these ARE the design questions)

I had a second, non-Claude model try to break it. The limitations below are real and left in on purpose — they're exactly the decisions a core version would have to make, and I'd rather name them than hide them:

- **Glitches on diamonds.** `C = f(A, B)` with `A, B` both derived from `S`: on `S` change, propagation is synchronous + depth-first, so an effect reading `C` can briefly see `A=new, B=old` and run twice. No topological scheduling.
- **No batching.** `obj.a = 1; obj.b = 2` re-runs a dependent effect twice; observers can see non-transactional intermediate state.
- **Sync callables only.** An `async def` body is never awaited, so its reads aren't captured. Not async-compatible.
- **Effects must be retained** (they're held weakly, like reaktiv's "assign to a variable" rule) and disposed on client disconnect — no automatic lifecycle binding yet.
- **`id(owner)`-keyed deps** share the existing binding code's id-reuse caveat.
- **Cleanup is partial:** `reset()` now also clears reactive subscriptions, but `binding.remove(objects)` does **not** yet drop `computed()`/`effect()` subscriptions for those objects — part of the same lifecycle work above.

A production version's real work is scheduling correctness (glitch-free, batched, lifecycle-bound), not the API surface — which is precisely why this is an RFC.

### Progress

- [x] `computed()` / `effect()` on `BindableProperty`, dynamic dependency tracking, `dispose()`
- [x] Tests (`tests/test_binding.py`): derive+update, computed-on-computed, effect fire/dispose, dynamic re-capture
- [x] `pre-commit`, `mypy ./nicegui`, `pylint ./nicegui` (10.00/10) green locally
- [ ] **Design decision — does this belong in core at all?** (that's the discussion)
- [ ] If yes: glitch-free scheduling, batching, client-bound effect lifecycle
- [ ] Docs / example

Not asking anyone to review this as production code — asking whether this *shape* is the direction, or whether reactive state stays in the ecosystem. cc @falkoschindler
