### PR TITLE
Raise KeyError from ObservableDict.pop for a missing key, like dict.pop

### DIFF
--- a/nicegui/observables.py
+++ b/nicegui/observables.py
@@ -11,6 +11,8 @@ from typing_extensions import Self
 
 from . import events, helpers
 
+_MISSING = object()
+
 
 class ObservableCollection(abc.ABC):  # noqa: B024
 
@@ -141,8 +143,13 @@ class ObservableDict(ObservableCollection, dict):
         for key, value in self.items():
             super().__setitem__(key, self._observe(value))
 
-    def pop(self, k: Any, d: Any = None) -> Any:
-        item = super().pop(k, d)
+    def pop(self, k: Any, d: Any = _MISSING) -> Any:
+        try:
+            item = super().pop(k)
+        except KeyError:  # nothing was removed, so skip _unobserve/_handle_change below
+            if d is _MISSING:
+                raise
+            return d
         self._unobserve(item)
         self._handle_change()
         return item

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -4,6 +4,8 @@ import gc
 import pickle
 import weakref
 
+import pytest
+
 from nicegui import ui
 from nicegui.observables import ObservableDict, ObservableList, ObservableSet
 from nicegui.testing import Screen, User
@@ -306,3 +308,16 @@ def test_nested_observables_are_picklable():
     root = ObservableList(restored, on_change=increment_counter)
     root[0]['x'] = 1
     assert count == 1, 'a restored tree should wire up freshly and notify exactly once'
+
+
+def test_pop_missing_key_raises_keyerror():
+    reset_counter()
+    data = ObservableDict({'a': 1}, on_change=increment_counter)
+    with pytest.raises(KeyError):
+        data.pop('missing')  # like dict.pop, a missing key without default raises
+    assert count == 0, 'a failed pop must not fire a change event'
+    assert data.pop('missing', 'default') == 'default'
+    assert count == 0, 'popping a missing key with a default must not fire a change event'
+    assert data.pop('a') == 1
+    assert count == 1, 'popping an existing key fires exactly one change event'
+    assert data.pop('a', None) is None and count == 1, 'default is returned without an event when key is gone'

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -320,4 +320,5 @@ def test_pop_missing_key_raises_keyerror():
     assert count == 0, 'popping a missing key with a default must not fire a change event'
     assert data.pop('a') == 1
     assert count == 1, 'popping an existing key fires exactly one change event'
-    assert data.pop('a', None) is None and count == 1, 'default is returned without an event when key is gone'
+    assert data.pop('a', None) is None, 'the default is returned when the key is gone'
+    assert count == 1, 'popping a now-missing key with a default must not fire another change event'


### PR DESCRIPTION
*Opened by Claude Code on @evnchn's behalf.*

### Motivation

Fixes #6163. `ObservableDict.pop` breaks the `dict.pop` contract: with the signature `pop(self, k, d=None)`, `super().pop(k, d)` is always called with a default, so a missing key returns `None` instead of raising `KeyError`, and a no-op pop still fires a change event. This is user-facing — `app.storage.general` / `.user` / `.tab` / `.client` are all `ObservableDict`s. Pre-existing; surfaced while reviewing #6140.

### Implementation

Use a module-level `_MISSING` sentinel (same pattern already in `binding.py`) so `pop` can tell "no default given" from an explicit `None`, and only mutate/notify on a real removal:

- missing key, no default → `KeyError` (was: `None`)
- missing key, with default → returns default, no change event (was: fired one)
- present key → detaches the item (unchanged from #6140) and fires exactly one change event

Internal tolerant-removal callers already pass an explicit default (e.g. `props.py`), and `storage._users.pop(...)` is a plain `dict`, so nothing regresses. `ObservableList.pop` / `ObservableSet.pop` have different signatures and are untouched.

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API — aligns `ObservableDict.pop` with `dict.pop`; a missing-key-without-default call that previously returned `None` now raises `KeyError` (the documented `dict` behavior).

<details><summary><b>Verification</b></summary>

Rebased onto current `main` (with #6140), so the removal path keeps `self._unobserve(item)`.

```text
tests/test_observables.py   18 passed   (incl. new test_pop_missing_key_raises_keyerror)
tests/test_storage.py + tests/test_binding.py   47 passed
pre-commit  all pass   ·   mypy ./nicegui  clean (245 files)   ·   pylint  10.00/10
```

Empirical (public storage surface, and #6140 detach preserved):

```text
app.storage.general.pop('nope')  -> KeyError        (was: None)
pop('x', 'def')                  -> 'def', 0 events
pop('present')                   -> value, 1 event, popped child detached (no further events)
pop('gone', None)                -> None
```

Fresh-lineage review (Codex): confirmed it's a genuine contract bug (not a deliberate convention — internal callers pass explicit defaults), recommended fixing both the `KeyError` contract and the spurious event, and proposed the try/except shape used here.
</details>
