### PR TITLE
Fix timer parent-slot error after pruned HTTP-only clients

### DIFF
--- a/nicegui/elements/timer.py
+++ b/nicegui/elements/timer.py
@@ -26,6 +26,9 @@ class Timer(BaseTimer, Element, component='timer.js'):
         """
         try:
             await self.client.connected()
+            # Client.delete() wakes connected() waiters after removing elements (#6226).
+            if self.is_deleted or self.client.id not in Client.instances:
+                return False
             return True
         except ClientConnectionTimeout:
             self.cancel()

--- a/nicegui/timer.py
+++ b/nicegui/timer.py
@@ -73,6 +73,10 @@ class Timer:
         try:
             if not await self._can_start():
                 return
+            # Check before entering context: Client.delete() can wake connected()
+            # waiters after the element/slot tree is already gone (#6226).
+            if self._should_stop():
+                return
             with self._get_context():
                 await asyncio.sleep(self.interval)
                 if self.active and not self._should_stop():
@@ -86,6 +90,10 @@ class Timer:
             if not self._immediate:
                 await asyncio.sleep(self.interval)
             if not await self._can_start():
+                return
+            # Check before entering context: Client.delete() can wake connected()
+            # waiters after the element/slot tree is already gone (#6226).
+            if self._should_stop():
                 return
             with self._get_context():
                 while not self._should_stop():

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -275,3 +275,23 @@ def test_no_leak_when_client_deleted(screen: Screen):
     Client.prune_instances(client_age_threshold=0)
     screen.wait(1)
     assert not any(isinstance(obj, ui.timer) for obj in gc.get_objects())
+
+
+def test_no_parent_slot_error_when_pruned_before_connect(screen: Screen):
+    """HTTP-only load + prune must not raise parent-slot RuntimeError (#6226)."""
+    exceptions: list[Exception] = []
+    app.on_exception(exceptions.append)
+
+    @ui.page('/')
+    def page():
+        ui.timer(60, lambda: None)
+
+    screen.start_server()
+    httpx.get(screen.url)
+    screen.wait(0.2)
+    Client.prune_instances(client_age_threshold=0)
+    gc.collect()
+    screen.wait(0.5)
+
+    parent_slot_errors = [e for e in exceptions if 'parent slot' in str(e).lower()]
+    assert not parent_slot_errors, f'unexpected parent-slot errors: {parent_slot_errors}'


### PR DESCRIPTION
## Summary
- Check `_should_stop()` before entering `_get_context()` in `_run_in_loop` / `_run_once`, so timers woken by `Client.delete()` / `prune_instances` exit cleanly instead of touching a dead `parent_slot`.
- Harden element `Timer._can_start()` to return `False` when the wake came from a deleted client.
- Add regression test for HTTP-only load + prune (#6226).

Fixes #6226.

## Test plan
- [x] `uv run pytest tests/test_timer.py::test_no_parent_slot_error_when_pruned_before_connect tests/test_timer.py::test_no_leak_when_client_deleted tests/test_timer.py::test_timer_on_deleted_container tests/test_timer.py::test_once_timer_task_cancelled_on_client_delete -q`

Made with [Cursor](https://cursor.com)