### PR TITLE
Add pointer cursor to the ui.popup demo's anchor label

### DIFF
--- a/website/documentation/content/popup_documentation.py
+++ b/website/documentation/content/popup_documentation.py
@@ -9,7 +9,7 @@ def main_demo() -> None:
 
     app.storage.client['name'] = 'NiceGUI User'
 
-    with ui.label().bind_text_from(app.storage.client, 'name'):
+    with ui.label().bind_text_from(app.storage.client, 'name').classes('cursor-pointer'):
         with ui.popup() as popup:
             ui.input().props('autofocus') \
                 .bind_value(app.storage.client, 'name') \


### PR DESCRIPTION
### Motivation

A user reported in https://github.com/zauberzeug/nicegui/discussions/6178 that the `ui.popup` documentation demo "isn't working — there's just a label, and clicking on it doesn't trigger any response."

The demo is not broken. `ui.popup` opens when the user clicks the element it is nested inside, and in the demo that anchor is a bare `ui.label()` — a `<div>` with no classes and `cursor: auto`, so it looks like static text. Clicking the words does open the popup; clicking 30 px below them (still inside the demo panel) does not. Nothing tells the reader which pixels are live.

`ui.menu`'s demo anchors on a `ui.button(icon='menu')` and `ui.context_menu`'s on a `ui.image`, so both read as interactive. `ui.popup`'s is the only one of the three with no affordance.

### Implementation

Add `cursor-pointer` to the anchor label, matching how the date and time docs already mark their click-to-open anchors:

- `website/documentation/content/date_documentation.py:32` — `ui.icon('edit_calendar').on('click', menu.open).classes('cursor-pointer')`
- `website/documentation/content/time_documentation.py:32` — same pattern

This keeps the demo's teaching point intact (nest the popup inside the element that should open it) rather than swapping the label for a button, which would obscure it. One line, no behaviour change.

<details>
<summary><b>Empirical A/B — booted the real website entrypoint, not a copy of the demo</b></summary>

`main.py` served locally, `getComputedStyle(anchor).cursor` read off `/documentation/popup` in headless Chromium:

| tree | anchor classes | computed cursor | popup still opens |
|---|---|---|---|
| `upstream/main` (this change stashed) | `''` | `auto` | yes |
| with this change | `'cursor-pointer'` | `pointer` | yes |

Opens in both trees, so this is purely the missing affordance — no behavioural change.

</details>

<details>
<summary><b>Why the demo reads as broken (measurements from the live docs page)</b></summary>

Measured on https://nicegui.io/documentation/popup before this change:

```
anchor box     : x=912, y=550, width=82.5, height=23.8
cursor style   : auto          <- no pointer cursor
tag / classes  : DIV | (none)  <- no styling hint at all
aria-haspopup  : None
title          : ''
```

Two clicks in the same run:

```
--- clicking 30px below the label (inside demo area, outside anchor) ---
popup opened?  : False
--- clicking the label text itself ---
popup opened?  : True
```

So the outcome is binary on hitting an unmarked ~83×24 px region that looks like prose.

The element itself is fine — confirmed opening as `.q-menu` at 1280 px and `.q-dialog` at 400 px (the documented 450 px `breakpoint`), including touch taps on emulated iPhone 15 and Pixel 7. No console errors in any run.

</details>

<details>
<summary><b>Local gates</b></summary>

Base `upstream/main` @ `ff073f46`.

```
pre-commit run --files website/documentation/content/popup_documentation.py
  ruff / autopep8 / trailing-whitespace / end-of-files / double-quote-fixer / codespell ... Passed
  mdformat ................................................ Skipped (no md files)
mypy ./nicegui ............ Success: no issues found in 245 source files
pylint ./nicegui .......... 10.00/10
pytest tests/test_popup.py -rs ... 1 passed, 0 skipped
```

`tests/test_popup.py` reported 0 skipped, so the covering test genuinely ran rather than silently skipping. CI's `_check.yml` scopes `mypy`/`pylint` to `./nicegui`, so `pre-commit run --all-files` is the gate that covers this file.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary. <!-- cosmetic docs-only change; tests/test_popup.py still passes -->
- [x] Documentation has been updated.
- [x] No breaking changes to the public API.
