### PR TITLE
Fix typing of `bindable_dataclass` when called with arguments

### DIFF
--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -8,7 +8,7 @@ import weakref
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
 
 from typing_extensions import dataclass_transform
 
@@ -32,7 +32,6 @@ active_links: list[ActiveLink] = []
 _active_links_added = asyncio.Event()
 _binding_keys_by_object: defaultdict[int, set[BindingKey]] = defaultdict(set)
 
-TC = TypeVar('TC', bound=type)
 T = TypeVar('T')
 
 _MISSING = object()
@@ -343,10 +342,22 @@ def reset() -> None:
     _binding_keys_by_object.clear()
 
 
+@overload
+def bindable_dataclass(cls: type[T], /, *,
+                       bindable_fields: Iterable[str] | None = ...,
+                       **kwargs: Any) -> type[T]: ...
+
+
+@overload
+def bindable_dataclass(cls: None = ..., /, *,
+                       bindable_fields: Iterable[str] | None = ...,
+                       **kwargs: Any) -> IdentityFunction: ...
+
+
 @dataclass_transform()
-def bindable_dataclass(cls: TC | None = None, /, *,
+def bindable_dataclass(cls: type[T] | None = None, /, *,
                        bindable_fields: Iterable[str] | None = None,
-                       **kwargs: Any) -> type[DataclassInstance] | IdentityFunction:
+                       **kwargs: Any) -> type[T] | IdentityFunction:
     """A decorator that transforms a class into a dataclass with bindable fields.
 
     This decorator extends the functionality of ``dataclasses.dataclass`` by making specified fields bindable.
@@ -371,8 +382,8 @@ def bindable_dataclass(cls: TC | None = None, /, *,
         if kwargs.get(unsupported_option):
             raise ValueError(f'`{unsupported_option}=True` is not supported with bindable_dataclass')
 
-    dataclass: type[DataclassInstance] = dataclasses.dataclass(**kwargs)(cls)
-    field_names = {field.name for field in dataclasses.fields(dataclass)}
+    dataclass: type[T] = dataclasses.dataclass(**kwargs)(cls)
+    field_names = {field.name for field in dataclasses.fields(cast('type[DataclassInstance]', dataclass))}
     if bindable_fields is None:
         bindable_fields = field_names
     for field_name in bindable_fields:


### PR DESCRIPTION
### Motivation

Fixes #6251.

`bindable_dataclass` is annotated `-> type[DataclassInstance] | IdentityFunction`. That union claims the *decorator-factory* call may return a class, so a type checker picks the `type[DataclassInstance]` arm and the parameterized form breaks:

```python
from nicegui import binding

@binding.bindable_dataclass(bindable_fields=['state'])   # error: Expected 0 positional arguments
class ControllerState:
    state: str = 'STARTUP'

c = ControllerState()   # error: Object of type "DataclassInstance" is not callable
```

`@dataclass_transform()` cannot rescue this, because an explicit return annotation wins over the transform.

This is **not** the case that was fixed in #5798. That one was the *bare* `@bindable_dataclass` form, closed as a pyright bug and fixed upstream in pyright 1.1.408 / Pylance 2026.1.1. The parameterized form is the residual case that upstream fix does not cover — the reporter is already on Pylance 2026.3.1, and it still reproduces here on pyright 1.1.411 **and** on mypy.

<details>
<summary><b>Before / after, both checkers (confirmed — ran it)</b></summary>

Repro file (`repro.py`), checked against `nicegui==3.15.0` in a clean venv on Python 3.13:

```python
from nicegui import binding


@binding.bindable_dataclass(bindable_fields=["state"])
class ControllerState:
    state: str = "STARTUP"


c = ControllerState()
reveal_type(c)
reveal_type(ControllerState)
c.state = "RUNNING"


@binding.bindable_dataclass
class Bare:
    value: int = 0


b = Bare()
reveal_type(b)
b.value = 1
```

| | before | after |
|---|---|---|
| pyright 1.1.411, line 4 | `error: Expected 0 positional arguments` | — |
| pyright 1.1.411, line 9 | `error: Object of type "DataclassInstance" is not callable` | — |
| pyright `reveal_type(c)` | `Unknown \| ControllerState` | `ControllerState` |
| pyright `reveal_type(ControllerState)` | `type[ControllerState] \| DataclassInstance` | `type[ControllerState]` |
| mypy (current, run against this tree) | `error: Too many arguments for "DataclassInstance"  [call-arg]` | — |
| bare `@bindable_dataclass` (`Bare`) | already clean | still clean |

The mypy rows were produced by stashing/unstashing this diff in the same worktree, so both runs resolve `nicegui` to the same tree. (Worth a caveat for anyone re-checking: an editable install elsewhere on the machine will silently win over `site-packages`, and then mypy never sees your patch at all — `mypy -v | grep binding` shows which file it actually parsed.)

</details>

### Implementation

Two `@overload` signatures preserve the decorated class through a `TypeVar`, which is the approach @falkoschindler [proposed on #5798](https://github.com/zauberzeug/nicegui/issues/5798#issuecomment-3921787350):

- `cls` given → `type[T]` (the bare-decorator and direct-call forms)
- `cls` omitted → `IdentityFunction` (the factory form), which preserves the class through the returned decorator

`TC` is dropped — it had exactly one use, the signature being replaced, and `type[T]` is the more faithful type. The local is retyped `type[T]` accordingly, and `dataclasses.fields()` gets a `cast` since `type[T]` is not statically known to be a dataclass at that point (it is at runtime — `dataclasses.dataclass(**kwargs)(cls)` on the line above establishes it, and `slots=True` is already rejected before that path).

**No pytest is added.** The bug is purely static — nothing observable at runtime changes, so a runtime test cannot fail on it. The repo has no pyright dependency, and CI's `mypy ./nicegui` does not reach a fixture file under `tests/`. Catching this in CI would mean either adding a checker dependency or a dedicated typing-test harness plus a CI job. That felt disproportionate to a 17-line typing fix, but it is genuinely your call — happy to add it in this PR or a follow-up if you would rather have the guard. It would cover #5798's bare form too.

**Scope, stated precisely:** this restores the decorated class's type in both decorator forms. It does not make a checker synthesize dataclass `__init__` parameters through an assigned alias (`Foo = bindable_dataclass(Bar, ...)`) — plain `dataclasses.dataclass` has the same limitation.

<details>
<summary><b>Why #5807 did not already cover this (and credit where it is due)</b></summary>

#5807 was closed as unnecessary once pyright 1.1.408 shipped, so it is reasonable to wonder whether this is the same patch coming back. It is not — and I checked rather than assumed.

That PR's two overload arms were swapped relative to the suggestion they were implementing: `cls: None` returned `type[DataclassInstance]` and `cls: TC` returned `IdentityFunction`, i.e. the no-class call was typed as returning a class and the class-given call as returning a decorator. Reconstructing that exact shape on top of current `main` and re-running the repro:

| | #5807's overload shape | this PR |
|---|---|---|
| line 4 | `error: Expected 0 positional arguments` | — |
| line 9 | `error: Object of type "DataclassInstance" is not callable` | — |
| `reveal_type(c)` | `Unknown` | `ControllerState` |
| `reveal_type(ControllerState)` | `DataclassInstance` | `type[ControllerState]` |

So #6251 would still be open even if #5807 had merged. That is a subtle inversion in a signature nobody could test at the time — the bare form was the only reported symptom, and pyright's `dataclass_transform` handling masked the difference. @platinops's analysis and cross-platform testing on #5798 were what pinned the problem down in the first place, and this PR is the same idea with the arms the other way round.

</details>

<details>
<summary><b>Gates, runtime spot-check, and second-opinion review</b></summary>

```
pre-commit run --files nicegui/binding.py   all passed (mdformat skipped, no md files)
mypy ./nicegui                              Success: no issues found in 245 source files
pylint ./nicegui                            10.00/10
pytest tests/test_binding.py -q -rs         23 passed, 0 skipped
```

Runtime behaviour unchanged (run against this tree):

```
S(state='STARTUP', other=0)
state descriptor: BindableProperty      # listed field still bindable
other descriptor: int                   # unlisted field still plain
bare: B(v=3) | v descriptor: BindableProperty
error path intact: "nope" is not a dataclass field
frozen guard intact: `frozen=True` is not supported with bindable_dataclass
```

Also checked and rejected: adding `@dataclass_transform()` to the overloads as well. It is unnecessary — the decorator on the implementation alone satisfies both checkers — so it was dropped to keep the diff minimal.

Reviewed by Codex (GPT-5.2, different model lineage) with an adversarial prompt: **9/10, no must-fix or worth-improving findings.** It independently confirmed the fix on pyright 1.1.411, judged the `cast` sound rather than papering over a runtime bug, agreed `TC`'s removal is safe and that `IdentityFunction` introduces no new runtime hazard (the `get_type_hints()` caveat pre-existed in the old annotation), and agreed skipping the test is defensible. Its one recommendation was to not overclaim the scope — hence the "Scope, stated precisely" paragraph above.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

---

<sub>Prepared with Claude Code. Every empirical claim above was run, not inferred.</sub>
