### PR TITLE
Fix `run.cpu_bound` hanging when the process pool uses the forkserver start method

### DIFF
--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -69,6 +69,9 @@ def setup() -> None:
     """Setup the process pool. (For internal use only.)"""
     global process_pool, _pool_context, _pool_uses_implicit_fork  # pylint: disable=global-statement # noqa: PLW0603
     _pool_context = _resolve_cpu_bound_context()
+    if _pool_context.get_start_method() == 'forkserver':
+        # let the workers re-import __main__, where the MainProcess guard catches it, not the daemon (#6166)
+        _pool_context.set_forkserver_preload([])
     _pool_uses_implicit_fork = process_pool_start_method is None and _pool_context.get_start_method() == 'fork'
     try:
         process_pool = ProcessPoolExecutor(mp_context=_pool_context, initializer=_ignore_sigint)

--- a/nicegui/run.py
+++ b/nicegui/run.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import multiprocessing
+import multiprocessing.forkserver
 import signal
 import traceback
 from collections.abc import Callable
@@ -70,8 +71,11 @@ def setup() -> None:
     global process_pool, _pool_context, _pool_uses_implicit_fork  # pylint: disable=global-statement # noqa: PLW0603
     _pool_context = _resolve_cpu_bound_context()
     if _pool_context.get_start_method() == 'forkserver':
-        # let the workers re-import __main__, where the MainProcess guard catches it, not the daemon (#6166)
-        _pool_context.set_forkserver_preload([])
+        # drop __main__ from the preload so the workers re-import it, where the MainProcess guard catches it,
+        # not the daemon (#6166); other (user-configured) preload modules are kept
+        fork_server = multiprocessing.forkserver._forkserver  # pylint: disable=protected-access
+        preload = fork_server._preload_modules  # type: ignore[attr-defined]  # pylint: disable=protected-access
+        _pool_context.set_forkserver_preload([module for module in preload if module != '__main__'])
     _pool_uses_implicit_fork = process_pool_start_method is None and _pool_context.get_start_method() == 'fork'
     try:
         process_pool = ProcessPoolExecutor(mp_context=_pool_context, initializer=_ignore_sigint)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,5 +1,6 @@
 import asyncio
 import multiprocessing
+import multiprocessing.forkserver
 import os
 import time
 from collections.abc import Callable, Generator
@@ -116,13 +117,16 @@ async def test_returns_none_when_app_is_stopping(user: User, func: Callable):
 
 @pytest.fixture
 def isolate_pool_state() -> Generator[None, None, None]:
-    """Restore run.process_pool_start_method, drop the test's pool and forget shown warnings."""
+    """Restore run.process_pool_start_method and the forkserver preload, drop the pool and forget warnings."""
     original = run.process_pool_start_method
+    forkserver = multiprocessing.forkserver._forkserver  # pylint: disable=protected-access
+    original_preload = forkserver._preload_modules  # pylint: disable=protected-access
     nicegui_warnings.reset()
     try:
         yield
     finally:
         run.process_pool_start_method = original
+        forkserver.set_forkserver_preload(original_preload)
         run.reset()
         nicegui_warnings.reset()
 
@@ -139,6 +143,17 @@ def test_pool_uses_configured_start_method(method):
     assert run.process_pool is not None
     assert run.process_pool._mp_context is not None  # pylint: disable=protected-access
     assert run.process_pool._mp_context.get_start_method() == expected  # pylint: disable=protected-access
+
+
+@pytest.mark.usefixtures('isolate_pool_state')
+async def test_forkserver_pool_does_not_preload_main():
+    """A "forkserver" pool must not re-import __main__, which would re-run the user's ui.run() (#6166)."""
+    if 'forkserver' not in multiprocessing.get_all_start_methods():
+        pytest.skip('forkserver is not available on this platform')
+    run.process_pool_start_method = 'forkserver'
+    run.setup()
+    assert multiprocessing.forkserver._forkserver._preload_modules == []  # pylint: disable=protected-access
+    assert await run.cpu_bound(good_function)
 
 
 @pytest.mark.usefixtures('isolate_pool_state')

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -147,12 +147,13 @@ def test_pool_uses_configured_start_method(method):
 
 @pytest.mark.usefixtures('isolate_pool_state')
 async def test_forkserver_pool_does_not_preload_main():
-    """A "forkserver" pool must not re-import __main__, which would re-run the user's ui.run() (#6166)."""
+    """A "forkserver" pool must drop the __main__ preload (it would re-run ui.run()) but keep user modules (#6166)."""
     if 'forkserver' not in multiprocessing.get_all_start_methods():
         pytest.skip('forkserver is not available on this platform')
+    multiprocessing.set_forkserver_preload(['json', '__main__'])
     run.process_pool_start_method = 'forkserver'
     run.setup()
-    assert multiprocessing.forkserver._forkserver._preload_modules == []  # pylint: disable=protected-access
+    assert multiprocessing.forkserver._forkserver._preload_modules == ['json']  # pylint: disable=protected-access
     assert await run.cpu_bound(good_function)
 
 


### PR DESCRIPTION
### Motivation

Fixes #6166.

When the `cpu_bound` pool uses the `forkserver` start method, the forkserver daemon re-imports the user's script, a second NiceGUI server starts, and `run.cpu_bound` never returns — the process hangs.

Two ways to reach it:

- **No opt-in at all, Linux + Python 3.14.** CPython 3.14 changed the default start method on POSIX (except macOS) from `fork` to `forkserver`, and the pool inherits the platform default via `_resolve_cpu_bound_context()`. Also present in released 3.14.0.
- **`run.process_pool_start_method = 'forkserver'` on CPython >= 3.13**, any OS — the option added in #6117, which `section_action_events.py` currently suggests.

The reason our existing defence misses it: `ui_run.py` guards re-entrancy with `current_process().name != 'MainProcess'`. Under `spawn` that works, because `spawn.prepare()` renames the process before the main-module fixup. Under `forkserver` on CPython >= 3.13 the **daemon** preloads `__main__` while still named `MainProcess`, so the guard does not fire. On 3.12 the daemon does not preload at all — workers import as `ForkServerProcess-N`, the guard fires, and everything is fine.

<details>
<summary>Version matrix (each row a real run; <code>TOP</code> = times the script's top level executed, 1 healthy / 2 bug)</summary>

| Python | OS | NiceGUI | `process_pool_start_method` | effective | result |
|---|---|---|---|---|---|
| 3.12.13 | Linux | 3.14.0 | *(default)* | fork | PASS — exit 0, TOP=1 |
| 3.13.14 | Linux | 3.14.0 | *(default)* | fork | PASS — exit 0, TOP=1 |
| 3.14.6 | Linux | 3.14.0 | *(default)* | **forkserver** | **HANG — exit 124, TOP=2** |
| 3.14.6 | Linux | main | *(default)* | **forkserver** | **HANG — exit 124, TOP=2** |
| 3.12.13 | Linux | main | `'forkserver'` | forkserver | PASS — exit 0, TOP=1 |
| 3.13.14 | Linux | main | `'forkserver'` | forkserver | **HANG — exit 124, TOP=2** |
| 3.14.6 | Linux | main | `'forkserver'` | forkserver | **HANG — exit 124, TOP=2** |
| 3.13.11 | macOS | main | `'forkserver'` | forkserver | **HANG — exit 124, TOP=2** |
| 3.13.11 | macOS | main | `'spawn'` | spawn | PASS — exit 0, TOP=1 |

</details>

### Implementation

Clear the forkserver preload list in `setup()` so the daemon does not import `__main__`.

The condition is on the **resolved context**, not on `process_pool_start_method`, so it covers both entry points above — the explicit setting *and* the implicit Python 3.14 default. It sits in `setup()` because the preload must be configured before the daemon starts; `ProcessPoolExecutor(mp_context=...)` does not start it (the first `submit()` does), so this is early enough.

**To be precise: this does not stop `__main__` being re-imported — it relocates it.** Instead of the daemon importing it once (as `MainProcess`, invisible to the guard), each worker imports it in `spawn.prepare()` → `_fixup_main_from_path` as `ForkServerProcess-N`, where the existing `ui_run.py` guard fires. Net effect: **`forkserver` now behaves exactly like `spawn`.**

```
### DEFAULT preload ['__main__']   (buggy)
TOPLEVEL RAN  __name__='__main__'     procname='MainProcess'
TOPLEVEL RAN  __name__='__mp_main__'  procname='MainProcess'          <-- the daemon; guard misses it
### preload CLEARED               (this PR)
TOPLEVEL RAN  __name__='__main__'     procname='MainProcess'
TOPLEVEL RAN  __name__='__mp_main__'  procname='ForkServerProcess-1'  <-- a worker; guard fires
```

That framing matters for two follow-on questions. Pickling is unaffected — a `cpu_bound` callable defined in the user's `main.py` still resolves, because `_fixup_main_from_path` aliases `sys.modules['__main__']`. And the cost of losing the preload is that each worker re-imports the user's module rather than the daemon doing it once — which is precisely `spawn`'s existing cost, not a new class of overhead. The `ui_run.py` guard remains load-bearing after this change; it is what makes the worker-side import harmless.

**Trade-off worth flagging:** `set_forkserver_preload()` mutates a process-global (`multiprocessing.forkserver._forkserver`), not a per-context value, so it would wipe a preload list a user or another library had configured before startup. The public API only offers a setter, so a narrower "remove just `__main__`" variant would need private state in production code. Given that the alternative is a hung app with no actionable error, clearing looks like the right call — but happy to go the narrower route if you prefer. Note also that this only affects *future* forkserver launches: if something else already started the daemon before `setup()`, we cannot retune it.

The perf cost should be negligible — CPython's default preload is `['__main__']`, not heavy modules — except for users who deliberately configured a preload list.

<details>
<summary>Verification</summary>

**The new test fails without the fix and passes with it** (not just green-on-green):

```
$ git stash push nicegui/run.py && pytest tests/test_run.py -k forkserver
FAILED tests/test_run.py::test_forkserver_pool_does_not_preload_main - AssertionError: assert ['__main__'] == []
1 failed, 1 passed, 16 deselected
```

**Local gates:** `pre-commit` all passed · `mypy ./nicegui` success, 245 files · `pylint ./nicegui` 10.00/10 · `pytest tests/test_run.py` 15 passed, 3 skipped.

**Empirical, with the MRE from #6166** (`app.on_startup` + `app.shutdown()`, so no HTTP client involved):

| scenario | before | after |
|---|---|---|
| macOS py3.13, explicit `'forkserver'` | hang (exit 124), TOP=2, 2× "ready to go" | exit 0, TOP=1, 1× "ready to go", `returned: 36` |
| Linux py3.14, **zero config**, wheel built from this branch | hang (exit 124), TOP=2, `ConnectionResetError` | exit 0, TOP=1, 1× "ready to go", `returned: 36` |

The `isolate_pool_state` fixture now also saves/restores the forkserver preload list, since both this test and the existing `test_pool_uses_configured_start_method[forkserver]` mutate that global via `setup()`.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

---

*Staged first on the fork — evnchn/nicegui#212 — which is also green on the identical commit. (This PR was opened while `quick-test` was still running; it has since passed.)*
