### PR TITLE
Fix deleted-client warning from `page_title`, `add_head_html`, `add_body_html` and `add_css`

### DIFF
--- a/nicegui/functions/html.py
+++ b/nicegui/functions/html.py
@@ -12,7 +12,7 @@ def add_head_html(code: str, *, shared: bool = False) -> None:
         Client.shared_head_html += code + '\n'
     else:
         client = context.client
-        if client._response_built:  # pylint: disable=protected-access
+        if client._response_built and not client.is_deleted:  # pylint: disable=protected-access
             client.run_javascript(f'document.head.insertAdjacentHTML("beforeend", {code!r});')
         client._head_html += code + '\n'  # pylint: disable=protected-access
 
@@ -27,6 +27,6 @@ def add_body_html(code: str, *, shared: bool = False) -> None:
         Client.shared_body_html += code + '\n'
     else:
         client = context.client
-        if client._response_built:  # pylint: disable=protected-access
+        if client._response_built and not client.is_deleted:  # pylint: disable=protected-access
             client.run_javascript(f'document.querySelector("#app").insertAdjacentHTML("beforebegin", {code!r});')
         client._body_html += code + '\n'  # pylint: disable=protected-access

--- a/nicegui/functions/page_title.py
+++ b/nicegui/functions/page_title.py
@@ -13,5 +13,5 @@ def page_title(title: str) -> None:
     client.title = title
     if core.app.native.main_window:
         core.app.native.main_window.set_title(title)
-    if client._response_built:  # pylint: disable=protected-access
+    if client._response_built and not client.is_deleted:  # pylint: disable=protected-access
         client.run_javascript(f'document.title = {json.dumps(title)}')

--- a/nicegui/functions/style.py
+++ b/nicegui/functions/style.py
@@ -66,5 +66,5 @@ def _add_javascript(code: str, *, shared: bool = False) -> None:
     else:
         client = context.client
         client._head_html += script_html + '\n'
-    if client is not None and client._response_built:  # pylint: disable=protected-access
+    if client is not None and client._response_built and not client.is_deleted:  # pylint: disable=protected-access
         client.run_javascript(code)

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -1,3 +1,4 @@
+import asyncio
 import weakref
 
 import pytest
@@ -220,6 +221,31 @@ async def test_usage_after_delete(user: User, caplog: pytest.LogCaptureFixture, 
     label.get_computed_prop('bar')
     expected_warnings = 0 if deletion_method == 'client_delete' else 1
     assert len([record for record in caplog.records if 'still being used' in record.message]) == expected_warnings
+
+
+async def test_head_functions_after_client_delete(user: User, caplog: pytest.LogCaptureFixture):
+    """Patching head or body of a disconnected and deleted client stays silent (benign reload race)."""
+    label = None
+
+    @ui.page('/')
+    def page():
+        nonlocal label
+        label = ui.label('hi')
+
+    await user.open('/')
+    assert isinstance(label, ui.label)
+    client = label.client
+    client.tab_id = None  # what handle_disconnect() does before the delayed delete()
+    client.delete()
+    assert client.is_deleted
+
+    with client:
+        ui.page_title('late title')
+        ui.add_head_html('<meta name="late">')
+        ui.add_body_html('<span>late</span>')
+        ui.add_css('body {color: red}')
+    await asyncio.sleep(0)  # let the fire-and-forget tasks of run_javascript run
+    assert not [record for record in caplog.records if 'still being used' in record.message]
 
 
 async def test_parent_slot_error(user: User):

--- a/tests/test_element_delete.py
+++ b/tests/test_element_delete.py
@@ -201,7 +201,7 @@ def test_slot_children_cleared_on_delete(screen: Screen):
 
 @pytest.mark.parametrize('deletion_method', ['client_delete', 'element_delete'])
 async def test_usage_after_delete(user: User, caplog: pytest.LogCaptureFixture, deletion_method: str):
-    """Using an element after deletion is silent when the client is gone (benign reload race)
+    """Using an element or head functions after deletion is silent when the client is gone (benign reload race)
     but warns once when only the element was deleted (a user bug). See issue #6058."""
     label = None
 
@@ -219,33 +219,14 @@ async def test_usage_after_delete(user: User, caplog: pytest.LogCaptureFixture, 
     label.run_method('foo')
     label.update()
     label.get_computed_prop('bar')
-    expected_warnings = 0 if deletion_method == 'client_delete' else 1
-    assert len([record for record in caplog.records if 'still being used' in record.message]) == expected_warnings
-
-
-async def test_head_functions_after_client_delete(user: User, caplog: pytest.LogCaptureFixture):
-    """Patching head or body of a disconnected and deleted client stays silent (benign reload race)."""
-    label = None
-
-    @ui.page('/')
-    def page():
-        nonlocal label
-        label = ui.label('hi')
-
-    await user.open('/')
-    assert isinstance(label, ui.label)
-    client = label.client
-    client.tab_id = None  # what handle_disconnect() does before the delayed delete()
-    client.delete()
-    assert client.is_deleted
-
-    with client:
+    with label.client:
         ui.page_title('late title')
         ui.add_head_html('<meta name="late">')
         ui.add_body_html('<span>late</span>')
         ui.add_css('body {color: red}')
     await asyncio.sleep(0)  # let the fire-and-forget tasks of run_javascript run
-    assert not [record for record in caplog.records if 'still being used' in record.message]
+    expected_warnings = 0 if deletion_method == 'client_delete' else 1
+    assert len([record for record in caplog.records if 'still being used' in record.message]) == expected_warnings
 
 
 async def test_parent_slot_error(user: User):


### PR DESCRIPTION
### Motivation

`ui.page_title()`, `ui.add_head_html()`, `ui.add_body_html()` and `ui.add_css()` now warn *"Client has been deleted but is still being used. This is most likely a bug in your application code."* — with a stack trace — when they run against a client that has already gone away. On 3.14.0 the same call was a silent no-op.

This is a regression from #6148, which changed the guard from `client.has_socket_connection` to `client._response_built` so that content set *after* the response is built still reaches the browser. That part is right; the problem is that the two predicates differ on teardown:

- `_response_built` is **monotonic** — set `False` at `client.py:117`, `True` at `client.py:179`, never reset.
- `has_socket_connection` is `tab_id is not None`, and `handle_disconnect()` clears `tab_id` (`client.py:375`) before the delayed `delete()`.

So for a disconnected-and-deleted client the new guard is `True` where the old one was `False`, and the call proceeds into `run_javascript()` → `Outbox.enqueue_message()` (`outbox.py:77`) → `Client.check_existence()` (`client.py:477`) → `warn_once(..., stack_info=True)`.

That contradicts the policy this project deliberately established in #6058 and covers with a test: using something after deletion warns when *only the element* was deleted (a real user bug), but stays **silent when the client is gone**, because an async callback resuming after teardown is a benign reload race, not user error. `element.py:423` encodes it as `if client is None or client.is_deleted: return False`, and `test_usage_after_delete` asserts exactly 0 warnings for the client-gone case.

The result today is that `label.update()` on a deleted client is silent while `ui.page_title()` on the *same* deleted client accuses the user's code.

### Implementation

Add `and not client.is_deleted` to the four guards, so a built response still allows late injection, but a dead client does not.

**Scope note, worth a maintainer's eye:** keying on `is_deleted` also silences one case that 3.14.0 *did* warn about — a client deleted directly via `client.delete()` while `tab_id` is still set (no disconnect). Strictly, restoring 3.14.0 behaviour would mean keying on `has_socket_connection or not is_deleted`. I went with `is_deleted` because it makes these four functions agree with the #6058 policy and with `element.py:423`, rather than reproducing an inconsistency 3.14.0 also had. Happy to narrow it if you'd rather this PR restore the old behaviour exactly and leave that case alone.

Two things that make the widening easy to accept: the "real user bug" signal #6058 cares about is an *element* deleted while the client is alive, which this does not touch; and by the time `delete()` has run, `outbox.stop()` has already been called, so the JavaScript could never have been delivered anyway — the warning was the only observable effect.

The case #6148 exists for is unaffected: a client that is alive but not yet socket-connected has `_response_built=True` and `is_deleted=False`, so late injection still runs and the outbox delivers it at handshake. #6148's own tests confirm it (18 passed, below).

**One residual slice I deliberately left out of this PR.** Calling these functions from an `on_delete` handler still warns. `delete()` invokes the handlers first and sets `self._deleted = True` only at the end (`client.py:466-480`), so the guard sees `is_deleted=False` and calls `run_javascript()` — but the actual `enqueue_message` happens inside `AwaitableResponse`'s `background_tasks.create(self._fire())`, which runs after `delete()` has returned and `_deleted` is `True`. v3.14.0 did not warn there either, so it is strictly a leftover sliver of the same #6148 regression. It is narrow (only the delete-handler window, and only for the deferred `run_javascript` sink — `element.update()` enqueues synchronously and has no such window). I think the right repair is at the sink — making `check_existence`/`enqueue_message` silent for a deleted client, matching `element.py:423` — rather than a fifth call-site guard, so I would rather not smuggle it into a regression fix. Happy to open it as a follow-up if you agree.

<details>
<summary>Verification</summary>

**Three-way A/B on the new test** — this is what establishes it as a regression rather than a pre-existing wart, and that the fix restores the reload-race behaviour (not, per the scope note above, every 3.14.0 edge case):

| variant | `tests/test_element_delete.py -k head_functions` |
|---|---|
| `main` @ 034db3b7, unfixed | **FAIL** — `Client has been deleted but is still being used` |
| `v3.14.0` guards | PASS |
| `main` + this fix | PASS |

**Gates:** `pre-commit` all passed · `mypy ./nicegui` success, 245 files · `pylint ./nicegui` 10.00/10.

**Tests:** `tests/test_element_delete.py` 12 passed · `tests/test_page_title.py` + `tests/test_add_html.py` 18 passed (the features #6148 added still work).

**One trap worth recording for whoever touches this test next:** `run_javascript()` returns an `AwaitableResponse`, which fires its callback via `background_tasks.create()` (`awaitable_response.py:21`) rather than synchronously. Without the `await asyncio.sleep(0)` the assertion runs before the task does and the test passes *even against unfixed code* — a worthless guard. The sleep is what makes it fail correctly.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

---

*Staged first on the fork — evnchn/nicegui#213. (This PR was opened while `quick-test` was still running; it has since passed.)*
