### PR TITLE
Fix `ui.scene.move_camera()` recreating the camera controls when the up vector is unchanged

### DIFF
--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -194,7 +194,7 @@ export default {
       this.scene.add(grid);
     }
     this.controlClass = { trackball: TrackballControls, map: MapControls }[this.controlType] || OrbitControls;
-    this.create_controls();
+    this.create_controls(this.camera.up);
     this.drag_controls = new DragControls(this.draggable_objects, this.camera, this.renderer.domElement);
     this.drag_controls.transformGroup = true;
     const applyConstraint = (constraint, position) => {
@@ -506,20 +506,17 @@ export default {
       this.move(object_id, x, y, z);
       this.rotate(object_id, R);
     },
-    create_controls() {
+    create_controls(up) {
       this.controls = new this.controlClass(this.camera, this.renderer.domElement);
-      // TrackballControls rotates the camera's up vector, so the vector the controls were created for
-      // must be remembered separately to tell a user rotation apart from an actual camera move
-      this.controls_up = this.camera.up.clone();
+      // remember the up vector the controls were built for: camera.up may differ from it after a user rotation
+      // (TrackballControls) or an interrupted tween, so it cannot be used to decide whether a rebuild is needed
+      this.controls_up = up.clone();
     },
     move_camera(x, y, z, look_at_x, look_at_y, look_at_z, up_x, up_y, up_z, duration) {
+      if (!this.controls) return; // WebGL renderer could not be created
       if (this.camera_tween) this.camera_tween.stop();
-      const target_up = new THREE.Vector3(
-        up_x === null ? this.camera.up.x : up_x,
-        up_y === null ? this.camera.up.y : up_y,
-        up_z === null ? this.camera.up.z : up_z,
-      );
-      // the controls are only rebuilt if the up vector they were created for really changes,
+      const target_up = new THREE.Vector3(up_x, up_y, up_z);
+      // the controls are only rebuilt if the up vector they were built for really changes,
       // because rebuilding resets their configuration
       const camera_up_changed = !this.controls_up.equals(target_up);
       this.camera_tween = new TWEEN.Tween([
@@ -533,20 +530,7 @@ export default {
         this.look_at.y,
         this.look_at.z,
       ])
-        .to(
-          [
-            x === null ? this.camera.position.x : x,
-            y === null ? this.camera.position.y : y,
-            z === null ? this.camera.position.z : z,
-            target_up.x,
-            target_up.y,
-            target_up.z,
-            look_at_x === null ? this.look_at.x : look_at_x,
-            look_at_y === null ? this.look_at.y : look_at_y,
-            look_at_z === null ? this.look_at.z : look_at_z,
-          ],
-          duration * 1000,
-        )
+        .to([x, y, z, up_x, up_y, up_z, look_at_x, look_at_y, look_at_z], duration * 1000)
         .onUpdate((p) => {
           this.camera.position.set(p[0], p[1], p[2]);
           this.camera.up.set(p[3], p[4], p[5]); // before calling lookAt
@@ -556,14 +540,14 @@ export default {
         })
         .onComplete(() => {
           if (camera_up_changed) {
-            this.camera.up.copy(target_up); // remove interpolation residue, so the next comparison is exact
             this.controls.dispose();
-            this.create_controls();
+            this.create_controls(target_up);
             this.controls.target.copy(this.look_at);
             this.camera.lookAt(this.look_at);
           }
         })
         .start();
+      if (duration === 0) this.camera_tween.update(); // settle immediately, so subsequent JavaScript sees the final state
     },
     get_camera() {
       return {
@@ -593,6 +577,7 @@ export default {
         this.camera.right = (this.camera.aspect * this.cameraParams.size) / 2;
       }
       this.camera.updateProjectionMatrix();
+      this.controls.handleResize?.(); // TrackballControls caches the canvas rect
     },
     init_objects(data) {
       this.resize();

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -508,7 +508,13 @@ export default {
     },
     move_camera(x, y, z, look_at_x, look_at_y, look_at_z, up_x, up_y, up_z, duration) {
       if (this.camera_tween) this.camera_tween.stop();
-      const camera_up_changed = up_x !== null || up_y !== null || up_z !== null;
+      const target_up = new THREE.Vector3(
+        up_x === null ? this.camera.up.x : up_x,
+        up_y === null ? this.camera.up.y : up_y,
+        up_z === null ? this.camera.up.z : up_z,
+      );
+      // NOTE: the controls are only rebuilt if the up vector really changes, because that resets their configuration
+      const camera_up_changed = !this.camera.up.equals(target_up);
       this.camera_tween = new TWEEN.Tween([
         this.camera.position.x,
         this.camera.position.y,
@@ -525,9 +531,9 @@ export default {
             x === null ? this.camera.position.x : x,
             y === null ? this.camera.position.y : y,
             z === null ? this.camera.position.z : z,
-            up_x === null ? this.camera.up.x : up_x,
-            up_y === null ? this.camera.up.y : up_y,
-            up_z === null ? this.camera.up.z : up_z,
+            target_up.x,
+            target_up.y,
+            target_up.z,
             look_at_x === null ? this.look_at.x : look_at_x,
             look_at_y === null ? this.look_at.y : look_at_y,
             look_at_z === null ? this.look_at.z : look_at_z,

--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -194,7 +194,7 @@ export default {
       this.scene.add(grid);
     }
     this.controlClass = { trackball: TrackballControls, map: MapControls }[this.controlType] || OrbitControls;
-    this.controls = new this.controlClass(this.camera, this.renderer.domElement);
+    this.create_controls();
     this.drag_controls = new DragControls(this.draggable_objects, this.camera, this.renderer.domElement);
     this.drag_controls.transformGroup = true;
     const applyConstraint = (constraint, position) => {
@@ -506,6 +506,12 @@ export default {
       this.move(object_id, x, y, z);
       this.rotate(object_id, R);
     },
+    create_controls() {
+      this.controls = new this.controlClass(this.camera, this.renderer.domElement);
+      // TrackballControls rotates the camera's up vector, so the vector the controls were created for
+      // must be remembered separately to tell a user rotation apart from an actual camera move
+      this.controls_up = this.camera.up.clone();
+    },
     move_camera(x, y, z, look_at_x, look_at_y, look_at_z, up_x, up_y, up_z, duration) {
       if (this.camera_tween) this.camera_tween.stop();
       const target_up = new THREE.Vector3(
@@ -513,8 +519,9 @@ export default {
         up_y === null ? this.camera.up.y : up_y,
         up_z === null ? this.camera.up.z : up_z,
       );
-      // NOTE: the controls are only rebuilt if the up vector really changes, because that resets their configuration
-      const camera_up_changed = !this.camera.up.equals(target_up);
+      // the controls are only rebuilt if the up vector they were created for really changes,
+      // because rebuilding resets their configuration
+      const camera_up_changed = !this.controls_up.equals(target_up);
       this.camera_tween = new TWEEN.Tween([
         this.camera.position.x,
         this.camera.position.y,
@@ -549,8 +556,9 @@ export default {
         })
         .onComplete(() => {
           if (camera_up_changed) {
+            this.camera.up.copy(target_up); // remove interpolation residue, so the next comparison is exact
             this.controls.dispose();
-            this.controls = new this.controlClass(this.camera, this.renderer.domElement);
+            this.create_controls();
             this.controls.target.copy(this.look_at);
             this.camera.lookAt(this.look_at);
           }

--- a/nicegui/elements/scene/scene_view.js
+++ b/nicegui/elements/scene/scene_view.js
@@ -124,20 +124,7 @@ export default {
         this.look_at.y,
         this.look_at.z,
       ])
-        .to(
-          [
-            x === null ? this.camera.position.x : x,
-            y === null ? this.camera.position.y : y,
-            z === null ? this.camera.position.z : z,
-            up_x === null ? this.camera.up.x : up_x,
-            up_y === null ? this.camera.up.y : up_y,
-            up_z === null ? this.camera.up.z : up_z,
-            look_at_x === null ? this.look_at.x : look_at_x,
-            look_at_y === null ? this.look_at.y : look_at_y,
-            look_at_z === null ? this.look_at.z : look_at_z,
-          ],
-          duration * 1000,
-        )
+        .to([x, y, z, up_x, up_y, up_z, look_at_x, look_at_y, look_at_z], duration * 1000)
         .onUpdate((p) => {
           this.camera.position.set(p[0], p[1], p[2]);
           this.camera.up.set(p[3], p[4], p[5]); // before calling lookAt

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -291,6 +291,28 @@ def test_custom_controls(screen: Screen, control_type: Literal['map', 'trackball
     assert screen.selenium.execute_script(f'return getElement({scene.id}).controls.constructor.name') == constructor
 
 
+def test_moving_camera_keeps_controls_unless_up_vector_changes(screen: Screen):
+    scene = None
+
+    @ui.page('/')
+    def page():
+        nonlocal scene
+        scene = ui.scene()
+
+    screen.open('/')
+    screen.wait_for(lambda: scene is not None)
+    enable_rotate = f'getElement({scene.id}).controls.enableRotate'
+    screen.selenium.execute_script(f'{enable_rotate} = false')
+
+    scene.move_camera(x=1, duration=0)
+    screen.wait_for(lambda: screen.selenium.execute_script(f'return getElement({scene.id}).camera.position.x') == 1)
+    assert screen.selenium.execute_script(f'return {enable_rotate}') is False, 'controls survive a plain camera move'
+
+    scene.move_camera(up_y=1, up_z=0, duration=0)
+    screen.wait_for(lambda: screen.selenium.execute_script(f'return getElement({scene.id}).camera.up.y') == 1)
+    assert screen.selenium.execute_script(f'return {enable_rotate}') is True, 'controls are rebuilt for a new up vector'
+
+
 async def test_dragend_after_object_deleted(user: User):
     events: list[str] = []
     scene = None

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 from selenium.common.exceptions import JavascriptException
 from selenium.webdriver import ActionChains
-from selenium.webdriver.common.by import By
 
 from nicegui import app, ui
 from nicegui.elements.scene import Object3D
@@ -330,7 +329,8 @@ def test_moving_camera_keeps_trackball_controls_after_rotating(screen: Screen):
     static_moving = f'getElement({scene.id}).controls.staticMoving'
     screen.selenium.execute_script(f'{static_moving} = true')  # no rotation momentum after releasing the mouse
 
-    canvas = screen.selenium.find_element(By.CSS_SELECTOR, '.nicegui-scene canvas')
+    canvas = screen.find_by_tag('canvas')
+    screen.wait_for(canvas.is_displayed)  # the scene is hidden until it is initialized
     ActionChains(screen.selenium).click_and_hold(canvas).move_by_offset(50, 50).release().perform()
     camera_up_z = f'getElement({scene.id}).camera.up.z'
     screen.wait_for(lambda: screen.selenium.execute_script(f'return {camera_up_z}') != 1)  # the user rotated the scene
@@ -339,6 +339,40 @@ def test_moving_camera_keeps_trackball_controls_after_rotating(screen: Screen):
     scene.move_camera(x=1, duration=0)
     screen.wait_for(lambda: screen.selenium.execute_script(f'return {camera_x}') == pytest.approx(1))
     assert screen.selenium.execute_script(f'return {static_moving}') is True
+
+
+def test_trackball_controls_follow_canvas_size(screen: Screen):
+    scene = None
+
+    @ui.page('/')
+    def page():
+        nonlocal scene
+        scene = ui.scene(control_type='trackball').classes('w-full h-64')
+
+    screen.open('/')
+    canvas = screen.find_by_tag('canvas')
+    screen.wait_for(canvas.is_displayed)  # the scene is hidden until it is initialized
+    assert canvas.size['width'] != 400, 'the canvas has been resized from its default size'
+    screen_width = f'getElement({scene.id}).controls.screen.width'
+    assert screen.selenium.execute_script(f'return {screen_width}') == canvas.size['width']
+
+
+def test_configuring_controls_after_initialization(screen: Screen):
+    scene = None
+
+    @ui.page('/')
+    async def page():
+        nonlocal scene
+        scene = ui.scene()
+        scene.move_camera(up_y=1, up_z=0)
+        await scene.initialized()
+        ui.run_javascript(f'getElement({scene.id}).controls.enableRotate = false')
+
+    screen.open('/')
+    camera_up_y = f'getElement({scene.id}).camera.up.y'
+    screen.wait_for(lambda: screen.selenium.execute_script(f'return {camera_up_y}') == pytest.approx(1))
+    enable_rotate = f'getElement({scene.id}).controls.enableRotate'
+    assert screen.selenium.execute_script(f'return {enable_rotate}') is False, 'configuration survives initialization'
 
 
 async def test_dragend_after_object_deleted(user: User):

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -5,6 +5,8 @@ from typing import Literal
 import numpy as np
 import pytest
 from selenium.common.exceptions import JavascriptException
+from selenium.webdriver import ActionChains
+from selenium.webdriver.common.by import By
 
 from nicegui import app, ui
 from nicegui.elements.scene import Object3D
@@ -304,13 +306,39 @@ def test_moving_camera_keeps_controls_unless_up_vector_changes(screen: Screen):
     enable_rotate = f'getElement({scene.id}).controls.enableRotate'
     screen.selenium.execute_script(f'{enable_rotate} = false')
 
+    camera_x = f'getElement({scene.id}).camera.position.x'
     scene.move_camera(x=1, duration=0)
-    screen.wait_for(lambda: screen.selenium.execute_script(f'return getElement({scene.id}).camera.position.x') == 1)
+    screen.wait_for(lambda: screen.selenium.execute_script(f'return {camera_x}') == pytest.approx(1))
     assert screen.selenium.execute_script(f'return {enable_rotate}') is False, 'controls survive a plain camera move'
 
+    camera_up_y = f'getElement({scene.id}).camera.up.y'
     scene.move_camera(up_y=1, up_z=0, duration=0)
-    screen.wait_for(lambda: screen.selenium.execute_script(f'return getElement({scene.id}).camera.up.y') == 1)
+    screen.wait_for(lambda: screen.selenium.execute_script(f'return {camera_up_y}') == pytest.approx(1))
     assert screen.selenium.execute_script(f'return {enable_rotate}') is True, 'controls are rebuilt for a new up vector'
+
+
+def test_moving_camera_keeps_trackball_controls_after_rotating(screen: Screen):
+    scene = None
+
+    @ui.page('/')
+    def page():
+        nonlocal scene
+        scene = ui.scene(control_type='trackball')
+
+    screen.open('/')
+    screen.wait_for(lambda: scene is not None)
+    static_moving = f'getElement({scene.id}).controls.staticMoving'
+    screen.selenium.execute_script(f'{static_moving} = true')  # no rotation momentum after releasing the mouse
+
+    canvas = screen.selenium.find_element(By.CSS_SELECTOR, '.nicegui-scene canvas')
+    ActionChains(screen.selenium).click_and_hold(canvas).move_by_offset(50, 50).release().perform()
+    camera_up_z = f'getElement({scene.id}).camera.up.z'
+    screen.wait_for(lambda: screen.selenium.execute_script(f'return {camera_up_z}') != 1)  # the user rotated the scene
+
+    camera_x = f'getElement({scene.id}).camera.position.x'
+    scene.move_camera(x=1, duration=0)
+    screen.wait_for(lambda: screen.selenium.execute_script(f'return {camera_x}') == pytest.approx(1))
+    assert screen.selenium.execute_script(f'return {static_moving}') is True
 
 
 async def test_dragend_after_object_deleted(user: User):


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->

<!-- Please provide relevant links to corresponding issues and feature requests. -->

Fixes #6241.
Fixes #6247.

`scene.move_camera()` disposes and recreates the Three.js controls object on every call, so any configuration applied to it (`enableRotate`, `screenSpacePanning`, `mouseButtons`, custom properties) is reset to the control class defaults whenever the camera moves.

`scene.js` already intends this to be conditional (`camera_up_changed`), but `scene.py` resolves each `up_*` argument against the stored camera before sending it, so the values are never `null` and the guard is always true.
https://github.com/zauberzeug/nicegui/blob/1e3b0214db5c20e19d3e106d0f2e383835ac20b8/nicegui/elements/scene/scene.py#L261

Because the rebuild happens in the tween's `onComplete`, a `ui.run_javascript()` issued right after `move_camera()` is also a race: whether the configuration survives depends on round-trip timing.


### Implementation

The controls remember the up vector they were built for (`controls_up`), and `move_camera()` only rebuilds them when the requested up vector differs from that one. Comparing against the *live* `camera.up` would not work: TrackballControls rotates `camera.up` while the user drags, and an interrupted tween leaves it mid-interpolation, so `camera.up` can differ from the vector the controls were built for without any real change having been requested.

Since `scene.py` always sends resolved values, the `=== null` fallbacks in `move_camera()` were dead code and are removed.

Two things used to happen as a side effect of the unconditional rebuild and are now done explicitly:

- `resize()` calls `controls.handleResize()`, which TrackballControls needs to map pointer coordinates to the canvas (OrbitControls/MapControls read the canvas size live).
- Zero-duration camera moves settle synchronously instead of on the next render frame. This also closes the race from the motivation for the initial `move_camera(duration=0)` replay: `await scene.initialized()` followed by `ui.run_javascript(...)` used to lose the configuration again for scenes with a non-default up vector.

Keeping the controls alive changes a few details for code that pokes `controls` directly: momentum/damping state (Trackball `staticMoving=false`, Orbit `enableDamping`) is no longer discarded when a move ends, the `reset()`/`saveState()` baseline is only refreshed when the up vector changes, and user-set limits (`maxPolarAngle`, `maxDistance`, ...) now apply to the commanded pose.

This is done entirely in `scene.js`; the Python API and the arguments sent to the client are unchanged. _An alternative discussed in the issue: sending the raw arguments so the existing `null` handling applies. This would additionally change which pose wins for unspecified axes (Python's stored camera state vs. the browser's current pose), which is a separate behavioral question and is deliberately not part of this PR._

`ui.scene_view` resolves `up_*` the same way but creates no controls object, so it is unaffected.

Tests: the configuration survives a plain camera move and is reset when the up vector changes (OrbitControls); it survives a move after the user rotated a TrackballControls scene; TrackballControls follow the canvas size; and configuration applied after `await scene.initialized()` survives the initial camera move.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary. <!--Remove the option that does not apply.-->
- [x] No breaking changes to the public API.


