### PR TITLE
Make `AxesHelper`'s default color be same as docstring

### DIFF
--- a/nicegui/elements/scene/scene_objects.py
+++ b/nicegui/elements/scene/scene_objects.py
@@ -361,3 +361,4 @@ class AxesHelper(Object3D):
         :param length: length of the the axes (default: 1.0)
         """
         super().__init__('axes_helper', length)
+        self.color = None

--- a/nicegui/elements/scene/scene_objects.py
+++ b/nicegui/elements/scene/scene_objects.py
@@ -361,4 +361,4 @@ class AxesHelper(Object3D):
         :param length: length of the the axes (default: 1.0)
         """
         super().__init__('axes_helper', length)
-        self.color = None
+        self.material(color=None)


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
Make `AxesHelper`'s default color be same as docstring
<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->
Add `self.color = None` after super's `__init__`, change the color to `None`
<!-- Include any important technical decisions or trade-offs made. -->

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary. <!--Remove the option that does not apply.-->
- [x] Documentation has been added/updated or is not necessary. <!--Remove the option that does not apply.-->
- [x] No breaking changes to the public API or migration steps are described above. <!--Remove the option that does not apply.-->

Demo code:
```python
from nicegui import ui
from nicegui.elements.scene.scene_objects import AxesHelper


def index():
    scene = ui.scene().classes(
        'w-64 h-64'
    )
    with scene:
        AxesHelper()

ui.run(
    root=index,
)
```
<img width="356" height="361" alt="image" src="https://github.com/user-attachments/assets/eed1803e-21ab-4b53-85bf-90c681bb623a" />
