### PR TITLE
Prefer behavior tests over tests coupled to implementation details

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,6 @@
 - [ ] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
 - [ ] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
 - [ ] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
-- [ ] Pytests have been added/updated or are not necessary. <!--Remove the option that does not apply.-->
+- [ ] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary. <!--Remove the option that does not apply.-->
 - [ ] Documentation has been added/updated or is not necessary. <!--Remove the option that does not apply.-->
 - [ ] No breaking changes to the public API or migration steps are described above. <!--Remove the option that does not apply.-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,11 @@ Work as a pair programmer, not a silent code generator:
 - **Creating new files** when editing existing ones would suffice
 - **Global mutable state** in library code
 - **Unnecessary dependencies** — check if existing code suffices first
-- **Reflexive regression tests** — not every bug fix earns a test, and a test coupled to implementation details can be worse than none (see [CONTRIBUTING.md](CONTRIBUTING.md#coding-conventions))
+- **Reflexive regression tests** — not every bug fix earns a test, and a test coupled to implementation details can be worse than none.
+  Assert observable behavior, not internals: no private attributes, no patched machinery, no fake objects mirroring the code under test.
+  If you catch yourself building scaffolding to observe an internal mechanism, stop — find the user-visible effect to assert on, or skip the test and give the reason in the pull request.
+  Before writing a test, read a recent one in the same file and copy its shape.
+  (Details in [CONTRIBUTING.md](CONTRIBUTING.md#coding-conventions).)
 
 ## Before Claiming a Task Complete
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Work as a pair programmer, not a silent code generator:
 - **Creating new files** when editing existing ones would suffice
 - **Global mutable state** in library code
 - **Unnecessary dependencies** — check if existing code suffices first
+- **Reflexive regression tests** — not every bug fix earns a test, and a test coupled to implementation details can be worse than none (see [CONTRIBUTING.md](CONTRIBUTING.md#coding-conventions))
 
 ## Before Claiming a Task Complete
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,18 @@ The conventions below cover both general Python style and NiceGUI-specific patte
 
 - **Dataclasses**: Prefer `@dataclass(kw_only=True, slots=True)`
 
-- **Tests**: Include tests for new features and bug fixes. Prefer the `User` fixture (fast, runs in the same async context as NiceGUI, no browser); use the `Screen` fixture only when testing browser/JavaScript interactions.
+- **Tests**
+
+  - Include tests for new features and bug fixes — but test observable behavior, not implementation.
+    A test should read like a small demo of the public API: create elements, interact, assert what a user would see.
+    Avoid tests that reach into internals — private attributes, call counts, monkeypatched browser or library APIs, hand-built fake objects.
+    They break when the implementation changes (so they get rewritten along with it, guarding nothing) and they are hard to read for anyone who doesn't know the internals.
+  - Prefer the `User` fixture (fast, runs in the same async context as NiceGUI, no browser); use the `Screen` fixture only when testing browser/JavaScript interactions.
+  - Not every change needs a test.
+    We have over a thousand tests and the browser-based ones dominate the runtime, so each new test is a permanent cost for every contributor.
+    If a fix can only be covered by an elaborate test that mirrors the implementation, skipping the test can be the better choice — say so in the pull request, so it reads as a deliberate decision and not as an oversight.
+    A small, obviously correct fix with a clear explanation is often worth more than an unreadable regression test.
+  - If you find yourself building scaffolding to observe an internal mechanism (e.g. patching `ResizeObserver` to check that `disconnect()` was called), that is the signal to stop and either find the user-visible effect to assert on, or skip the test.
 
 ### Before submitting a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,10 +206,14 @@ The conventions below cover both general Python style and NiceGUI-specific patte
     A test should read like a small demo of the public API: create elements, interact, assert what a user would see.
     Avoid tests that reach into internals — private attributes, call counts, monkeypatched browser or library APIs, hand-built fake objects.
     They break when the implementation changes (so they get rewritten along with it, guarding nothing) and they are hard to read for anyone who doesn't know the internals.
+  - Before writing a test, read a recent one in the same file.
+    The existing suite is almost entirely behavior tests, and copying a neighbouring test's shape is faster and safer than inventing a new one.
   - Prefer the `User` fixture (fast, runs in the same async context as NiceGUI, no browser); use the `Screen` fixture only when testing browser/JavaScript interactions.
+  - A regression test must fail when the fix is reverted — verify that once before trusting it.
+    A test that has only ever been seen green proves nothing.
   - Not every change needs a test.
     We have over a thousand tests and the browser-based ones dominate the runtime, so each new test is a permanent cost for every contributor.
-    If a fix can only be covered by an elaborate test that mirrors the implementation, skipping the test can be the better choice — say so in the pull request, so it reads as a deliberate decision and not as an oversight.
+    If a fix can only be covered by an elaborate test that mirrors the implementation, skipping the test can be the better choice — give the reason in the **Implementation** section of the pull request, so it reads as a deliberate decision and not as an oversight.
     A small, obviously correct fix with a clear explanation is often worth more than an unreadable regression test.
   - If you find yourself building scaffolding to observe an internal mechanism (e.g. patching `ResizeObserver` to check that `disconnect()` was called), that is the signal to stop and either find the user-visible effect to assert on, or skip the test.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -29,9 +29,11 @@ For coding rules, see [CONTRIBUTING.md](CONTRIBUTING.md); for general agent guid
 - **Logging & observability**
   - Noisy logs, missing error context, debug prints in library code
 - **Tests**
-  - New features and bug fixes need tests (see CONTRIBUTING.md for `User` vs `Screen` fixture choice)
-  - Edge cases: empty/None, large payloads, cancellation
-  - Flakiness, time-dependence, hidden network deps
+  - Missing test for a new feature or bug fix, with no reason given in the pull request
+  - Tests coupled to implementation details — private attributes, call counts, patched internals, fake request objects — where the user-visible effect could be asserted instead
+  - Test cost out of proportion to the risk: a `Screen` test where the `User` fixture would do, elaborate scaffolding for a marginal edge case (see [CONTRIBUTING.md](CONTRIBUTING.md#coding-conventions))
+  - Untested edge cases: empty/None, large payloads, cancellation
+  - Flaky, time-dependent, or network-dependent tests
 - **Docs & examples**
   - Code that diverges from documented behavior
   - Examples that no longer run


### PR DESCRIPTION
### Motivation

When reviewing recent pull requests, a pattern kept showing up: a small fix, plus a new test that guards it by reaching into the implementation — patching a browser API to observe that an internal method was called, asserting on private attributes, or building fake objects that mirror the machinery under test.

Two problems with that:

1. Such a test inverts its own purpose. It has to be rewritten whenever the implementation changes, so it does not protect against the regression it claims to guard. And it is hard to read for anyone who does not already know the internals, which makes it hard to review.
2. It is not free. We are past a thousand tests, and the browser-based ones dominate the runtime for every contributor, forever.

Our docs did not say anything about this — CONTRIBUTING.md only covered the `User` vs. `Screen` choice, and REVIEW.md said flatly "New features and bug fixes need tests", which nudges towards writing *some* test at any cost. This PR writes the actual preference down, so humans and AI assistants know it up front instead of discovering it in review.

Two recent examples where the test was dropped in the last commit: #6196 and #6189.

### Implementation

- **CONTRIBUTING.md**: the `**Tests**` bullet grows into four points — test observable behavior rather than internals; fixture choice (unchanged); not every change needs a test, and skipping one is fine if it is stated in the PR; and a concrete "you are building scaffolding to observe a mechanism" smell test.
- **AGENTS.md**: one bullet under "What to Avoid", pointing at CONTRIBUTING.md.
- **REVIEW.md**: the `**Tests**` checklist is rephrased so every item names a defect a reviewer flags. The previous list mixed "coverage is missing" with "the test itself is bad" in terse fragments (`Edge cases: …`, `Flakiness, …`) without making clear which was which.

Deliberate trade-off: some changes will now ship without a regression guard. That is not a new situation — we do not test the full visual appearance either, and a single broken CSS selector could take down a page. We cannot protect every line against every possible future mistake, so the honest question is one of proportion: what does a test cost to write, read and run, and what does it actually buy? When a one-line correction would need an elaborate piece of scaffolding to be guarded, the balance tips, and we would rather say that out loud than let it happen silently in review.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been updated.
- [x] No breaking changes to the public API.
