### PR TITLE
Dispatch on_anchor_change handlers from Python instead of a second socket listener

### DIFF
--- a/nicegui/elements/codemirror/line_anchors.py
+++ b/nicegui/elements/codemirror/line_anchors.py
@@ -33,6 +33,7 @@ class LineAnchorElement(Element):
         super().__init__(**kwargs)
         self._anchor_positions: dict[str, int] = {}
         self._anchors_pending = True
+        self._anchor_change_handlers: list[Handler[CodeMirrorAnchorChangeEventArguments]] = []
         if line_anchors:
             self._props['line-anchors'] = line_anchors
         self.on('anchor-positions', self._update_anchor_mirror)
@@ -74,12 +75,11 @@ class LineAnchorElement(Element):
         return dict_
 
     def on_anchor_change(self, handler: Handler[CodeMirrorAnchorChangeEventArguments]) -> Self:
-        """Register a callback to be invoked whenever tracked anchor positions change.
+        """Add a callback to be invoked when tracked anchor positions change.
 
         *Added in version 3.16.0*
         """
-        self.on('anchor-positions', lambda e: handle_event(handler,
-                CodeMirrorAnchorChangeEventArguments(sender=self, client=self.client, anchors=e.args['anchors'])))
+        self._anchor_change_handlers.append(handler)
         return self
 
     def _update_anchor_mirror(self, e: GenericEventArguments) -> None:
@@ -88,6 +88,10 @@ class LineAnchorElement(Element):
         # A separate dict keeps a caller mutating the exposed positions from rewriting what we send.
         with self._props.suspend_updates():
             self._props['line-anchors'] = dict(self._anchor_positions)
+        for handler in self._anchor_change_handlers:
+            # A fresh dict per handler keeps one of them from rewriting the mirror or the others' view.
+            handle_event(handler, CodeMirrorAnchorChangeEventArguments(
+                sender=self, client=self.client, anchors=dict(self._anchor_positions)))
 
 
 def _validate(anchors: dict[str, int]) -> None:

--- a/nicegui/elements/codemirror/line_anchors.py
+++ b/nicegui/elements/codemirror/line_anchors.py
@@ -89,7 +89,7 @@ class LineAnchorElement(Element):
         with self._props.suspend_updates():
             self._props['line-anchors'] = dict(self._anchor_positions)
         for handler in self._anchor_change_handlers:
-            # A fresh dict per handler keeps one of them from rewriting the mirror or the others' view.
+            # A fresh dict per handler keeps one of them from rewriting the exposed positions or the others' view.
             handle_event(handler, CodeMirrorAnchorChangeEventArguments(
                 sender=self, client=self.client, anchors=dict(self._anchor_positions)))
 

--- a/tests/test_codemirror_line_anchors.py
+++ b/tests/test_codemirror_line_anchors.py
@@ -225,6 +225,7 @@ def test_on_anchor_change_handler(screen: Screen):
     """on_anchor_change fires with the current positions on every change."""
     editor: ui.codemirror = None  # type: ignore[assignment]
     received: list[dict] = []
+    late: list[dict] = []
 
     @ui.page('/')
     def page():
@@ -239,3 +240,9 @@ def test_on_anchor_change_handler(screen: Screen):
     # A remapping edit fires the handler again with the new line.
     screen.selenium.execute_script(f'getElement({editor.id}).editor.dispatch({{changes: {{from: 0, insert: "X\\n"}}}})')
     screen.wait_for(lambda: received[-1] == {'mid': 4})
+
+    # A handler added after the first render fires as well, without re-creating the editor.
+    editor.on_anchor_change(lambda e: late.append(e.anchors))
+    screen.selenium.execute_script(f'getElement({editor.id}).editor.dispatch({{changes: {{from: 0, insert: "Y\\n"}}}})')
+    screen.wait_for(lambda: late == [{'mid': 5}])
+    assert 'Event listeners changed after initial definition.' not in screen.render_js_logs()


### PR DESCRIPTION
*Opened by Claude Code on @evnchn's behalf.*

### Motivation

`on_anchor_change()` (new in 3.16.0, merged in #5988) registers a **second** socket listener on the same event `LineAnchorElement.__init__` already listens to:

```python
self.on('anchor-positions', self._update_anchor_mirror)   # __init__
self.on('anchor-positions', lambda e: handle_event(...))  # on_anchor_change
```

Two consequences:

1. **Every anchor movement costs two round trips**, each carrying the full anchors dict — working against the 50 ms debounce, whose stated purpose is sparing high-latency connections.
2. **Registering a handler after the first render mutates the serialized listener set**, so the late-registration path from PR 5439 fires: the element is dropped and re-created, and the CodeMirror view is rebuilt.

<details>
<summary><b>Measured on the merged code (2 emits vs 1, with a control)</b></summary>

Two `ui.codemirror`s, same document, same edit, differing only in whether `on_anchor_change=` is passed. Socket `emit` instrumented in the browser and listener ids mapped back to event names:

| element | `anchorPositions` listeners | `anchorPositions` emits per edit | `update:value` emits |
|---|---|---|---|
| `on_anchor_change=…` | **2** | **2** | 1 |
| control | 1 | 1 | 1 |

`update:value` staying at 1 on both sides confirms the edit itself was identical. Run against `8fb479bc` (the merge commit of PR 5988), Chrome 141.

</details>

### Implementation

Handlers move to a Python-side list dispatched from `_update_anchor_mirror`, which is the pattern this codebase already standardised on in PR 2704 / PR 2708 — and which both neighbours already use: `ValueElement._change_handlers` and `KeyBindingElement`'s single `self.on('keybinding', self._dispatch_keybinding)`.

One socket listener now serves any number of handlers, so runtime registration is free and no longer touches the frontend listener set.

Two details worth flagging:

- **Ordering is now guaranteed rather than incidental.** Handlers run after the mirror is updated because they are dispatched from it. Previously that held only because `__init__` happened to register the mirror listener first.
- **Each handler gets its own `dict`.** Previously each listener had its own deserialized payload, so handlers could not see each other's mutations. Passing the live `_anchor_positions` would have let a handler rewrite the server mirror through `e.anchors`, so the dispatch copies per handler — preserving the intent already documented on the line above it.

No public API change: `on_anchor_change()` keeps its signature and `Self` return.

<details>
<summary><b>Verification</b></summary>

Extended the nearest existing test (`test_on_anchor_change_handler`) rather than adding a standalone one, asserting observable behaviour only — that a handler registered after the first render fires, and that the "Event listeners changed" warning does *not* appear. Per `AGENTS.md`, no private attributes or patched machinery.

**Seen to fail.** With the fix reverted, the test fails with the expected symptom in the log:

```
WARNING  nicegui:client.py:408 Event listeners changed after initial definition. Re-rendering affected elements.
FAILED tests/test_codemirror_line_anchors.py::test_on_anchor_change_handler
```

Restored → 12 passed. Local gates on `e41a3f13`:

| gate | result |
|---|---|
| `pre-commit` (changed files) | passed |
| `mypy ./nicegui` | no issues, 264 files |
| `pylint ./nicegui` | 10.00/10 |
| `pytest tests/test_codemirror_line_anchors.py tests/test_codemirror.py -rs` | 31 passed, **0 skipped** |

Reviewed by Codex (different lineage), which raised the shared-mutable-dict issue above; that is applied. It scored the result 8/10 and confirmed the premise was worth proposing.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary — the docstring wording is aligned with `ValueElement.on_value_change`, and behaviour is unchanged from the user's side.
- [x] No breaking changes to the public API.

[※](https://zauberzeug.github.io/colophon/#m=claude-opus-5&t=Agent%20measured%20the%20behaviour%2C%20wrote%20the%20change%2C%20the%20test%20and%20this%20description%3B%20the%20decision%20to%20propose%20it%20is%20the%20author%27s.&p=agent&a=claude-code "claude-opus-5: Agent measured the behaviour, wrote the change, the test and this description; the decision to propose it is the author's.")


<details>
<summary><b>Runnable repro</b> — the script behind the table above</summary>

Two editors, same document, same edit; only `on_anchor_change=` differs. Run it, open the page, then paste the instrumentation below into the browser console.

```python
from nicegui import ui

seen: list[dict] = []

a = ui.codemirror('l1\nl2\nl3\nl4\nl5', line_anchors={'x': 3},
                  on_anchor_change=lambda e: seen.append(e.anchors))  # 2 listeners
b = ui.codemirror('l1\nl2\nl3\nl4\nl5', line_anchors={'x': 3})        # control: 1 listener

ui.label().bind_text_from(a, 'id', lambda i: f'A(with handler) element id = {i}')
ui.label().bind_text_from(b, 'id', lambda i: f'B(control)       element id = {i}')

ui.run(reload=False)
```

```js
window.__ev = [];
const orig = window.socket.emit.bind(window.socket);
window.socket.emit = (name, payload, ...rest) => {
  if (name === 'event') window.__ev.push({id: payload.id, lid: payload.listener_id});
  return orig(name, payload, ...rest);
};
const comps = Object.values(mounted_app.$refs).filter(r => r && r.editor);
comps.forEach(c => c.editor.dispatch({changes: {from: 0, insert: 'NEW\n'}}));
// then map listener_id -> event name via mounted_app.elements[id].events
```

Observed against `8fb479bc`:

```
registered listeners  4: [update:value, anchorPositions, anchorPositions, keybinding]
                      5: [update:value, anchorPositions, keybinding]
emits per edit        4:anchorPositions = 2     5:anchorPositions = 1
                      4:update:value    = 1     5:update:value    = 1
```

`update:value` staying at 1 on both sides confirms the edit itself was identical; only the anchor event doubles.

</details>

---
*Changelog — 2026-08-12: added the runnable repro behind the measurement table.*
