### PR TITLE
Limit the number of tab storages a single client can create

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -138,7 +138,8 @@ class Air:
         @relay.on('handshake')
         def _handle_handshake(data: dict[str, Any]) -> bool:
             if client := Client.instances.get(data['client_id']):
-                if not client.accept_handshake(data['sid'], data['tab_id'], data['environ']):
+                # the relay's environ crosses as JSON and may lack the connecting query, so a missing client_id is tolerated
+                if not client.accept_handshake(data['sid'], data['tab_id'], data['environ'], require_client_id=False):
                     return False
                 client.environ = data['environ']
                 if data.get('old_tab_id'):

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -138,7 +138,7 @@ class Air:
         @relay.on('handshake')
         def _handle_handshake(data: dict[str, Any]) -> bool:
             if client := Client.instances.get(data['client_id']):
-                if not client.register_tab_id(data['tab_id']):
+                if not client.accept_handshake(data['sid'], data['tab_id'], data['environ']):
                     return False
                 client.environ = data['environ']
                 if data.get('old_tab_id'):

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -138,8 +138,7 @@ class Air:
         @relay.on('handshake')
         def _handle_handshake(data: dict[str, Any]) -> bool:
             if client := Client.instances.get(data['client_id']):
-                # the relay's environ crosses as JSON and may lack the connecting query, so a missing client_id is tolerated
-                if not client.accept_handshake(data['sid'], data['tab_id'], data['environ'], require_client_id=False):
+                if not client.accept_handshake(data['sid'], data['tab_id'], data['environ']):
                     return False
                 client.environ = data['environ']
                 if data.get('old_tab_id'):

--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -138,6 +138,8 @@ class Air:
         @relay.on('handshake')
         def _handle_handshake(data: dict[str, Any]) -> bool:
             if client := Client.instances.get(data['client_id']):
+                if not client.register_tab_id(data['tab_id']):
+                    return False
                 client.environ = data['environ']
                 if data.get('old_tab_id'):
                     core.app.storage.copy_tab(data['old_tab_id'], data['tab_id'])

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -74,9 +74,6 @@ class Client:
     instances: ClassVar[dict[str, Client]] = {}
     '''Maps client IDs to clients.'''
 
-    MAX_TAB_STORAGES_PER_CLIENT: ClassVar[int] = 128
-    '''Maximum number of tab storages a single client may create (a browser presents only one tab ID per client).'''
-
     shared_head_html = ''
     '''HTML to be inserted in the <head> of every page template.'''
 
@@ -354,8 +351,8 @@ class Client:
         self._exception_handlers.append(handler)
 
     def register_tab_id(self, tab_id: str) -> bool:
-        """Remember a tab ID, unless `MAX_TAB_STORAGES_PER_CLIENT` is already exhausted. (For internal use only.)"""
-        if tab_id not in self._tab_ids and len(self._tab_ids) >= self.MAX_TAB_STORAGES_PER_CLIENT:
+        """Remember a tab ID, unless ``max_tab_storages_per_client`` is already exhausted. (For internal use only.)"""
+        if tab_id not in self._tab_ids and len(self._tab_ids) >= core.app.storage.max_tab_storages_per_client:
             return False
         self._tab_ids.add(tab_id)
         return True
@@ -395,6 +392,8 @@ class Client:
             if self._num_connections[document_id] == 0:
                 self._num_connections.pop(document_id)
                 self._delete_tasks.pop(document_id)
+                active_elsewhere = {client.tab_id for client in Client.instances.values() if client is not self}
+                await core.app.storage.prune_empty_tabs(self._tab_ids - active_elsewhere)
                 await core.app.storage.close_tab(tab_id_to_close)
                 self.delete()
         self._delete_tasks[document_id] = \

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast
-from urllib.parse import quote
+from urllib.parse import parse_qs, quote
 
 from fastapi import Request
 from fastapi.responses import Response
@@ -61,6 +61,14 @@ HTML_ESCAPE_TABLE = str.maketrans({
 HEADWIND_CONTENT = (Path(__file__).parent / 'static' / 'headwind.css').read_text().strip()
 
 
+def _client_id_from_query(environ: dict[str, Any]) -> str | None:
+    """Read the ``client_id`` a socket connected with, or ``None`` if its environment does not carry one."""
+    query_string = environ.get('QUERY_STRING') or environ.get('asgi.scope', {}).get('query_string') or ''
+    if isinstance(query_string, (bytes, bytearray)):
+        query_string = query_string.decode()
+    return parse_qs(query_string).get('client_id', [None])[0]
+
+
 class ClientConnectionTimeout(TimeoutError):
     def __init__(self, client: Client) -> None:
         super().__init__(f'ClientConnectionTimeout: {client.id}')
@@ -99,7 +107,7 @@ class Client:
         self._deleted = False
         self._socket_to_document_id: dict[str, str] = {}
         self.tab_id: str | None = None
-        self._tab_ids: set[str] = set()
+        self._pinned_tab_id: str | None = None
         self._exception_handlers: list[Callable[[Exception], Any] | Callable[[], Any]] = []
 
         self.page = page
@@ -350,12 +358,19 @@ class Client:
         """
         self._exception_handlers.append(handler)
 
-    def register_tab_id(self, tab_id: str) -> bool:
-        """Remember a tab ID, unless ``max_tab_storages_per_client`` is already exhausted. (For internal use only.)"""
-        if tab_id not in self._tab_ids and len(self._tab_ids) >= core.app.storage.max_tab_storages_per_client:
+    def accept_handshake(self, socket_id: str, tab_id: str, environ: dict[str, Any] | None) -> bool:
+        """Check whether a handshake may proceed, pinning the client's tab ID on the first one.
+
+        A browser opens one socket per client, handshakes it once, and keeps the same tab ID for the client's whole
+        lifetime, so a handshake that breaks any of these is a replayed frame. (For internal use only.)
+        """
+        if socket_id in self._socket_to_document_id:
             return False
-        self._tab_ids.add(tab_id)
-        return True
+        if environ is not None and _client_id_from_query(environ) not in (None, self.id):
+            return False
+        if self._pinned_tab_id is None:
+            self._pinned_tab_id = tab_id
+        return self._pinned_tab_id == tab_id
 
     def handle_handshake(self, socket_id: str, document_id: str, next_message_id: int | None) -> None:
         """Cancel pending disconnect task and invoke connect handlers. (For internal use only.)"""
@@ -392,12 +407,16 @@ class Client:
             if self._num_connections[document_id] == 0:
                 self._num_connections.pop(document_id)
                 self._delete_tasks.pop(document_id)
-                active_elsewhere = {client.tab_id for client in Client.instances.values() if client is not self}
-                await core.app.storage.prune_empty_tabs(self._tab_ids - active_elsewhere)
+                if self._pinned_tab_id is not None and not self._tab_id_is_held_elsewhere():
+                    await core.app.storage.prune_empty_tab(self._pinned_tab_id)
                 await core.app.storage.close_tab(tab_id_to_close)
                 self.delete()
         self._delete_tasks[document_id] = \
             background_tasks.create(delete_content(), name=f'delete content {document_id}')
+
+    def _tab_id_is_held_elsewhere(self) -> bool:
+        return any(client._pinned_tab_id == self._pinned_tab_id and client._socket_to_document_id  # pylint: disable=protected-access
+                   for client in Client.instances.values() if client is not self)
 
     def _cancel_delete_task(self, document_id: str) -> None:
         if document_id in self._delete_tasks:

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -358,22 +358,20 @@ class Client:
         """
         self._exception_handlers.append(handler)
 
-    def accept_handshake(self, socket_id: str, tab_id: str, environ: dict[str, Any] | None, *,
-                         require_client_id: bool = True) -> bool:
+    def accept_handshake(self, socket_id: str, tab_id: str, environ: dict[str, Any] | None) -> bool:
         """Check whether a handshake may proceed, pinning the client's tab ID on the first one.
 
-        A browser opens one socket per client, handshakes it once, keeps the same tab ID for the client's whole
-        lifetime, and always carries its client ID in the socket's connecting query --
-        so a handshake that breaks any of these is a replayed or forged frame.
-        Pass ``require_client_id=False`` for transports whose environ may legitimately lack the connecting query
-        (the Air relay), or ``environ=None`` to skip the query check entirely (tests). (For internal use only.)
+        A browser opens one socket per client, handshakes it once, and keeps the same tab ID for the client's whole
+        lifetime, so a handshake that breaks any of these is a replayed frame.
+        A socket query without a client ID is tolerated:
+        the query is no trust boundary (a forger could simply echo the claimed client ID into it),
+        and query-less sockets must keep working (see ``test_disconnect_without_client_id_in_connect_query``).
+        (For internal use only.)
         """
         if socket_id in self._socket_to_document_id:
             return False
-        if environ is not None:
-            client_id = _client_id_from_query(environ)
-            if client_id != self.id and (client_id is not None or require_client_id):
-                return False
+        if environ is not None and _client_id_from_query(environ) not in (None, self.id):
+            return False
         if self._pinned_tab_id is None:
             self._pinned_tab_id = tab_id
         return self._pinned_tab_id == tab_id

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -358,16 +358,22 @@ class Client:
         """
         self._exception_handlers.append(handler)
 
-    def accept_handshake(self, socket_id: str, tab_id: str, environ: dict[str, Any] | None) -> bool:
+    def accept_handshake(self, socket_id: str, tab_id: str, environ: dict[str, Any] | None, *,
+                         require_client_id: bool = True) -> bool:
         """Check whether a handshake may proceed, pinning the client's tab ID on the first one.
 
-        A browser opens one socket per client, handshakes it once, and keeps the same tab ID for the client's whole
-        lifetime, so a handshake that breaks any of these is a replayed frame. (For internal use only.)
+        A browser opens one socket per client, handshakes it once, keeps the same tab ID for the client's whole
+        lifetime, and always carries its client ID in the socket's connecting query --
+        so a handshake that breaks any of these is a replayed or forged frame.
+        Pass ``require_client_id=False`` for transports whose environ may legitimately lack the connecting query
+        (the Air relay), or ``environ=None`` to skip the query check entirely (tests). (For internal use only.)
         """
         if socket_id in self._socket_to_document_id:
             return False
-        if environ is not None and _client_id_from_query(environ) not in (None, self.id):
-            return False
+        if environ is not None:
+            client_id = _client_id_from_query(environ)
+            if client_id != self.id and (client_id is not None or require_client_id):
+                return False
         if self._pinned_tab_id is None:
             self._pinned_tab_id = tab_id
         return self._pinned_tab_id == tab_id
@@ -407,16 +413,10 @@ class Client:
             if self._num_connections[document_id] == 0:
                 self._num_connections.pop(document_id)
                 self._delete_tasks.pop(document_id)
-                if self._pinned_tab_id is not None and not self._tab_id_is_held_elsewhere():
-                    await core.app.storage.prune_empty_tab(self._pinned_tab_id)
                 await core.app.storage.close_tab(tab_id_to_close)
                 self.delete()
         self._delete_tasks[document_id] = \
             background_tasks.create(delete_content(), name=f'delete content {document_id}')
-
-    def _tab_id_is_held_elsewhere(self) -> bool:
-        return any(client._pinned_tab_id == self._pinned_tab_id and client._socket_to_document_id  # pylint: disable=protected-access
-                   for client in Client.instances.values() if client is not self)
 
     def _cancel_delete_task(self, document_id: str) -> None:
         if document_id in self._delete_tasks:

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -74,6 +74,9 @@ class Client:
     instances: ClassVar[dict[str, Client]] = {}
     '''Maps client IDs to clients.'''
 
+    MAX_TAB_STORAGES_PER_CLIENT: ClassVar[int] = 128
+    '''Maximum number of tab storages a single client may create (a browser presents only one tab ID per client).'''
+
     shared_head_html = ''
     '''HTML to be inserted in the <head> of every page template.'''
 
@@ -99,6 +102,7 @@ class Client:
         self._deleted = False
         self._socket_to_document_id: dict[str, str] = {}
         self.tab_id: str | None = None
+        self._tab_ids: set[str] = set()
         self._exception_handlers: list[Callable[[Exception], Any] | Callable[[], Any]] = []
 
         self.page = page
@@ -348,6 +352,13 @@ class Client:
         The callback has an optional parameter of `Exception`.
         """
         self._exception_handlers.append(handler)
+
+    def register_tab_id(self, tab_id: str) -> bool:
+        """Remember a tab ID, unless `MAX_TAB_STORAGES_PER_CLIENT` is already exhausted. (For internal use only.)"""
+        if tab_id not in self._tab_ids and len(self._tab_ids) >= self.MAX_TAB_STORAGES_PER_CLIENT:
+            return False
+        self._tab_ids.add(tab_id)
+        return True
 
     def handle_handshake(self, socket_id: str, document_id: str, next_message_id: int | None) -> None:
         """Cancel pending disconnect task and invoke connect handlers. (For internal use only.)"""

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -206,7 +206,8 @@ async def _on_handshake(sid: str, data: dict[str, Any]) -> bool:
     if not client:
         return False
     is_test = sid.startswith('test-')
-    if not client.accept_handshake(sid, data['tab_id'], None if is_test else sio.get_environ(sid)):
+    environ = None if is_test else sio.get_environ(sid)
+    if not client.accept_handshake(sid, data['tab_id'], environ):
         return False
     if data.get('old_tab_id'):
         app.storage.copy_tab(data['old_tab_id'], data['tab_id'])
@@ -214,7 +215,7 @@ async def _on_handshake(sid: str, data: dict[str, Any]) -> bool:
     if is_test:
         client.environ = {'asgi.scope': {'description': 'test client', 'type': 'test'}}
     else:
-        client.environ = sio.get_environ(sid)
+        client.environ = environ
         await sio.enter_room(sid, client.id)
     client.handle_handshake(sid, data['document_id'],
                             int(data['next_message_id']) if 'next_message_id' in data else None)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -205,12 +205,13 @@ async def _on_handshake(sid: str, data: dict[str, Any]) -> bool:
     client = Client.instances.get(data['client_id'])
     if not client:
         return False
-    if not client.register_tab_id(data['tab_id']):
+    is_test = sid.startswith('test-')
+    if not client.accept_handshake(sid, data['tab_id'], None if is_test else sio.get_environ(sid)):
         return False
     if data.get('old_tab_id'):
         app.storage.copy_tab(data['old_tab_id'], data['tab_id'])
     client.tab_id = data['tab_id']
-    if sid.startswith('test-'):
+    if is_test:
         client.environ = {'asgi.scope': {'description': 'test client', 'type': 'test'}}
     else:
         client.environ = sio.get_environ(sid)

--- a/nicegui/nicegui.py
+++ b/nicegui/nicegui.py
@@ -205,6 +205,8 @@ async def _on_handshake(sid: str, data: dict[str, Any]) -> bool:
     client = Client.instances.get(data['client_id'])
     if not client:
         return False
+    if not client.register_tab_id(data['tab_id']):
+        return False
     if data.get('old_tab_id'):
         app.storage.copy_tab(data['old_tab_id'], data['tab_id'])
     client.tab_id = data['tab_id']

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -3,7 +3,6 @@ import contextvars
 import os
 import uuid
 from collections import Counter
-from collections.abc import Iterable
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -93,9 +92,6 @@ class Storage:
 
     max_tab_storage_age: float = timedelta(days=30).total_seconds()
     '''Maximum age in seconds before tab storage is automatically purged. Defaults to 30 days.'''
-
-    max_tab_storages_per_client: int = 4
-    '''Maximum number of distinct tab storages a single client may create (a browser presents one tab ID per client, so this is headroom). Defaults to 4.'''
 
     def __init__(self) -> None:
         self._general = Storage._create_persistent_dict(GENERAL_ID)
@@ -207,15 +203,14 @@ class Storage:
         if tab_id and isinstance(tab := self._tabs.get(tab_id), PersistentDict):
             await tab.close()
 
-    async def prune_empty_tabs(self, tab_ids: Iterable[str]) -> None:
-        """Discard empty tab storages among the given IDs, e.g. when their client is deleted. (For internal use only.)"""
-        for tab_id in list(tab_ids):
-            tab = self._tabs.get(tab_id)
-            if tab is not None and not tab:
-                tab.clear()
-                if isinstance(tab, PersistentDict):
-                    await tab.close()
-                del self._tabs[tab_id]
+    async def prune_empty_tab(self, tab_id: str) -> None:
+        """Discard the given tab storage if it is empty, e.g. when its client is deleted. (For internal use only.)"""
+        tab = self._tabs.get(tab_id)
+        if tab is not None and not tab:
+            tab.clear()
+            if isinstance(tab, PersistentDict):
+                await tab.close()
+            del self._tabs[tab_id]
 
     def clear(self) -> None:
         """Clears all storage."""

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -203,15 +203,6 @@ class Storage:
         if tab_id and isinstance(tab := self._tabs.get(tab_id), PersistentDict):
             await tab.close()
 
-    async def prune_empty_tab(self, tab_id: str) -> None:
-        """Discard the given tab storage if it is empty, e.g. when its client is deleted. (For internal use only.)"""
-        tab = self._tabs.get(tab_id)
-        if tab is not None and not tab:
-            tab.clear()
-            if isinstance(tab, PersistentDict):
-                await tab.close()
-            del self._tabs[tab_id]
-
     def clear(self) -> None:
         """Clears all storage."""
         self._general.clear()

--- a/nicegui/storage.py
+++ b/nicegui/storage.py
@@ -3,6 +3,7 @@ import contextvars
 import os
 import uuid
 from collections import Counter
+from collections.abc import Iterable
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -92,6 +93,9 @@ class Storage:
 
     max_tab_storage_age: float = timedelta(days=30).total_seconds()
     '''Maximum age in seconds before tab storage is automatically purged. Defaults to 30 days.'''
+
+    max_tab_storages_per_client: int = 4
+    '''Maximum number of distinct tab storages a single client may create (a browser presents one tab ID per client, so this is headroom). Defaults to 4.'''
 
     def __init__(self) -> None:
         self._general = Storage._create_persistent_dict(GENERAL_ID)
@@ -202,6 +206,16 @@ class Storage:
         """Close the tab storage. (For internal use only.)"""
         if tab_id and isinstance(tab := self._tabs.get(tab_id), PersistentDict):
             await tab.close()
+
+    async def prune_empty_tabs(self, tab_ids: Iterable[str]) -> None:
+        """Discard empty tab storages among the given IDs, e.g. when their client is deleted. (For internal use only.)"""
+        for tab_id in list(tab_ids):
+            tab = self._tabs.get(tab_id)
+            if tab is not None and not tab:
+                tab.clear()
+                if isinstance(tab, PersistentDict):
+                    await tab.close()
+                del self._tabs[tab_id]
 
     def clear(self) -> None:
         """Clears all storage."""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -265,8 +265,6 @@ async def test_client_is_pinned_to_one_tab_id(user: User):
                             {'asgi.scope': {'query_string': b'client_id=somebody-else'}}]:
         assert not client.accept_handshake('test-foreign', user.tab_id, foreign_environ), \
             'a handshake naming a client other than the one its socket connected with must be refused'
-    assert not client.accept_handshake('test-foreign', user.tab_id, {'QUERY_STRING': ''}), \
-        'a browser always sends its client_id in the socket query, so a query without one must be refused'
 
 
 def test_client_storage(screen: Screen):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,7 +4,6 @@ import re
 import threading
 import time
 from collections.abc import Callable
-from uuid import uuid4
 
 import httpx
 import pytest
@@ -248,21 +247,53 @@ def test_clear_tab_storage(screen: Screen):
 async def test_tab_storage_is_capped_per_client(user: User):
     @ui.page('/')
     def page():
-        ui.label('ok')
+        pass
 
     client = await user.open('/')  # registers the first tab ID
 
-    async def handshake_with_a_fresh_tab_id() -> bool:
-        return await _on_handshake(f'test-{uuid4()}', {
-            'client_id': client.id,
-            'tab_id': str(uuid4()),
-            'document_id': str(uuid4()),
-        })
+    async def handshake_with_tab(tab_id: str) -> bool:
+        return await _on_handshake(f'test-{tab_id}', {'client_id': client.id, 'tab_id': tab_id, 'document_id': 'doc'})
 
-    for _ in range(Client.MAX_TAB_STORAGES_PER_CLIENT - 1):
-        assert await handshake_with_a_fresh_tab_id()
-    assert not await handshake_with_a_fresh_tab_id()
-    assert len(app.storage._tabs) == Client.MAX_TAB_STORAGES_PER_CLIENT  # pylint: disable=protected-access
+    for i in range(app.storage.max_tab_storages_per_client - 1):  # the client already registered one tab ID on open
+        assert await handshake_with_tab(f'tab-{i}')
+    assert not await handshake_with_tab('one-too-many')
+
+
+async def test_empty_tab_storages_are_reclaimed_when_client_is_deleted(user: User):
+    @ui.page('/', reconnect_timeout=0)
+    def page():
+        pass
+
+    client = await user.open('/')  # creates one empty tab storage
+    assert await _on_handshake('test-a', {'client_id': client.id, 'tab_id': 'empty', 'document_id': 'doc-a'})
+    assert await _on_handshake('test-b', {'client_id': client.id, 'tab_id': 'used', 'document_id': 'doc-b'})
+    app.storage._tabs['used']['keep'] = 'me'  # pylint: disable=protected-access
+
+    client.handle_disconnect('test-a')  # deletes the client after reconnect_timeout=0
+    await asyncio.sleep(0.1)
+
+    tabs = app.storage._tabs  # pylint: disable=protected-access
+    assert 'empty' not in tabs, 'empty tab storages should be reclaimed with their client'
+    assert 'used' in tabs, 'tab storages holding data must survive'
+
+
+async def test_empty_tab_storage_shared_by_a_live_client_is_not_reclaimed(user: User):
+    # a page reload reuses the tab ID under a fresh client ID, so the old and new client briefly share one tab storage
+    @ui.page('/', reconnect_timeout=0)
+    def page():
+        pass
+
+    new_client = await user.open('/')  # the reloaded page; owns an (empty) tab storage
+    tab_id = new_client.tab_id
+    assert tab_id in app.storage._tabs  # pylint: disable=protected-access
+
+    old_client = Client(new_client.page, request=new_client.request)  # the pre-reload client, about to be reaped
+    assert await _on_handshake('test-old', {'client_id': old_client.id, 'tab_id': tab_id, 'document_id': 'doc-old'})
+
+    old_client.handle_disconnect('test-old')  # reaps the old client after reconnect_timeout=0
+    await asyncio.sleep(0.1)
+
+    assert tab_id in app.storage._tabs, 'a tab storage still claimed by a live client must survive'  # pylint: disable=protected-access
 
 
 def test_client_storage(screen: Screen):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,6 +4,7 @@ import re
 import threading
 import time
 from collections.abc import Callable
+from uuid import uuid4
 
 import httpx
 import pytest
@@ -11,6 +12,7 @@ import pytest
 from nicegui import Client, app, background_tasks, context, core, ui
 from nicegui.app import app as app_module
 from nicegui.app.app import prune_tab_storage, prune_user_storage
+from nicegui.nicegui import _on_handshake
 from nicegui.persistence.file_persistent_dict import FilePersistentDict
 from nicegui.storage import Storage
 from nicegui.testing import Screen, User
@@ -241,6 +243,26 @@ def test_clear_tab_storage(screen: Screen):
     screen.click('clear')
     screen.wait(0.5)
     assert not tab_storages
+
+
+async def test_tab_storage_is_capped_per_client(user: User):
+    @ui.page('/')
+    def page():
+        ui.label('ok')
+
+    client = await user.open('/')  # registers the first tab ID
+
+    async def handshake_with_a_fresh_tab_id() -> bool:
+        return await _on_handshake(f'test-{uuid4()}', {
+            'client_id': client.id,
+            'tab_id': str(uuid4()),
+            'document_id': str(uuid4()),
+        })
+
+    for _ in range(Client.MAX_TAB_STORAGES_PER_CLIENT - 1):
+        assert await handshake_with_a_fresh_tab_id()
+    assert not await handshake_with_a_fresh_tab_id()
+    assert len(app.storage._tabs) == Client.MAX_TAB_STORAGES_PER_CLIENT  # pylint: disable=protected-access
 
 
 def test_client_storage(screen: Screen):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -244,19 +244,27 @@ def test_clear_tab_storage(screen: Screen):
     assert not tab_storages
 
 
-async def test_tab_storage_is_capped_per_client(user: User):
-    @ui.page('/')
+async def test_client_is_pinned_to_one_tab_id(user: User):
+    @ui.page('/', reconnect_timeout=10)
     def page():
         pass
 
-    client = await user.open('/')  # registers the first tab ID
+    client = await user.open('/')  # pins the tab ID the user fixture presents
 
-    async def handshake_with_tab(tab_id: str) -> bool:
-        return await _on_handshake(f'test-{tab_id}', {'client_id': client.id, 'tab_id': tab_id, 'document_id': 'doc'})
+    async def handshake(socket_id: str, tab_id: str) -> bool:
+        return await _on_handshake(socket_id, {'client_id': client.id, 'tab_id': tab_id, 'document_id': 'doc'})
 
-    for i in range(app.storage.max_tab_storages_per_client - 1):  # the client already registered one tab ID on open
-        assert await handshake_with_tab(f'tab-{i}')
-    assert not await handshake_with_tab('one-too-many')
+    assert await handshake('test-reconnect', user.tab_id), 'a reconnect presents the same tab ID and must be accepted'
+    assert not await handshake('test-reconnect', user.tab_id), 'a socket may only handshake once'
+    assert not await handshake('test-replay', 'other-tab'), 'a second tab ID on one client must be refused'
+
+    client.handle_disconnect('test-reconnect')  # nulls client.tab_id, but the pin must survive it
+    assert not await handshake('test-after-disconnect', 'other-tab')
+
+    for foreign_environ in [{'QUERY_STRING': 'client_id=somebody-else'},  # both shapes Engine.IO provides
+                            {'asgi.scope': {'query_string': b'client_id=somebody-else'}}]:
+        assert not client.accept_handshake('test-foreign', user.tab_id, foreign_environ), \
+            'a handshake naming a client other than the one its socket connected with must be refused'
 
 
 async def test_empty_tab_storages_are_reclaimed_when_client_is_deleted(user: User):
@@ -264,12 +272,15 @@ async def test_empty_tab_storages_are_reclaimed_when_client_is_deleted(user: Use
     def page():
         pass
 
-    client = await user.open('/')  # creates one empty tab storage
-    assert await _on_handshake('test-a', {'client_id': client.id, 'tab_id': 'empty', 'document_id': 'doc-a'})
-    assert await _on_handshake('test-b', {'client_id': client.id, 'tab_id': 'used', 'document_id': 'doc-b'})
+    template = await user.open('/')  # only to get hold of a page and a request
+    empty_client = Client(template.page, request=template.request)  # one browser tab whose storage stays empty
+    used_client = Client(template.page, request=template.request)  # another one whose storage holds data
+    assert await _on_handshake('test-empty', {'client_id': empty_client.id, 'tab_id': 'empty', 'document_id': 'doc'})
+    assert await _on_handshake('test-used', {'client_id': used_client.id, 'tab_id': 'used', 'document_id': 'doc'})
     app.storage._tabs['used']['keep'] = 'me'  # pylint: disable=protected-access
 
-    client.handle_disconnect('test-a')  # deletes the client after reconnect_timeout=0
+    empty_client.handle_disconnect('test-empty')  # deletes both clients after reconnect_timeout=0
+    used_client.handle_disconnect('test-used')
     await asyncio.sleep(0.1)
 
     tabs = app.storage._tabs  # pylint: disable=protected-access

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -265,46 +265,8 @@ async def test_client_is_pinned_to_one_tab_id(user: User):
                             {'asgi.scope': {'query_string': b'client_id=somebody-else'}}]:
         assert not client.accept_handshake('test-foreign', user.tab_id, foreign_environ), \
             'a handshake naming a client other than the one its socket connected with must be refused'
-
-
-async def test_empty_tab_storages_are_reclaimed_when_client_is_deleted(user: User):
-    @ui.page('/', reconnect_timeout=0)
-    def page():
-        pass
-
-    template = await user.open('/')  # only to get hold of a page and a request
-    empty_client = Client(template.page, request=template.request)  # one browser tab whose storage stays empty
-    used_client = Client(template.page, request=template.request)  # another one whose storage holds data
-    assert await _on_handshake('test-empty', {'client_id': empty_client.id, 'tab_id': 'empty', 'document_id': 'doc'})
-    assert await _on_handshake('test-used', {'client_id': used_client.id, 'tab_id': 'used', 'document_id': 'doc'})
-    app.storage._tabs['used']['keep'] = 'me'  # pylint: disable=protected-access
-
-    empty_client.handle_disconnect('test-empty')  # deletes both clients after reconnect_timeout=0
-    used_client.handle_disconnect('test-used')
-    await asyncio.sleep(0.1)
-
-    tabs = app.storage._tabs  # pylint: disable=protected-access
-    assert 'empty' not in tabs, 'empty tab storages should be reclaimed with their client'
-    assert 'used' in tabs, 'tab storages holding data must survive'
-
-
-async def test_empty_tab_storage_shared_by_a_live_client_is_not_reclaimed(user: User):
-    # a page reload reuses the tab ID under a fresh client ID, so the old and new client briefly share one tab storage
-    @ui.page('/', reconnect_timeout=0)
-    def page():
-        pass
-
-    new_client = await user.open('/')  # the reloaded page; owns an (empty) tab storage
-    tab_id = new_client.tab_id
-    assert tab_id in app.storage._tabs  # pylint: disable=protected-access
-
-    old_client = Client(new_client.page, request=new_client.request)  # the pre-reload client, about to be reaped
-    assert await _on_handshake('test-old', {'client_id': old_client.id, 'tab_id': tab_id, 'document_id': 'doc-old'})
-
-    old_client.handle_disconnect('test-old')  # reaps the old client after reconnect_timeout=0
-    await asyncio.sleep(0.1)
-
-    assert tab_id in app.storage._tabs, 'a tab storage still claimed by a live client must survive'  # pylint: disable=protected-access
+    assert not client.accept_handshake('test-foreign', user.tab_id, {'QUERY_STRING': ''}), \
+        'a browser always sends its client_id in the socket query, so a query without one must be refused'
 
 
 def test_client_storage(screen: Screen):


### PR DESCRIPTION
*Drafted by Claude Code on @evnchn's behalf. Updated by @falkoschindler for `23d7b46c` (removes the empty-tab reclamation again) and `d9977fa5a` (tolerates query-less sockets again, after the client-leak advisory fix on `main` made them a supported flow) — reasoning in the comments below.*

**TL;DR** — One unauthenticated `GET /` yields a valid `client_id`; replaying `handshake` frames on a socket then minted one tab storage per fresh `tab_id`, each retained for `max_tab_storage_age` (30 days) and surviving the peer's disconnect. This enforces **one socket ↔ one client ↔ one handshake** in the handshake handler and **pins each client to a single tab ID**. Over real sockets, 5000 replayed frames go from **5000 tab storages to 1**, and the socket's stranded `_num_connections` from **5999 to 1**. 36 insertions across 3 library files (+24 test), no storage-format change.

**Advisory route already cleared.** Raised with Falko on Slack as a possible GHSA; his verdict was that it does not warrant an advisory, so it goes the ordinary-PR route. That is why the security checkbox below is ticked.

### Motivation

`_on_handshake` gated only on `client_id` naming a live client, then reached `app.storage._create_tab_storage(tab_id)`, which for the default in-memory backend does `self._tabs[tab_id] = ObservableDict()` with no bound. `prune_tab_storage` only reclaims entries older than 30 days and `close_tab` is a no-op for `ObservableDict`, so the flooded entries outlive the peer.

The browser never behaves this way: the socket query carries `client_id`, the explicit handshake emits that very same `options.query`, a reconnect is a new sid, and `TAB_ID` is a JS `const` per page load — every new page render (reload, duplicate tab, back/forward) mints a fresh `client_id`, and a bfcache restore resumes the same const. So one client sees exactly one tab ID **by construction**, not by measurement.

### Implementation

`Client.accept_handshake(socket_id, tab_id, environ)` refuses a frame when any of the three invariants break, and is the single gate both transports call — `_on_handshake` in `nicegui/nicegui.py` and `Air._handle_handshake` in `nicegui/air.py`:

- **the socket's own client** — a `client_id` in the socket's connecting query must match the one the handshake names. A query *without* a `client_id` is tolerated: the query is no trust boundary (a forger simply echoes the claimed id into it), and query-less sockets are a supported flow since the client-leak advisory fix on `main`. `test-` sids keep their special case.
- **one handshake per socket** — a sid already in `_socket_to_document_id` is refused.
- **one tab ID per client** — the first handshake pins it; a later one presenting a different ID is refused.

The pin is a scalar with **its own never-reset field**, not `client.tab_id`, which `handle_disconnect` nulls on every disconnect — otherwise handshake A → disconnect → handshake B still mints two storages. `max_tab_storages_per_client` is gone as a public knob.

Empty tab storages are left to the existing 30-day pruner: the event-driven reclamation on client deletion from earlier rounds is removed again in `23d7b46c`. It decided a destructive delete of possibly shared state from process-local snapshots (the in-memory mirror for "empty", this process's `Client.instances` for "held elsewhere"), which carried a multi-worker Redis race and a reconnect-window race — and with the pin bounding the deposit to one empty tab storage per unauthenticated GET, that race surface no longer bought anything a frontline rate limit does not already cover.

Separate Air issue filed as #6310, as requested.

<details>
<summary><b>Verification</b> — before/after over real sockets, seen-to-fail per guard, local gates</summary>

**Real sockets** (measured on `42ab1d93`; the follow-up commits do not touch the pin path). A separate `ui.run()` process, a real `python-socketio` client, one `GET /` for the `client_id`, then replayed frames; counts read back through a plain `@app.get` endpoint. Before is `a9121acf`, the PR's base, served from its own worktree; each server prints the `nicegui.__file__` it is actually serving.

| one GET, then… | tab storages — before | tab storages — after |
|---|---|---|
| 1000 frames on one socket, fresh `tab_id` each | 1000 | **1** |
| 5000 frames on one socket, fresh `tab_id` each | 5000 | **1** |
| 12 sockets, one handshake each, fresh `tab_id` | 12 | **1** |
| 64 sockets, one handshake each, fresh `tab_id` | 64 | **1** |

Two by-products of the same run, both on the 5000-frame case: `_num_connections` on that socket goes **5999 → 1** (the replay path flagged in an earlier round — the one-handshake-per-socket rule closes it), and a handshake naming a *different* client than the socket connected with goes **accepted → refused**.

**Seen-to-fail, one guard at a time.** Each guard was reverted individually with the rest of the commit in place; each lands on a different assertion of `test_client_is_pinned_to_one_tab_id`:

| reverted | fails at |
|---|---|
| one handshake per socket | line 258 |
| `client_id` must match the socket's | line 266 |
| the `QUERY_STRING` arm of that check | line 266 |
| the pin itself | line 259 |
| pin bound to `client.tab_id` instead | line 262 |

**Local gates** (on `d9977fa5a`, `main` merged)

```
pre-commit run --files <the changed files>            all Passed
mypy ./nicegui                                        Success: no issues found in 265 source files
pylint ./nicegui                                      10.00/10, exit 0
pytest tests/test_storage.py tests/test_lifecycle.py tests/test_reconnect.py   41 passed
pytest tests/test_air.py tests/test_user_simulation.py                         85 passed
```

CI is the authoritative gate; not claiming green until the run lands.

</details>

<details>
<summary><b>What is not covered</b></summary>

**The Air arm of the `client_id` check is unverified.** `air.py` passes `data['environ']`, which crosses the relay as JSON, so its shape is unconfirmed without a relay. The helper reads both `QUERY_STRING` and `asgi.scope.query_string`, tolerates `str` or `bytes`, and fails open when neither query shape is present — so On Air cannot start refusing legitimate handshakes because of it. The other two invariants apply on Air unchanged.

**The real `sio.get_environ` path has no pytest.** `test-` sids bypass `sio.get_environ` by design, so the `client_id` check is asserted against `accept_handshake` directly with both environ shapes. The end-to-end refusal is covered by the real-socket measurement above, not by the suite; a pytest for it would need a raw Socket.IO client fixture.

**The pin test is white-box by necessity.** Replayed handshake frames are not reachable through the `User`/`Screen` fixtures, so `test_client_is_pinned_to_one_tab_id` drives `_on_handshake` directly — the justification AGENTS.md asks for when a test cannot assert observable behavior.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue. <!-- raised as a possible GHSA on Slack; Falko's verdict was that it does not warrant an advisory -->
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.