### PR TITLE
Skip the page re-render when a global event is registered late

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -504,6 +504,7 @@ function createApp(elements, options) {
           for (const [id, element] of Object.entries(msg)) {
             if (element === null) continue;
             if (!(id in this.elements)) continue;
+            if (id === "0") continue; // the layout's event props are refreshed without remounting (see #6248)
             const oldListenerIds = new Set((this.elements[id]?.events || []).map((ev) => ev.listener_id));
             if (element.events?.some((e) => !oldListenerIds.has(e.listener_id))) {
               delete this.elements[id];

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -294,3 +294,23 @@ async def test_late_event_registration(screen: Screen):
     assert 'Event listeners changed after initial definition. Re-rendering affected elements.' in screen.render_js_logs()
     screen.assert_py_logger('WARNING',
                             'Event listeners changed after initial definition. Re-rendering affected elements.')
+
+
+def test_late_global_event_registration(screen: Screen):
+    events = []
+
+    @ui.page('/')
+    def page():
+        ui.html('<input id="raw">', sanitize=False)
+        ui.button('Register', on_click=lambda: ui.on('some_event', lambda: events.append('fired')))
+        ui.button('Fire', on_click=lambda: ui.run_javascript('emitEvent("some_event")'))
+
+    screen.open('/')
+    screen.selenium.execute_script('document.getElementById("raw").value = "kept"')
+    screen.click('Register')
+    screen.wait(0.5)
+    assert screen.selenium.execute_script('return document.getElementById("raw").value') == 'kept', \
+        'the page must not be re-rendered (see #6248)'
+    screen.click('Fire')
+    screen.wait(0.5)
+    assert events == ['fired']


### PR DESCRIPTION
### Motivation

Fixes #6248: calling `ui.on()` on a page that has already rendered destroys and re-creates **every element on the page** — flicker, lost focus, lost AG Grid scroll/column state, and lost input that had not synced yet.

`ui.on()` registers its listener on `context.client.layout`, and the layout is the first element constructed for every client — element **0**, the root of the tree. The late-registration guard reacts to any previously-unseen `listener_id` by dropping that element so Vue re-creates it. For element 0 that is the whole page.

<details>
<summary>Reproduction of the state loss (the issue's MRE plus an unrelated label)</summary>

```python
from nicegui import ui

@ui.page('/')
def main():
    ui.html('<input placeholder="type here">', sanitize=False)  # plain HTML: the server never sees this value
    ui.label('LABEL')
    ui.button('register a listener', on_click=lambda: ui.on('some_event', lambda e: None))

ui.run()
```

DOM nodes tagged before the click, re-read after:

| | before | after one `ui.on()` |
|---|---|---|
| raw `<input>` value | `TYPED-BY-USER` | `""` |
| raw `<input>` node identity | original | replaced |
| unrelated `ui.label` node identity | original | replaced |

</details>

### Implementation

Skip the delete-and-re-create for element 0 only.

The root does not need it: the regular update path further down the same handler replaces `this.elements[0]`, so the render function reruns and the root vnode receives its refreshed event props without a remount. That covers both dispatch routes — `emitEvent()` → `$emit`, and real DOM events reaching the root through Vue's fallthrough attrs.

The guard stays exactly as it was for every other element, where it is genuinely load-bearing.

<details>
<summary>Why the guard has to stay for non-root elements</summary>

Disabling the delete for *all* ids, verified in a live browser:

| late registration | without the guard |
|---|---|
| `label.on('click')` (plain div) | fires |
| `input.on('keydown.b')` (Quasar `q-input`) | **silently does not fire** |

That second row is the existing `test_late_event_registration`, which still passes unchanged.

</details>

<details>
<summary>Verification</summary>

`tests/test_events.py::test_late_global_event_registration` asserts both halves — that an unsynced raw `<input>` keeps its value across the late registration, and that the late handler still receives the event.

Seen to fail against the unfixed tree before the fix existed:

```
>       assert screen.selenium.execute_script('return document.getElementById("raw").value') == 'kept', \
            'the page must not be re-rendered (see #6248)'
E       AssertionError: the page must not be re-rendered (see #6248)
E       assert '' == 'kept'
```

Local gates:

```
pre-commit run --files nicegui/static/nicegui.js tests/test_events.py   all Passed
mypy ./nicegui                                    Success: no issues found in 245 source files
pylint ./nicegui                                  10.00/10
pytest tests/test_events.py -rs                   14 passed, 0 skipped
pytest tests/test_keyboard.py tests/test_sub_pages.py   55 passed
```

Full local suite: 1003 passed. The `test_dark_mode` failures reproduce identically with `nicegui/static/nicegui.js` reverted to `origin/main`, and are caused by this machine running macOS in Dark appearance, so the "auto" colour-scheme cases resolve to dark.

</details>

<details>
<summary>Note on the warning message</summary>

Element 0 no longer emits `Event listeners changed after initial definition. Re-rendering affected elements.`, since after this change nothing is re-rendered there and the message would be inaccurate. Late registrations on every other element still warn.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
