### PR TITLE
Fix visibility of exceptions raised from async `@ui.refreshable` body during rebuild

### DIFF
--- a/nicegui/functions/refreshable.py
+++ b/nicegui/functions/refreshable.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar, Concatenate, Generic, TypeVar, cast
 
 from typing_extensions import ParamSpec, Self
 
-from .. import background_tasks, context, helpers
+from .. import background_tasks, helpers
 from ..awaitable_response import AwaitableResponse
 from ..element import Element
 
@@ -28,7 +28,7 @@ class RefreshableTarget:
     locals: list[Any] = field(default_factory=list)
     next_index: int = 0
 
-    def run(self, func: Callable[..., _T]) -> _T:
+    def run(self, func: Callable[..., _T], *, report_exceptions: bool = False) -> _T:
         """Run the function and return the result."""
         RefreshableTarget.current_target = self
         self.next_index = 0
@@ -40,16 +40,17 @@ class RefreshableTarget:
                 result = func(self.instance, *self.args, **self.kwargs)
 
         if helpers.should_await(result):
-            return cast(_T, self._await_with_context(result))
+            if report_exceptions:
+                return cast(_T, self._await_and_report(result))
+            return cast(_T, helpers.await_with_context(result, self.container))
 
         return result
 
-    async def _await_with_context(self, awaitable: Awaitable[_T]) -> _T:
+    async def _await_and_report(self, awaitable: Awaitable[_T]) -> _T:
         try:
             return await helpers.await_with_context(awaitable, self.container)
         except Exception as e:
-            if not context.slot_stack:
-                self.container.client.handle_exception(e)
+            self.container.client.handle_exception(e)
             raise
 
 
@@ -105,7 +106,7 @@ class refreshable(Generic[_P, _T]):
         instance = self.instance
 
         def fire_and_forget() -> None:
-            if awaitables := self._execute_refresh(args, kwargs, instance=instance):
+            if awaitables := self._execute_refresh(args, kwargs, instance=instance, report_exceptions=True):
                 background_tasks.create_or_defer(asyncio.gather(*awaitables), name=f'refresh {self.func.__name__}')
 
         async def wait_for_completion() -> None:
@@ -114,7 +115,8 @@ class refreshable(Generic[_P, _T]):
 
         return AwaitableResponse(fire_and_forget, wait_for_completion)
 
-    def _execute_refresh(self, args: tuple[Any, ...], kwargs: dict[str, Any], *, instance: Any) -> list[Awaitable[Any]]:
+    def _execute_refresh(self, args: tuple[Any, ...], kwargs: dict[str, Any], *,
+                         instance: Any, report_exceptions: bool = False) -> list[Awaitable[Any]]:
         """Execute the refresh and return a list of awaitables for async functions."""
         awaitables: list[Awaitable[Any]] = []
         for target in self.targets:
@@ -124,7 +126,7 @@ class refreshable(Generic[_P, _T]):
             target.args = args or target.args
             target.kwargs.update(kwargs)
             try:
-                result = target.run(self.func)
+                result = target.run(self.func, report_exceptions=report_exceptions)
             except TypeError as e:
                 if 'got multiple values for argument' in str(e):
                     function = str(e).split()[0].split('.')[-1]

--- a/nicegui/functions/refreshable.py
+++ b/nicegui/functions/refreshable.py
@@ -50,7 +50,8 @@ class RefreshableTarget:
         try:
             return await helpers.await_with_context(awaitable, self.container)
         except Exception as e:
-            self.container.client.handle_exception(e)
+            if not self.container.is_deleted:
+                self.container.client.handle_exception(e)
             raise
 
 

--- a/nicegui/functions/refreshable.py
+++ b/nicegui/functions/refreshable.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
-from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Concatenate, Generic, TypeVar, cast
 
@@ -41,16 +40,16 @@ class RefreshableTarget:
                 result = func(self.instance, *self.args, **self.kwargs)
 
         if helpers.should_await(result):
-            return cast(_T, self._await_with_context(result, self.container))
+            return cast(_T, self._await_with_context(result))
 
         return result
 
-    async def _await_with_context(self, awaitable: Awaitable[_T], container: AbstractContextManager) -> _T:
+    async def _await_with_context(self, awaitable: Awaitable[_T]) -> _T:
         try:
-            return await helpers.await_with_context(awaitable, container)
+            return await helpers.await_with_context(awaitable, self.container)
         except Exception as e:
             if not context.slot_stack:
-                container.client.handle_exception(e)
+                self.container.client.handle_exception(e)
             raise
 
 

--- a/nicegui/functions/refreshable.py
+++ b/nicegui/functions/refreshable.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Concatenate, Generic, TypeVar, cast
 
 from typing_extensions import ParamSpec, Self
 
-from .. import background_tasks, helpers
+from .. import background_tasks, context, helpers
 from ..awaitable_response import AwaitableResponse
 from ..element import Element
 
@@ -40,9 +41,17 @@ class RefreshableTarget:
                 result = func(self.instance, *self.args, **self.kwargs)
 
         if helpers.should_await(result):
-            return cast(_T, helpers.await_with_context(result, self.container))
+            return cast(_T, self._await_with_context(result, self.container))
 
         return result
+
+    async def _await_with_context(self, awaitable: Awaitable[_T], container: AbstractContextManager) -> _T:
+        try:
+            return await helpers.await_with_context(awaitable, container)
+        except Exception as e:
+            if not context.slot_stack:
+                container.client.handle_exception(e)
+            raise
 
 
 class RefreshableContainer(Element, component='refreshable.js'):

--- a/tests/test_refreshable.py
+++ b/tests/test_refreshable.py
@@ -310,7 +310,8 @@ def test_awaitable_refresh(screen: Screen):
     assert events == ['update started', 'refresh started', 'refresh failed', 'update finished']
 
 
-async def test_report_exception_async(user: User, caplog: pytest.LogCaptureFixture):
+@pytest.mark.parametrize('awaited', [False, True])
+async def test_report_exception_async(user: User, caplog: pytest.LogCaptureFixture, awaited: bool):
     seen: list[Exception] = []
 
     @ui.page('/')
@@ -323,8 +324,11 @@ async def test_report_exception_async(user: User, caplog: pytest.LogCaptureFixtu
             if explode:
                 raise RuntimeError('boom')
 
+        async def refresh_awaited():
+            await part.refresh(True)
+
         await part()
-        ui.button('fire', on_click=lambda: part.refresh(True))
+        ui.button('fire', on_click=refresh_awaited if awaited else lambda: part.refresh(True))
 
     await user.open('/')
     user.find('fire').click()

--- a/tests/test_refreshable.py
+++ b/tests/test_refreshable.py
@@ -1,7 +1,9 @@
 import asyncio
 
+import pytest
+
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import Screen, User
 
 
 def test_refreshable(screen: Screen) -> None:
@@ -306,3 +308,26 @@ def test_awaitable_refresh(screen: Screen):
     screen.click('Try 0')
     screen.should_contain('error handled')
     assert events == ['update started', 'refresh started', 'refresh failed', 'update finished']
+
+
+async def test_report_exception_async(user: User, caplog: pytest.LogCaptureFixture):
+    seen: list[Exception] = []
+
+    @ui.page('/')
+    async def page():
+        ui.on_exception(seen.append)
+
+        @ui.refreshable
+        async def part(explode: bool = False):
+            await asyncio.sleep(0)
+            if explode:
+                raise RuntimeError('boom')
+
+        await part()
+        ui.button('fire', on_click=lambda: part.refresh(True))
+
+    await user.open('/')
+    user.find('fire').click()
+    await asyncio.sleep(0.1)
+    caplog.records.clear()
+    assert len(seen) == 1, f'ui.on_exception saw {len(seen)}, expected 1'


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->

<!-- Please provide relevant links to corresponding issues and feature requests. -->

Fixed #6262

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->

<!-- Include any important technical decisions or trade-offs made. -->

This issue is similar to #6234 except for the async part.
The fix is similar to #6258 except for where the `try/except` is placed.
`try/except` cannot be placed in `RefreshableTarget.run` as it doesn't _execute_ the async body.
```python
if helpers.should_await(result):
    return cast(_T, helpers.await_with_context(result, self.container))
```
I didn't want to add `try/except` to a helper function either.
Even though it would actually work, it will most definitely cause more issues later on.

My solution is to add an async method to `RefreshableTarget`,
where the functionality of `helpers.await_with_context` is covered by a `try/except` similar to #6258.
This way, the `try/except` block becomes part of the returned awaitable.

I tested using the 2 test cases provided in #6262.
I have added the test case for this issue in another commit to `tests/test_refreshable.py` under a similar descriptive name.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary. <!--Remove the option that does not apply.-->
- [x] Documentation has been added/updated or is not necessary. <!--Remove the option that does not apply.-->
- [x] No breaking changes to the public API or migration steps are described above. <!--Remove the option that does not apply.-->
