### PR TITLE
Add TestMu AI back to the special sponsors

### DIFF
--- a/website/github_stats.json
+++ b/website/github_stats.json
@@ -1,7 +1,8 @@
 {
   "special": {
     "lechler-gmbh": "https://www.lechler.com/",
-    "discolike": "https://www.discolike.com/"
+    "discolike": "https://www.discolike.com/",
+    "testmu-ai": "https://www.testmuai.com/?utm_medium=sponsor&utm_source=nicegui"
   },
   "top": [],
   "total": 24,


### PR DESCRIPTION
*Posted by Claude Code on evnchn's behalf.*

**TestMu AI (formerly LambdaTest) is sponsoring Zauberzeug again**, but is no longer shown on the website — they were removed from the sponsor list in 44cc19e5. Their logo files were never deleted, so restoring them is a one-line change.

Feel free to close this if you would rather not show them, or if the timing is off — this is only a nudge based on what the public sponsors page shows.

### Motivation

[github.com/sponsors/zauberzeug](https://github.com/sponsors/zauberzeug) currently lists `@LambdaTest-Inc` — *"TestMu AI Open Source Office (Formerly LambdaTest)"* — under **Current sponsors**, but `website/github_stats.json` no longer has an entry for them, so they do not appear in the sponsors section on nicegui.io.

<details>
<summary><b>How the sponsoring status was checked</b></summary>

The account is under the "Current sponsors" heading on the public sponsors page (not a past-sponsor section):

```console
$ curl -s -L https://github.com/sponsors/zauberzeug > /tmp/sp.html
# for each sponsor link, report the nearest preceding heading
LambdaTest-Inc   under heading: 'Current sponsors 25'
lechler-gmbh     under heading: 'Current sponsors 25'
discolike        under heading: 'Current sponsors 25'

$ curl -s https://api.github.com/users/LambdaTest-Inc | jq -r '.login + " | " + .name'
LambdaTest-Inc | TestMu AI Open Source Office (Formerly LambdaTest)
```

Side note: the page heading says 25 current sponsors while `github_stats.json` records `"total": 24`, which is consistent with the count being stale. Regenerating that file needs a token, so this PR leaves the generated numbers alone — `fetch_github_stats.py` preserves `special` and refreshes the rest on its next run.

</details>

### Implementation

Re-add the `special` entry. The logo files `testmu-ai.{dark,light}.webp` are still in `website/static/sponsors/`, untouched since 3db26172, so no assets are needed:

```json
"testmu-ai": "https://www.testmuai.com/?utm_medium=sponsor&utm_source=nicegui"
```

The key `testmu-ai` and the URL are both exactly the values the entry last carried (877b2b1c), so this restores the previous state rather than inventing one. Appended last so the existing two logos keep their positions — happy to reorder if you would prefer them somewhere else.

No test is added: the rendering path is unchanged and already exercised by the other special sponsors.

<details>
<summary><b>Verified in a browser: all three logos load</b></summary>

Ran `main.py` from this branch and measured the decoded image dimensions, so a broken image would show as `naturalWidth: 0`:

| image | naturalWidth × naturalHeight | |
|---|---|---|
| `lechler-gmbh.light.webp` | 984 × 432 | OK |
| `lechler-gmbh.dark.webp` | 984 × 432 | OK |
| `discolike.light.webp` | 553 × 164 | OK — but see the caveat below |
| `discolike.dark.webp` | 553 × 164 | OK — but see the caveat below |
| **`testmu-ai.light.webp`** | **1848 × 660** | **OK** |
| **`testmu-ai.dark.webp`** | **1848 × 660** | **OK** |

The rendered row reads: Lechler · DiscoLike · TestMu AI · "Become a sponsor".

**Caveat, so this table is not read as more than it is:** the two `discolike` rows pass here only because this run was on macOS, whose filesystem is case-insensitive. On the Linux server those files are named `Discolike.*` and 404 — that is a separate bug, fixed in #6253. This PR neither causes nor fixes it, and the `testmu-ai` rows are unaffected either way, since that key and its filenames match exactly.

</details>

<details>
<summary><b>One thing worth knowing: the key does not match their GitHub login</b></summary>

Not introduced by this PR, and not something I have changed — but it is adjacent enough to flag, since it is the same coupling that produced #6253.

The keys in `special` do double duty: they name the logo files *and* they are used for a case-sensitive exclusion in `fetch_github_stats.py`, so that a special sponsor is not also listed as a top sponsor:

```python
if s['tier_amount'] >= 100 and not s['tier_is_one_time'] and s['login'] not in special_sponsors
```

This sponsor's actual login is `LambdaTest-Inc`, while the key is `testmu-ai` (renamed for the rebrand in 3db26172, together with the logo files). So the exclusion will not match them. **This only bites if their tier is $100+ and recurring** — in that case they would be rendered twice, once as a logo and once as a top-sponsor avatar. I cannot see tier amounts without a token, so I have not changed anything here; `top` is currently empty, which suggests it has not been an issue so far.

If it ever does bite, the fix is to key them by `LambdaTest-Inc` and rename the two logo files to match — deliberately not done here, since it would trade a hypothetical problem for a real rename.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] The **Implementation** section explains why pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
