### PR TITLE
Fix FAB action placement and order under dir=rtl

### DIFF
--- a/nicegui/templates/index.html
+++ b/nicegui/templates/index.html
@@ -24,6 +24,29 @@
         blockquote, dd, dl, figure, h1, h2, h3, h4, h5, h6, hr, p, pre {
           margin: revert-layer; /* HACK: revert Quasar's margin styles */
         }
+        /* DEPRECATED: mirror of quasarframework/quasar#18413 + #18419, remove with the Quasar bump for NiceGUI 4.0 */
+        [dir="rtl"] .q-fab__actions--right {
+          transform-origin: 0 50%;
+          right: auto;
+          margin-right: 0;
+          left: 100%;
+          margin-left: 9px;
+          flex-direction: row-reverse;
+        }
+        [dir="rtl"] .q-fab__actions--right:not(.q-fab__actions--opened) {
+          transform: scale(0.4) translateX(-62px);
+        }
+        [dir="rtl"] .q-fab__actions--left {
+          transform-origin: 100% 50%;
+          left: auto;
+          margin-left: 0;
+          right: 100%;
+          margin-right: 9px;
+          flex-direction: row;
+        }
+        [dir="rtl"] .q-fab__actions--left:not(.q-fab__actions--opened) {
+          transform: scale(0.4) translateX(62px);
+        }
       }
       @layer overrides {
         {{ headwind_css | safe }}


### PR DESCRIPTION
### Motivation

`ui.fab` / `ui.fab_action` are laid out wrongly under `dir="rtl"`: the actions overlap the parent FAB, and their order is reversed so the first action ends up farthest from it. Reported in #6165 by @roximn148.

Both defects are Quasar's, not NiceGUI's — NiceGUI is only involved because it deliberately ships Quasar's RTL-capable stylesheet so app-wide `dir=rtl` works. Two separate defects, two separate upstream PRs:

| Defect | Upstream fix | Status |
|---|---|---|
| Actions container mirrored → **overlaps the parent FAB** | quasarframework/quasar#18413 | merged to `dev`, **not in any published release** |
| Action **order** still text-relative → first action farthest from the FAB | quasarframework/quasar#18419 | open |

Neither can reach users by bumping Quasar: the fixes aren't released, and NiceGUI bumps Quasar only once a year for a major release — 2.18.5 → 2.22.x brings a raised browser-support floor plus broad undeclared interaction churn across ~20 wrapped components (analysis in #6165). So this mirrors both fixes locally until the bump.

![NiceGUI FAB RTL before and after](https://raw.githubusercontent.com/evnchn/nicegui/88ae205ba9af9e9371bd8443d2aedf063d32755b/nicegui-fab-rtl-6165.png)

### Implementation

Four CSS rules in the `@layer quasar` block of `nicegui/templates/index.html`, where Quasar fixups are already collected — same layer as Quasar's own import but later in source order, so equal-specificity rules win without `!important`. Tagged `DEPRECATED` with both upstream PR numbers, to be **deleted at the Quasar bump for 4.0**.

The block is @falkoschindler's, verbatim from #6165 — I verified it rather than rewrote it. `--up`/`--down` are untouched (they were already correct: `column`/`column-reverse` are unaffected by `direction`).

<details>
<summary><b>Why it's 23 lines — every declaration is load-bearing, and the shorter forms were tried</b></summary>

The line count overstates it: **23 lines is 14 declarations** across 4 selectors plus the comment. The file writes one declaration per line — same style as the `margin: revert-layer` hack directly above it and as `nicegui/static/nicegui.css` — so collapsing to one line per rule would save newlines, not bytes, and would fight the surrounding convention. The number worth arguing about is 14.

I checked each one by ablation, against an oracle that renders all four FAB directions × `{ltr, rtl}` and requires **every action button's physical offset from its parent FAB centre to be identical in RTL and LTR**, opened and closed:

| Removed | Result |
|---|---|
| *(nothing — the full block)* | ✅ 0 violations |
| `transform-origin` | ❌ 8 (closed/animating state anchors on the wrong edge) |
| `left`/`right` positioning | ❌ 16 (**the overlap bug** — the quasarframework/quasar#18413 half) |
| `flex-direction` | ❌ 12 (**the order bug** — the quasarframework/quasar#18419 half) |
| closed-state `transform` | ❌ 8 (actions fly in from the wrong side) |
| the `margin` pair | ✅ 0 — *removable, but see below* |

The margins are the one droppable piece and I left them in deliberately: without them it passes only because Quasar's *own* mirrored `margin-right/left: 9px` happens to land the box correctly. That is an accidental coupling to a vendored value — if Quasar changes that `9px` in a patch release before 4.0, the override drifts by 9px with nothing failing loudly. Two declarations aren't worth that.

The `:not(.q-fab__actions--opened)` split on the two `transform` rules is required: Quasar's opened-state rule has equal specificity, so an unconditionally-appended `transform` would win by source order and leave the actions permanently shrunk while open.

**Shorter forms tried and rejected**, so nobody re-treads them:

| Idea | Why not |
|---|---|
| Group `--right` and `--left` into one selector list | Every declaration differs in value between them (opposite signs throughout). Nothing to factor out. |
| `revert-layer` / `revert` / `unset` / `all` to reset to the LTR values | No CSS primitive copies another *selector's* values. On an RTL element the `[dir="ltr"]` rule never matches, in any layer, so a revert lands on the CSS initial value, not the LTR one. |
| Drop the `[dir="rtl"]` qualifier and apply the LTR values unconditionally | `flex-direction` is direction-relative, so this breaks LTR. |
| Logical shorthands (`inset-inline` / `margin-inline`), −4 declarations | Behaviourally identical and verified so, but they resolve against the *element's own* `direction`, not the `[dir="rtl"]` ancestor the selector matched — app code setting `direction` on `.q-fab__actions` would break it. Also raises the floor to Chrome 87 / Safari 14.1. |
| Move to the later `overrides` layer to win with lower specificity | Same declarations, same selectors. Swaps one cascade-win mechanism for another; no saving. |
| Native CSS nesting (`&:not(...)`) | Saves selector text only, no declarations, and raises the browser floor (Chrome 112 / Safari 16.5). |
| Patch the four rules out at vendoring time in `extract_core_libraries.py` | Needs a new selector-filter step in the extraction pipeline, and buries the fix and its removal condition away from where the bug shows up. |
| Move the block to `nicegui/static/nicegui.css` (cached a year) instead of the per-request template | The one alternative with a real, if tiny, upside: ~249 gzipped bytes saved per page load, and the `nicegui` layer already outranks `quasar`. Kept in the template because that is where the sibling Quasar fixup lives. Happy to move it if you'd rather have the bytes. |
</details>

<details>
<summary><b>Verification</b></summary>

A real NiceGUI boot (editable install) serving the exact repro from #6165:

- **Before:** RTL actions overlap the parent FAB, sit on the wrong side, and run `3 2 1` inward.
- **After:** `direction='right'` → `[FAB] 1 2 3`, `direction='left'` → `3 2 1 [FAB]`, matching the LTR column; open/close animation correct in both states.
- **LTR untouched:** measured LTR offsets are identical before and after the patch.
- **Cross-engine:** identical measured geometry in Chromium, WebKit and Firefox.
- **`up`/`down`:** unaffected — the block does not touch them.

As a check that the measurement really binds, I also removed the block again and re-measured: the RTL offsets for `direction='right'` go from `[65, 115, 165]` (matching LTR) to `[10, -40, -90]` — i.e. the actions land back on top of the parent FAB.
</details>

<details>
<summary><b>Removal criteria (for whoever does the 4.0 bump)</b></summary>

Delete the whole `[dir="rtl"] .q-fab__actions--*` block once the bundled Quasar contains **both** quasarframework/quasar#18413 and quasarframework/quasar#18419. If only the first has shipped, the positioning declarations can go but the two `flex-direction` lines must stay. Re-running the repro from #6165 in LTR and RTL is enough to confirm.
</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.
