### PR TITLE
Update docstring parameters for light and decay values

### DIFF
--- a/nicegui/elements/scene/scene_object3d.py
+++ b/nicegui/elements/scene/scene_object3d.py
@@ -102,7 +102,7 @@ class Object3D:
 
         :param color: CSS color string (default: '#ffffff')
         :param opacity: opacity between 0.0 and 1.0 (default: 1.0)
-        :param side: 'front', 'back', or 'double' (default: 'front')
+        :param side: 'front', 'back', or 'both' (default: 'front')
         """
         if self.color != color or self.opacity != opacity or self.side_ != side or not self.material_is_set:
             self.color = color

--- a/nicegui/elements/scene/scene_objects.py
+++ b/nicegui/elements/scene/scene_objects.py
@@ -311,7 +311,7 @@ class SpotLight(Object3D):
         :param distance: maximum distance of light (default: 0.0)
         :param angle: maximum angle of light (default: π/3)
         :param penumbra: penumbra (default: 0.0)
-        :param decay: decay (default: 2.0)
+        :param decay: decay (default: 1.0)
         """
         super().__init__('spot_light', color, intensity, distance, angle, penumbra, decay)
 

--- a/nicegui/elements/scene/scene_objects.py
+++ b/nicegui/elements/scene/scene_objects.py
@@ -309,7 +309,7 @@ class SpotLight(Object3D):
         :param color: CSS color string (default: '#ffffff')
         :param intensity: light intensity (default: 1.0)
         :param distance: maximum distance of light (default: 0.0)
-        :param angle: maximum angle of light (default: π/2)
+        :param angle: maximum angle of light (default: π/3)
         :param penumbra: penumbra (default: 0.0)
         :param decay: decay (default: 2.0)
         """


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
Improve clarity and correctness of API docstrings so that developers reading the code or generated docs see accurate parameter names and default values. This reduces confusion and helps keep docs consistent with intended usage.
<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->
Change the default value of parameters in docstring to actual default value
<!-- Include any important technical decisions or trade-offs made. -->

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary. <!--Remove the option that does not apply.-->
- [x] Documentation has been added/updated or is not necessary. <!--Remove the option that does not apply.-->
- [x] No breaking changes to the public API or migration steps are described above. <!--Remove the option that does not apply.-->
