### PR TITLE
Add review rules distilled from recent maintainer review commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,9 @@ The conventions below cover both general Python style and NiceGUI-specific patte
     Match the sibling elements first — a popup-like element opens and closes like `ui.menu` and `ui.dialog`, usually by inheriting `OpenableElement` rather than reimplementing them — and the wrapped Quasar or JavaScript component's own terms second.
     Check what NiceGUI already means by a candidate name: `show()`/`hide()` are the layout vocabulary of `ui.drawer`, `ui.header` and `ui.footer`, and `bind_*` belongs to data binding, so borrowing either for a different concept reads as the wrong one.
     Renaming after release is a breaking change, so settle names before merge.
+  - **Event handlers**: When a public `on_*` method listens to an event `__init__` already registered with the same payload, append the callback to a Python-side list and let the one listener fan out, as `ValueElement` does with `_change_handlers`.
+    Each listener emits its own client-to-server socket event, so a second registration doubles the traffic for that event.
+    Separate `self.on(...)` calls are right when the payloads genuinely differ: `EChart.on_point_click()` and `EChart.on_click()` both listen to `componentClick` but request different argument subsets.
   - **Mixins**: Elements use mixin composition; inheritance order matters for Python's Method Resolution Order (MRO)
   - **Props vs. attributes**: Use `self._props` for data that syncs to Vue/frontend; use instance attributes for Python-only state
   - **Context managers**: Elements can be used as context managers (`with element:`) for slot/child management

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,8 @@ The conventions below cover both general Python style and NiceGUI-specific patte
   - Follow **PEP 8** with a 120 character line length
   - Use single quotes in Python, double quotes in JavaScript
   - Use f-strings wherever possible (mark performance-critical exceptions with a comment)
-  - Explain important implementation details and non-obvious code with comments
+  - Explain important implementation details and non-obvious code with comments.
+    Verify the explanation before writing it: a comment that guesses at a mechanism, overclaims a guarantee the tests contradict, or names an identifier that does not exist is worse than no comment, because it will be trusted.
   - Use `# NOTE:` only to draw special attention, e.g. to changes that need to be mirrored elsewhere or hidden cross-file coupling
   - No mutable defaults (`[]`, `{}`) without `# noqa: B006` and a justification — prefer `None`
   - Put high-level/interesting code at the top of files; helper functions go below their usage
@@ -172,6 +173,10 @@ The conventions below cover both general Python style and NiceGUI-specific patte
 
 - **Elements** (core library)
 
+  - **Naming**: Borrow vocabulary before inventing it.
+    Match the sibling elements first — a popup-like element opens and closes like `ui.menu` and `ui.dialog`, usually by inheriting `OpenableElement` rather than reimplementing them — and the wrapped Quasar or JavaScript component's own terms second.
+    Check what NiceGUI already means by a candidate name: `show()`/`hide()` are the layout vocabulary of `ui.drawer`, `ui.header` and `ui.footer`, and `bind_*` belongs to data binding, so borrowing either for a different concept reads as the wrong one.
+    Renaming after release is a breaking change, so settle names before merge.
   - **Mixins**: Elements use mixin composition; inheritance order matters for Python's Method Resolution Order (MRO)
   - **Props vs. attributes**: Use `self._props` for data that syncs to Vue/frontend; use instance attributes for Python-only state
   - **Context managers**: Elements can be used as context managers (`with element:`) for slot/child management
@@ -208,6 +213,10 @@ The conventions below cover both general Python style and NiceGUI-specific patte
     They break when the implementation changes (so they get rewritten along with it, guarding nothing) and they are hard to read for anyone who doesn't know the internals.
   - Before writing a test, read a recent one in the same file.
     The existing suite is almost entirely behavior tests, and copying a neighbouring test's shape is faster and safer than inventing a new one.
+    Better still, extend it: if a test already covers the same element, page or contract, adding a case to its parametrization or an assertion to its body is usually better than a new function with its own scaffolding.
+    Write a separate test when the setup genuinely differs or when it covers a distinct contract; otherwise the extra page and fixtures are permanent cost in an already-long suite.
+  - Make sure the test exercises the path production actually takes.
+    Reaching the bug through an easier substitute trigger can pass, and fail, for the wrong reason — the fix looks guarded while the real path stays broken.
   - Prefer the `User` fixture (fast, runs in the same async context as NiceGUI, no browser); use the `Screen` fixture only when testing browser/JavaScript interactions.
   - A regression test must fail when the fix is reverted — verify that once before trusting it.
     A test that has only ever been seen green proves nothing.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -60,6 +60,9 @@ Review what the code does, not what the description says it does.
 - When a fix depends on undocumented behavior of an upstream or vendored library, ask for a test against the real library, so an upstream change fails loudly instead of silently.
 - A reported bug is a sample, not the population.
   Before merging, look for the same shape elsewhere in the codebase and say what you found.
+- The same caution applies to your own findings.
+  Before reporting existing behavior as a defect, check that nobody chose it: the source shows what the code does, not whether it was intended.
+  Search the tracker for the symptom, and `git blame` the warning or guard being flagged — or `git log -S` it when the string is stable — to find the pull request that introduced it, because a deliberate trade-off and a defect look identical in the diff.
 
 ## Severity vocabulary
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,7 +1,7 @@
 # Code Review Guidelines for NiceGUI
 
 This file augments any review prompt — the built-in `/review` command, Cursor commands, or an ad-hoc "review this" request.
-It defines _what to look for_ and _how to label severity_, but leaves the layout to whatever invokes the review.
+It defines _what to look for_, _how far to trust the pull request_, and _how to label severity_, but leaves the layout to whatever invokes the review.
 For coding rules, see [CONTRIBUTING.md](CONTRIBUTING.md); for general agent guidance, see [AGENTS.md](AGENTS.md).
 
 ## What to look for
@@ -49,6 +49,17 @@ For coding rules, see [CONTRIBUTING.md](CONTRIBUTING.md); for general agent guid
   - Tests asserting CPython-only semantics — immediate weakref cleanup via refcounting, exact CPython error-message wording — need a PyPy `skipif` or a tolerant match (PyPy compatibility is tracked externally, not promised)
 - **Readability**
   - Complex logic without comments explaining intent; magic numbers
+
+## How far to trust the pull request
+
+A pull request's measurements, mechanisms and root-cause stories are the author's hypotheses, not evidence.
+Review what the code does, not what the description says it does.
+
+- Re-derive load-bearing claims yourself: rebuild the artifact, run the reproduction, read the upstream source.
+  A number, a benchmark or a "this is why it happens" that nobody re-checked is an open question, not a finding.
+- When a fix depends on undocumented behavior of an upstream or vendored library, ask for a test against the real library, so an upstream change fails loudly instead of silently.
+- A reported bug is a sample, not the population.
+  Before merging, look for the same shape elsewhere in the codebase and say what you found.
 
 ## Severity vocabulary
 


### PR DESCRIPTION
### Motivation

@falkoschindler asked, roughly: *if we sent an agent over the last fifty pull requests to look at the commits I made through my reviews, what could we distill? Which rules are still missing that would let AIs catch the kinds of issues I keep finding myself?* He named two candidates — an unclean API, and the more fundamental "is this feature actually needed at all".

So I ran it. The corpus is the 70 most recently merged PRs (2026-06-20 → 2026-08-05): every non-merge commit Falko pushed onto someone else's branch — **94 commits, 7,111 diff lines** — plus his review, inline and issue comments on 46 of them. Every rule below was clustered from that, and scored against what `CONTRIBUTING.md` / `REVIEW.md` / `AGENTS.md` already say, so nothing here restates an existing rule.

**Both of his hunches check out.** API naming shows up in 7 PRs and necessity in 8, and neither is written down. But the two largest findings were ones the question did not anticipate, and they are what this PR leads with.

This PR is deliberately **the high-confidence subset**, not the whole distillation — see the fold at the bottom for the eleven rules that did not make the cut and why.

**Update — two more rules, found from the opposite direction.** The four above were mined from your review commits, i.e. from someone with complete repo history. These two came from removing it: I ran a **context-free** reviewer over PR `#5988` — a web session with the pull request and the source, but no tracker, no blame, no memory of the repo.

It returned one correct finding (which became PR `#6282`) and one misframing, and the misframing is the useful part: it read a *deliberate, tested* mechanism as a defect. I then compounded that into a bug report and had to retract it within the hour (issue 6280, closed as not-planned). A miss, and mine rather than the reviewer's — I had the history available and did not check it.

But it is a productive one, because a reviewer *with* repo history never surfaces either gap: it silently compensates for both and you learn nothing. Both rules below are things our agent-facing docs genuinely do not say, and we only know that because something read them without any other context.

### Implementation

Six additions, each placed next to the rule it extends.

**1. `REVIEW.md` — a new "How far to trust the pull request" section.** The most-cited single behavior in the corpus, and it is not a commit pattern at all — it is only visible in the review prose. In 7 of 46 PRs Falko re-derived a load-bearing claim rather than accepting it: rebuilding artifacts, running the repro, reading upstream source.

> "every number checked out when I rebuilt both artifacts at the PR head myself"

This is the one that explains the *gap* rather than listing its symptoms. An AI reviewer reasons over the diff and the PR body and calls that a review — which is exactly the failure mode. The other three rules here are checklist items an agent can pattern-match; this one changes what counts as evidence. The section also carries the "a reported bug is a sample, not the population" rule (the same `ResizeObserver` leak turned up in two elements) and the "ask for a test against the real library" rule from #6213.

**2. `CONTRIBUTING.md` Tests — extend the nearest existing test rather than adding a standalone one.** Ten PRs, the largest cluster in the corpus, and #6219 does not close it: the current text says *read* a neighbouring test and *copy its shape*, never *extend it instead of adding one*. Almost every one of those commits deletes a new test function with its own page and scaffolding and adds one row to a parametrization instead. Written as the default with a stated exception, not an absolute — a separate test is still right when the setup genuinely differs or it covers a distinct contract.

Also in that bullet list: a test must exercise the path production actually takes. Sharper than the existing "must fail when the fix is reverted", which a test can satisfy while validating the wrong mechanism.

**3. `CONTRIBUTING.md` Elements — a `**Naming**` bullet.** Falko's gap (a). Renaming after release is a breaking change, so this is cheap to enforce at review time and expensive to miss.

**4. `CONTRIBUTING.md` Style — a comment must be verified, not merely present.** Eight PRs fix comments that were present and wrong, which is worse than absent because a wrong comment gets trusted. The current rule only requires comments to *exist*.

**5. `REVIEW.md` — the reviewer's own finding is a hypothesis too.** One bullet, extending the section above it. `REVIEW.md` already says to ask rather than assert on weak evidence, and `AGENTS.md` says to research before guessing — but that one sits under "Pair Programming" and is aimed at *implementing*. Nothing tells a reviewer to establish that a behaviour was not chosen on purpose before reporting it as a defect. In the diff, a deliberate trade-off and a bug look the same; the difference lives in blame and the tracker. `SECURITY.md` has the narrow version of this for scanner false positives (`#6239`), which is precedent for it being worth writing down, not a duplicate.

**6. `CONTRIBUTING.md` Elements — the event-handler convention.** A public `on_*` method appends to a Python-side list and lets one socket listener fan out, as `ValueElement` does with `_change_handlers`. This was rolled out across the library in `#2704` and is now the shape of most `on_*` methods, but it is written down nowhere — a contributor following `CONTRIBUTING.md` today would add a second `self.on(...)` and be within the documented rules. Scoped deliberately to *identical payloads*: `EChart.on_point_click()` and `EChart.on_click()` both listen to `componentClick` while requesting 10 and 2 arguments respectively, and collapsing those would force the union payload on everyone.

**Tests:** not applicable — documentation only.

<details>
<summary><b>Evidence trail — every rule, with its citations</b></summary>

> PR numbers below are deliberately written in backticks so they do not post cross-references onto thirty merged PRs' timelines. They are still clickable by search.

**Verify the claim yourself** (7): `#6123` `#6155` `#6167` `#6206` `#6209` `#6210` `#6213`

**Extend the nearest existing test** (10): `#6113` `#6116` `#6124` `#6125` `#6137` `#6148` `#6159` `#6162` `#6168` `#6176`
Representative: `#6116` deleted a new Selenium test and added one row to the existing `html_id` parametrization; `#6113` collapsed three test functions into one `accept × user_agent` matrix; `#6168` folded head-function coverage into `test_usage_after_delete`.

**Naming / adopt existing vocabulary** (7): `#5613` (`show()`/`hide()` → `open()`/`close()`; `on_show`/`on_hide` → `on_open`/`on_close`) · `#6000` (`keybindings=` → `keymap=`, `binding` → `KeyBinding`, `on_keybinding()` → `map_key()`, adopting CodeMirror's own vocabulary and avoiding a collision with `bind_*`) · `#6000` again for PascalCase-for-value-classes and the nested-dataclass convention · `#6113` (`ua` → `user_agent`) · `#6135` (rename-only type aliases dropped) · `#6117` (`Literal[...]` rather than `str`)

**A comment must be verified** (8): `#6213` ("this sometimes happens when the internal socketio client is not yet ready" → the actual race) · `#6124` (a "no-op for any well-formed prefix" claim the non-ASCII test cases contradicted) · `#6000` (docstring named the `KeyBinding` class where the wire event is `"keybinding"`) · `#6113` · `#6117` ×2 · `#6123` · `#5613`

**Bug is a sample, not the population** (3): `#6155` `#6189` `#6196`

**Test the production path** (1): `#6149`

Intervention rate, for context: **50 of 62** non-Falko PRs in the window end with a commit by Falko; **40 of 62** received at least one substantive one. Four PRs (`#6000`, `#6135`, `#6117`, `#5613`) account for 44 of the 94 commits, so they carry disproportionate weight in every cluster.

</details>

<details>
<summary><b>What was left out, and why</b></summary>

Eleven further rules cleared the evidence bar but not the "worth a doc line" bar, mostly because the principle already exists and only the *teeth* are missing. Happy to add any of them if you disagree — they are one commit each.

| rule | weight | why held back |
|---|---|---|
| Every line must earn its place — inline single-use helpers/constants, delete unreachable guards | 10 commits | "Always prefer simple solutions" technically covers it; needs a carve-out for test seams or it flags correct code |
| Don't own what the client, library or a base class already owns | 8 PRs | "Avoid duplication" covers it abstractly; the wrapped-library angle is the genuinely new part |
| Validate before mutating; honour the invariant on every parallel path | 8 PRs | overlaps "missing input validation at system boundaries" |
| Docstring conventions — `*Added in version X*` above the `:param` list, double backticks for literals, `# DEPRECATED:` not `# TODO:`, one-line test docstrings | 7 commits | mechanical and very AI-checkable, but a big bullet block; say the word and I'll add it |
| A breaking change needs a runway — `None` sentinel, targeted `warn_once`, flip on the major | 2 PRs | REVIEW.md has "breaking changes without an explicit deprecation path"; what's missing is *what a deprecation path is made of* |
| Shipped docs are part of the behavior (`nicegui/llms.md`) | 1 PR | single citation |
| A new CI job must be in the merge gate's `needs:`; assert on the built artifact, not the packaging config | 2 PRs | genuinely missing, but felt like a separate PR |
| Test mechanics — `usefixtures` for side-effect-only fixtures, `gc.collect()` before a weakref assert, one assertion per fact, extract a timing constant so tests can monkeypatch it | 5 commits | small and real; held back for diff size |
| Keep the PR description in sync with the final shape | 2 PRs | process, not code |

**A caveat I'd rather state than have found:** 54 of the 70 PRs in the window are mine, and most were agent-assisted. So this corpus is closer to *"what AI-written NiceGUI PRs get wrong"* than to contributions in general. For the question Falko actually asked that skew helps; for onboarding human contributors it is a real limitation. A cross-check over an older window with a wider author mix would settle it, and I'm happy to run it.

</details>

<details>
<summary><b>Verification — including two claims this PR got wrong first</b></summary>

The diff was reviewed by a second model (Codex, read-only) before pushing, specifically to attack the factual claims. It found two, both real, both now fixed — and both were exactly the failure mode the new comment rule warns about:

- The first draft said `show`/`hide` "collides with" `visible`/`set_visibility()`. **Not true in this repo:** `ui.drawer`, `ui.header` and `ui.footer` all expose public `show()`/`hide()`/`toggle()`. Falko's point in #5613 was about a popup-like element specifically, and I had over-generalised it. The text now describes `show()`/`hide()` as the layout vocabulary rather than a forbidden one.
- The first draft justified extending tests with "a new standalone test costs another browser start forever". **Also not true:** `nicegui_driver` in `nicegui/testing/screen_plugin.py` is `scope='session'`, so the driver is reused. The cost is the extra page and fixtures, which is what the text now says.

Also verified directly against the source before writing: `OpenableElement` exists and is inherited by `Menu` and `Dialog` (`ContextMenu` reimplements `open()`/`close()` against Quasar, so it is deliberately not cited as a mixin example); `visible` is a `BindableProperty` on the `Visibility` mixin; `set_visibility()` and the `bind_*` family exist as described.

`uv run pre-commit run --files CONTRIBUTING.md REVIEW.md` passes (mdformat, codespell, whitespace, EOF).

**Additions 5 and 6 went through the same gate, and it caught a third wrong claim.** My first draft of the event-handler bullet stated the rule without qualification: *a public `on_*` method appends to a Python-side handler list*, and a second `self.on(...)` costs "one extra round trip carrying the full payload". Codex refuted both halves:

- **"Round trip" and "full payload" were wrong.** Each listener emits its own client-to-server socket event — not necessarily a round trip — and the payload is whatever that listener's `args` selects, not everything.
- **The unqualified rule would have made real code worse.** `EChart.on_point_click()` and `EChart.on_click()` deliberately register two listeners on `componentClick` because they want different argument subsets; `SlideItem.on_slide()` registers side-specific events. I verified both in the source rather than taking the reviewer's word — `echart.py` requests 10 arguments in one and 2 in the other. The bullet is now scoped to *identical payloads* and carries the `EChart` case as the stated exception.

That is the same failure this PR's addition 5 is about, caught one step earlier: I had verified that the mechanism was real without checking whether the rule I drew from it was one the codebase actually wanted.

Codex also pushed back on `git log -S` as the default command, since `-S` only tracks occurrence counts of an exact string; the text now leads with `git blame` and keeps `git log -S` for the stable-string case.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation has been added/updated.
- [x] No breaking changes to the public API.

