### PR TITLE
Never show a fabricated GitHub star count

### DIFF
--- a/website/components/sponsors_section.py
+++ b/website/components/sponsors_section.py
@@ -20,7 +20,7 @@ def create() -> None:
             .classes(f'self-center text-center {d.TEXT_SECONDARY}')
 
         with ui.row(align_items='center').classes('gap-12 justify-center my-10 w-full'):
-            with ui.column(align_items='center').classes('gap-0'):
+            with ui.column(align_items='center').classes('gap-0').bind_visibility_from(stars, 'string', bool):
                 phosphor_icon('ph-star').classes(f'{d.TEXT_32PX} {d.TEXT_ACCENT}')
                 ui.label().classes(d.TEXT_24PX).bind_text_from(stars, 'string')
                 ui.label('GitHub Stars').classes(f'{d.TEXT_13PX} {d.TEXT_SECONDARY}')

--- a/website/github_stars.py
+++ b/website/github_stars.py
@@ -5,7 +5,7 @@ from nicegui import app, binding, logging
 
 @binding.bindable_dataclass
 class GitHubStars:
-    string: str = app.storage.general.get('github_stars', '0')
+    string: str = app.storage.general.get('github_stars', '')  # empty means "unknown", so we hide the count
 
 
 stars = GitHubStars()


### PR DESCRIPTION
### Motivation

nicegui.io confidently displays "0 GitHub Stars" whenever the star count cannot be fetched. The count is seeded from `app.storage.general` with a `'0'` fallback and is only ever overwritten on a *successful* fetch, so a machine that has never had a successful fetch shows a plausible-looking number that is simply wrong.

Fixes #6211 on the presentation side. The fetch failure itself (a 403 from GitHub's 60/hour unauthenticated per-IP rate limit, permanently exhausted on the Fly machines' shared egress IPs) is a deployment-side problem and stays tracked in #6211.

### Implementation

Two lines, both about never rendering a number we do not have:

- Seed `GitHubStars.string` with `''` instead of `'0'`, so "unknown" is representable and distinct from a real count.
- Bind the visibility of the star tile to `bool(stars.string)`, so an unknown count hides the tile instead of rendering an empty or fabricated one.

Deliberately *not* included: a retry back-off for the failing fetch. Against a persistently exhausted per-IP budget a 403 stays a 403 no matter how often we ask, so retrying faster only adds requests without adding stars. Tests for such back-off internals were dropped along with it.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
