### PR TITLE
Fix ChromeDriver install instructions for Linux in tests/README.md

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -8,8 +8,12 @@ Even if automated testing needs a lot of infrastructure and results in long exec
 
 ## Setup
 
-Please be aware that the below commands install the latest version of the ChromeDriver binary, which is compatible with the version of Google Chrome installed on your system.
-If you have a different version of Chrome installed, you may need to install a different version of ChromeDriver or update your Chrome installation to be compatible with the installed ChromeDriver version.
+Usually you don't need to install ChromeDriver at all.
+The `selenium` test dependency comes with a helper called Selenium Manager that downloads a matching Chrome and ChromeDriver for you the first time the tests run.
+Our tests use this helper first, so on a normal x86_64 (Intel/AMD) machine, installing the test dependencies is enough.
+
+You only need to install a browser and driver by hand in two cases: on ARM machines (like a Raspberry Pi or an ARM dev container), where the helper has nothing to download, or when you'd rather use a browser that your system installed.
+If you do install ChromeDriver yourself, make sure its version matches your Chrome or Chromium — otherwise the tests won't start.
 
 ### Mac
 
@@ -31,12 +35,15 @@ If you haven't, you can follow the instructions on https://chocolatey.org/instal
 
 ### Linux
 
-For Debian-based Linux distribution:
+For Debian:
 
 ```bash
 sudo apt-get update
-sudo apt-get install chromium-chromedriver
+sudo apt-get install chromium-driver
 ```
+
+On Ubuntu, both `chromium-chromedriver` and `chromium-driver` resolve to the same transitional stub that pulls in the Chromium snap, which is a dead end in containers, WSL, and minimal CI images.
+Prefer Selenium Manager (see above), or install a matching ChromeDriver manually.
 
 For Arch-based Linux distribution:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,12 +31,20 @@ If you haven't, you can follow the instructions on https://chocolatey.org/instal
 
 ### Linux
 
+For Debian-based Linux distribution:
+
 ```bash
 sudo apt-get update
 sudo apt-get install chromium-chromedriver
 ```
 
-Note: The above instructions assume that you are using a Debian-based Linux distribution.
+For Arch-based Linux distribution:
+
+```bash
+sudo pacman -S chromium
+```
+
+Note:
 If you are using a different distribution, the package manager and package names may differ.
 Please refer to the documentation for your distribution for more information.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,6 @@ For Arch-based Linux distribution:
 sudo pacman -S chromium
 ```
 
-Note:
 If you are using a different distribution, the package manager and package names may differ.
 Please refer to the documentation for your distribution for more information.
 


### PR DESCRIPTION
*Filed by Claude Code on SaadZahem's behalf.*

### Motivation

Fixes #6267

The `tests/README.md` setup instructions told Linux contributors to run `sudo apt-get install chromium-chromedriver`. Verified in clean containers, that command is wrong on both distro families the note claimed to cover:

- **Debian 12** — no such package (`E: Unable to locate package chromium-chromedriver`); the correct name is `chromium-driver`.
- **Ubuntu 24.04** — both `chromium-chromedriver` and `chromium-driver` resolve to the same transitional stub that pulls in the Chromium snap, which is a dead end in containers, WSL, and minimal CI images.

The preamble also framed a manual ChromeDriver install as a required setup step. In practice it usually isn't: since Selenium 4.6 the `selenium` dependency bundles Selenium Manager, which auto-downloads a matched Chrome + ChromeDriver on x86_64, and our fixture (`nicegui/testing/screen_plugin.py`) already tries that path first.

### Implementation

- Rewrote the `## Setup` preamble in plain language to explain that Selenium Manager handles the download automatically on x86_64, and that a manual install is only needed on ARM (where Chrome for Testing publishes no builds) or when using a system-installed browser.
- Fixed the Debian package name to `chromium-driver` and relabeled the block "Debian" instead of "Debian-based".
- Added a note that Ubuntu's apt packages are snap transitions, pointing users to Selenium Manager or a manual ChromeDriver.
- Kept the Arch instructions and the "refer to your distribution's documentation" catch-all unchanged.

This is a documentation-only change, so no tests are added.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests are not necessary, as this is a documentation-only change.
- [x] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)