### PR TITLE
Reject a line anchor on a fractional line instead of snapping it

### DIFF
--- a/nicegui/elements/codemirror/codemirror.js
+++ b/nicegui/elements/codemirror/codemirror.js
@@ -203,7 +203,7 @@ export default {
       const doc = this.editor.state.doc;
       const ranges = [];
       for (const [id, line] of Object.entries(anchors || {})) {
-        if (line >= 1 && line <= doc.lines) {
+        if (Number.isInteger(line) && line >= 1 && line <= doc.lines) {
           const pos = doc.line(line).from;
           ranges.push(new AnchorValue(id).range(pos, pos));
         } else {

--- a/nicegui/elements/codemirror/codemirror.js
+++ b/nicegui/elements/codemirror/codemirror.js
@@ -203,7 +203,11 @@ export default {
       const doc = this.editor.state.doc;
       const ranges = [];
       for (const [id, line] of Object.entries(anchors || {})) {
-        if (Number.isInteger(line) && line >= 1 && line <= doc.lines) {
+        if (!Number.isInteger(line)) {
+          // doc.line() resolves a fractional line to a neighbouring one rather than refusing it,
+          // which would place the anchor where nobody asked for it.
+          logAndEmit("warning", `line_anchors: anchor ${JSON.stringify(id)} on line ${line} is not a whole line`);
+        } else if (line >= 1 && line <= doc.lines) {
           const pos = doc.line(line).from;
           ranges.push(new AnchorValue(id).range(pos, pos));
         } else {

--- a/nicegui/elements/codemirror/codemirror.js
+++ b/nicegui/elements/codemirror/codemirror.js
@@ -203,11 +203,7 @@ export default {
       const doc = this.editor.state.doc;
       const ranges = [];
       for (const [id, line] of Object.entries(anchors || {})) {
-        if (!Number.isInteger(line)) {
-          // doc.line() resolves a fractional line to a neighbouring one rather than refusing it,
-          // which would place the anchor where nobody asked for it.
-          logAndEmit("warning", `line_anchors: anchor ${JSON.stringify(id)} on line ${line} is not a whole line`);
-        } else if (line >= 1 && line <= doc.lines) {
+        if (line >= 1 && line <= doc.lines) {
           const pos = doc.line(line).from;
           ranges.push(new AnchorValue(id).range(pos, pos));
         } else {

--- a/nicegui/elements/codemirror/line_anchors.py
+++ b/nicegui/elements/codemirror/line_anchors.py
@@ -56,6 +56,8 @@ class LineAnchorElement(Element):
         Lines beyond the end of the document are dropped on the JS side with a warning via NiceGUI's
         logger, just like ``line_tooltips``, so a read never reports a position that was not applied.
         A line below 1 is rejected right away with a ``ValueError``.
+        A line that is not a whole number is dropped the same way as one beyond the end,
+        since it cannot address a line without silently resolving to a neighbouring one.
 
         *Added in version 3.16.0*
         """

--- a/nicegui/elements/codemirror/line_anchors.py
+++ b/nicegui/elements/codemirror/line_anchors.py
@@ -56,7 +56,7 @@ class LineAnchorElement(Element):
         Lines beyond the end of the document are dropped on the JS side with a warning via NiceGUI's
         logger, just like ``line_tooltips``, so a read never reports a position that was not applied.
         A line below 1 is rejected right away with a ``ValueError``.
-        A line that is not a whole number is dropped the same way as one beyond the end,
+        A line at or above 1 that is not a whole number is dropped the same way as one beyond the end,
         since it cannot address a line without silently resolving to a neighbouring one.
 
         *Added in version 3.16.0*

--- a/nicegui/elements/codemirror/line_anchors.py
+++ b/nicegui/elements/codemirror/line_anchors.py
@@ -55,9 +55,7 @@ class LineAnchorElement(Element):
 
         Lines beyond the end of the document are dropped on the JS side with a warning via NiceGUI's
         logger, just like ``line_tooltips``, so a read never reports a position that was not applied.
-        A line below 1 is rejected right away with a ``ValueError``.
-        A line at or above 1 that is not a whole number is dropped the same way as one beyond the end,
-        since it cannot address a line without silently resolving to a neighbouring one.
+        A line below 1 or not a whole number is rejected right away with a ``ValueError``.
 
         *Added in version 3.16.0*
         """
@@ -98,5 +96,5 @@ class LineAnchorElement(Element):
 
 def _validate(anchors: dict[str, int]) -> None:
     for id_, line in anchors.items():
-        if line < 1:
-            raise ValueError(f'line_anchors: anchor {id_!r} has line {line}, but lines are 1-indexed')
+        if not isinstance(line, int) or line < 1:
+            raise ValueError(f'line_anchors: anchor {id_!r} has line {line!r}, but lines are 1-indexed whole numbers')

--- a/tests/test_codemirror_line_anchors.py
+++ b/tests/test_codemirror_line_anchors.py
@@ -67,6 +67,21 @@ def test_anchors_out_of_range(screen: Screen):
     screen.wait_for(lambda: editor.line_anchors == {'inside': 2})
 
 
+def test_anchors_on_a_fractional_line(screen: Screen):
+    """A line that is not a whole number resolves to a neighbouring one, so it is dropped like one past the end."""
+    editor: ui.codemirror = None  # type: ignore[assignment]
+
+    @ui.page('/')
+    def page():
+        nonlocal editor
+        editor = ui.codemirror('a\nb\nc')
+
+    screen.open('/')
+    _wait_for_editor(screen)
+    editor.line_anchors = {'inside': 3, 'fractional': 2.5}  # type: ignore[dict-item]
+    screen.wait_for(lambda: editor.line_anchors == {'inside': 3})
+
+
 async def test_rejected_anchors_leave_no_editor_behind(user: User):
     """The constructor must refuse before the element registers itself, not halfway through building it."""
     @ui.page('/')

--- a/tests/test_codemirror_line_anchors.py
+++ b/tests/test_codemirror_line_anchors.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from selenium.webdriver.common.by import By
 
@@ -80,6 +82,7 @@ def test_anchors_on_a_fractional_line(screen: Screen):
     _wait_for_editor(screen)
     editor.line_anchors = {'inside': 3, 'fractional': 2.5}  # type: ignore[dict-item]
     screen.wait_for(lambda: editor.line_anchors == {'inside': 3})
+    screen.assert_py_logger('WARNING', re.compile('is not a whole line'))
 
 
 async def test_rejected_anchors_leave_no_editor_behind(user: User):

--- a/tests/test_codemirror_line_anchors.py
+++ b/tests/test_codemirror_line_anchors.py
@@ -1,5 +1,3 @@
-import re
-
 import pytest
 from selenium.webdriver.common.by import By
 
@@ -52,7 +50,7 @@ def test_anchor_remapping(screen: Screen, anchors: dict[str, int], change: str, 
 
 
 def test_anchors_out_of_range(screen: Screen):
-    """A line below 1 is refused outright; one past the end is dropped rather than moved somewhere else."""
+    """A line below 1 or not a whole number is refused outright; one past the end is dropped rather than moved."""
     editor: ui.codemirror = None  # type: ignore[assignment]
 
     @ui.page('/')
@@ -64,25 +62,11 @@ def test_anchors_out_of_range(screen: Screen):
     _wait_for_editor(screen)
     with pytest.raises(ValueError, match='1-indexed'):
         editor.line_anchors = {'bad': 0}
+    with pytest.raises(ValueError, match='whole numbers'):
+        editor.line_anchors = {'bad': 2.5}  # type: ignore[dict-item]
 
     editor.line_anchors = {'inside': 2, 'beyond': 50}
     screen.wait_for(lambda: editor.line_anchors == {'inside': 2})
-
-
-def test_anchors_on_a_fractional_line(screen: Screen):
-    """A line that is not a whole number resolves to a neighbouring one, so it is dropped like one past the end."""
-    editor: ui.codemirror = None  # type: ignore[assignment]
-
-    @ui.page('/')
-    def page():
-        nonlocal editor
-        editor = ui.codemirror('a\nb\nc')
-
-    screen.open('/')
-    _wait_for_editor(screen)
-    editor.line_anchors = {'inside': 3, 'fractional': 2.5}  # type: ignore[dict-item]
-    screen.wait_for(lambda: editor.line_anchors == {'inside': 3})
-    screen.assert_py_logger('WARNING', re.compile('is not a whole line'))
 
 
 async def test_rejected_anchors_leave_no_editor_behind(user: User):


### PR DESCRIPTION
*Opened by Claude Code on @Jepson2k's behalf.*

### Motivation

Spotted by @falkoschindler while reviewing #5991: `applyLineAnchors` takes its line number as given, without requiring a whole one.

A line of `2.5` passes the range check and reaches `doc.line(2.5)`, which resolves it to a neighbouring line instead of refusing it — so the anchor lands where the caller never asked for it and is mirrored back as if that had been the declaration. On `9f3f764b`, `{'inside': 3, 'fractional': 2.5}` reads back as `{'inside': 3, 'fractional': 3}`, with no exception and no warning.

The other line-number check in the file, `setLineTooltips`, runs its key through `parseInt` before the range check, so a fractional line is truncated there rather than refused. Aligning the two is out of scope here.

### Implementation

`_validate` now requires `isinstance(line, int)` alongside the existing `line < 1` check, so a fractional line raises `ValueError` right away, on both the constructor and the setter, exactly like a line below 1. Whether a line is whole does not depend on the document, so there is no reason to defer it to the browser; only "beyond the end" needs `doc.lines` and stays a JS-side warning. `applyLineAnchors` is unchanged from `main`.

The fractional case is one more `pytest.raises` in `test_anchors_out_of_range`; no browser round-trip needed. Seen to fail before the fix.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation has been added — the docstring listed what happens to a line past the end and to one below 1, but said nothing about a line that is not whole.
- [x] No breaking changes to the public API — `dict[str, int]` never admitted floats, though a caller passing one now gets a `ValueError` instead of a silently snapped anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
