### PR TITLE
Add an a11y heading tree to the homepage

### DIFF
--- a/website/components/cta_section.py
+++ b/website/components/cta_section.py
@@ -10,7 +10,8 @@ def create() -> None:
         with ui.column(align_items='center') \
                 .classes(f'reveal w-full text-center gap-0 {d.BG_BLUE}/25 rounded-xl py-16 max-sm:px-6 min-sm:px-16 {d.SHADOW_CARD}'):
             ui.label('Browse through plenty of live demos.') \
-                .classes(f'{d.TEXT_CTA_TITLE} font-semibold tracking-tight mb-2 {d.TEXT_PRIMARY}')
+                .classes(f'{d.TEXT_CTA_TITLE} font-semibold tracking-tight mb-2 {d.TEXT_PRIMARY}') \
+                .props('role=heading aria-level=2')
             ui.label('Fun-Fact: This whole website is also made with NiceGUI.') \
                 .classes(f'{d.TEXT_19PX} mb-8 {d.TEXT_SECONDARY}')
             cta_button('Documentation', on_click=lambda: ui.navigate.to('/documentation')).classes('mb-12')

--- a/website/components/examples_section.py
+++ b/website/components/examples_section.py
@@ -31,5 +31,5 @@ def example_card(example: Example) -> None:
             ui.interactive_image(example.screenshot) \
                 .classes('size-full object-cover transition-transform duration-300')
         with ui.column().classes('p-5 gap-0'):
-            ui.label(example.title).classes(f'{d.TEXT_19PX} font-semibold')
+            ui.label(example.title).classes(f'{d.TEXT_19PX} font-semibold').props('role=heading aria-level=3')
             ui.markdown(example.description).classes(f'{d.TEXT_15PX} leading-normal {d.TEXT_SECONDARY}')

--- a/website/components/features_section.py
+++ b/website/components/features_section.py
@@ -14,7 +14,7 @@ def create() -> None:
         with ui.grid().classes('reveal w-full grid-cols-3 gap-6 max-lg:grid-cols-2 max-sm:grid-cols-1'):
             _card('ph-arrows-left-right', 'Interaction', [
                 '[Buttons](/documentation/button), [switches](/documentation/switch), '
-                '[sliders](/documentation/slider), [inputs](/documentation/input), ...',
+                '[sliders](/documentation/slider), [inputs](/documentation/input), …',
                 '[Notifications](/documentation/notification), [dialogs](/documentation/dialog) '
                 'and [menus](/documentation/menu)',
                 '[Interactive images](/documentation/interactive_image) with SVG overlays',
@@ -60,8 +60,9 @@ def _card(icon: str, title: str, items: list[str]) -> None:
     with ui.column().classes(f'relative rounded-2xl p-7 gap-0 group transition-transform duration-200 cursor-default hover:-translate-y-0.5 {d.BG_SURFACE} {d.BORDER}'):
         ui.label('ui.card()') \
             .classes(f'absolute top-2.5 right-3 font-mono {d.TEXT_13PX} {d.TEXT_BLUE} opacity-0 group-hover:opacity-30 transition-opacity duration-300 pointer-events-none')
-        phosphor_icon(icon) \
-            .classes(f'{d.TEXT_32PX} {d.TEXT_BLUE} [&_i::before]:text-[{d.ACCENT}] [&_i::before]:!opacity-40 [&_i::after]:relative')
-        ui.label(title).classes(f'{d.TEXT_19PX} font-semibold mb-3 tracking-tight')
+        with ui.row(align_items='center').classes('gap-2.5 mb-3'):
+            phosphor_icon(icon) \
+                .classes(f'{d.TEXT_32PX} {d.TEXT_BLUE} [&_i::before]:text-[{d.ACCENT}] [&_i::before]:!opacity-40 [&_i::after]:relative')
+            ui.label(title).classes(f'{d.TEXT_19PX} font-semibold tracking-tight').props('role=heading aria-level=3')
         ui.markdown('\n'.join(f'- {item}' for item in items)) \
             .classes(f'{d.TEXT_15PX} leading-7 {d.TEXT_SECONDARY} [&_ul]:pl-4 [&_li]:pl-1 [&_li]:marker:{d.TEXT_BLUE}/50')

--- a/website/components/features_section.py
+++ b/website/components/features_section.py
@@ -14,7 +14,7 @@ def create() -> None:
         with ui.grid().classes('reveal w-full grid-cols-3 gap-6 max-lg:grid-cols-2 max-sm:grid-cols-1'):
             _card('ph-arrows-left-right', 'Interaction', [
                 '[Buttons](/documentation/button), [switches](/documentation/switch), '
-                '[sliders](/documentation/slider), [inputs](/documentation/input), …',
+                '[sliders](/documentation/slider), [inputs](/documentation/input), ...',
                 '[Notifications](/documentation/notification), [dialogs](/documentation/dialog) '
                 'and [menus](/documentation/menu)',
                 '[Interactive images](/documentation/interactive_image) with SVG overlays',
@@ -60,9 +60,8 @@ def _card(icon: str, title: str, items: list[str]) -> None:
     with ui.column().classes(f'relative rounded-2xl p-7 gap-0 group transition-transform duration-200 cursor-default hover:-translate-y-0.5 {d.BG_SURFACE} {d.BORDER}'):
         ui.label('ui.card()') \
             .classes(f'absolute top-2.5 right-3 font-mono {d.TEXT_13PX} {d.TEXT_BLUE} opacity-0 group-hover:opacity-30 transition-opacity duration-300 pointer-events-none')
-        with ui.row(align_items='center').classes('gap-2.5 mb-3'):
-            phosphor_icon(icon) \
-                .classes(f'{d.TEXT_32PX} {d.TEXT_BLUE} [&_i::before]:text-[{d.ACCENT}] [&_i::before]:!opacity-40 [&_i::after]:relative')
-            ui.label(title).classes(f'{d.TEXT_19PX} font-semibold tracking-tight').props('role=heading aria-level=3')
+        phosphor_icon(icon) \
+            .classes(f'{d.TEXT_32PX} {d.TEXT_BLUE} [&_i::before]:text-[{d.ACCENT}] [&_i::before]:!opacity-40 [&_i::after]:relative')
+        ui.label(title).classes(f'{d.TEXT_19PX} font-semibold mb-3 tracking-tight').props('role=heading aria-level=3')
         ui.markdown('\n'.join(f'- {item}' for item in items)) \
             .classes(f'{d.TEXT_15PX} leading-7 {d.TEXT_SECONDARY} [&_ul]:pl-4 [&_li]:pl-1 [&_li]:marker:{d.TEXT_BLUE}/50')

--- a/website/components/hero_section.py
+++ b/website/components/hero_section.py
@@ -18,7 +18,8 @@ def create() -> None:
             ui.html(svg.HAPPY_FACE_SVG, sanitize=False) \
                 .classes(f'hero-mascot size-40 stroke-[{d.BLUE}] stroke-2 mb-8')
             ui.markdown('Meet the *NiceGUI*.') \
-                .classes(f'{d.TEXT_HERO} font-semibold tracking-tighter leading-none [&_em]:not-italic [&_em]:{d.TEXT_BLUE} {d.TEXT_PRIMARY} -mb-2')
+                .classes(f'{d.TEXT_HERO} font-semibold tracking-tighter leading-none [&_em]:not-italic [&_em]:{d.TEXT_BLUE} {d.TEXT_PRIMARY} -mb-2') \
+                .props('role=heading aria-level=1')
             ui.markdown('''
                 Let any browser be the frontend of your Python code.<br>
                 Loved by robotics, IoT, and ML teams worldwide.

--- a/website/components/shared.py
+++ b/website/components/shared.py
@@ -24,7 +24,8 @@ def section_label(text: str) -> ui.label:
 def section_title(text: str) -> ui.label:
     """Large section title."""
     return ui.label(text) \
-        .classes(f'{d.TEXT_SECTION_TITLE} font-semibold tracking-tight leading-tight mb-3 {d.TEXT_PRIMARY}')
+        .classes(f'{d.TEXT_SECTION_TITLE} font-semibold tracking-tight leading-tight mb-3 {d.TEXT_PRIMARY}') \
+        .props('role=heading aria-level=2')
 
 
 def section_desc(text: str) -> ui.label:

--- a/website/components/why_section.py
+++ b/website/components/why_section.py
@@ -41,5 +41,5 @@ def _pillar(icon: str, title: str, description: str) -> None:
     """Render a single value proposition pillar."""
     with ui.column(align_items='center').classes('gap-3 flex-1 px-8 py-4 text-center'):
         phosphor_icon(icon).classes(f'text-3xl {d.TEXT_BLUE}')
-        ui.label(title).classes(f'{d.TEXT_19PX} font-semibold {d.TEXT_PRIMARY}')
+        ui.label(title).classes(f'{d.TEXT_19PX} font-semibold {d.TEXT_PRIMARY}').props('role=heading aria-level=3')
         ui.label(description).classes(f'{d.TEXT_15PX} leading-relaxed {d.TEXT_SECONDARY}')


### PR DESCRIPTION
## Motivation

The homepage renders every title through `ui.markdown` / `ui.label`, so the rendered DOM contains **0 heading elements** (`h1`–`h6`). Assistive tech and search crawlers get no heading structure, even though the page has a clear visual hierarchy.

## Implementation

Adds `role=heading` + `aria-level` to the hero (1), section titles (2, via the shared `section_title()` helper), and the feature-card / example-card / why-pillar titles (3), giving a real **H1 → H2 → H3** outline. **No visual change.** *(Badges below drawn by a throwaway script for the screenshot only.)*

![a11y heading tree](https://raw.githubusercontent.com/evnchn/nicegui/79ba83efed971d0ebafe0273102ea35392250cf5/demo2-a11y-headings.png)

```
H1  Meet the NiceGUI.
H2  Interact with Python · Three lines to a run · Code nicely. · …   (section titles)
H3  Interaction · Layout · Visualization · Styling · Coding · Foundation · example cards · Why pillars
```

> Two unrelated ride-alongs from the first draft — the feature-card icon-inline layout and the `…` ellipsis swap — were **reverted during review** to keep this a pure, risk-free accessibility change.

## Progress

- [x] `pre-commit`, `pylint` (10.00/10), `mypy` — clean on changed files
- [x] Rendering verified live (heading tree)
- [x] Reviewed on fork first (evnchn/nicegui#209)
- [x] CI green

<sub>Uses `role=heading` on existing elements rather than native `<h1>` tags — NiceGUI has no `ui.h1`, and Quasar's global CSS styles bare headings, so ARIA sidesteps a styling fight. Settled during review. · Screenshot assets live on branch `pr209-demo-assets` of the fork.</sub>

