### PR TITLE
Add instruction for how to install ChromeDriver on arch-based linux distribution

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -31,12 +31,20 @@ If you haven't, you can follow the instructions on https://chocolatey.org/instal
 
 ### Linux
 
+For Debian-based Linux distribution:
+
 ```bash
 sudo apt-get update
 sudo apt-get install chromium-chromedriver
 ```
 
-Note: The above instructions assume that you are using a Debian-based Linux distribution.
+For Arch-based Linux distribution:
+
+```bash
+sudo pacman -S chromium
+```
+
+Note:
 If you are using a different distribution, the package manager and package names may differ.
 Please refer to the documentation for your distribution for more information.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,6 @@ For Arch-based Linux distribution:
 sudo pacman -S chromium
 ```
 
-Note:
 If you are using a different distribution, the package manager and package names may differ.
 Please refer to the documentation for your distribution for more information.
 


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->

<!-- Please provide relevant links to corresponding issues and feature requests. -->

The current `tests/README.md` doesn't mention arch-based linux distribution in "Setup" section:

> ### Linux
> 
> ```bash
> sudo apt-get update
> sudo apt-get install chromium-chromedriver
> ```
> 
> Note: The above instructions assume that you are using a Debian-based Linux distribution.
> If you are using a different distribution, the package manager and package names may differ.
> Please refer to the documentation for your distribution for more information.

This became an issue for me when I needed to run the tests. Because:
1. The first result that appears when I search for "chromedriver archwiki" is `chromedriver` from the AUR.
2. The correct package to install has a different name `chromium` (installed via `sudo pacman -S chromium`).

To ensure that this doesn't bother any other arch linux user, I made this PR.

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->

<!-- Include any important technical decisions or trade-offs made. -->

1. Added instructions for installing `chromium` on arch-based linux distributions along side debian-based linux systems.
2. Still refer the reader to their system's documentation if it's not one of the two.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary. <!--Remove the option that does not apply.-->
- [x] Documentation has been added/updated or is not necessary. <!--Remove the option that does not apply.-->
- [x] No breaking changes to the public API or migration steps are described above. <!--Remove the option that does not apply.-->
