### PR TITLE
Fix node ID extraction for ui.mermaid click events

### DIFF
--- a/nicegui/elements/mermaid/mermaid.py
+++ b/nicegui/elements/mermaid/mermaid.py
@@ -6,6 +6,20 @@ from ...helpers import remove_indentation
 from ..mixins.content_element import ContentElement
 
 
+def _extract_node_id(html_id: str, svg_id: str) -> str:
+    """Extract the Mermaid node ID from a clicked node's HTML ID.
+
+    Mermaid prefixes every node ID with the SVG ID. Most diagram types then add a type token and a
+    trailing index (``<svg_id>-<type>-<node_id>-<index>``), but block, mindmap and requirement
+    diagrams emit ``<svg_id>-<node_id>`` verbatim.
+    """
+    prefix = f'{svg_id}-'
+    if not html_id.startswith(prefix):
+        return html_id  # unexpected shape: hand back the raw ID rather than mis-parse it
+    parts = html_id[len(prefix):].split('-')
+    return '-'.join(parts[1:-1] if len(parts) >= 3 and parts[-1].isdigit() else parts)
+
+
 class Mermaid(ContentElement, component='mermaid.js', esm={'nicegui-mermaid': 'dist'}):
     CONTENT_PROP = 'content'
 
@@ -47,20 +61,10 @@ class Mermaid(ContentElement, component='mermaid.js', esm={'nicegui-mermaid': 'd
         self.on('node_click', lambda e: handle_event(callback, MermaidNodeClickEventArguments(
             sender=self,
             client=self.client,
-            node_id=self._extract_node_id(e.args),
+            node_id=_extract_node_id(e.args, f'{self.html_id}_mermaid'),
         )))
         self._props['clickable'] = True
         return self
-
-    def _extract_node_id(self, html_id: str) -> str:
-        """Extract the Mermaid node ID from a clicked node's HTML ID.
-
-        Mermaid prefixes every node ID with the SVG ID. Most diagram types add a type token and a
-        trailing index (``<svg_id>-<type>-<node_id>-<index>``), but block, mindmap and requirement
-        diagrams emit ``<svg_id>-<node_id>`` verbatim.
-        """
-        parts = html_id.removeprefix(f'{self.html_id}_mermaid-').split('-')
-        return '-'.join(parts[1:-1] if len(parts) >= 3 and parts[-1].isdigit() else parts)
 
     def _handle_content_change(self, content: str) -> None:
         content = remove_indentation(content)

--- a/nicegui/elements/mermaid/mermaid.py
+++ b/nicegui/elements/mermaid/mermaid.py
@@ -47,7 +47,7 @@ class Mermaid(ContentElement, component='mermaid.js', esm={'nicegui-mermaid': 'd
         self.on('node_click', lambda e: handle_event(callback, MermaidNodeClickEventArguments(
             sender=self,
             client=self.client,
-            node_id='-'.join(e.args.split('-')[1:-1])  # extract Node ID from HTML ID (<type>-<node_id>-<index>)
+            node_id='-'.join(e.args.split('-')[2:-1])  # extract from HTML ID (<svg_id>-<type>-<node_id>-<index>)
         )))
         self._props['clickable'] = True
         return self

--- a/nicegui/elements/mermaid/mermaid.py
+++ b/nicegui/elements/mermaid/mermaid.py
@@ -47,10 +47,20 @@ class Mermaid(ContentElement, component='mermaid.js', esm={'nicegui-mermaid': 'd
         self.on('node_click', lambda e: handle_event(callback, MermaidNodeClickEventArguments(
             sender=self,
             client=self.client,
-            node_id='-'.join(e.args.split('-')[2:-1])  # extract from HTML ID (<svg_id>-<type>-<node_id>-<index>)
+            node_id=self._extract_node_id(e.args),
         )))
         self._props['clickable'] = True
         return self
+
+    def _extract_node_id(self, html_id: str) -> str:
+        """Extract the Mermaid node ID from a clicked node's HTML ID.
+
+        Mermaid prefixes every node ID with the SVG ID. Most diagram types add a type token and a
+        trailing index (``<svg_id>-<type>-<node_id>-<index>``), but block, mindmap and requirement
+        diagrams emit ``<svg_id>-<node_id>`` verbatim.
+        """
+        parts = html_id.removeprefix(f'{self.html_id}_mermaid-').split('-')
+        return '-'.join(parts[1:-1] if len(parts) >= 3 and parts[-1].isdigit() else parts)
 
     def _handle_content_change(self, content: str) -> None:
         content = remove_indentation(content)

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -2,6 +2,7 @@ import pytest
 from selenium.webdriver.common.by import By
 
 from nicegui import events, ui
+from nicegui.elements.mermaid.mermaid import _extract_node_id
 from nicegui.testing import Screen
 
 
@@ -179,6 +180,24 @@ def test_node_click_handler(screen: Screen):
 
     screen.click('Node With Hyphen')
     screen.should_contain('clicked [Node-With-Hyphen]')  # make sure our ID extraction works even with hyphens
+
+
+@pytest.mark.parametrize(('svg_id', 'html_id', 'node_id'), [
+    ('c4_mermaid', 'c4_mermaid-flowchart-A-0', 'A'),
+    ('c4_mermaid', 'c4_mermaid-flowchart-Node-With-Hyphen-1', 'Node-With-Hyphen'),
+    ('c7_mermaid', 'c7_mermaid-state-s1-0', 's1'),
+    ('c8_mermaid', 'c8_mermaid-classId-Animal-0', 'Animal'),
+    ('c9_mermaid', 'c9_mermaid-entity-CUSTOMER-ORDER-0', 'CUSTOMER-ORDER'),
+    ('c13_mermaid', 'c13_mermaid-A', 'A'),  # block, mindmap and requirement: no type token, no index
+    ('c10_mermaid', 'c10_mermaid-node_0', 'node_0'),
+    ('c11_mermaid', 'c11_mermaid-test_req', 'test_req'),
+    ('c4_mermaid', 'c4_mermaid-flowchart-A-123-0', 'A-123'),  # a node ID may end in digits: the index is still last
+    ('c13_mermaid', 'c13_mermaid-A-B-123', 'B'),  # known limit: indistinguishable from <type>-<node_id>-<index>
+    # an unknown prefix must yield the raw ID, never a positional guess that recreates the old bug
+    ('c4_mermaid', 'custom_mermaid-flowchart-A-0', 'custom_mermaid-flowchart-A-0'),
+])
+def test_extract_node_id(svg_id: str, html_id: str, node_id: str):
+    assert _extract_node_id(html_id, svg_id) == node_id
 
 
 @pytest.mark.parametrize(('content', 'label', 'node_id'), [

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -181,14 +181,19 @@ def test_node_click_handler(screen: Screen):
     screen.should_contain('clicked [Node-With-Hyphen]')  # make sure our ID extraction works even with hyphens
 
 
-def test_node_click_handler_with_other_diagram_type(screen: Screen):
+@pytest.mark.parametrize(('content', 'label', 'node_id'), [
+    ('classDiagram\n class Animal', 'Animal', 'Animal'),  # type token is "classId", not "flowchart"
+    ('stateDiagram-v2\n s1 --> s2', 's1', 's1'),
+    ('erDiagram\n CUSTOMER-ORDER ||--o{ LINE-ITEM : has', 'CUSTOMER-ORDER', 'CUSTOMER-ORDER'),
+    # block, mindmap and requirement diagrams emit "<svg_id>-<node_id>": no type token, no index.
+    # Only block is exercised here because Selenium cannot click the other two's SVG labels.
+    ('block-beta\n columns 1\n A', 'A', 'A'),
+])
+def test_node_click_handler_with_other_diagram_types(screen: Screen, content: str, label: str, node_id: str):
     @ui.page('/')
     def page():
-        ui.mermaid('''
-            classDiagram
-                class Animal
-        ''', on_node_click=lambda e: ui.notify(f'clicked [{e.node_id}]'))
+        ui.mermaid(content, on_node_click=lambda e: ui.notify(f'clicked [{e.node_id}]'))
 
     screen.open('/')
-    screen.click('Animal')
-    screen.should_contain('clicked [Animal]')  # the type prefix is "classId" here, not "flowchart"
+    screen.click(label)
+    screen.should_contain(f'clicked [{node_id}]')

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -168,14 +168,27 @@ def test_node_click_handler(screen: Screen):
                 A[Node A];
                 B[Node B];
                 Node-With-Hyphen[Node With Hyphen];
-        ''', on_node_click=lambda e: ui.notify(f'{e.node_id} clicked'))
+        ''', on_node_click=lambda e: ui.notify(f'clicked [{e.node_id}]'))
 
     screen.open('/')
     screen.click('Node A')
-    screen.should_contain('A clicked')
+    screen.should_contain('clicked [A]')  # the brackets keep a partially stripped ID like "flowchart-A" from matching
 
     screen.click('Node B')
-    screen.should_contain('B clicked')
+    screen.should_contain('clicked [B]')
 
     screen.click('Node With Hyphen')
-    screen.should_contain('Node-With-Hyphen clicked')  # make sure our ID extraction works even with hyphens
+    screen.should_contain('clicked [Node-With-Hyphen]')  # make sure our ID extraction works even with hyphens
+
+
+def test_node_click_handler_with_other_diagram_type(screen: Screen):
+    @ui.page('/')
+    def page():
+        ui.mermaid('''
+            classDiagram
+                class Animal
+        ''', on_node_click=lambda e: ui.notify(f'clicked [{e.node_id}]'))
+
+    screen.open('/')
+    screen.click('Animal')
+    screen.should_contain('clicked [Animal]')  # the type prefix is "classId" here, not "flowchart"


### PR DESCRIPTION
*Opened by Claude Code on evnchn's behalf.*

@falkoschindler — flagging you early rather than at review time, because there is a **version question** here that should be settled before the diff matters. See "The question for you" at the end.

### Motivation

`ui.mermaid(on_node_click=…)` has delivered the wrong `node_id` since it shipped in 3.3.0.

Mermaid renders via `mermaid.render(element.id + "_mermaid", content)`, so it prefixes every node's DOM id with the SVG id. The extraction assumed `<type>-<node_id>-<index>` and sliced `[1:-1]` — but the real id carries a fourth leading segment, so handlers receive `flowchart-A` where the diagram says `A`.

Two things kept it hidden for four minor releases:

1. **The test written to catch this could not fail.** `Screen.should_contain` is a substring match, so `'flowchart-A clicked'` satisfies `should_contain('A clicked')` — including the hyphenated case it explicitly claims to verify.
2. **Three diagram types were silently worse**, handing the callback an empty string rather than a wrong one.

### Implementation

Strip the SVG prefix deterministically — it is `f'{self.html_id}_mermaid-'`, known to the element — then peel a type token and trailing index **only when a numeric index is actually present**. On an unknown prefix, return the raw id rather than guess:

```python
def _extract_node_id(html_id: str, svg_id: str) -> str:
    prefix = f'{svg_id}-'
    if not html_id.startswith(prefix):
        return html_id  # unexpected shape: hand back the raw ID rather than mis-parse it
    parts = html_id[len(prefix):].split('-')
    return '-'.join(parts[1:-1] if len(parts) >= 3 and parts[-1].isdigit() else parts)
```

Positional slicing alone cannot work, because the two id shapes have different arities. Measured from the DOM (`g.node` — the exact selector the component binds to) across 14 diagram types:

| diagram | raw `g.node` id | before | after |
|---|---|---|---|
| flowchart | `c4_mermaid-flowchart-A-0` | `flowchart-A` | `A` |
| flowchart (hyphenated) | `c4_mermaid-flowchart-Node-With-Hyphen-1` | `flowchart-Node-With-Hyphen` | `Node-With-Hyphen` |
| graph | `c5_mermaid-flowchart-A-0` | `flowchart-A` | `A` |
| subgraph | `c6_mermaid-flowchart-A-0` | `flowchart-A` | `A` |
| state | `c7_mermaid-state-s1-0` | `state-s1` | `s1` |
| class | `c8_mermaid-classId-Animal-0` | `classId-Animal` | `Animal` |
| ER (hyphenated) | `c9_mermaid-entity-CUSTOMER-ORDER-0` | `entity-CUSTOMER-ORDER` | `CUSTOMER-ORDER` |
| block | `c13_mermaid-A` | `''` | `A` |
| mindmap | `c10_mermaid-node_0` | `''` | `node_0` |
| requirement | `c11_mermaid-test_req` | `''` | `test_req` |

`c4`, `gantt`, `journey`, `pie` and `sequence` render no `g.node` elements, so nothing is clickable there and nothing changes.

The existing test's notification is now delimited (`clicked [A]`) so a partially-stripped id can no longer satisfy the assertion.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [ ] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation has been added/updated or is not necessary.
- [ ] No breaking changes to the public API or migration steps are described above. — **left unchecked deliberately; this is the open question below.**

### The question for you

**Is this a bugfix, or 4.0 material?**

Anyone who wrote a handler against the *current* behaviour is matching on `flowchart-A` (or working around `''`). This fix changes the value they observe. Two honest readings:

- **Normal bugfix.** `on_node_click` documents a Mermaid node id; `flowchart-A` is `<type>-<node_id>` glued together and `''` is nothing at all. Neither was ever the promised value, so shipping the correct one is a fix, not a break. *(This is also the conclusion of an independent GPT-5.5 review — verbatim: "The behavior change from `"flowchart-A"` or `""` to `"A"` is a normal bugfix: `on_node_click` promises a Mermaid node id, and the old value was visibly wrong since 3.3.0.")*
- **Breaking change.** It is still an observable-value change in a public callback, and node ids are the kind of thing people match on exactly. If you would rather not surprise anyone mid-minor, this is 4.0 material.

We lean bugfix, but it is your call and it decides the target branch, so we would rather ask now than after review.

**A related design call, also yours:** `mermaid.js` still emits the raw `node.id`, so `element.on('node_click', …)` consumers see a different value than `on_node_click`. We kept the normalization Python-side for minimal blast radius. The alternative is emitting a structured payload (`{html_id, node_id}`) from JS — cleaner, but it changes the wire contract. Happy to switch if you prefer that shape.

<details><summary><b>Verification</b></summary>

- **Raw ids measured, not inferred** — probed `g.node` ids in headless Chrome across the 14 diagram types above.
- **Seen to fail.** Reverting the extraction while keeping the tests fails the `block-beta` case; reverting the unknown-prefix guard fails with `assert 'flowchart-A' == 'custom_mermaid-flowchart-A-0'` — i.e. the guard demonstrably prevents a silent relapse into the original bug.
- `tests/test_mermaid.py`: **25 passed**, `-rs` shows 0 skipped.
- `ruff` clean · `mypy` clean · `pylint` 10.00/10 · `pre-commit` passed.
- Reviewed by GPT-5.5 under an adversarial prompt: 8/10, no blockers. Its three suggestions are all applied — unit tests for the extractor, the unknown-prefix guard, and surfacing the JS-contract question above.

</details>

<details><summary><b>Known limitation</b></summary>

For the prefix-less diagram types, a node id that itself ends in `-<digits>` and splits into three or more parts is indistinguishable from `<type>-<node_id>-<index>`: `c13_mermaid-A-B-123` yields `B`. This is pinned as an explicit test case rather than left to be discovered. Mermaid generates the ids for all three affected types (`A`, `node_0`, `test_req`), so we could not construct a real diagram that triggers it — but the heuristic is a heuristic, and the only way to remove it entirely is to move extraction into the JS where the node id is known before it is concatenated.

</details>

<details><summary><b>Adjacent bug, deliberately not fixed here</b></summary>

A user-supplied DOM id (`.props('id=my-mermaid')`) never reaches Python at all: `getElement()` assumes the `"c"` prefix and does `id.slice(1)`, so the click listener throws `Cannot read properties of undefined (reading '$emit')` and no event fires for any diagram type. Pre-existing and unaffected by this PR; left out to keep the diff scoped. Happy to file it separately.

</details>
