### PR TITLE
Fix page_title/add_*_html/add_css lost when set after the response is built

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -114,6 +114,7 @@ class Client:
 
         self.title: str | None = None
         self.status_code: int = 200
+        self._response_built = False
 
         self._head_html = ''
         self._body_html = ''
@@ -174,6 +175,8 @@ class Client:
 
     def build_response(self, request: Request, status_code: int = 200) -> Response:
         """Build a FastAPI response for the client."""
+        # After this point the initial HTML (incl. title/head/body) is emitted; later changes must be pushed via JS.
+        self._response_built = True
         if self.page.resolve_markdown() and _did_user_request_markdown(request):
             parts = []
             if title := self.resolve_title():

--- a/nicegui/functions/html.py
+++ b/nicegui/functions/html.py
@@ -12,7 +12,7 @@ def add_head_html(code: str, *, shared: bool = False) -> None:
         Client.shared_head_html += code + '\n'
     else:
         client = context.client
-        if client.has_socket_connection:
+        if client._response_built:  # pylint: disable=protected-access
             client.run_javascript(f'document.head.insertAdjacentHTML("beforeend", {code!r});')
         client._head_html += code + '\n'  # pylint: disable=protected-access
 
@@ -27,6 +27,6 @@ def add_body_html(code: str, *, shared: bool = False) -> None:
         Client.shared_body_html += code + '\n'
     else:
         client = context.client
-        if client.has_socket_connection:
+        if client._response_built:  # pylint: disable=protected-access
             client.run_javascript(f'document.querySelector("#app").insertAdjacentHTML("beforebegin", {code!r});')
         client._body_html += code + '\n'  # pylint: disable=protected-access

--- a/nicegui/functions/page_title.py
+++ b/nicegui/functions/page_title.py
@@ -13,5 +13,5 @@ def page_title(title: str) -> None:
     client.title = title
     if core.app.native.main_window:
         core.app.native.main_window.set_title(title)
-    if client.has_socket_connection:
+    if client._response_built:  # pylint: disable=protected-access
         client.run_javascript(f'document.title = {json.dumps(title)}')

--- a/nicegui/functions/style.py
+++ b/nicegui/functions/style.py
@@ -66,5 +66,5 @@ def _add_javascript(code: str, *, shared: bool = False) -> None:
     else:
         client = context.client
         client._head_html += script_html + '\n'
-    if client is not None and client.has_socket_connection:  # no need to run JavaScript if there is no client yet
+    if client is not None and client._response_built:  # pylint: disable=protected-access
         client.run_javascript(code)

--- a/tests/test_add_html.py
+++ b/tests/test_add_html.py
@@ -87,37 +87,23 @@ def test_sass(screen: Screen, shared: bool, delayed: bool):
     assert label.value_of_css_property('color') == 'rgba(128, 0, 128, 1)'
 
 
-def test_add_body_html_after_await_in_async_sub_page(screen: Screen):
-    """add_body_html must survive a page load when called after an await in an async sub page builder,
-    without being injected twice on a normal load (#6147)."""
+def test_add_body_html_and_css_after_await_in_async_sub_page(screen: Screen):
     async def sub():
-        await asyncio.sleep(0)  # resumes after the response is built, before the socket connects
-        ui.add_body_html('<div id="injected-marker">injected</div>')
-
-    @ui.page('/')
-    def index():
-        ui.sub_pages({'/': sub})
-
-    screen.open('/')
-    screen.wait(0.5)
-    assert screen.selenium.execute_script('return document.querySelectorAll("#injected-marker").length') == 1
-
-
-def test_add_css_after_await_in_async_sub_page(screen: Screen):
-    """add_css must survive a page load when called after an await in an async sub page builder (#6147)."""
-    async def sub():
+        ui.add_body_html('<div>early body html</div>')
         await asyncio.sleep(0)  # resumes after the response is built, before the socket connects
         ui.add_css('.late { color: rgb(255, 0, 0); }')
-        ui.label('late css').classes('late')
+        ui.label('late label').classes('late')
+        ui.add_body_html('<div>late body html</div>')
 
     @ui.page('/')
     def index():
         ui.sub_pages({'/': sub})
 
     screen.open('/')
-    label = screen.find('late css')
-    screen.wait(0.5)
-    assert label.value_of_css_property('color') == 'rgba(255, 0, 0, 1)'
+    screen.should_contain('late body html')  # enqueued last, so the CSS has been applied once this arrives
+    assert len(screen.find_all('early body html')) == 1, 'build-time HTML should not be injected a second time via JS'
+    assert len(screen.find_all('late body html')) == 1, 'late HTML should be injected exactly once'
+    assert screen.find('late label').value_of_css_property('color') == 'rgba(255, 0, 0, 1)'
 
 
 def test_add_css_with_script(screen: Screen):

--- a/tests/test_add_html.py
+++ b/tests/test_add_html.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from nicegui import ui
@@ -83,6 +85,39 @@ def test_sass(screen: Screen, shared: bool, delayed: bool):
     label = screen.find('This is purple on yellow with SASS.')
     screen.wait(0.5)
     assert label.value_of_css_property('color') == 'rgba(128, 0, 128, 1)'
+
+
+def test_add_body_html_after_await_in_async_sub_page(screen: Screen):
+    """add_body_html must survive a page load when called after an await in an async sub page builder,
+    without being injected twice on a normal load (#6147)."""
+    async def sub():
+        await asyncio.sleep(0)  # resumes after the response is built, before the socket connects
+        ui.add_body_html('<div id="injected-marker">injected</div>')
+
+    @ui.page('/')
+    def index():
+        ui.sub_pages({'/': sub})
+
+    screen.open('/')
+    screen.wait(0.5)
+    assert screen.selenium.execute_script('return document.querySelectorAll("#injected-marker").length') == 1
+
+
+def test_add_css_after_await_in_async_sub_page(screen: Screen):
+    """add_css must survive a page load when called after an await in an async sub page builder (#6147)."""
+    async def sub():
+        await asyncio.sleep(0)  # resumes after the response is built, before the socket connects
+        ui.add_css('.late { color: rgb(255, 0, 0); }')
+        ui.label('late css').classes('late')
+
+    @ui.page('/')
+    def index():
+        ui.sub_pages({'/': sub})
+
+    screen.open('/')
+    label = screen.find('late css')
+    screen.wait(0.5)
+    assert label.value_of_css_property('color') == 'rgba(255, 0, 0, 1)'
 
 
 def test_add_css_with_script(screen: Screen):

--- a/tests/test_page_title.py
+++ b/tests/test_page_title.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from nicegui import ui
 from nicegui.testing import Screen
 
@@ -23,3 +25,19 @@ def test_page_title(screen: Screen):
     screen.open('/test')
     screen.wait(0.5)
     screen.should_contain('Title: test')
+
+
+def test_page_title_after_await_in_async_sub_page(screen: Screen):
+    """The title must survive a page load when set after an await in an async sub page builder (#6147)."""
+    async def sub():
+        ui.page_title('before')
+        await asyncio.sleep(0)  # resumes after the response is built, before the socket connects
+        ui.page_title('after')
+
+    @ui.page('/')
+    def index():
+        ui.sub_pages({'/': sub})
+
+    screen.open('/')
+    screen.wait(0.5)
+    assert screen.selenium.title == 'after'

--- a/tests/test_page_title.py
+++ b/tests/test_page_title.py
@@ -28,7 +28,6 @@ def test_page_title(screen: Screen):
 
 
 def test_page_title_after_await_in_async_sub_page(screen: Screen):
-    """The title must survive a page load when set after an await in an async sub page builder (#6147)."""
     async def sub():
         ui.page_title('before')
         await asyncio.sleep(0)  # resumes after the response is built, before the socket connects
@@ -39,5 +38,4 @@ def test_page_title_after_await_in_async_sub_page(screen: Screen):
         ui.sub_pages({'/': sub})
 
     screen.open('/')
-    screen.wait(0.5)
-    assert screen.selenium.title == 'after'
+    screen.wait_for(lambda: screen.selenium.title == 'after')


### PR DESCRIPTION
*Drafted by Claude Code working with @evnchn.*

### Motivation

Closes #6147.

`ui.page_title` set after a fast `await` inside an async `ui.sub_pages` builder is silently lost on a full page load. The reporter's own diagnosis and @falkoschindler's confirmation pinpoint a **dead zone**: `ui.sub_pages` runs async builders as background tasks, so on a fresh load the builder resumes *after* the HTTP response (with the initial title) is already emitted, but *before* the websocket connects. In that window `client.has_socket_connection` is `False`, so `ui.page_title` skips its `document.title = …` JavaScript and the update is dropped — neither in the HTML nor pushed via JS.

Widening the scope (see the [issue discussion](https://github.com/zauberzeug/nicegui/issues/6147)): the **same guard exists at two more call sites** and loses writes in the identical dead zone:

- `ui.add_head_html` / `ui.add_body_html` (`functions/html.py`)
- `ui.add_css` / `add_scss` / `add_sass` (`functions/style.py`, via `_add_javascript`)

### Implementation

The `if client.has_socket_connection:` guard was only ever a *proxy* for the real question — **"has the initial HTML already been emitted?"** — which is what decides whether a value rides the HTML or must be pushed via JavaScript. `run_javascript` has enqueued into the outbox (buffered until the socket connects) since NiceGUI 3.0, so the guard is no longer needed to defer JS; it just answers the wrong question in the dead zone.

This PR adds a small `Client._response_built` flag (set once at the top of `build_response`) and uses it in place of the guard at all four call sites:

- **before render** → write the Python state (feeds the initial HTML), skip the JS
- **after render** (dead zone *or* connected) → run the JS; the outbox buffers it until the socket connects

**Why not simply drop the guard?** It is safe for `page_title` (whose JS is idempotent: `document.title = …`), but `add_*_html`/`add_css` are **additive** (`insertAdjacentHTML` / `addStyle`) and their payload is *already baked into the initial HTML* via `_head_html`/`_body_html`. Always-enqueuing would inject a **second copy on every normal load**. The `_response_built` predicate avoids that while still covering the dead zone.

<details><summary><b>Empirical evidence (measured in the DOM)</b></summary>

Dead-zone loss reproduced with an async sub-page + fast `await` (`/fast` = dead zone, `/slow` = control), on `3.13.0.post24.dev0`:

```
/slow  [post-connect control] add_body_html marker present: True  | add_css --mre: '42'
/fast  [DEAD ZONE           ] add_body_html marker present: False | add_css --mre: ''
```

Why dropping the guard is wrong for the additive functions — `add_body_html` markers counted in the DOM across three source variants:

| source | build-time (normal load) | dead zone |
|---|---|---|
| unpatched (guard intact) | `1` ✓ | `0` ✗ lost |
| naive drop-the-guard | `2` ✗ double-injected | `1` ✓ |
| `_response_built` (this PR) | `1` ✓ | `1` ✓ |

Auto-index shared client verified: `page_title` + `add_body_html` + `add_css` at module scope render the title, exactly one marker (no double), and the CSS — `_response_built` flips on the first response and is `False` during pre-GET setup, so the payload rides the HTML.

</details>

<details><summary><b>Tests</b></summary>

Three regression tests (proven red on `main`, green with this PR), each driving the dead-zone path (async sub-page → `await` → operation → fresh load):

- `test_page_title.py::test_page_title_after_await_in_async_sub_page`
- `test_add_html.py::test_add_body_html_after_await_in_async_sub_page` (also asserts a single injection, guarding against the double-inject regression)
- `test_add_html.py::test_add_css_after_await_in_async_sub_page`

`ruff` / `mypy` / `pylint` clean; `test_page_title.py` + `test_add_html.py` full files pass (19).

Deliberately deferred: a reconnect-window test (server-side `page_title`/`add_css` during a disconnect, arriving after reconnect). That path is pre-existing outbox buffering, not new logic here — happy to add it if you'd like.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API. (`_response_built` is a private attribute.)
