### PR TITLE
Add element identity to "parent slot has been deleted" error

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -145,7 +145,8 @@ class Element(Visibility):
             return None
         parent_slot = self._parent_slot()
         if parent_slot is None:
-            raise RuntimeError('The parent slot of the element has been deleted.')
+            markers = f' markers={",".join(self._markers)}' if self._markers else ''
+            raise RuntimeError(f'The parent slot of {type(self).__name__}(id={self.id}){markers} has been deleted.')
         return parent_slot
 
     @parent_slot.setter

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -145,8 +145,9 @@ class Element(Visibility):
             return None
         parent_slot = self._parent_slot()
         if parent_slot is None:
-            markers = f' markers={",".join(self._markers)}' if self._markers else ''
-            raise RuntimeError(f'The parent slot of {type(self).__name__}(id={self.id}){markers} has been deleted.')
+            name = self.tag if type(self) is Element else type(self).__name__  # pylint: disable=unidiomatic-typecheck
+            markers = f', markers={",".join(self._markers)}' if self._markers else ''
+            raise RuntimeError(f'The parent slot of {name}(id={self.id}{markers}) has been deleted.')
         return parent_slot
 
     @parent_slot.setter

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -222,6 +222,22 @@ async def test_usage_after_delete(user: User, caplog: pytest.LogCaptureFixture, 
     assert len([record for record in caplog.records if 'still being used' in record.message]) == expected_warnings
 
 
+async def test_parent_slot_error(user: User):
+    label = card = None
+
+    @ui.page('/')
+    def page():
+        nonlocal label, card
+        with ui.card() as card:
+            label = ui.label('hi').mark('my_label')
+
+    await user.open('/')
+    card.delete()
+    del card  # drop the last strong reference to the card and its slots
+    with pytest.raises(RuntimeError, match=r'The parent slot of Label\(id=5, markers=my_label\) has been deleted\.'):
+        _ = label.parent_slot
+
+
 def test_event_listeners_cleared_on_delete(screen: Screen):
     """Event listeners are cleared when element is deleted and no cyclic references are left behind (issue #5110)."""
     buttons = weakref.WeakSet[ui.button]()


### PR DESCRIPTION
### Motivation

`Element.parent_slot` raises `RuntimeError('The parent slot of the element has been deleted.')` with no indication of _which_ element. When it surfaces from a background task (e.g. a `ui.timer` callback), the traceback is entirely internal NiceGUI frames, so the user has nothing to go on.

Reported by @pascalzauberzeug:

> Is it possible to let the `The parent slot of the element has been deleted` RuntimeError provide more information which element is missing or where the error is coming from?

with this (unhelpful) traceback:

```
[ERROR] nicegui/app/app.py:179: The parent slot of the element has been deleted.
  File ".../nicegui/background_tasks.py", line 152, in _handle_exceptions
  File ".../nicegui/timer.py", line 90, in _run_in_loop
  File ".../nicegui/elements/timer.py", line 15, in _get_context
  File ".../nicegui/element.py", line 148, in parent_slot
RuntimeError: The parent slot of the element has been deleted.
```

### Implementation

At the raise site `self` (the element whose parent slot was deleted) is **still alive** — only the parent `Slot` weakref target is gone. So its class name (or tag), `id`, and user `.mark(...)` labels are already in memory and can be surfaced at **zero extra per-element storage cost** (no captured stack, no new attributes):

```python
name = self.tag if type(self) is Element else type(self).__name__
markers = f', markers={",".join(self._markers)}' if self._markers else ''
raise RuntimeError(f'The parent slot of {name}(id={self.id}{markers}) has been deleted.')
```

**Before → after** (triggered via natural container deletion):

|                              | Message                                                              |
| ---------------------------- | -------------------------------------------------------------------- |
| Before                       | `The parent slot of the element has been deleted.`                   |
| After (marked)               | `The parent slot of Label(id=5, markers=my_label) has been deleted.` |
| After (plain `ui.element()`) | `The parent slot of div(id=6) has been deleted.`                     |

A regression test in `tests/test_element_delete.py` deletes a container naturally and asserts the enriched error message.

<details><summary>Design notes / trade-offs</summary>

- **Why not `str(self)`?** `Element.__str__` recurses the whole child subtree — too heavy/noisy for an error line. This uses only the element's own class/tag, `id` and markers.
- **Why the tag for bare `Element` instances?** Same idiom as `__str__`: for a plain `ui.element('canvas')` the class name `Element` carries no information, the tag does.
- **Why markers (not text/props)?** Markers are purpose-built identifiers the user chose; text/props can be long or multiline and would need sanitizing. Kept to "just enough to be helpful". Trivial to extend if you'd prefer more.
- **Scope:** limited to `parent_slot` (the reported site). The sibling "has been deleted" messages in `element.py` (client), `slot.py` and `style.py` were considered but left alone — in the slot/style cases the object being described _is_ the deleted one, so there is no free identity to add. The client one (`self` is the element) is an easy follow-up if wanted.
- No stored data, no new imports, no public API change.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytest has been added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
