### PR TITLE
Report exceptions from async event and validation handler to `ui.on_exception`

### DIFF
--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -3,7 +3,7 @@ from typing import Any, TypeAlias, cast
 
 from typing_extensions import Self
 
-from ... import background_tasks, helpers
+from ... import background_tasks, context, helpers
 from ...events import ValueT
 from .value_element import ValueElement
 
@@ -70,7 +70,12 @@ class ValidationElement(ValueElement[ValueT]):
             result = self._validation(self.value)
             if helpers.should_await(result):
                 async def await_error():
-                    self.error = await result
+                    try:
+                        self.error = await result
+                    except Exception as e:
+                        if not context.slot_stack:  #6233
+                            self.client.handle_exception(e)
+                        raise
                 background_tasks.create(await_error(), name=f'validate {self.id}')
                 return True
             self.error = cast(str | None, result)

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -4,7 +4,6 @@ from typing import Any, TypeAlias, cast
 from typing_extensions import Self
 
 from ... import background_tasks, helpers
-from ...context import context
 from ...events import ValueT
 from .value_element import ValueElement
 

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -74,7 +74,7 @@ class ValidationElement(ValueElement[ValueT]):
                     try:
                         self.error = await result
                     except Exception as e:
-                        if not context.slot_stack:  # 6233
+                        if not self.is_deleted:
                             self.client.handle_exception(e)
                         raise
                 background_tasks.create(await_error(), name=f'validate {self.id}')

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -74,7 +74,7 @@ class ValidationElement(ValueElement[ValueT]):
                     try:
                         self.error = await result
                     except Exception as e:
-                        if not context.slot_stack:  #6233
+                        if not context.slot_stack:  # 6233
                             self.client.handle_exception(e)
                         raise
                 background_tasks.create(await_error(), name=f'validate {self.id}')

--- a/nicegui/elements/mixins/validation_element.py
+++ b/nicegui/elements/mixins/validation_element.py
@@ -3,7 +3,8 @@ from typing import Any, TypeAlias, cast
 
 from typing_extensions import Self
 
-from ... import background_tasks, context, helpers
+from ... import background_tasks, helpers
+from ...context import context
 from ...events import ValueT
 from .value_element import ValueElement
 

--- a/nicegui/event.py
+++ b/nicegui/event.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import weakref
 from collections.abc import Awaitable, Callable
-from contextlib import nullcontext
+from contextlib import nullcontext, suppress
 from dataclasses import dataclass
 from typing import Any, ClassVar, Generic
 from weakref import WeakSet
@@ -32,16 +32,19 @@ class Callback(Generic[P]):
         with (self.slot and self.slot()) or nullcontext():
             return self.func(*args, **kwargs) if self.expect_args else self.func()  # type: ignore[call-arg]
 
-    async def await_and_handle_result(self, result: Awaitable) -> Any:
-        """Await the result of the callback reporting exceptions if necessary."""
-        empty_stack = not context.slot_stack  # 6233
+    async def await_and_handle_result(self, result: Awaitable, *, report_exceptions: bool = False) -> Any:
+        """Await the result of the callback, reporting exceptions if nobody downstream will."""
         with (self.slot and self.slot()) or nullcontext():
-            if not empty_stack:
+            if not report_exceptions:
                 return await result
             try:
                 return await result
             except Exception as e:
-                core.app.handle_exception(e)
+                client = None
+                with suppress(RuntimeError):  # the client may already be deleted
+                    client = context.client if context.slot_stack else None
+                if client is not None:
+                    client.handle_exception(e)
                 raise
 
 
@@ -145,7 +148,7 @@ def _invoke_and_forget(callback: Callback[P], *args: P.args, **kwargs: P.kwargs)
     try:
         result = callback.run(*args, **kwargs)
         if helpers.should_await(result):
-            background_tasks.create_or_defer(callback.await_and_handle_result(result),
+            background_tasks.create_or_defer(callback.await_and_handle_result(result, report_exceptions=True),
                                              name=f'{callback.filepath}:{callback.line}')
     except Exception as e:
         core.app.handle_exception(e)

--- a/nicegui/event.py
+++ b/nicegui/event.py
@@ -32,10 +32,17 @@ class Callback(Generic[P]):
         with (self.slot and self.slot()) or nullcontext():
             return self.func(*args, **kwargs) if self.expect_args else self.func()  # type: ignore[call-arg]
 
-    async def await_result(self, result: Awaitable) -> Any:
-        """Await the result of the callback."""
+    async def await_and_handle_result(self, result: Awaitable) -> Any:
+        """Await the result of the callback reporting exceptions if necessary."""
+        empty_stack = not context.slot_stack  #6233
         with (self.slot and self.slot()) or nullcontext():
-            return await result
+            if not empty_stack:
+                return await result
+            try:
+                return await result
+            except Exception as e:
+                core.app.handle_exception(e)
+                raise
 
 
 class Event(Generic[P]):
@@ -138,7 +145,7 @@ def _invoke_and_forget(callback: Callback[P], *args: P.args, **kwargs: P.kwargs)
     try:
         result = callback.run(*args, **kwargs)
         if helpers.should_await(result):
-            background_tasks.create_or_defer(callback.await_result(result), name=f'{callback.filepath}:{callback.line}')
+            background_tasks.create_or_defer(callback.await_and_handle_result(result), name=f'{callback.filepath}:{callback.line}')
     except Exception as e:
         core.app.handle_exception(e)
 
@@ -146,7 +153,7 @@ def _invoke_and_forget(callback: Callback[P], *args: P.args, **kwargs: P.kwargs)
 async def _invoke_and_await(callback: Callback[P], *args: P.args, **kwargs: P.kwargs) -> Any:
     result = callback.run(*args, **kwargs)
     if helpers.should_await(result):
-        result = await callback.await_result(result)
+        result = await callback.await_and_handle_result(result)
     return result
 
 

--- a/nicegui/event.py
+++ b/nicegui/event.py
@@ -34,7 +34,7 @@ class Callback(Generic[P]):
 
     async def await_and_handle_result(self, result: Awaitable) -> Any:
         """Await the result of the callback reporting exceptions if necessary."""
-        empty_stack = not context.slot_stack  #6233
+        empty_stack = not context.slot_stack  # 6233
         with (self.slot and self.slot()) or nullcontext():
             if not empty_stack:
                 return await result
@@ -145,7 +145,8 @@ def _invoke_and_forget(callback: Callback[P], *args: P.args, **kwargs: P.kwargs)
     try:
         result = callback.run(*args, **kwargs)
         if helpers.should_await(result):
-            background_tasks.create_or_defer(callback.await_and_handle_result(result), name=f'{callback.filepath}:{callback.line}')
+            background_tasks.create_or_defer(callback.await_and_handle_result(result),
+                                             name=f'{callback.filepath}:{callback.line}')
     except Exception as e:
         core.app.handle_exception(e)
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -204,3 +204,24 @@ async def test_ui_on_exception(user: User, caplog: pytest.LogCaptureFixture):
     await asyncio.sleep(0.1)
     assert len(exceptions) == 2 and 'sync error' in str(exceptions[0]) and 'async error' in str(exceptions[1])
     caplog.records.clear()
+
+
+async def test_ui_on_exception_from_async_subscriber(user: User, caplog: pytest.LogCaptureFixture):
+    seen: list[Exception] = []
+
+    @ui.page('/')
+    def page():
+        event: Event[[]] = Event()
+
+        async def subscriber():
+            raise RuntimeError('boom')
+
+        event.subscribe(subscriber)
+        ui.on_exception(seen.append)
+        ui.button('fire', on_click=lambda: event.emit())
+
+    await user.open('/')
+    user.find('fire').click()
+    await asyncio.sleep(0.1)
+    caplog.records.clear()
+    assert len(seen) == 1, f'ui.on_exception saw {len(seen)}, expected 1'

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -225,3 +225,36 @@ async def test_ui_on_exception_from_async_subscriber(user: User, caplog: pytest.
     await asyncio.sleep(0.1)
     caplog.records.clear()
     assert len(seen) == 1, f'ui.on_exception saw {len(seen)}, expected 1'
+
+
+@pytest.mark.parametrize('caught', [False, True])
+async def test_awaited_event_call_reports_once(user: User, caplog: pytest.LogCaptureFixture, caught: bool):
+    seen: list[Exception] = []
+
+    @ui.page('/')
+    def page():
+        event: Event[[]] = Event()
+
+        async def subscriber():
+            raise RuntimeError('boom')
+
+        event.subscribe(subscriber)
+        ui.on_exception(seen.append)
+
+        async def fire():
+            if not caught:
+                await event.call()
+                return
+            try:
+                await event.call()
+            except RuntimeError:
+                pass
+
+        ui.button('fire', on_click=fire)
+
+    await user.open('/')
+    user.find('fire').click()
+    await asyncio.sleep(0.1)
+    caplog.records.clear()
+    expected = 0 if caught else 1
+    assert len(seen) == expected, f'ui.on_exception saw {len(seen)}, expected {expected}'

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
 from nicegui import ui
-from nicegui.testing import Screen
+from nicegui.testing import Screen, User
 
 
 def test_input(screen: Screen):
@@ -127,6 +127,25 @@ def test_validation_with_lagging_value_change_events(screen: Screen):
     element.send_keys('45678')  # keep typing after the error message arrived
     screen.should_contain('Still 2 characters missing')
     assert element.get_attribute('value') == '12345678'
+
+
+async def test_ui_on_exception_from_async_validation(user: User, caplog: pytest.LogCaptureFixture):
+    seen: list[Exception] = []
+
+    async def check(value):
+        raise RuntimeError('boom')
+
+    @ui.page('/')
+    def page():
+        ui.on_exception(seen.append)
+        field = ui.input('field', validation=check)
+        ui.button('validate', on_click=lambda: field.validate(return_result=False))
+
+    await user.open('/')
+    user.find('validate').click()
+    await asyncio.sleep(0.1)
+    caplog.records.clear()
+    assert len(seen) == 1, f'ui.on_exception saw {len(seen)}, expected 1'
 
 
 def test_input_with_multi_word_error_message(screen: Screen):


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->

<!-- Please provide relevant links to corresponding issues and feature requests. -->

Fixes #6233

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->

<!-- Include any important technical decisions or trade-offs made. -->

The fix is just an echo of #5946, #6258, #6265.
It is a `try/except` that wraps whatever code was already there.
It is indeed messy, and it fixes the described issue.

I tested using the 4 test cases provided in #6233.
Pytests were added:
1. `test_ui_on_exception_from_async_subscriber` in `tests/test_event.py`
2. `test_ui_on_exception_from_async_validation` in `tests/test_input.py`

Ready for review!

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary. <!--Remove the option that does not apply.-->
- [x] Documentation has been added/updated or is not necessary. <!--Remove the option that does not apply.-->
- [x] No breaking changes to the public API or migration steps are described above. <!--Remove the option that does not apply.-->
