### PR TITLE
Fix task leak by resolving awaited dialogs when they are deleted

### DIFF
--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -65,7 +65,7 @@ class Dialog(OpenableElement, NoImplicitAwait, component='dialog.js'):
         self.open()
         yield from self.submitted.wait().__await__()  # pylint: disable=no-member
         result = self._result
-        if not self.is_deleted:
+        if not self.is_deleted:  # closing a deleted dialog would warn about using a deleted element
             self.close()
         return result
 

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -82,7 +82,7 @@ class Dialog(OpenableElement, NoImplicitAwait, component='dialog.js'):
 
     def _handle_delete(self) -> None:
         # resolve pending awaits so their tasks don't wait forever, e.g. when the client is deleted after a disconnect
+        # (keep self._result untouched: a result submitted just before deletion should still reach the awaiting task)
         if self._submitted is not None:
-            self._result = None
             self._submitted.set()
         super()._handle_delete()

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -25,6 +25,9 @@ class Dialog(OpenableElement, NoImplicitAwait, component='dialog.js'):
         That means it is not removed when closed, but only hidden.
         You should either create it only once and then reuse it, or remove it with `.clear()` after dismissal.
 
+        *Updated in version 3.16.0: Awaiting a dialog resolves with ``None`` when the dialog is deleted,
+        e.g. because the client disconnected.*
+
         :param value: whether the dialog should be opened on creation (default: `False`)
         """
         with context.client.layout:
@@ -55,12 +58,15 @@ class Dialog(OpenableElement, NoImplicitAwait, component='dialog.js'):
         return super().toggle()
 
     def __await__(self):
+        if self.is_deleted:
+            return None  # a deleted dialog can never be submitted or closed, so we resolve immediately
         self._result = None
         self.submitted.clear()
         self.open()
         yield from self.submitted.wait().__await__()  # pylint: disable=no-member
         result = self._result
-        self.close()
+        if not self.is_deleted:
+            self.close()
         return result
 
     def submit(self, result: Any) -> None:
@@ -73,3 +79,10 @@ class Dialog(OpenableElement, NoImplicitAwait, component='dialog.js'):
         if not self.value:
             self._result = None
             self.submitted.set()
+
+    def _handle_delete(self) -> None:
+        # resolve pending awaits so their tasks don't wait forever, e.g. when the client is deleted after a disconnect
+        if self._submitted is not None:
+            self._result = None
+            self._submitted.set()
+        super()._handle_delete()

--- a/nicegui/elements/dialog.py
+++ b/nicegui/elements/dialog.py
@@ -45,7 +45,10 @@ class Dialog(OpenableElement, NoImplicitAwait, component='dialog.js'):
 
     @property
     def submitted(self) -> asyncio.Event:
-        """An event that is set when the dialog is submitted."""
+        """An event that is set when the dialog is submitted.
+
+        *Updated in version 3.16.0: The event is also set when the dialog is deleted.*
+        """
         if self._submitted is None:
             self._submitted = asyncio.Event()
         return self._submitted
@@ -58,13 +61,14 @@ class Dialog(OpenableElement, NoImplicitAwait, component='dialog.js'):
         return super().toggle()
 
     def __await__(self):
-        if self.is_deleted:
-            return None  # a deleted dialog can never be submitted or closed, so we resolve immediately
+        if not self._is_safe_to_interact():
+            return None  # the dialog cannot be submitted anymore, so we resolve immediately instead of waiting forever
         self._result = None
         self.submitted.clear()
         self.open()
         yield from self.submitted.wait().__await__()  # pylint: disable=no-member
         result = self._result
+        self._result = None  # release the result so a deleted dialog does not keep it alive (close() would do the same)
         if not self.is_deleted:  # closing a deleted dialog would warn about using a deleted element
             self.close()
         return result
@@ -83,6 +87,5 @@ class Dialog(OpenableElement, NoImplicitAwait, component='dialog.js'):
     def _handle_delete(self) -> None:
         # resolve pending awaits so their tasks don't wait forever, e.g. when the client is deleted after a disconnect
         # (keep self._result untouched: a result submitted just before deletion should still reach the awaiting task)
-        if self._submitted is not None:
-            self._submitted.set()
+        self.submitted.set()
         super()._handle_delete()

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -129,6 +129,31 @@ async def test_awaited_dialog_resolves_when_client_is_deleted(user: User):
     assert await dialog is None  # awaiting a deleted dialog resolves immediately
 
 
+async def test_submit_and_delete_dialog_in_same_handler(user: User):
+    """A result submitted right before the dialog is deleted must still reach the awaiting task."""
+    results = []
+
+    @ui.page('/')
+    def page():
+        with ui.dialog() as dialog, ui.card():
+            def confirm() -> None:
+                dialog.submit('Yes')
+                dialog.delete()
+            ui.button('Yes', on_click=confirm)
+
+        async def show() -> None:
+            results.append(await dialog)
+
+        ui.button('Open', on_click=show)
+
+    await user.open('/')
+    user.find('Open').click()
+    await asyncio.sleep(0.1)
+    user.find('Yes').click()
+    await asyncio.sleep(0.1)
+    assert results == ['Yes']
+
+
 @pytest.mark.parametrize('element_factory,selector,text', [
     (lambda: ui.input('Input'), '//*[@aria-label="Input"]', 'input'),
     (lambda: ui.textarea('Textarea'), '//*[@aria-label="Textarea"]', 'textarea'),

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -118,21 +118,19 @@ async def test_awaited_dialog_resolves_when_client_is_deleted(user: User):
 
     await user.open('/')
     user.find('Open').click()
-    await asyncio.sleep(0.1)
-    assert not results  # the dialog is open and the button handler is awaiting it
+    await asyncio.sleep(0.1)  # let the button handler start awaiting the dialog
+    assert not results
 
     assert isinstance(dialog, ui.dialog)
     dialog.client.delete()
-    await asyncio.sleep(0.1)
-    assert results == [None]  # the handler resumed instead of waiting forever
+    await asyncio.sleep(0.1)  # let the handler resume
+    assert results == [None]  # the handler resumed with None instead of waiting forever
 
     assert await dialog is None  # awaiting a deleted dialog resolves immediately
 
 
 async def test_submit_and_delete_dialog_in_same_handler(user: User):
     """A result submitted right before the dialog is deleted must still reach the awaiting task."""
-    results = []
-
     @ui.page('/')
     def page():
         with ui.dialog() as dialog, ui.card():
@@ -142,16 +140,15 @@ async def test_submit_and_delete_dialog_in_same_handler(user: User):
             ui.button('Yes', on_click=confirm)
 
         async def show() -> None:
-            results.append(await dialog)
+            ui.notify(f'Result: {await dialog}')
 
         ui.button('Open', on_click=show)
 
     await user.open('/')
     user.find('Open').click()
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(0.1)  # let the button handler start awaiting the dialog
     user.find('Yes').click()
-    await asyncio.sleep(0.1)
-    assert results == ['Yes']
+    await user.should_see('Result: Yes')
 
 
 @pytest.mark.parametrize('element_factory,selector,text', [

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Callable
 
 import pytest
@@ -5,7 +6,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import Screen, User
 
 
 def test_open_close_dialog(screen: Screen):
@@ -97,6 +98,35 @@ def test_dialog_in_menu(screen: Screen):
     screen.click('Delete menu')
     screen.wait(0.5)
     screen.should_not_contain('Dialog content')  # it has been deleted together with the menu
+
+
+async def test_awaited_dialog_resolves_when_client_is_deleted(user: User):
+    """The task awaiting a dialog must not wait forever when the client is deleted, e.g. after a disconnect."""
+    dialog = None
+    results = []
+
+    @ui.page('/')
+    def page():
+        nonlocal dialog
+        with ui.dialog() as dialog, ui.card():
+            ui.label('Content')
+
+        async def show() -> None:
+            results.append(await dialog)
+
+        ui.button('Open', on_click=show)
+
+    await user.open('/')
+    user.find('Open').click()
+    await asyncio.sleep(0.1)
+    assert not results  # the dialog is open and the button handler is awaiting it
+
+    assert isinstance(dialog, ui.dialog)
+    dialog.client.delete()
+    await asyncio.sleep(0.1)
+    assert results == [None]  # the handler resumed instead of waiting forever
+
+    assert await dialog is None  # awaiting a deleted dialog resolves immediately
 
 
 @pytest.mark.parametrize('element_factory,selector,text', [


### PR DESCRIPTION
### Motivation

An event handler that awaits a dialog leaks its task when the client is deleted while the dialog is open.

Minimal example — the label counts the handler tasks that are still pending:

```python
from nicegui import background_tasks, ui


@ui.page('/')
def page():
    with ui.dialog() as dialog, ui.card():
        ui.label('Are you sure?')
        ui.button('Yes', on_click=lambda: dialog.submit(True))

    async def show() -> None:
        result = await dialog
        ui.notify(f'Result: {result}')

    ui.button('Open', on_click=show)
    ui.label().bind_text_from(background_tasks, 'running_tasks',
                              backward=lambda tasks: f'{sum(1 for t in tasks if "show" in t.get_name())} pending "show" handlers')


ui.run()
```

Steps to reproduce:

1. Open the page and click "Open" — the dialog opens and the label shows `1 pending "show" handlers` while the handler waits on `await dialog`.
2. Close the tab and wait a few seconds past the reconnect timeout, so the client is deleted.
3. Open the page again: the label still shows `1 pending "show" handlers`, even though the dialog's client is gone and no dialog is open.

Each repetition of these steps increases the counter by one; it never goes down.
`Client.delete()` removes all elements, but nothing sets the dialog's `submitted` event and nothing cancels the handler task.
The task waits forever on an event that no one will ever set.
It stays in `background_tasks.running_tasks` until server shutdown and keeps everything alive that its coroutine frame references — often the whole page object graph.
This is easy to hit in practice because a dialog opened via `await` is often the main working view of a page, and users end their session by simply closing the tab.
On a long-running server this accumulates hundreds of pending tasks (and their memory) over time.

This is the same class of leak as #5598, which fixed it for `client.connected()` waits; awaited dialogs were not covered.

### Implementation

- `Dialog._handle_delete` now resolves pending awaits with `None` — the same result as dismissing the dialog — so waiting tasks finish instead of waiting forever.
  This covers both client deletion and explicit deletion of the dialog (or a parent).
  In the example above, the counter drops back to `0` as soon as the client is deleted.
- The `submitted` event is set unconditionally on deletion, so a task that touches the public `submitted` property only after deletion resumes as well instead of waiting on a fresh event forever.
  (The event was already set on dismissal without submission, so this extends the existing "the dialog is done" semantics rather than changing them.)
- After resuming, `__await__` skips `close()` if the dialog has been deleted, so the resumed await doesn't trigger the "element has been deleted but is still being used" warning for something that isn't a user bug.
- A resumed handler that still interacts with the deleted client (e.g. via `ui.notify`) hits the pre-existing "Client has been deleted but is still being used" warning, once per process.
  This is intentional: the message goes nowhere, which is worth surfacing.
- Awaiting an already-deleted dialog resolves immediately with `None`.
  If the dialog was explicitly deleted while its client is still alive, the established use-after-delete warning (#3028) is emitted — the same policy `update()` follows — instead of failing silently.
- `__await__` releases the submitted result after reading it — like `close()` does in the normal path — so a deleted dialog does not keep a submitted result alive.

The new pytest fails without the fix (verified) and passes with it.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation has been added/updated (version notes in the `ui.dialog` and `Dialog.submitted` docstrings).
- [x] No breaking changes to the public API.
