### PR TITLE
Fix `ui.scene` trackball rotation misaligned after a window resize

### DIFF
--- a/nicegui/elements/scene/scene.js
+++ b/nicegui/elements/scene/scene.js
@@ -445,6 +445,7 @@ export default {
         this.camera.right = (this.camera.aspect * this.cameraParams.size) / 2;
       }
       this.camera.updateProjectionMatrix();
+      this.controls?.handleResize?.();
     },
   },
 

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -329,6 +329,38 @@ def test_custom_controls(screen: Screen, control_type: Literal['map', 'trackball
     assert screen.selenium.execute_script(f'return getElement({scene.id}).controls.constructor.name') == constructor
 
 
+def test_trackball_controls_follow_window_resize(screen: Screen):
+    scene = None
+
+    @ui.page('/')
+    def page():
+        nonlocal scene
+        scene = ui.scene(control_type='trackball').classes('w-full h-64')
+
+    screen.open('/')
+    screen.wait_for(lambda: scene is not None)
+
+    def rects():
+        return screen.selenium.execute_script(f'''
+            const el = getElement({scene.id});
+            const r = el.renderer.domElement.getBoundingClientRect();
+            return {{cached: [el.controls.screen.width, el.controls.screen.height],
+                     actual: [r.width, r.height]}};
+        ''')
+
+    original_size = screen.selenium.get_window_size()
+    try:
+        before = rects()
+        assert before['cached'] == before['actual']  # fresh controls agree
+
+        screen.selenium.set_window_size(700, 620)
+        screen.wait(1.0)
+        after = rects()
+        assert after['cached'] == after['actual']  # cached rect follows the resize (was stale before the fix)
+    finally:
+        screen.selenium.set_window_size(original_size['width'], original_size['height'])
+
+
 async def test_dragend_after_object_deleted(user: User):
     events: list[str] = []
     scene = None


### PR DESCRIPTION
*Filed by Claude Code on SaadZahem's behalf.*

### Motivation

Fixes #6247

`ui.scene(control_type='trackball')` rotates incorrectly after the browser window is resized.
`TrackballControls` caches the canvas rectangle in `this.screen` and refreshes it **only in its constructor** (via `handleResize()`).
Nothing else ever calls it: three.js registers no resize listener of its own, and NiceGUI's `scene.js` → `resize()` updates the renderers and the camera projection but not the controls.
Because `getMouseOnScreen()` / `getMouseOnCircle()` normalize pointer coordinates against that cached rectangle, after a resize the scene rotates by the wrong amount around an off-centre pivot until the page is reloaded.

`control_type='orbit'` and `'map'` are unaffected — OrbitControls works from element-relative pointer deltas and caches no rectangle.

This is currently masked by `move_camera()` disposing and recreating the controls on every call, which re-runs the constructor and therefore `handleResize()`, so an app that moves the camera after a resize accidentally repairs itself.
That masking is independent of this fix and is removed by #6242, so it is worth fixing on its own regardless.

### Implementation

`resize()` now refreshes the controls' cached rectangle after resizing the renderers and camera:

```js
this.controls?.handleResize?.();
```

The optional chaining keeps it safe and targeted: it is a no-op for OrbitControls / MapControls (which define no `handleResize`), and it tolerates an early `resize` that fires before the controls exist.
No imports or build steps change — `scene.js` is served directly.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added: `test_trackball_controls_follow_window_resize` asserts the cached rect still matches the canvas after a window resize (it fails without this change).
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.