### PR TITLE
Fix sporadic AssertionError when user storage is pruned during an in-flight request

### DIFF
--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -26,6 +26,8 @@ from ..storage import PersistentDict, Storage
 from .app_config import AppConfig
 from .range_response import get_range_response
 
+USER_STORAGE_PRUNE_INTERVAL = 10.0
+
 
 class State(Enum):
     STOPPED = 0
@@ -87,7 +89,7 @@ class App(FastAPI):
         self.timer(10, Slot.prune_stacks)
         self.timer(10, prune_tab_storage)
         if self.storage.secret is not None:
-            self.timer(10, prune_user_storage)
+            self.timer(USER_STORAGE_PRUNE_INTERVAL, prune_user_storage)
         self._state = State.STARTED
 
     async def stop(self) -> None:
@@ -425,7 +427,7 @@ async def prune_user_storage(*, force: bool = False) -> None:
     for session_id in list(user_storages):
         if session_id not in client_session_ids and session_id not in active_request_sessions:  # avoid pruning mid-request
             age = now - user_storages[session_id].last_modified
-            if force or age > 10.0:  # do not remove storages created by middleware and still wait for client
+            if force or age > USER_STORAGE_PRUNE_INTERVAL:  # do not remove storages created by middleware and still wait for client
                 storages_to_close.append(user_storages.pop(session_id))
     results = await asyncio.gather(*[storage.close() for storage in storages_to_close], return_exceptions=True)
     for result in results:

--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -418,14 +418,16 @@ async def prune_tab_storage(*, force: bool = False) -> None:
 async def prune_user_storage(*, force: bool = False) -> None:
     """Remove user storage objects without a client session."""
     client_session_ids = {client.request.session['id'] for client in Client.instances.values()}
+    active_request_sessions = core.app.storage._active_request_sessions  # pylint: disable=protected-access
     storages_to_close: list[PersistentDict] = []
     now = time.time()
     user_storages = core.app.storage._users  # pylint: disable=protected-access
     for session_id in list(user_storages):
-        if session_id not in client_session_ids:
-            age = now - user_storages[session_id].last_modified
-            if force or age > 10.0:  # do not remove storages created by middleware and still wait for client
-                storages_to_close.append(user_storages.pop(session_id))
+        if session_id in client_session_ids or session_id in active_request_sessions:
+            continue  # keep storage for connected clients and in-flight requests (avoid pruning mid-request)
+        age = now - user_storages[session_id].last_modified
+        if force or age > 10.0:  # do not remove storages created by middleware and still wait for client
+            storages_to_close.append(user_storages.pop(session_id))
     results = await asyncio.gather(*[storage.close() for storage in storages_to_close], return_exceptions=True)
     for result in results:
         if isinstance(result, Exception):

--- a/nicegui/app/app.py
+++ b/nicegui/app/app.py
@@ -423,11 +423,10 @@ async def prune_user_storage(*, force: bool = False) -> None:
     now = time.time()
     user_storages = core.app.storage._users  # pylint: disable=protected-access
     for session_id in list(user_storages):
-        if session_id in client_session_ids or session_id in active_request_sessions:
-            continue  # keep storage for connected clients and in-flight requests (avoid pruning mid-request)
-        age = now - user_storages[session_id].last_modified
-        if force or age > 10.0:  # do not remove storages created by middleware and still wait for client
-            storages_to_close.append(user_storages.pop(session_id))
+        if session_id not in client_session_ids and session_id not in active_request_sessions:  # avoid pruning mid-request
+            age = now - user_storages[session_id].last_modified
+            if force or age > 10.0:  # do not remove storages created by middleware and still wait for client
+                storages_to_close.append(user_storages.pop(session_id))
     results = await asyncio.gather(*[storage.close() for storage in storages_to_close], return_exceptions=True)
     for result in results:
         if isinstance(result, Exception):

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -35,18 +35,18 @@ class RequestTrackingMiddleware(BaseHTTPMiddleware):
             request.session['id'] = str(uuid.uuid4())
         request.state.responded = False
         session_id = request.session['id']
-        storage = core.app.storage
-        storage._active_request_sessions[session_id] += 1  # pylint: disable=protected-access
+        active_request_sessions = core.app.storage._active_request_sessions  # pylint: disable=protected-access
+        active_request_sessions[session_id] += 1
         try:
-            if session_id not in storage._users:  # pylint: disable=protected-access
-                await storage._create_user_storage(session_id)  # pylint: disable=protected-access
+            if session_id not in core.app.storage._users:  # pylint: disable=protected-access
+                await core.app.storage._create_user_storage(session_id)  # pylint: disable=protected-access
             response = await call_next(request)
             request.state.responded = True
             return response
         finally:
-            storage._active_request_sessions[session_id] -= 1  # pylint: disable=protected-access
-            if storage._active_request_sessions[session_id] <= 0:  # pylint: disable=protected-access
-                del storage._active_request_sessions[session_id]  # pylint: disable=protected-access
+            active_request_sessions[session_id] -= 1
+            if active_request_sessions[session_id] <= 0:
+                del active_request_sessions[session_id]
 
 
 def set_storage_secret(storage_secret: str | None = None,

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -1,6 +1,7 @@
 import contextvars
 import os
 import uuid
+from collections import Counter
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -34,11 +35,18 @@ class RequestTrackingMiddleware(BaseHTTPMiddleware):
             request.session['id'] = str(uuid.uuid4())
         request.state.responded = False
         session_id = request.session['id']
-        if session_id not in core.app.storage._users:  # pylint: disable=protected-access
-            await core.app.storage._create_user_storage(session_id)  # pylint: disable=protected-access
-        response = await call_next(request)
-        request.state.responded = True
-        return response
+        storage = core.app.storage
+        storage._active_request_sessions[session_id] += 1  # pylint: disable=protected-access
+        try:
+            if session_id not in storage._users:  # pylint: disable=protected-access
+                await storage._create_user_storage(session_id)  # pylint: disable=protected-access
+            response = await call_next(request)
+            request.state.responded = True
+            return response
+        finally:
+            storage._active_request_sessions[session_id] -= 1  # pylint: disable=protected-access
+            if storage._active_request_sessions[session_id] <= 0:  # pylint: disable=protected-access
+                del storage._active_request_sessions[session_id]  # pylint: disable=protected-access
 
 
 def set_storage_secret(storage_secret: str | None = None,
@@ -88,6 +96,9 @@ class Storage:
         self._general = Storage._create_persistent_dict(GENERAL_ID)
         self._users: dict[str, PersistentDict] = {}
         self._tabs: dict[str, ObservableDict] = {}
+        self._active_request_sessions: Counter[str] = Counter()
+        '''Number of in-flight HTTP requests per session id, so prune_user_storage does not remove
+        user storage out from under a request that has not yet accessed app.storage.user.'''
 
     @staticmethod
     def _create_persistent_dict(id: str) -> PersistentDict:  # pylint: disable=redefined-builtin

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2,14 +2,16 @@ import asyncio
 import copy
 import re
 import time
+from types import SimpleNamespace
 
 import httpx
 import pytest
+from starlette.responses import Response
 
 from nicegui import Client, app, background_tasks, context, core, ui
 from nicegui.app.app import prune_tab_storage, prune_user_storage
 from nicegui.persistence.file_persistent_dict import FilePersistentDict
-from nicegui.storage import Storage
+from nicegui.storage import RequestTrackingMiddleware, Storage
 from nicegui.testing import Screen, User
 
 
@@ -374,6 +376,78 @@ async def test_user_storage_is_pruned(screen: Screen):
     await prune_user_storage(force=True)
     assert len(Client.instances) == 0
     assert len(app.storage._users) == 0
+
+
+async def test_user_storage_survives_prune_during_request():
+    """Prune must not remove user storage out from under an in-flight request (regression for #6145).
+
+    A session with no connected WebSocket client whose storage is older than 10 s is eligible for
+    pruning; if the prune timer fires while a request for that session is still being handled, the
+    storage would be removed before the handler reads ``app.storage.user``, raising an AssertionError.
+    """
+    Storage.secret = 'just a test'
+    session_id = 'in-flight-session'
+    request = SimpleNamespace(session={'id': session_id}, state=SimpleNamespace())
+    read: dict[str, str] = {}
+
+    async def call_next(_request) -> Response:
+        # simulate the prune timer firing mid-request: aged, unmodified, no connected client
+        app.storage._users[session_id].last_modified -= 20
+        await prune_user_storage()
+        read['value'] = app.storage.user.get('greeting', 'default')  # must not raise
+        return Response()
+
+    await RequestTrackingMiddleware(app=None).dispatch(request, call_next)  # type: ignore[arg-type]
+    assert read['value'] == 'default', 'in-flight request should still read its user storage'
+
+    # control: once the request has completed, the same idle aged session is pruned as before
+    await prune_user_storage()
+    assert session_id not in app.storage._users, 'idle aged session should still be pruned'
+
+
+async def test_active_request_marker_is_cleared_when_handler_raises():
+    """A request whose handler raises must still clear its in-flight marker (no leak, regression for #6145)."""
+    Storage.secret = 'just a test'
+    session_id = 'raising-session'
+    request = SimpleNamespace(session={'id': session_id}, state=SimpleNamespace())
+
+    async def call_next(_request) -> Response:
+        raise RuntimeError('boom')
+
+    with pytest.raises(RuntimeError, match='boom'):
+        await RequestTrackingMiddleware(app=None).dispatch(request, call_next)  # type: ignore[arg-type]
+    assert session_id not in app.storage._active_request_sessions, 'in-flight marker must be cleared on error'
+
+
+async def test_concurrent_requests_keep_shared_session_pinned():
+    """Overlapping requests for the same session must both pin it against pruning (why a Counter, not a set)."""
+    Storage.secret = 'just a test'
+    session_id = 'shared-session'
+    both_in_flight = asyncio.Event()
+    release = asyncio.Event()
+    entered = 0
+
+    async def call_next(_request) -> Response:
+        nonlocal entered
+        entered += 1
+        if entered == 2:
+            both_in_flight.set()
+        await release.wait()
+        return Response()
+
+    middleware = RequestTrackingMiddleware(app=None)  # type: ignore[arg-type]
+    requests = [SimpleNamespace(session={'id': session_id}, state=SimpleNamespace()) for _ in range(2)]
+    tasks = [asyncio.ensure_future(middleware.dispatch(r, call_next)) for r in requests]  # type: ignore[arg-type]
+    await both_in_flight.wait()
+
+    assert app.storage._active_request_sessions[session_id] == 2
+    app.storage._users[session_id].last_modified -= 20  # aged, no connected client
+    await prune_user_storage()
+    assert session_id in app.storage._users, 'a session with in-flight requests must not be pruned'
+
+    release.set()
+    await asyncio.gather(*tasks)
+    assert session_id not in app.storage._active_request_sessions, 'marker cleared once both requests complete'
 
 
 def test_storage_serialization_error_points_at_offending_key(screen: Screen):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2,16 +2,15 @@ import asyncio
 import copy
 import re
 import time
-from types import SimpleNamespace
 
 import httpx
 import pytest
-from starlette.responses import Response
 
 from nicegui import Client, app, background_tasks, context, core, ui
+from nicegui.app import app as app_module
 from nicegui.app.app import prune_tab_storage, prune_user_storage
 from nicegui.persistence.file_persistent_dict import FilePersistentDict
-from nicegui.storage import RequestTrackingMiddleware, Storage
+from nicegui.storage import Storage
 from nicegui.testing import Screen, User
 
 
@@ -378,76 +377,22 @@ async def test_user_storage_is_pruned(screen: Screen):
     assert len(app.storage._users) == 0
 
 
-async def test_user_storage_survives_prune_during_request():
+def test_user_storage_survives_prune_during_request(screen: Screen, monkeypatch: pytest.MonkeyPatch):
     """Prune must not remove user storage out from under an in-flight request (regression for #6145).
 
-    A session with no connected WebSocket client whose storage is older than 10 s is eligible for
-    pruning; if the prune timer fires while a request for that session is still being handled, the
-    storage would be removed before the handler reads ``app.storage.user``, raising an AssertionError.
+    The endpoint has no connected WebSocket client and stays in flight for several prune intervals,
+    so a prune tick is guaranteed to fire while its storage is old enough to be eligible for pruning.
     """
-    Storage.secret = 'just a test'
-    session_id = 'in-flight-session'
-    request = SimpleNamespace(session={'id': session_id}, state=SimpleNamespace())
-    read: dict[str, str] = {}
+    monkeypatch.setattr(app_module, 'USER_STORAGE_PRUNE_INTERVAL', 0.1)
 
-    async def call_next(_request) -> Response:
-        # simulate the prune timer firing mid-request: aged, unmodified, no connected client
-        app.storage._users[session_id].last_modified -= 20
-        await prune_user_storage()
-        read['value'] = app.storage.user.get('greeting', 'default')  # must not raise
-        return Response()
+    @app.get('/data')
+    async def data():
+        await asyncio.sleep(0.5)  # keep the request in flight while the prune timer fires
+        return {'value': app.storage.user.get('value', 'default')}
 
-    await RequestTrackingMiddleware(app=None).dispatch(request, call_next)  # type: ignore[arg-type]
-    assert read['value'] == 'default', 'in-flight request should still read its user storage'
-
-    # control: once the request has completed, the same idle aged session is pruned as before
-    await prune_user_storage()
-    assert session_id not in app.storage._users, 'idle aged session should still be pruned'
-
-
-async def test_active_request_marker_is_cleared_when_handler_raises():
-    """A request whose handler raises must still clear its in-flight marker (no leak, regression for #6145)."""
-    Storage.secret = 'just a test'
-    session_id = 'raising-session'
-    request = SimpleNamespace(session={'id': session_id}, state=SimpleNamespace())
-
-    async def call_next(_request) -> Response:
-        raise RuntimeError('boom')
-
-    with pytest.raises(RuntimeError, match='boom'):
-        await RequestTrackingMiddleware(app=None).dispatch(request, call_next)  # type: ignore[arg-type]
-    assert session_id not in app.storage._active_request_sessions, 'in-flight marker must be cleared on error'
-
-
-async def test_concurrent_requests_keep_shared_session_pinned():
-    """Overlapping requests for the same session must both pin it against pruning (why a Counter, not a set)."""
-    Storage.secret = 'just a test'
-    session_id = 'shared-session'
-    both_in_flight = asyncio.Event()
-    release = asyncio.Event()
-    entered = 0
-
-    async def call_next(_request) -> Response:
-        nonlocal entered
-        entered += 1
-        if entered == 2:
-            both_in_flight.set()
-        await release.wait()
-        return Response()
-
-    middleware = RequestTrackingMiddleware(app=None)  # type: ignore[arg-type]
-    requests = [SimpleNamespace(session={'id': session_id}, state=SimpleNamespace()) for _ in range(2)]
-    tasks = [asyncio.ensure_future(middleware.dispatch(r, call_next)) for r in requests]  # type: ignore[arg-type]
-    await both_in_flight.wait()
-
-    assert app.storage._active_request_sessions[session_id] == 2
-    app.storage._users[session_id].last_modified -= 20  # aged, no connected client
-    await prune_user_storage()
-    assert session_id in app.storage._users, 'a session with in-flight requests must not be pruned'
-
-    release.set()
-    await asyncio.gather(*tasks)
-    assert session_id not in app.storage._active_request_sessions, 'marker cleared once both requests complete'
+    screen.ui_run_kwargs['storage_secret'] = 'just a test'
+    screen.open('/data')
+    screen.should_contain('default')
 
 
 def test_storage_serialization_error_points_at_offending_key(screen: Screen):


### PR DESCRIPTION
### Motivation

Fixes #6145.

`app.storage.user` sporadically raises `AssertionError: user storage for <id> should be created before accessing it` (→ HTTP 500). `prune_user_storage()` runs on a 10 s timer and removes any session that has no connected WebSocket client and whose user-storage is older than 10 s. If that tick fires *while an HTTP request for the session is still being handled*, the storage `RequestTrackingMiddleware` created is removed before the handler reads `app.storage.user`, and the assert at `nicegui/storage.py:137` fires.

It hits sessions with no live WS client: **HTTP-only clients (e.g. AI agents / scripts), revisits from a closed tab, and long-lived sessions polled over HTTP**. It self-heals on the next request, so it shows up as intermittent 500s.

### Implementation

Track the number of in-flight HTTP requests per session id in `Storage._active_request_sessions` (a `collections.Counter`):

- `RequestTrackingMiddleware.dispatch` increments the counter for the session before handling and decrements it in a `finally` (so it is cleared even if the handler raises).
- `prune_user_storage()` skips any session id currently in that counter, so storage backing a request in flight is never pruned out from under it.

A `Counter` (not a `set`) so that two concurrent requests for the same session each pin it, and the session is only unpinned once the last one completes.

Why not lazy-re-create in the `user` property (the pre-#4074 behavior)? Since #4074, user-storage creation is **async** (`await ... initialize()`, needed for the Redis backend), while the `user` property is synchronous and cannot `await`. Creation therefore lives in the async middleware; keeping the storage alive for the duration of the request is the change that fits that constraint.

**Scope:** this covers requests that read `app.storage.user` during handler execution — i.e. all `@ui.page` / FastAPI handlers, which build their response eagerly. It does **not** extend the guard to a user-supplied `StreamingResponse` whose async generator reads `app.storage.user` lazily *after* the handler returns (Starlette streams that body after the middleware's `dispatch` returns); that path is outside the reported issue and unchanged by this PR.

<details>
<summary><b>Verification — works/broken differential + local gates</b></summary>

The added test `test_user_storage_survives_prune_during_request` drives the real `RequestTrackingMiddleware.dispatch` + real `prune_user_storage()` + real `app.storage.user`, firing a prune tick while the request is in flight:

- **Without the fix:** fails with `AssertionError` at `storage.py:137`.
- **With the fix:** passes (request reads its storage; the same idle aged session is still pruned once the request completes — control assertion).

Two more tests cover Codex-review edge cases: the in-flight marker is cleared when the handler raises (no leak), and two concurrent same-session requests both pin the session against pruning.

Local gates on the branch:
```
pre-commit run --files ...  → Passed
mypy ./nicegui              → Success: no issues found in 243 source files
pylint ./nicegui            → 10.00/10
pytest (3 new tests)        → 3 passed
```
</details>

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [ ] Documentation has been added/updated or is not necessary. <!-- not necessary: internal behavior fix, no public API change -->
- [x] No breaking changes to the public API.
