### PR TITLE
Document which random IDs are secrets and which are not

### DIFF
--- a/website/documentation/content/section_security.py
+++ b/website/documentation/content/section_security.py
@@ -201,6 +201,23 @@ doc.text('Client-Side Secrets', '''
     - **Do not expose `client_id`** in logs, URLs, or API responses visible to other users.
     - **Treat `client_id` like a session token**: anyone who knows it can send events on behalf of that client.
     - **Secure pages, not `/_nicegui/`**: protect where the credential is issued, not where it is consumed.
+
+    **Not every random ID is a secret.**
+
+    NiceGUI mints a random UUID for several different jobs, and they do not all carry the same authority:
+
+    - **Public by design**: event listener, Leaflet layer and scene object IDs travel to the browser in plain sight.
+      They only need to be unique, and knowing one grants nothing.
+    - **A bearer capability**: the `client_id` above,
+      and the tab ID that keys `app.storage.tab` (minted by the browser and sent with the connection, not issued by the server).
+      Anyone who knows one can act as that client or read and write that tab's storage,
+      so both need the protections listed above.
+    - **A storage key**: the `app.storage.user` ID lives in a session cookie signed with your `storage_secret`.
+      The signature is the access boundary there, not the ID,
+      so guessing the ID alone does not unlock another user's storage.
+
+    Only the second class needs protecting as a secret.
+    Randomness is not what fails in practice — leakage is, which is what the practices above guard against.
 ''')
 
 


### PR DESCRIPTION
*Drafted by Claude Code on @evnchn's behalf.*

### Motivation

The docs half of #6239, as requested [there](https://github.com/zauberzeug/nicegui/pull/6239#issuecomment-5208501482).
That PR's new **"Guessing a `uuid4` identifier"** bullet links to the Security Best Practices page for *"describes which is which"* — this adds the taxonomy that link promises.

The split is the one agreed in the thread: `SECURITY.md` answers *"should I file this?"*, the documentation answers *"how do I build this safely?"*.

### Implementation

One paragraph appended to the **Client-Side Secrets** section, sorting the random UUIDs NiceGUI mints into three classes — public-by-design, bearer capability, and storage key — and naming what actually protects each.

Two notes on scope, both easy to revert if you disagree:

- **The tab ID is included** as a second bearer capability. It is not in #6239's bullet, but it is the only other ID an application author can reach (`app.storage.tab`), and it is the one case where the ID is minted by the *browser* rather than the server — so a reader working through "which is which" would otherwise be left guessing. Verified against the source below.
- **`element.id` is deliberately left out.** It is an integer counter, not a UUID, so it falls outside the paragraph's stated scope ("a random UUID for several different jobs") and outside #6239's bullet. Happy to widen the framing if you'd rather it be named.

Documentation-only, no code or behaviour change, so no pytests.

<details>
<summary><b>Every claim in the new prose, checked against the source</b></summary>

Reviewed by Codex (fresh lineage, read-only over this checkout) with the instruction to refute each claim from the source rather than from the prose. Verdict: **8/10, no MUST-FIX**, one wording fix which is applied. Line references are `main` at 257e3405.

| Claim in the new prose | Verified at | Holds? |
|---|---|---|
| Event listener IDs are `uuid4`, travel to the browser | `nicegui/event_listener.py:23`, sent in event args | ✅ |
| Leaflet layer IDs are `uuid4`, sent to the browser | `nicegui/elements/leaflet/leaflet_layer.py:21` | ✅ |
| Scene object IDs are `uuid4`, sent to the browser | `nicegui/elements/scene/scene_object3d.py:20` | ✅ |
| Knowing a public ID grants nothing *on its own* | dispatch selects `client_id` first (`nicegui/nicegui.py:235`), then element, then listener | ✅ — the authority is the `client_id`, never the listener UUID |
| Tab ID is minted by the **browser** | `nicegui/static/nicegui.js:386` — `createRandomUUID()` into `sessionStorage` | ✅ |
| …and sent with the connection | `nicegui/static/nicegui.js:415` — `options.query.tab_id = TAB_ID` | ✅ |
| …and knowing one grants read/write of that tab's storage | server takes `data['tab_id']` verbatim (`nicegui/nicegui.py:210`); `_create_tab_storage` reuses an existing entry (`nicegui/storage.py:181-190`); `app.storage.tab` indexes by it (`nicegui/storage.py:171-179`) | ✅ — and `copy_tab` likewise trusts `old_tab_id` (`nicegui/nicegui.py:208`, `nicegui/storage.py:192`) |
| `app.storage.user` ID lives in a **signed** cookie | `SessionMiddleware, secret_key=storage_secret` (`nicegui/storage.py:76`); minted at `nicegui/storage.py:36` | ✅ |
| …so the ID alone does not unlock another user's storage | user storage resolves only from `request.session['id']`; no path accepts a bare UUID from the client | ✅ |

**The one change Codex asked for.** The draft said the tab ID is *"sent with the Socket.IO handshake"*. On a normal implicit handshake it rides the connection **query**, not the explicit `handshake` event — true but underspecified. Reworded to *"sent with the connection, not issued by the server"*, which is both accurate and closer to the point the sentence is making.

**Correcting myself from the thread.** My original comment on #6239 called this *"the UUID anti-collision assumption"*, singular. It is not one assumption — lumping the `app.storage.user` ID in with `client_id` overstates it, since an attacker who guesses that ID still cannot present a validly signed cookie. That is why the paragraph splits the storage key out as its own class rather than folding it in with the bearer capability.

</details>

<details>
<summary><b>Gates and rendering check</b></summary>

```
pre-commit run --files website/documentation/content/section_security.py
  ruff check ........................ Passed
  autopep8 .......................... Passed
  trim trailing whitespace .......... Passed
  fix end of files .................. Passed
  fix double quoted strings ......... Passed
  codespell ......................... Passed
```

`pylint` on the file scores 8.68/10, unchanged from `main` — the four findings are pre-existing (`missing-function-docstring` / `import-outside-toplevel` in the existing demo functions at lines 100, 101, 137, 138). No code was added, only string content.

Rendering verified by serving the site locally and reading the generated HTML for `/documentation/section_security`, rather than assuming the Markdown parses:

```html
<p><strong>Not every random ID is a secret.</strong></p>
<p>NiceGUI mints a random UUID for several different jobs, and they do not all carry the same authority:</p>
<ul>
<li><strong>Public by design</strong>: event listener, Leaflet layer and scene object IDs travel to the browser in plain sight.
They only need to be unique, and knowing one grants nothing.</li>
<li><strong>A bearer capability</strong>: the <code>client_id</code> above, ...
```

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue. (Documentation only — it explains an existing model, no code or behaviour change.)
- [x] Pytests are not necessary (documentation-only change).
- [x] Documentation has been added/updated.
- [x] No breaking changes to the public API.
