### PR TITLE
Add a Windows CI leg for the storage file-lock tests

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -27,6 +27,24 @@ jobs:
       python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       scope: '["pytest", "startup"]'
 
+  windows-test:
+    if: github.event_name != 'merge_group'
+    name: windows / storage
+    runs-on: windows-2022
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Install Python
+        run: uv python install 3.10
+      - name: Install dependencies
+        run: uv sync --locked
+      - name: pytest tests/test_storage.py
+        run: uv run pytest tests/test_storage.py
+
   quick-test-gate:
     runs-on: ubuntu-latest
     needs: [check, quick-test]

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked
       - name: pytest tests/test_storage.py
-        run: uv run pytest tests/test_storage.py
+        run: uv run --with pytest-rerunfailures pytest tests/test_storage.py --reruns 2 --reruns-delay 2
 
   quick-test-gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -28,10 +28,9 @@ jobs:
       scope: '["pytest", "startup"]'
 
   windows-test:
-    if: github.event_name != 'merge_group'
     name: windows / storage
     runs-on: windows-2022
-    timeout-minutes: 40
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
@@ -43,7 +42,13 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked
       - name: pytest tests/test_storage.py
-        run: uv run --with pytest-rerunfailures pytest tests/test_storage.py --reruns 2 --reruns-delay 2
+        run: uv run --with pytest-rerunfailures==16.4 pytest tests/test_storage.py --reruns 2 --reruns-delay 2 --only-rerun TimeoutException --only-rerun PytestUnraisableExceptionWarning
+      - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: screenshots-windows
+          path: screenshots/**/*.failed.png
+          retention-days: 14
 
   quick-test-gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -41,27 +41,27 @@ jobs:
         run: uv python install 3.10
       - name: Install dependencies
         run: uv sync --locked
-      - name: pytest tests/test_storage.py
+      - name: pytest tests/test_storage.py -m "not screen"
         run: uv run pytest tests/test_storage.py -m "not screen"
 
   quick-test-gate:
     runs-on: ubuntu-latest
-    needs: [check, quick-test]
+    needs: [check, quick-test, windows-test]
     if: always() && github.event_name != 'merge_group'
     steps:
       - name: Verify all dependencies passed
-        if: needs.check.result != 'success' || needs.quick-test.result != 'success'
+        if: needs.check.result != 'success' || needs.quick-test.result != 'success' || needs.windows-test.result != 'success'
         run: |
-          echo "Dependencies failed: check=${{ needs.check.result }}, quick-test=${{ needs.quick-test.result }}"
+          echo "Dependencies failed: check=${{ needs.check.result }}, quick-test=${{ needs.quick-test.result }}, windows-test=${{ needs.windows-test.result }}"
           exit 1
 
   full-test-gate:
     runs-on: ubuntu-latest
-    needs: [check, full-test]
+    needs: [check, full-test, windows-test]
     if: always() && github.event_name == 'merge_group'
     steps:
       - name: Verify all dependencies passed
-        if: needs.check.result != 'success' || needs.full-test.result != 'success'
+        if: needs.check.result != 'success' || needs.full-test.result != 'success' || needs.windows-test.result != 'success'
         run: |
-          echo "Dependencies failed: check=${{ needs.check.result }}, full-test=${{ needs.full-test.result }}"
+          echo "Dependencies failed: check=${{ needs.check.result }}, full-test=${{ needs.full-test.result }}, windows-test=${{ needs.windows-test.result }}"
           exit 1

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -28,7 +28,7 @@ jobs:
       scope: '["pytest", "startup"]'
 
   windows-test:
-    name: windows / storage
+    name: windows / storage (non-browser)
     runs-on: windows-2022
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -42,13 +42,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked
       - name: pytest tests/test_storage.py
-        run: uv run --with pytest-rerunfailures==16.4 pytest tests/test_storage.py --reruns 2 --reruns-delay 2 --only-rerun TimeoutException --only-rerun PytestUnraisableExceptionWarning
-      - uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: screenshots-windows
-          path: screenshots/**/*.failed.png
-          retention-days: 14
+        run: uv run pytest tests/test_storage.py -m "not screen"
 
   quick-test-gate:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ addopts = "--driver Chrome"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 main_file = ""
+markers = ["screen: uses the browser-based screen fixture"]
 testpaths = ["tests"]
 filterwarnings = [
   'error',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,5 +7,5 @@ pytest_plugins = ['nicegui.testing.plugin']
 
 def pytest_collection_modifyitems(items) -> None:
     for item in items:
-        if 'screen' in getattr(item, 'fixturenames', ()):
+        if 'screen' in item.fixturenames:
             item.add_marker('screen')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,3 +3,9 @@ import os
 os.environ.setdefault('MPLBACKEND', 'Agg')  # force a non-GUI Matplotlib backend during tests
 
 pytest_plugins = ['nicegui.testing.plugin']
+
+
+def pytest_collection_modifyitems(items) -> None:
+    for item in items:
+        if 'screen' in getattr(item, 'fixturenames', ()):
+            item.add_marker('screen')


### PR DESCRIPTION
*Opened by Claude Code on evnchn's behalf.*

### Motivation

Our CI matrix is Ubuntu-only, but a whole class of `Storage.clear()` / `FilePersistentDict` teardown bugs is **Windows-only** — `PermissionError [WinError 32]` when a storage file is unlinked while an in-flight backup still holds it open (see #6159, #6158). These are invisible to us today: #6159's regression tests are green on Linux *with or without* the fix, because the race can't occur on POSIX. This adds one narrow, cheap Windows job to close that blind spot.

### Implementation

- **New `windows-test` job** in `ci-gate.yml` on `windows-2022`, running `pytest tests/test_storage.py -m "not screen"` — the non-browser storage tests. On current `main` these are exactly the three file-race/teardown tests from #6159, i.e. the tests that only have teeth on Windows. The job takes under a minute.
- **New `screen` marker**, registered in `pyproject.toml` and auto-applied by a small `conftest.py` hook to every test that uses the browser-based `screen` fixture — so the Windows job selects by mechanism, not by a hand-maintained test list.
- **Gating:** the job is wired into the `needs` of both `quick-test-gate` and `full-test-gate`, so a Windows storage regression blocks both PR merges and the merge queue. Since the selected tests are deterministic `user`-fixture tests (no Selenium), there is no flakiness risk in the gate.
- **Verified red→green on real Windows** (from #6159): with the fix present, the file-race test passes; with `unlink_with_retry` reverted to a plain `unlink()`, it fails with `PermissionError: [WinError 32]`. On Linux it is green either way — which is exactly why this leg exists.

<details><summary><b>Why the browser tests are excluded</b></summary>

25 of the storage tests use the Selenium `screen` fixture and are intermittently flaky on `windows-2022` for reasons unrelated to storage: `Timed out receiving message from renderer` in the browser, and a `ConnectionResetError: [WinError 10054]` from the Windows Proactor event loop during teardown that `filterwarnings = error` elevates to a failure. An earlier draft of this PR ran the full file with `pytest-rerunfailures --reruns 2` as a safety net; excluding the browser tests via the `screen` marker removes the flakiness at the root instead, and loses nothing relevant — the Windows-only failure mode lives entirely in the file layer, which the browser-independent tests cover.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb ("Add ...").
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary — this runs existing tests on a new platform; no new tests added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
