### PR TITLE
Add a fallback backend for native mode when pywebview is absent

### DIFF
--- a/nicegui/native/chromium.py
+++ b/nicegui/native/chromium.py
@@ -1,0 +1,721 @@
+# pylint: disable=C0116
+"""Fallback backend for native mode, using a browser that is already installed.
+
+Native mode normally runs on pywebview, which embeds a platform webview and therefore needs a
+platform GUI stack: pyobjc on macOS, pythonnet on Windows, WebKitGTK or QtWebEngine on Linux.
+That is why it lives behind the `native` extra.
+
+This module provides a fallback for when that extra is not installed, adding no packages beyond
+what NiceGUI already installs. Instead of embedding an engine, it drives a Chromium-family
+browser that is already on the machine in `--app` mode: a window with no tabs and no omnibox,
+its own taskbar entry and its own lifecycle. Window control and JavaScript evaluation go over
+the Chrome DevTools Protocol on loopback.
+
+It deliberately exposes the same names `native_mode` and `native` already use from pywebview
+(`create_window`, `start`, `settings`, `Window`, `FixPoint`, `dom.DOMEventHandler`), so it can
+stand in without those modules growing a second code path.
+
+Its fidelity is lower than pywebview's on purpose - see `UNSUPPORTED_METHODS` below - so prefer
+`pip install nicegui[native]` when a real embedded window matters.
+"""
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import queue
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from contextlib import suppress
+from enum import IntEnum, IntFlag
+from pathlib import Path
+from types import SimpleNamespace
+from typing import IO, Any
+
+from .. import helpers
+from ..logging import log
+
+BROWSER_ENV_VAR = 'NICEGUI_NATIVE_BROWSER'
+
+_CANDIDATES: dict[str, list[str]] = {
+    'darwin': [
+        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        '/Applications/Chromium.app/Contents/MacOS/Chromium',
+        '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+        '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+        '/Applications/Vivaldi.app/Contents/MacOS/Vivaldi',
+        '~/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        '~/Applications/Chromium.app/Contents/MacOS/Chromium',
+    ],
+    'win32': [
+        # a per-user (non-admin) Chrome install lives under LOCALAPPDATA, not Program Files
+        r'%LOCALAPPDATA%\Google\Chrome\Application\chrome.exe',
+        r'C:\Program Files\Google\Chrome\Application\chrome.exe',
+        r'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe',
+        r'%LOCALAPPDATA%\Chromium\Application\chrome.exe',
+        r'C:\Program Files\Microsoft\Edge\Application\msedge.exe',
+        r'C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe',
+        r'C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe',
+        r'C:\Program Files\Vivaldi\Application\vivaldi.exe',
+        r'%LOCALAPPDATA%\Vivaldi\Application\vivaldi.exe',
+    ],
+}
+_LINUX_CANDIDATES = [
+    'google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser',
+    'microsoft-edge', 'microsoft-edge-stable', 'brave-browser', 'vivaldi-stable',
+]
+
+# pywebview window methods this backend cannot provide. Listed explicitly so that calling one
+# warns instead of raising, while a genuine typo still raises AttributeError.
+UNSUPPORTED_METHODS = {
+    'clear_cookies',
+    'create_confirmation_dialog',
+    'create_file_dialog',
+    'expose',
+    'load_css',
+    'load_html',
+    'run_js',
+}
+
+
+def _warn_unsupported(what: str) -> None:
+    """Report something the fallback cannot do, once, pointing at the backend that can."""
+    helpers.warn_once(f'the fallback native backend does not support {what}; '
+                      'run "pip install nicegui[native]" to use pywebview instead')
+
+
+class FileDialog(IntEnum):
+    """Mirrors ``webview.FileDialog``.
+
+    Accepted so that signatures match; this backend cannot open native file pickers.
+    """
+
+    OPEN = 10
+    FOLDER = 20
+    SAVE = 30
+
+
+class FixPoint(IntFlag):
+    """Mirrors ``webview.window.FixPoint``.
+
+    Accepted for signature compatibility; the DevTools Protocol always anchors a resize at the
+    window's top-left, so the flag cannot be honoured.
+    """
+
+    NORTH = 1
+    WEST = 2
+    SOUTH = 4
+    EAST = 8
+
+
+class DOMEventHandler:
+    """Mirrors ``webview.dom.DOMEventHandler``.
+
+    Handlers are accepted and never invoked: a browser cannot hand us the filesystem paths of
+    dropped files the way an embedded webview can.
+    """
+
+    def __init__(self, callback: Callable, prevent_default: bool = False, stop_propagation: bool = False) -> None:
+        self.callback = callback
+        self.prevent_default = prevent_default
+        self.stop_propagation = stop_propagation
+
+
+# pywebview's pre-5.x aliases, still referenced by native.py as default argument values
+OPEN_DIALOG = FileDialog.OPEN
+FOLDER_DIALOG = FileDialog.FOLDER
+SAVE_DIALOG = FileDialog.SAVE
+
+dom = SimpleNamespace(DOMEventHandler=DOMEventHandler)
+
+settings: dict[str, Any] = {}
+
+
+def find_browser() -> str | None:
+    """Return the path of an installed Chromium-family browser, or ``None`` if there is none."""
+    if override := os.environ.get(BROWSER_ENV_VAR):
+        override = os.path.expandvars(os.path.expanduser(override))
+        if Path(override).exists():
+            return override
+        if found := shutil.which(override):
+            return found
+        log.warning(f'{BROWSER_ENV_VAR} is set to "{override}", but no such browser was found')
+        return None
+    for candidate in _CANDIDATES.get(sys.platform, _LINUX_CANDIDATES):
+        expanded = os.path.expandvars(os.path.expanduser(candidate))
+        if '%' not in expanded and Path(expanded).exists():
+            return expanded
+        if found := shutil.which(expanded):
+            return found
+    return None
+
+
+class _EventSlot:
+    """Mirrors pywebview's ``window.events.<name> += handler`` interface."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._handlers: list[Callable] = []
+
+    def __iadd__(self, handler: Callable) -> _EventSlot:
+        self._handlers.append(handler)
+        return self
+
+    def __isub__(self, handler: Callable) -> _EventSlot:
+        if handler in self._handlers:
+            self._handlers.remove(handler)
+        return self
+
+    def fire(self, *args: Any) -> None:
+        for handler in list(self._handlers):
+            try:
+                handler(*args)
+            except Exception:
+                log.exception(f'error in native "{self.name}" handler')
+
+
+class _Events:
+
+    def __init__(self) -> None:
+        self.shown = _EventSlot('shown')
+        self.loaded = _EventSlot('loaded')
+        self.closed = _EventSlot('closed')
+        self.closing = _EventSlot('closing')
+        self.minimized = _EventSlot('minimized')
+        self.maximized = _EventSlot('maximized')
+        self.restored = _EventSlot('restored')
+        self.resized = _EventSlot('resized')
+        self.moved = _EventSlot('moved')
+
+
+class _DevToolsProtocol:
+    """A minimal Chrome DevTools Protocol client: blocking requests, plus a reader thread."""
+
+    def __init__(self, ws_url: str) -> None:
+        # Imported lazily so that apps which never open a native window do not pay for it.
+        # websockets arrives with uvicorn[standard], which requires >=10.4, while the synchronous
+        # client used here was added in 11.0 - so only websockets 10.4 exactly is too old, and it
+        # is reported rather than pinned, to avoid constraining a widely shared dependency.
+        try:
+            from websockets.sync.client import connect  # pylint: disable=import-outside-toplevel
+        except ImportError as e:
+            raise RuntimeError('The fallback native backend needs websockets>=11, which provides '
+                               'its synchronous client. Please upgrade websockets, or run '
+                               '"pip install nicegui[native]" to use pywebview instead.') from e
+        self._connection = connect(ws_url, max_size=None, open_timeout=10)
+        self._next_id = 0
+        self._send_lock = threading.Lock()
+        self._replies: dict[int, dict] = {}
+        self._pending: set[int] = set()
+        self._reply_ready = threading.Condition()
+        self._closed = threading.Event()
+        self.on_event: Callable[[str, dict], None] = lambda method, params: None
+        threading.Thread(target=self._read_loop, daemon=True).start()
+
+    def _read_loop(self) -> None:
+        try:
+            for raw in self._connection:
+                message = json.loads(raw)
+                if 'id' in message:
+                    with self._reply_ready:
+                        if message['id'] in self._pending:  # otherwise the caller gave up: drop it
+                            self._replies[message['id']] = message
+                            self._reply_ready.notify_all()
+                elif 'method' in message:
+                    self.on_event(message['method'], message.get('params', {}))
+        except Exception:
+            pass  # the browser closing tears down the socket; `closed` handling lives in Window
+        finally:
+            self._closed.set()
+            with self._reply_ready:
+                self._reply_ready.notify_all()
+
+    def send(self, method: str, params: dict | None = None, timeout: float = 10.0) -> dict:
+        """Issue a command and wait for its reply.
+
+        Never call this from `on_event`: the reply can only be delivered by the reader thread,
+        so waiting for one inside a handler that runs on that thread deadlocks.
+        """
+        with self._send_lock:
+            self._next_id += 1
+            message_id = self._next_id
+            with self._reply_ready:
+                self._pending.add(message_id)
+            self._connection.send(json.dumps({'id': message_id, 'method': method, 'params': params or {}}))
+        deadline = time.time() + timeout
+        try:
+            with self._reply_ready:
+                while message_id not in self._replies:
+                    if self._closed.is_set():
+                        raise ConnectionError(f'DevTools connection closed while waiting for {method}')
+                    if not self._reply_ready.wait(max(0.0, deadline - time.time())):
+                        raise TimeoutError(f'DevTools timeout on {method}')
+                reply = self._replies.pop(message_id)
+        finally:
+            with self._reply_ready:
+                self._pending.discard(message_id)
+        if 'error' in reply:
+            raise RuntimeError(f'DevTools error on {method}: {reply["error"]}')
+        return reply.get('result', {})
+
+    def close(self) -> None:
+        with suppress(Exception):
+            self._connection.close()
+
+
+class Window:
+    """A browser window driven over the DevTools Protocol, shaped like ``webview.Window``."""
+
+    def __init__(self, url: str = '', title: str = '', width: int = 800, height: int = 600,
+                 fullscreen: bool = False, frameless: bool = False, profile_dir: str | None = None,
+                 x: int | None = None, y: int | None = None, on_top: bool = False,
+                 **kwargs: Any) -> None:
+        self.url = url
+        self._title = title
+        self.fullscreen = fullscreen
+        self.frameless = frameless
+        self.events = _Events()
+        self.dom = SimpleNamespace(document=SimpleNamespace(events=SimpleNamespace(drop=_EventSlot('drop'))))
+        self.native = None  # no platform widget to hand out; pywebview exposes the real one here
+        self._initial_size = (width, height)
+        self._on_top = on_top
+        self._protocol: _DevToolsProtocol | None = None
+        self._window_id: int | None = None
+        self._bounds: dict[str, Any] = {}
+        self._protocol_ready = threading.Event()
+        self._process: subprocess.Popen | None = None
+        self._profile_dir = profile_dir
+        self._log_file: IO[bytes] | None = None
+        self._events: queue.Queue = queue.Queue()
+        self._synthetic_load_time = 0.0
+        self._bounds_checked_at = 0.0
+        self._position = (x, y)
+        for name, unsupported in [('frameless', frameless), ('on_top', on_top)]:
+            if unsupported:
+                _warn_unsupported(f'{name}=True')
+        if kwargs:
+            _warn_unsupported(f'the window arguments {sorted(kwargs)}')
+
+    # -- lifecycle ---------------------------------------------------------------------------
+
+    def _launch(self, browser: str) -> None:
+        if self._profile_dir is None:
+            self._profile_dir = tempfile.mkdtemp(prefix='nicegui-native-')
+        width, height = self._initial_size
+        arguments = [
+            browser,
+            f'--app={self.url}',
+            f'--user-data-dir={self._profile_dir}',
+            f'--window-size={width},{height}',
+            '--remote-debugging-port=0',
+            '--no-first-run',
+            '--no-default-browser-check',
+            '--disable-background-networking',
+            '--disable-component-update',
+            '--disable-sync',
+            '--no-service-autorun',
+        ]
+        if self.fullscreen:
+            arguments.append('--start-fullscreen')
+        # Best effort for callers that use this backend directly; NiceGUI's native mode also
+        # removes fallback profiles from the parent process, where app shutdown is observable.
+        atexit.register(self._remove_profile)
+        self._log_file = tempfile.TemporaryFile()  # pylint: disable=consider-using-with
+        # the browser must outlive this call; it is terminated in destroy()
+        self._process = subprocess.Popen(  # pylint: disable=consider-using-with
+            arguments, stdout=subprocess.DEVNULL, stderr=self._log_file)
+
+    def _wait_for_debugging_port(self, timeout: float = 30.0) -> int:
+        assert self._profile_dir is not None
+        port_file = Path(self._profile_dir) / 'DevToolsActivePort'
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self._process is not None and self._process.poll() is not None:
+                raise RuntimeError('the browser exited before reporting a debugging port. '
+                                   f'It said: {self._browser_output() or "nothing"}')
+            if port_file.exists():
+                first_line = port_file.read_text().splitlines()[:1]
+                if first_line and first_line[0].strip().isdigit():
+                    return int(first_line[0].strip())
+            time.sleep(0.05)
+        raise TimeoutError('the browser did not report a debugging port')
+
+    def _find_page(self, port: int, timeout: float = 30.0) -> str:
+        """Return the websocket URL of our page.
+
+        An `--app` window opens on about:blank and navigates a moment later, so prefer a target
+        that already shows our URL and fall back to any page once we have waited long enough.
+        """
+        deadline = time.time() + timeout
+        accept_any_page_after = time.time() + timeout / 2
+        while time.time() < deadline:
+            try:
+                with urllib.request.urlopen(f'http://127.0.0.1:{port}/json/list', timeout=2) as response:
+                    targets = json.load(response)
+            except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+                time.sleep(0.1)
+                continue
+            pages = [t for t in targets if t.get('type') == 'page' and t.get('webSocketDebuggerUrl')]
+            for target in pages:
+                if str(target.get('url', '')).startswith(self.url):
+                    return str(target['webSocketDebuggerUrl'])
+            if pages and time.time() > accept_any_page_after:
+                return str(pages[0]['webSocketDebuggerUrl'])  # still navigating; attach anyway
+            time.sleep(0.1)
+        raise TimeoutError('the browser did not open a page we could attach to')
+
+    def _attach(self, port: int) -> None:
+        threading.Thread(target=self._handle_events, daemon=True).start()
+        self._protocol = _DevToolsProtocol(self._find_page(port))
+        self._protocol_ready.set()
+        self._protocol.on_event = lambda method, params: self._events.put_nowait((method, params))
+        self._protocol.send('Page.enable')
+        self._protocol.send('Runtime.enable')
+        try:
+            result = self._protocol.send('Browser.getWindowForTarget')
+            self._window_id = result['windowId']
+            self._bounds = result['bounds']
+        except Exception:
+            log.debug('could not resolve the browser window; geometry will be approximate')
+        if self.title:
+            self._apply_title()
+        if self._position != (None, None):
+            self.move(self._position[0] or 0, self._position[1] or 0)
+        # We attach after launching, so the page may already have loaded, in which case
+        # Page.loadEventFired never arrives and anything waiting for `loaded` would wait forever.
+        if self._is_showing_app() and self.evaluate_js('document.readyState') == 'complete':
+            self._synthetic_load_time = time.time()
+            self._fire_loaded()
+
+    def _watch(self) -> None:
+        """Poll geometry until the browser window goes away, then report it closed."""
+        while self._process is not None and self._process.poll() is None:
+            self._poll_bounds()
+            time.sleep(0.25)
+        self._events.put_nowait(('__stop__', {}))
+        if self._protocol is not None:
+            self._protocol.close()
+        self._remove_profile()
+        self.events.closed.fire()
+
+    def _terminate_browser(self, timeout: float = 5.0) -> None:
+        """Stop the browser and wait for it to exit.
+
+        Waiting matters: a browser that is still running rewrites its profile directory as it
+        shuts down, so deleting the directory first only makes it reappear a moment later.
+        """
+        if self._process is None or self._process.poll() is not None:
+            return
+        self._process.terminate()
+        with suppress(subprocess.TimeoutExpired):
+            self._process.wait(timeout=timeout)
+        if self._process.poll() is None:
+            self._process.kill()
+            with suppress(subprocess.TimeoutExpired):
+                self._process.wait(timeout=timeout)
+
+    def _browser_output(self) -> str:
+        """The last of whatever the browser wrote to stderr, for diagnosing a failed launch."""
+        if self._log_file is None:
+            return ''
+        with suppress(OSError, ValueError):
+            self._log_file.seek(0)
+            lines = self._log_file.read().decode(errors='replace').strip().splitlines()
+            return ' | '.join(lines[-3:])
+        return ''
+
+    def _remove_profile(self) -> None:
+        """Delete the throwaway browser profile; it is only useful while the window lives.
+
+        Best effort: NiceGUI's native mode also removes fallback profiles from the parent process,
+        where app shutdown is observable.
+        """
+        if self._profile_dir is not None:
+            shutil.rmtree(self._profile_dir, ignore_errors=True)
+            self._profile_dir = None
+
+    # -- events ------------------------------------------------------------------------------
+
+    def _handle_events(self) -> None:
+        """Handle DevTools events off the reader thread, so a handler may itself issue commands."""
+        while True:
+            method, _ = self._events.get()
+            if method == '__stop__':
+                return
+            try:
+                if method == 'Page.loadEventFired':
+                    self._on_load()
+                elif method == 'Page.frameResized':
+                    self._poll_bounds()
+            except Exception:
+                log.exception(f'error handling DevTools event {method}')
+
+    def _on_load(self) -> None:
+        if time.time() - self._synthetic_load_time < 1.0:
+            return  # already reported when attaching
+        if not self._is_showing_app():
+            return  # an --app window loads about:blank first, which is not the page we serve
+        self._fire_loaded()
+
+    def _fire_loaded(self) -> None:
+        """Apply the title and report the page as loaded."""
+        if self.title:
+            self._apply_title()
+        self.events.loaded.fire()
+
+    def _is_showing_app(self) -> bool:
+        location = self.evaluate_js('location.href')
+        return isinstance(location, str) and location.startswith(self.url)
+
+    def _apply_title(self) -> None:
+        # `--app` takes the window title from the page, so set it explicitly to match pywebview.
+        # Note that this is observable to the app's own JavaScript, unlike a real window title.
+        self.evaluate_js(f'document.title = {json.dumps(self.title)};')
+
+    def _poll_bounds(self, max_age: float = 0.05) -> None:
+        """Refresh the cached window bounds, unless they were read a moment ago.
+
+        native_mode answers get_size() and get_position() by reading x, y, width and height in
+        turn, so without this each of those costs a separate round-trip to the browser.
+        """
+        if self._protocol is None or self._window_id is None:
+            return
+        if time.monotonic() - self._bounds_checked_at < max_age:
+            return
+        self._bounds_checked_at = time.monotonic()
+        try:
+            bounds = self._protocol.send('Browser.getWindowBounds', {'windowId': self._window_id})['bounds']
+        except Exception:
+            return
+        previous, self._bounds = self._bounds, bounds
+        if (bounds.get('width'), bounds.get('height')) != (previous.get('width'), previous.get('height')):
+            self.events.resized.fire(bounds.get('width', 0), bounds.get('height', 0))
+        if (bounds.get('left'), bounds.get('top')) != (previous.get('left'), previous.get('top')):
+            self.events.moved.fire(bounds.get('left', 0), bounds.get('top', 0))
+        if bounds.get('windowState') != previous.get('windowState'):
+            slot = {'minimized': self.events.minimized,
+                    'maximized': self.events.maximized,
+                    'normal': self.events.restored}.get(bounds.get('windowState', ''))
+            if slot is not None:
+                slot.fire()
+
+    # -- the pywebview window API ------------------------------------------------------------
+
+    def _await_protocol(self, timeout: float = 60.0) -> _DevToolsProtocol | None:
+        """Wait for the browser connection.
+
+        Callers may arrive before `start()` has attached: NiceGUI launches its window-method
+        executor first, and it only forwards a response when the method returns something other
+        than None, so returning None early would leave the caller waiting forever.
+
+        Callers that only read geometry must not use this: they have a usable default, and
+        blocking would turn a plain attribute read into a minute-long hang.
+        """
+        self._protocol_ready.wait(timeout)
+        return self._protocol
+
+    def evaluate_js(self, script: str, *_args: Any, **_kwargs: Any) -> Any:
+        protocol = self._await_protocol()
+        if protocol is None:
+            return None
+        try:
+            result = protocol.send('Runtime.evaluate', {
+                'expression': script,
+                'returnByValue': True,
+                'awaitPromise': True,
+                'userGesture': True,
+            })
+        except Exception:
+            log.debug(f'could not evaluate JavaScript: {script[:60]}')
+            return None
+        # NOTE: a None result is not forwarded by native_mode's window-method executor, which
+        # only queues a response when the method returns something else, and the requesting side
+        # waits without a timeout. So `undefined` results and evaluation errors leave an
+        # `await main_window.evaluate_js(...)` pending. This predates the fallback but the
+        # fallback reaches it more easily.
+        if result.get('exceptionDetails'):
+            log.debug(f'JavaScript raised: {result["exceptionDetails"].get("text")}')
+            return None
+        return result.get('result', {}).get('value')
+
+    def get_current_url(self) -> str:
+        # never return None: NiceGUI forwards a window method's result only when it is not None,
+        # and the requesting side waits for that response without a timeout
+        return self.evaluate_js('location.href') or ''
+
+    def get_cookies(self) -> list:
+        _warn_unsupported('window.get_cookies()')
+        return []
+
+    def _current_bounds(self) -> dict[str, Any]:
+        self._poll_bounds()  # deliberately does not wait for the connection; see _await_protocol
+        return self._bounds
+
+    @property
+    def x(self) -> int:
+        return int(self._current_bounds().get('left', 0))
+
+    @property
+    def y(self) -> int:
+        return int(self._current_bounds().get('top', 0))
+
+    @property
+    def width(self) -> int:
+        return int(self._current_bounds().get('width', self._initial_size[0]))
+
+    @property
+    def height(self) -> int:
+        return int(self._current_bounds().get('height', self._initial_size[1]))
+
+    @property
+    def title(self) -> str:
+        return self._title
+
+    @title.setter
+    def title(self, value: str) -> None:
+        self._title = value
+        if self._protocol is not None:  # deliberately does not wait; setting a title must not block
+            self._apply_title()
+
+    @property
+    def on_top(self) -> bool:
+        return self._on_top
+
+    @on_top.setter
+    def on_top(self, value: bool) -> None:
+        self._on_top = value
+        _warn_unsupported('keeping the window on top')
+
+    def _set_bounds(self, **bounds: Any) -> None:
+        protocol = self._await_protocol(timeout=5.0)  # nobody awaits a result, so do not wait long
+        if protocol is None or self._window_id is None:
+            return
+        try:
+            protocol.send('Browser.setWindowBounds', {'windowId': self._window_id, 'bounds': bounds})
+        except Exception:
+            log.debug('could not change the window bounds')
+
+    def resize(self, width: int, height: int,
+               fix_point: FixPoint = FixPoint.NORTH | FixPoint.WEST) -> None:  # pylint: disable=unused-argument
+        self._set_bounds(windowState='normal', width=int(width), height=int(height))
+
+    def set_window_size(self, width: int, height: int) -> None:
+        self.resize(width, height)
+
+    def move(self, x: int, y: int) -> None:
+        self._set_bounds(windowState='normal', left=int(x), top=int(y))
+
+    def minimize(self) -> None:
+        self._set_bounds(windowState='minimized')
+
+    def maximize(self) -> None:
+        self._set_bounds(windowState='maximized')
+
+    def restore(self) -> None:
+        self._set_bounds(windowState='normal')
+
+    def toggle_fullscreen(self) -> None:
+        is_fullscreen = self._current_bounds().get('windowState') == 'fullscreen'
+        self._set_bounds(windowState='normal' if is_fullscreen else 'fullscreen')
+
+    def show(self) -> None:
+        self.restore()
+
+    def hide(self) -> None:
+        self.minimize()
+
+    def load_url(self, url: str) -> None:
+        self.url = url
+        if self._protocol is not None:
+            self._protocol.send('Page.navigate', {'url': url})
+
+    def set_title(self, title: str) -> None:
+        self._title = title
+        self._apply_title()
+
+    def destroy(self) -> None:
+        if self._protocol is not None:
+            with suppress(Exception):
+                self._protocol.send('Browser.close', timeout=2)
+        self._terminate_browser()
+        # _watch() may not get to run: NiceGUI kills the window subprocess once the app shuts down
+        self._remove_profile()
+
+    def __getattr__(self, name: str) -> Callable:
+        if name not in UNSUPPORTED_METHODS:
+            raise AttributeError(name)
+
+        def unsupported(*_args: Any, **_kwargs: Any) -> None:
+            _warn_unsupported(f'window.{name}()')
+        return unsupported
+
+
+_windows: list[Window] = []
+
+
+def create_window(url: str = '', title: str = '', width: int = 800, height: int = 600,
+                  fullscreen: bool = False, frameless: bool = False, **kwargs: Any) -> Window:
+    """Mirrors ``webview.create_window``."""
+    window = Window(url=url, title=title, width=width, height=height,
+                    fullscreen=fullscreen, frameless=frameless, **kwargs)
+    _windows.append(window)
+    return window
+
+
+def _close_browsers_on_termination() -> None:
+    """Close the browser when this subprocess is told to exit.
+
+    NiceGUI terminates the window subprocess without waiting for it to drain its method queue, so
+    a queued `destroy` may never run. Without this the browser is left orphaned and keeps
+    rewriting its profile directory.
+    """
+    previous = signal.getsignal(signal.SIGTERM)
+
+    def handle(signum: int, frame: Any) -> None:
+        for window in _windows:
+            window._terminate_browser(timeout=2.0)  # pylint: disable=protected-access
+            window._remove_profile()  # pylint: disable=protected-access
+        if callable(previous) and previous not in (signal.SIG_DFL, signal.SIG_IGN):
+            previous(signum, frame)
+        sys.exit(0)
+
+    with suppress(ValueError):  # only possible on the main thread
+        signal.signal(signal.SIGTERM, handle)
+
+
+def start(*_args: Any, **_kwargs: Any) -> None:
+    """Mirrors ``webview.start``: open the window(s) and block until they are closed."""
+    browser = find_browser()
+    assert browser is not None, 'no browser found; native_mode.activate() should have caught this'
+    log.debug(f'using {browser} for native mode')
+    _close_browsers_on_termination()
+    for name, ignored in [('settings', sorted(settings)), ('start_args', sorted(_kwargs))]:
+        if ignored:
+            _warn_unsupported(f'app.native.{name} {ignored}')
+    for window in _windows:
+        window._launch(browser)  # pylint: disable=protected-access
+        try:
+            window._attach(window._wait_for_debugging_port())  # pylint: disable=protected-access
+        except Exception:
+            window.destroy()  # do not leave an orphaned browser and profile behind
+            window._remove_profile()  # pylint: disable=protected-access
+            raise
+        window.events.shown.fire()
+    watchers = [threading.Thread(target=w._watch) for w in _windows]  # pylint: disable=protected-access
+    for watcher in watchers:
+        watcher.start()
+    for watcher in watchers:
+        watcher.join()
+
+
+def active_window() -> Window | None:
+    """Mirrors ``webview.active_window``."""
+    return _windows[0] if _windows else None

--- a/nicegui/native/native.py
+++ b/nicegui/native/native.py
@@ -33,130 +33,131 @@ try:
         warnings.filterwarnings('ignore', category=DeprecationWarning)
         import webview
         from webview.window import FixPoint
+except ImportError:  # matches native_mode.py, which suppresses any ImportError
+    # pywebview is optional: the fallback backend exposes the same window interface
+    from . import chromium as webview  # type: ignore[no-redef]
+    from .chromium import FixPoint  # type: ignore[assignment]
 
-    class WindowProxy(webview.Window):
 
-        def __init__(self) -> None:  # pylint: disable=super-init-not-called
-            pass  # we don't call super().__init__ here because this is just a proxy to the actual window
+class WindowProxy(webview.Window):
 
-        async def get_always_on_top(self) -> bool:
-            """Get whether the window is always on top."""
-            return await self._request()
+    def __init__(self) -> None:  # pylint: disable=super-init-not-called
+        pass  # we don't call super().__init__ here because this is just a proxy to the actual window
 
-        def set_always_on_top(self, on_top: bool) -> None:
-            """Set whether the window is always on top."""
-            self._send(on_top)
+    async def get_always_on_top(self) -> bool:
+        """Get whether the window is always on top."""
+        return await self._request()
 
-        async def get_size(self) -> tuple[int, int]:
-            """Get the window size as tuple (width, height)."""
-            return await self._request()
+    def set_always_on_top(self, on_top: bool) -> None:
+        """Set whether the window is always on top."""
+        self._send(on_top)
 
-        async def get_position(self) -> tuple[int, int]:
-            """Get the window position as tuple (x, y)."""
-            return await self._request()
+    async def get_size(self) -> tuple[int, int]:
+        """Get the window size as tuple (width, height)."""
+        return await self._request()
 
-        def load_url(self, url: str) -> None:
-            self._send(url)
+    async def get_position(self) -> tuple[int, int]:
+        """Get the window position as tuple (x, y)."""
+        return await self._request()
 
-        def load_html(self, html: str, base_uri: str = ...) -> None:  # type: ignore
-            self._send(html, base_uri)
+    def load_url(self, url: str) -> None:
+        self._send(url)
 
-        def load_css(self, stylesheet: str) -> None:
-            self._send(stylesheet)
+    def load_html(self, html: str, base_uri: str = ...) -> None:  # type: ignore
+        self._send(html, base_uri)
 
-        def set_title(self, title: str) -> None:
-            self._send(title)
+    def load_css(self, stylesheet: str) -> None:
+        self._send(stylesheet)
 
-        async def get_cookies(self) -> Any:  # pylint: disable=invalid-overridden-method
-            return await self._request()
+    def set_title(self, title: str) -> None:
+        self._send(title)
 
-        async def get_current_url(self) -> str:  # type: ignore # pylint: disable=invalid-overridden-method
-            return await self._request()
+    async def get_cookies(self) -> Any:  # pylint: disable=invalid-overridden-method
+        return await self._request()
 
-        def destroy(self) -> None:
-            self._send()
+    async def get_current_url(self) -> str:  # type: ignore # pylint: disable=invalid-overridden-method
+        return await self._request()
 
-        def show(self) -> None:
-            self._send()
+    def destroy(self) -> None:
+        self._send()
 
-        def hide(self) -> None:
-            self._send()
+    def show(self) -> None:
+        self._send()
 
-        def set_window_size(self, width: int, height: int) -> None:
-            self._send(width, height)
+    def hide(self) -> None:
+        self._send()
 
-        def resize(self, width: int, height: int, fix_point: FixPoint = FixPoint.NORTH | FixPoint.WEST) -> None:
-            self._send(width, height, fix_point)
+    def set_window_size(self, width: int, height: int) -> None:
+        self._send(width, height)
 
-        def maximize(self) -> None:
-            self._send()
+    def resize(self, width: int, height: int, fix_point: FixPoint = FixPoint.NORTH | FixPoint.WEST) -> None:
+        self._send(width, height, fix_point)
 
-        def minimize(self) -> None:
-            self._send()
+    def maximize(self) -> None:
+        self._send()
 
-        def restore(self) -> None:
-            self._send()
+    def minimize(self) -> None:
+        self._send()
 
-        def toggle_fullscreen(self) -> None:
-            self._send()
+    def restore(self) -> None:
+        self._send()
 
-        def move(self, x: int, y: int) -> None:
-            self._send(x, y)
+    def toggle_fullscreen(self) -> None:
+        self._send()
 
-        async def evaluate_js(  # type: ignore # pylint: disable=arguments-differ,invalid-overridden-method
-            self,
-            script: str,
-        ) -> str:
-            return await self._request(script)
+    def move(self, x: int, y: int) -> None:
+        self._send(x, y)
 
-        async def create_confirmation_dialog(  # type: ignore # pylint: disable=invalid-overridden-method
-            self,
-            title: str,
-            message: str,
-        ) -> bool:
-            return await self._request(title, message)
+    async def evaluate_js(  # type: ignore # pylint: disable=arguments-differ,invalid-overridden-method
+        self,
+        script: str,
+    ) -> str:
+        return await self._request(script)
 
-        async def create_file_dialog(  # type: ignore # pylint: disable=invalid-overridden-method
-            self,
-            dialog_type: int = webview.FileDialog.OPEN if hasattr(webview, 'FileDialog') else webview.OPEN_DIALOG,
-            directory: str = '',
-            allow_multiple: bool = False,
-            save_filename: str = '',
-            file_types: tuple[str, ...] = (),
-        ) -> tuple[str, ...] | None:
-            return await self._request(
-                dialog_type=dialog_type,
-                directory=directory,
-                allow_multiple=allow_multiple,
-                save_filename=save_filename,
-                file_types=file_types,
-            )
+    async def create_confirmation_dialog(  # type: ignore # pylint: disable=invalid-overridden-method
+        self,
+        title: str,
+        message: str,
+    ) -> bool:
+        return await self._request(title, message)
 
-        def expose(self, function: Callable) -> None:  # type: ignore # pylint: disable=arguments-differ
-            raise NotImplementedError(f'exposing "{function}" is not supported')
+    async def create_file_dialog(  # type: ignore # pylint: disable=invalid-overridden-method
+        self,
+        dialog_type: int = webview.FileDialog.OPEN if hasattr(webview, 'FileDialog') else webview.OPEN_DIALOG,
+        directory: str = '',
+        allow_multiple: bool = False,
+        save_filename: str = '',
+        file_types: tuple[str, ...] = (),
+    ) -> tuple[str, ...] | None:
+        return await self._request(
+            dialog_type=dialog_type,
+            directory=directory,
+            allow_multiple=allow_multiple,
+            save_filename=save_filename,
+            file_types=file_types,
+        )
 
-        def _send(self, *args: Any, **kwargs: Any) -> None:
+    def expose(self, function: Callable) -> None:  # type: ignore # pylint: disable=arguments-differ
+        raise NotImplementedError(f'exposing "{function}" is not supported')
+
+    def _send(self, *args: Any, **kwargs: Any) -> None:
+        assert method_queue is not None
+        name = inspect.currentframe().f_back.f_code.co_name  # type: ignore
+        method_queue.put((name, args, kwargs))
+
+    async def _request(self, *args: Any, **kwargs: Any) -> Any:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             assert method_queue is not None
-            name = inspect.currentframe().f_back.f_code.co_name  # type: ignore
-            method_queue.put((name, args, kwargs))
+            assert response_queue is not None
+            try:
+                method_queue.put((name, args, kwargs))
+                return response_queue.get()  # wait for the method to be called and writing its result to the queue
+            except Exception:
+                log.exception(f'error in {name}')
+                return None
+        name = inspect.currentframe().f_back.f_code.co_name  # type: ignore
+        return await run.io_bound(wrapper, *args, **kwargs)
 
-        async def _request(self, *args: Any, **kwargs: Any) -> Any:
-            def wrapper(*args: Any, **kwargs: Any) -> Any:
-                assert method_queue is not None
-                assert response_queue is not None
-                try:
-                    method_queue.put((name, args, kwargs))
-                    return response_queue.get()  # wait for the method to be called and writing its result to the queue
-                except Exception:
-                    log.exception(f'error in {name}')
-                    return None
-            name = inspect.currentframe().f_back.f_code.co_name  # type: ignore
-            return await run.io_bound(wrapper, *args, **kwargs)
-
-        def signal_server_shutdown(self) -> None:
-            """Signal the server shutdown."""
-            self._send()
-
-except ModuleNotFoundError:
-    class WindowProxy:  # type: ignore
-        pass  # just a dummy if webview is not installed
+    def signal_server_shutdown(self) -> None:
+        """Signal the server shutdown."""
+        self._send()

--- a/nicegui/native/native_mode.py
+++ b/nicegui/native/native_mode.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import atexit
 import multiprocessing as mp
 import pickle
 import queue
+import shutil
 import socket
 import sys
+import tempfile
 import time
 import warnings
 from collections.abc import Callable
@@ -17,7 +20,7 @@ from typing import Any
 
 from .. import core, helpers, optional_features
 from ..logging import log
-from . import native, window_icon
+from . import chromium, native, window_icon
 from .event_manager import event_manager
 
 with suppress(ImportError):
@@ -28,6 +31,9 @@ with suppress(ImportError):
         import webview.dom
     optional_features.register('webview')
 
+if not optional_features.has('webview'):
+    from . import chromium as webview  # type: ignore[no-redef] # drives an installed browser instead
+
 
 def _open_window(
     protocol: str, host: str, port: int, title: str, width: int, height: int, fullscreen: bool, frameless: bool,
@@ -37,6 +43,7 @@ def _open_window(
     settings: dict[str, Any] | None = None,
     start_args: dict[str, Any] | None = None,
     dropped_keys: dict[str, list[str]] | None = None,
+    profile_dir: str | None = None,
 ) -> None:
     while not helpers.is_port_open(host, port):
         time.sleep(0.1)
@@ -65,6 +72,8 @@ def _open_window(
         'frameless': frameless,
         **window_args,
     }
+    if profile_dir is not None:
+        window_kwargs['profile_dir'] = profile_dir
     webview.settings.update(**settings)
     window = webview.create_window(**window_kwargs)
     assert window is not None
@@ -74,7 +83,8 @@ def _open_window(
 
     if sys.platform == 'win32' and favicon is not None:
         def on_shown() -> None:
-            window_icon.apply_icon(window.native.Handle.ToInt32(), title, str(favicon))
+            if window.native is not None:  # the fallback backend has no native handle to decorate
+                window_icon.apply_icon(window.native.Handle.ToInt32(), title, str(favicon))
             window.events.shown -= on_shown
         window.events.shown += on_shown
 
@@ -178,16 +188,41 @@ def activate(protocol: str, host: str, port: int, title: str, width: int, height
     def check_shutdown() -> None:
         while process.is_alive():
             time.sleep(0.1)
+        remove_profile_dir()
         if shutdown_event is not None:
             shutdown_event.set()
         core.stop_and_exit()
 
-    if not optional_features.has('webview'):
+    if not optional_features.has('webview') and chromium.find_browser() is None:
         log.error('Native mode is not supported in this configuration.\n'
-                  'Please run "pip install pywebview" to use it.')
+                  'Please run "pip install nicegui[native]" to use it, '
+                  'or install a Chromium-based browser (Chrome, Chromium, Edge) '
+                  'to run it on the fallback backend, '
+                  f'or set {chromium.BROWSER_ENV_VAR} to the path of a browser.')
         sys.exit(1)
 
     mp.freeze_support()
+    profile_dir = None if optional_features.has('webview') else tempfile.mkdtemp(prefix='nicegui-native-')
+
+    def remove_profile_dir() -> None:
+        nonlocal profile_dir
+        if profile_dir is None:
+            return
+        try:
+            shutil.rmtree(profile_dir)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            log.warning(f'could not remove fallback native browser profile "{profile_dir}": {e}')
+        else:
+            profile_dir = None
+
+    def remove_profile_dir_on_exit() -> None:
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
+        remove_profile_dir()
+
     native.create_queues()
     event_manager.start()
     window_args, dropped_window_args = _split_picklable(core.app.native.window_args)
@@ -196,9 +231,15 @@ def activate(protocol: str, host: str, port: int, title: str, width: int, height
     dropped_keys = {'window_args': dropped_window_args, 'settings': dropped_settings, 'start_args': dropped_start_args}
     args = (protocol, host, port, title, width, height, fullscreen, frameless,
             native.method_queue, native.response_queue, native.event_sender, favicon,
-            window_args, settings, start_args, dropped_keys)
+            window_args, settings, start_args, dropped_keys, profile_dir)
     process = native.SPAWN_CONTEXT.Process(target=_open_window, args=args, daemon=True)
-    process.start()
+    try:
+        process.start()
+    except Exception:
+        remove_profile_dir()
+        raise
+    if profile_dir is not None:
+        atexit.register(remove_profile_dir_on_exit)
 
     Thread(target=check_shutdown, daemon=True).start()
 

--- a/tests/test_native_chromium.py
+++ b/tests/test_native_chromium.py
@@ -1,0 +1,108 @@
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from nicegui.helpers import warnings
+from nicegui.native import chromium
+
+
+@pytest.fixture(autouse=True)
+def forget_shown_warnings() -> None:
+    warnings.reset()  # warn_once remembers across tests, which would hide expected messages
+
+
+# The fallback backend stands in for pywebview, so it must provide everything NiceGUI uses from
+# it. Deriving the expectation from the consuming modules keeps this honest: adding a new
+# `webview.<name>` call to native mode fails this test until the fallback provides it too.
+# That matters because a developer with pywebview installed never exercises the fallback, so a
+# missing attribute would otherwise surface only for users who do not have the extra.
+CONSUMERS = [Path(chromium.__file__).parent / name for name in ('native.py', 'native_mode.py')]
+
+# Members of pywebview's Window this backend knowingly does not provide. UNSUPPORTED_METHODS
+# warn and return; these are absent entirely. Kept explicit so that a new pywebview release
+# adding an API forces a decision here rather than silently widening the gap.
+KNOWN_ABSENT_WINDOW_MEMBERS = {'state'}
+
+
+def _webview_attributes_used_by(path: Path) -> set[str]:
+    """Names accessed as `webview.<name>` at runtime.
+
+    Import statements are skipped: `from webview.window import ...` names a submodule that only
+    the real pywebview branch ever resolves, so it is not part of the fallback's contract.
+    """
+    code = '\n'.join(line for line in path.read_text().splitlines()
+                     if not line.lstrip().startswith(('import webview', 'from webview')))
+    return set(re.findall(r'\bwebview\.([A-Za-z_][A-Za-z0-9_]*)', code))
+
+
+@pytest.mark.parametrize('path', CONSUMERS, ids=lambda p: p.name)
+def test_fallback_provides_what_native_mode_uses(path: Path) -> None:
+    used = _webview_attributes_used_by(path)
+    assert used, f'found no webview.* usage in {path.name}; has the parsing broken?'
+    missing = sorted(name for name in used if not hasattr(chromium, name))
+    assert not missing, f'{path.name} uses webview.{missing} but the fallback backend lacks it'
+
+
+@pytest.mark.skipif(importlib.util.find_spec('webview') is None, reason='pywebview is not installed')
+def test_fallback_covers_the_pywebview_window_api() -> None:
+    import webview  # pylint: disable=import-outside-toplevel
+    expected = {name for name in vars(webview.Window) if not name.startswith('_')}
+    # properties are looked up on the class so that they are not evaluated here
+    provided = {name for name in expected if hasattr(chromium.Window, name)}
+    missing = expected - provided - chromium.UNSUPPORTED_METHODS - KNOWN_ABSENT_WINDOW_MEMBERS
+    assert not missing, (f'pywebview offers Window.{sorted(missing)}, which the fallback neither '
+                         'implements nor lists as unsupported')
+
+
+@pytest.mark.parametrize('name', ['shown', 'loaded', 'closed', 'minimized',
+                                  'maximized', 'restored', 'resized', 'moved'])
+def test_window_exposes_the_events_native_mode_binds(name: str) -> None:
+    assert hasattr(chromium.Window(url='http://127.0.0.1').events, name)
+
+
+def test_dom_event_handlers_are_accepted() -> None:
+    window = chromium.Window(url='http://127.0.0.1')
+    window.dom.document.events.drop += chromium.DOMEventHandler(lambda _: None, True, False)
+
+
+@pytest.mark.parametrize('name', sorted(chromium.UNSUPPORTED_METHODS))
+def test_unsupported_methods_warn_instead_of_raising(name: str, caplog: pytest.LogCaptureFixture) -> None:
+    window = chromium.Window(url='http://127.0.0.1')
+    assert getattr(window, name)() is None
+    assert f'does not support window.{name}()' in caplog.text
+
+
+def test_unknown_attributes_still_raise() -> None:
+    window = chromium.Window(url='http://127.0.0.1')
+    with pytest.raises(AttributeError):
+        _ = window.no_such_method
+
+
+def test_ignored_window_args_are_reported(caplog: pytest.LogCaptureFixture) -> None:
+    chromium.Window(url='http://127.0.0.1', resizable=False, min_size=(300, 300))
+    assert 'does not support the window arguments' in caplog.text
+    assert 'resizable' in caplog.text and 'min_size' in caplog.text
+
+
+def test_honoured_window_args_are_not_reported(caplog: pytest.LogCaptureFixture) -> None:
+    chromium.Window(url='http://127.0.0.1', x=60, y=60)
+    assert 'does not support' not in caplog.text
+
+
+def test_browser_can_be_selected_by_environment_variable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(chromium.BROWSER_ENV_VAR, sys.executable)
+    assert chromium.find_browser() == sys.executable
+
+
+def test_browser_path_is_expanded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('NICEGUI_TEST_BROWSER_DIR', str(Path(sys.executable).parent))
+    monkeypatch.setenv(chromium.BROWSER_ENV_VAR, '$NICEGUI_TEST_BROWSER_DIR/' + Path(sys.executable).name)
+    assert chromium.find_browser() == sys.executable
+
+
+def test_missing_browser_is_reported_as_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(chromium.BROWSER_ENV_VAR, 'definitely-not-an-installed-browser')
+    assert chromium.find_browser() is None

--- a/website/documentation/content/section_configuration_deployment.py
+++ b/website/documentation/content/section_configuration_deployment.py
@@ -37,7 +37,24 @@ doc.intro(run_documentation)
     Additionally, you can change `webview.settings` via `app.native.settings`.
 
     In native mode the `app.native.main_window` object allows you to access the underlying window.
-    It is an async version of [`Window` from pywebview](https://pywebview.flowrl.com/api/#webview-window).
+    With pywebview installed it is an async version of
+    [`Window` from pywebview](https://pywebview.flowrl.com/api/#webview-window).
+
+    **Without pywebview:** `pip install nicegui[native]` installs pywebview, which embeds a platform
+    webview and therefore needs a platform GUI stack.
+    If it is not installed, native mode falls back to opening a Chromium-family browser that is
+    already on the machine as an app window, which needs no additional packages.
+    That fallback covers most of the window API but not all of it:
+    `frameless`, `transparent` and `on_top` are ignored, file and confirmation dialogs are
+    unavailable, dropped files do not report their paths, and window arguments the fallback cannot
+    act on are reported in the log rather than applied silently.
+    Install pywebview whenever any of that matters.
+    Set `NICEGUI_NATIVE_BROWSER` to a browser path or executable name to choose which browser it uses.
+
+    Note that the fallback controls the browser through the Chrome DevTools Protocol on a loopback
+    port, so any process running as the same user can evaluate JavaScript in the app's page while it
+    is open — including pages backed by `app.storage.user`.
+    Prefer pywebview if that matters for your deployment.
 
     Native mode requires a browser engine with ES module and import map support (Chrome 89+).
     On Linux, ensure you have a modern browser engine — e.g. an up-to-date WebKitGTK or Qt-based backend.
@@ -153,6 +170,8 @@ doc.text('', '''
     - `RST_CONTENT_CACHE_SIZE` (default: 1000): The maximum number of ReStructuredText content snippets that are cached in memory.
     - `NICEGUI_REDIS_URL` (default: None, means local file storage): The URL of the Redis server to use for shared persistent storage.
     - `NICEGUI_REDIS_KEY_PREFIX` (default: "nicegui:"): The prefix for Redis keys.
+    - `NICEGUI_NATIVE_BROWSER` (default: None, means auto-detect): The browser [native mode](/documentation/section_configuration_deployment#native_mode)
+        opens when pywebview is not installed, given as a path or an executable name.
 ''')
 def env_var_demo():
     from nicegui.elements import markdown


### PR DESCRIPTION
> **Draft, and genuinely no rush — please look whenever you have time.**
>
> **The only question I actually need answered is the one at the bottom: do you want a second native backend in core at all?** If the answer is no, please just say so and close this — that costs you one line and I will not be disappointed. Nothing below is worth your reading time unless the answer is yes.
>
> I am opening it as code rather than a discussion because "does it work?" is otherwise the first thing you would have to ask, and this way the answer is already in the CI tick.

### Motivation

`native=True` requires pywebview, which embeds a platform webview and so needs a platform GUI stack — pyobjc on macOS, pythonnet on Windows, WebKitGTK or QtWebEngine on Linux. That weight is why it sits behind the `native` extra (#1143), and on Linux it is where people get stuck.

Today the failure is a dead end rather than a degradation:

```python
if not optional_features.has('webview'):
    log.error('Native mode is not supported in this configuration.\n'
              'Please run "pip install pywebview" to use it.')
    sys.exit(1)
```

Meanwhile almost every desktop already has a Chromium-family browser that renders a NiceGUI page perfectly well in a chromeless window. This uses it when pywebview is absent, so native mode degrades instead of exiting.

**This does not try to replace pywebview.** `nicegui[native]` is unchanged and stays the way to get a real embedded window; the fallback is inert whenever `import webview` succeeds.

|                               | window                                                     |
| ----------------------------- | ---------------------------------------------------------- |
| `pip install nicegui`         | borrowed Chromium — works out of the box, reduced fidelity  |
| `pip install nicegui[native]` | pywebview — proper embedded native, full fidelity           |

### Implementation

`nicegui/native/chromium.py` launches an installed browser with `--app=<url> --user-data-dir=<tmp> --remote-debugging-port=0` and drives it over the Chrome DevTools Protocol: `Runtime.evaluate` for `evaluate_js`, `Browser.get/setWindowBounds` for geometry, `Page.loadEventFired` for `loaded`.

It exposes the same names `native_mode.py` and `native.py` already consume from pywebview (`create_window`, `start`, `settings`, `Window`, `FixPoint`, `FileDialog`, `dom.DOMEventHandler`) and is bound with `from . import chromium as webview` when the import fails — so neither module grows a second code path.

**No new dependencies and no new version constraints.** The DevTools channel needs a websocket client, and `websockets` already arrives with `uvicorn[standard]`. Its synchronous client landed in 11.0 while `uvicorn[standard]` requires `>=10.4`, so exactly one version is too old; that is reported at the point of use rather than pinned. `pyproject.toml` and `uv.lock` are untouched.

`native.py` is a **pure re-indentation** — `WindowProxy` moves out of the `try` block it no longer needs, since the import can no longer fail. `git diff -w` shows there is no logic change there beyond the import guard.

<details>
<summary><b>Deliberate fidelity gaps — all degrade with a warning, none raise</b></summary>

| Gap | Behaviour |
| --- | --- |
| `frameless` / `transparent` / `on_top` | warned once, ignored — an `--app` window keeps its frame |
| `create_file_dialog`, `create_confirmation_dialog`, `load_html`, `load_css`, `run_js`, `clear_cookies`, `expose` | warn and return; listed in `UNSUPPORTED_METHODS` so a genuine typo still raises `AttributeError` |
| `get_cookies` | warns, returns `[]` |
| native file drop | handlers accepted, never fire — a browser cannot hand over OS file paths |
| Windows taskbar icon | skipped (no native handle); unchanged for pywebview |
| Safari-only machines | no window; `--app` is Chromium-only. This is the design's real ceiling. |

Anything in `app.native.window_args` / `settings` / `start_args` the fallback cannot act on is reported via `helpers.warn_once` rather than silently dropped. `NICEGUI_NATIVE_BROWSER` overrides discovery.

</details>

<details>
<summary><b>Verified on all three platforms, driven through the public API</b></summary>

Each run uses `app.native.main_window`, not internals, with pywebview uninstalled.

| | macOS 26 / Chrome 151 | Linux (Debian, Chromium 151, Xvfb, non-root) | Windows 11 / Chrome |
| --- | --- | --- | --- |
| backend used | ✅ fallback | ✅ fallback | ✅ fallback |
| Vue / Quasar / socket.io | ✅ | ✅ | ✅ |
| `window_size` honoured | ✅ | ✅ | ✅ |
| `get_position()` | ✅ | ✅ | ✅ |
| runtime `resize()` | ✅ | ✅ | ✅ |
| profile dir removed | ✅ | ✅ | ✅ (despite file locks) |
| orphaned browser processes | ✅ none | — see below | ✅ none |
| unsupported dialog | ✅ warns, no raise | ✅ | ✅ |

Also verified: ES modules with an import map (the Chrome 89+ requirement `_warn_if_esm_unsupported` guards), and that `websockets` arrives with the locked runtime dependencies on a clean Linux install.

**One known gap:** interrupting with Ctrl-C on Linux intermittently leaves the temp profile and an orphaned browser. It is not the fallback's cleanup being wrong — the parent's `atexit` never runs on SIGINT there, so neither cleanup path fires. `app.shutdown()` is clean on all three platforms. This looks like the same family as #2107, and I did not want to attempt a fix for that inside this PR. Happy to take direction.

</details>

<details>
<summary><b>Tests, and the seen-to-fail check</b></summary>

`tests/test_native_chromium.py` follows `tests/test_window_icon.py`'s shape — parametrized, no browser, no `Screen` fixture, runs in 0.02 s.

It derives its expectations rather than hardcoding them: it greps `native.py` / `native_mode.py` for `webview.<name>` usage and checks the fallback provides each, and compares against `vars(webview.Window)` when pywebview is installed. That matters because a developer **with** pywebview installed never exercises the fallback, so a missing attribute is invisible — which happened twice while writing this (`webview.window.FixPoint`, then `webview.FileDialog`), each time failing *silently* into the old dummy `WindowProxy`. A hand-written list would not have caught either.

Per CONTRIBUTING.md the tests were watched failing: deliberately breaking `FileDialog`, the ignored-args warning, and the `title` property produced exactly three failures, one per defect; restored, all pass.

</details>

<details>
<summary><b>Review already done, so you are not the first reader</b></summary>

Staged on my fork first (evnchn/nicegui#290) and reviewed there before this was opened. Two independent passes found blockers that are fixed here, including one I had wrongly claimed was impossible:

- **A regression for existing pywebview users.** I had put `window.native is not None` in the *outer* guard around the Windows icon setup — but pywebview populates `.native` only after the window is created, which is exactly why the original code applied the icon inside `shown`. The guard now sits inside `on_shown`, and on pywebview 5.0.1 the old form would have raised `AttributeError` outright.
- **A hang.** `_start_window_method_executor` forwards a result only when it is not `None`, and the requesting side waits without a timeout, so `get_cookies()` returning `None` hung its caller and desynchronised the response queue for later calls. Now returns `[]`/`''` where a value is expected.
- Cleanup of the throwaway profile, which needed the browser to be *dead* first — a live browser rewrites its `--user-data-dir` as it exits, so deleting it early just makes it reappear.

</details>

### The question

**Do you want a second native backend in core at all?** It is ~700 new lines that will need maintaining alongside pywebview, and a reasonable answer is "no, the extra is fine". I would rather hear that than have you feel obliged to review the diff.

If the answer is yes, two smaller calls are yours and I have deliberately not made them:

1. **Fallback-only, or selectable?** Right now there is no way to ask for the browser when pywebview is installed. I added no public API (`app.native.backend`, an env var) because nothing needs it yet.
2. **Should the fidelity gaps warn, or raise?** They currently warn once and no-op, following the "warn, don't raise for non-critical" style — but for something like `create_file_dialog` returning nothing, an exception might serve users better.

### Progress

- [x] The PR title is a short phrase starting with a verb.
- [ ] The implementation is complete. — draft, pending the questions above
- [x] This PR does not address a security issue.
- [x] Pytests have been added.
- [x] Documentation has been added/updated. — the native-mode docs said `app.native.main_window` *is* an async pywebview `Window` and that any pywebview keyword argument can be passed; both are now scoped to "with pywebview installed", and the loopback DevTools port is noted as a security consideration.
- [x] No breaking changes to the public API.
