### PR TITLE
Run `examples/pytests` in CI so bundled example tests can't silently rot

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -35,11 +35,17 @@ jobs:
       - name: ${{ matrix.python }} / ${{ matrix.scope }}
         if: matrix.scope == 'pytest'
         run: uv run pytest
+      - name: ${{ matrix.python }} / examples/pytests
+        if: matrix.scope == 'pytest'
+        run: uv run --project ../.. pytest
+        working-directory: examples/pytests
       - uses: actions/upload-artifact@v7
         if: matrix.scope == 'pytest' && failure()
         with:
           name: screenshots-${{ matrix.python }}
-          path: screenshots/**/*.failed.png
+          path: |
+            screenshots/**/*.failed.png
+            examples/pytests/screenshots/**/*.failed.png
           retention-days: 14
       - name: ${{ matrix.python }} / ${{ matrix.scope }}
         if: matrix.scope == 'startup'


### PR DESCRIPTION
### Motivation

The `examples/pytests` project ships runnable pytest files as teaching material, but CI never executed them: `pyproject.toml` sets `testpaths = ["tests"]` and no workflow referenced `examples/`. A broken example stayed green — which is how the failing scope example in #6015 went unnoticed.

This gap has existed since the directory was created in #3121 (which added `testpaths = ["tests"]` in the same commit); it is not a regression from the uv migration.

Fixes #6141

### Implementation

Add one step to the `pytest` scope in `.github/workflows/_test.yml` that runs pytest inside `examples/pytests` using the repo's uv environment:

```yaml
- name: ${{ matrix.python }} / examples/pytests
  if: matrix.scope == 'pytest'
  run: uv run --project ../.. pytest
  working-directory: examples/pytests
```

Running from within the example directory picks up its own `pytest.ini` (`-p nicegui.testing.plugin`, `main_file = main.py`), exactly as a user of the example would run it. All required dev dependencies (pytest-selenium, pytest-asyncio) and Chrome are already available in the job. The failure-screenshot artifact path is extended to also cover `examples/pytests/screenshots/`, since the `Screen` fixture resolves its screenshot directory relative to the working directory.

Scope is deliberately narrow: only `examples/pytests` (the only example with real tests today), no generic sweep over `examples/**`.

Acceptance test from the issue: a temporary commit with a deliberately broken example test turned CI red ([red run](https://github.com/zauberzeug/nicegui/actions/runs/28769789223/job/85301057841)), and CI is green after removing it ([green run](https://github.com/zauberzeug/nicegui/actions/runs/28770680132/job/85303645517)).

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

