### PR TITLE
Fix move() orphaning an element when target_slot is invalid

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -508,22 +508,22 @@ class Element(Visibility):
         """
         parent_slot = self.parent_slot
         assert parent_slot is not None
-        parent_slot.children.remove(self)
-        parent_slot.parent.update()
         target_container = target_container or parent_slot.parent
 
         if target_slot is None:
-            parent_slot = target_container.default_slot
-            self.parent_slot = parent_slot
+            new_slot = target_container.default_slot
         elif target_slot in target_container.slots:
-            parent_slot = target_container.slots[target_slot]
-            self.parent_slot = parent_slot
+            new_slot = target_container.slots[target_slot]
         else:
             raise ValueError(f'Slot "{target_slot}" does not exist in the target container. '
                              f'Add it first using `add_slot("{target_slot}")`.')
 
-        target_index = target_index if target_index >= 0 else len(parent_slot.children)
-        parent_slot.children.insert(target_index, self)
+        parent_slot.children.remove(self)
+        parent_slot.parent.update()
+        self.parent_slot = new_slot
+
+        target_index = target_index if target_index >= 0 else len(new_slot.children)
+        new_slot.children.insert(target_index, self)
 
         target_container.update()
         return self

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -241,10 +241,10 @@ async def test_move_to_invalid_slot_keeps_element_in_place(user: User):
     with pytest.raises(ValueError, match='does not exist'):
         label.move(other, target_slot='does-not-exist')
 
-    assert label in card.default_slot.children, 'a failed move must not detach the element'
-    assert label.parent_slot is card.default_slot
+    assert label in card.default_slot.children, 'a failed move must keep the element in its original slot'
+    await user.should_see('X')
     label.delete()  # used to raise ValueError('list.remove(x): x not in list')
-    assert label not in card.default_slot.children
+    await user.should_not_see('X')
 
 
 def test_xss(screen: Screen):

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -7,7 +7,7 @@ from selenium.webdriver.common.by import By
 from nicegui import background_tasks, ui
 from nicegui.props import Props
 from nicegui.style import Style
-from nicegui.testing import Screen
+from nicegui.testing import Screen, User
 
 
 def test_classes(screen: Screen):
@@ -222,6 +222,29 @@ def test_move_slots(screen: Screen):
     screen.click('Move X to B')
     screen.wait(0.5)
     assert screen.find('B').location['y'] < screen.find('X').location['y'], 'X is in B.default'
+
+
+async def test_move_to_invalid_slot_keeps_element_in_place(user: User):
+    card = label = other = None
+
+    @ui.page('/')
+    def page():
+        nonlocal card, label, other
+        card = ui.card()
+        with card:
+            label = ui.label('X')
+        other = ui.card()
+
+    await user.open('/')
+    assert isinstance(card, ui.card) and isinstance(label, ui.label) and isinstance(other, ui.card)
+
+    with pytest.raises(ValueError, match='does not exist'):
+        label.move(other, target_slot='does-not-exist')
+
+    assert label in card.default_slot.children, 'a failed move must not detach the element'
+    assert label.parent_slot is card.default_slot
+    label.delete()  # used to raise ValueError('list.remove(x): x not in list')
+    assert label not in card.default_slot.children
 
 
 def test_xss(screen: Screen):


### PR DESCRIPTION
### Motivation

`Element.move()` detaches the element from its current slot (`parent_slot.children.remove(self)` + `parent_slot.parent.update()`) **before** it validates `target_slot`. When `target_slot` does not exist, the `ValueError` is raised *after* the element has already been removed — leaving it orphaned: gone from its old slot's `children`, yet still pointing at that slot via `parent_slot` and still present in `client.elements`. The element is then unrecoverable through the public API — a subsequent `delete()` (or another `move()`) raises `ValueError: list.remove(x): x not in list`.

A plausible user typo (`label.move(other, target_slot='heder')`) is enough to trigger it.

### Implementation

Resolve and validate `target_slot` **first**; only then perform the remove / update / insert. This is a pure reorder — the happy path is unchanged (the removal still happens before `target_index` normalization, so same-slot moves and `target_index=-1` append keep their previous child-order semantics). No public-API or on-success behavior change.

<details>
<summary>Reproduction, before/after, and independent review</summary>

**MRE (ran on 3.13.0.post24.dev0, Py3.12.11) — before the fix:**

```python
from nicegui import ui
card = ui.card()
with card:
    label = ui.label('X')
other = ui.card()
try:
    label.move(other, target_slot='doesnotexist')
except ValueError:
    pass
label.delete()   # <-- ValueError: list.remove(x): x not in list
```
```
BUG REPRODUCED: failed move orphaned the element; delete() raised: ValueError('list.remove(x): x not in list'); orphaned=True
```

**Regression test — three-way A/B (must be able to fail):**
| state | `test_move_to_invalid_slot_keeps_element_in_place` |
|---|---|
| unfixed (origin/main) | **FAIL** — `assert label in card.default_slot.children` → `label in []` |
| with fix | **PASS** |

**Local gates:** `pre-commit` ✓ · `mypy ./nicegui` ✓ (245 files) · `pylint ./nicegui` 10.00/10 ✓

**Different-lineage review (Codex, adversarial):** *approve / SHIP* — "target_slot is now resolved before detach, but removal still happens before target_index normalization/insertion, so same-slot moves and target_index=-1 append retain the previous child-order semantics. No material findings."
</details>

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary (internal behavior fix, no API change).
- [x] No breaking changes to the public API.
