### PR TITLE
Remove dead no-parent-event prop from the date picker

### DIFF
--- a/nicegui/elements/date_input.py
+++ b/nicegui/elements/date_input.py
@@ -39,7 +39,7 @@ class DateInput(LabelElement, ValueElement[str | None], DisableableElement):
         with self.add_slot('append'):
             with button(icon='edit_calendar', color=None).props('flat round') as self.button:
                 with menu() as self.menu:
-                    self.picker = date().props('no-parent-event').props('range' if range_input else '')
+                    self.picker = date().props('range' if range_input else '')
 
         self.picker.bind_value(self,
                                forward=lambda v: self._picker_to_input_value(v) if self._range_input else v,


### PR DESCRIPTION
### Motivation

`DateInput` applies `.props('no-parent-event')` to the inner `QDate` picker. Quasar 2.18.5's `QDate` has **no** `no-parent-event` prop — `noParentEvent` belongs to the anchor-props mixin that backs `QMenu`/`QTooltip`/`QPopupProxy`, not `QDate`. So the prop is a dead no-op: Vue passes it through as an inert root DOM attribute that Quasar never reads.

Introduced in `#4815` (commit `b8b75b20`). For contrast, the only place `no-parent-event` was ever load-bearing was on a **QMenu** (the 2023 `83951acb` "remove no-parent-event hack") — a different structural position from this child `QDate`.

### Implementation

Drop `.props('no-parent-event')` from the `QDate` only. The wrapping `QMenu` correctly never carried it (the calendar button *should* open the menu on its parent click). No behavior change — open / close / select is driven by the parent `QMenu`, not this inert child attribute.

<details>
<summary>Evidence: Quasar bundle grep + independent review</summary>

- In the vendored `nicegui/static/quasar.umd.js` (Quasar v2.18.5), `noParentEvent` is defined only inside the anchor-props mixin (consumed by `configureAnchorEl`). `QDate`'s prop set (`useDatetimeProps` + `useFormProps` + `useDarkProps` + `modelValue/multiple/range/…`) does not include it.
- `ui.menu()` does **not** set `no-parent-event`, so the button correctly opens the picker — removing the child's attribute can't change that.
- Repo grep finds no NiceGUI `.js`/`.vue`/`.css` reading `no-parent-event`.
- **No test added:** there is no behavioral delta to assert, and prop-presence assertions aren't the repo convention (only `test_defaults`/`test_element_filter` check prop *values*).
- **Different-lineage review (Codex, adversarial):** *approve / SHIP* — "QDate in vendored Quasar 2.18.5 does not define noParentEvent … could only fall through as an inert root DOM attribute … open/close behavior is controlled by the parent QMenu. No material findings."

Local gates: `pre-commit` ✓ · `mypy ./nicegui` ✓ · `pylint ./nicegui` 10.00/10 ✓
</details>

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary (inert-attribute removal, no behavioral delta; prop-presence asserts are off-convention).
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
