### PR TITLE
Fix template slots being remounted on every render (#6284)

### DIFF
--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -307,16 +307,17 @@ function renderRecursively(elements, id, propsContext) {
     slots[name] = (props) => {
       const rendered = [];
       if (data.template) {
+        // Cache the component definition on the slot so its identity is stable across renders.
+        // Otherwise a fresh object literal makes Vue treat each render as a new component type,
+        // unmounting and remounting the slot's DOM (losing local state) and recompiling the template.
+        data._component ??= {
+          props: { props: { type: Object, default: {} } },
+          template: data.template,
+        };
         rendered.push(
-          Vue.h(
-            {
-              props: { props: { type: Object, default: {} } },
-              template: data.template,
-            },
-            {
-              props: props,
-            },
-          ),
+          Vue.h(data._component, {
+            props: props,
+          }),
         );
       }
       const children = data.ids.map((id) => renderRecursively(elements, id, props || propsContext));
@@ -527,6 +528,16 @@ function createApp(elements, options) {
               }
             }
             delete element.preserved_props;
+            // Carry over compiled slot components so their identity stays stable across updates
+            // (as long as the template is unchanged), letting Vue patch the slot instead of
+            // remounting it and discarding its local DOM state. See renderRecursively.
+            const oldSlots = this.elements[id]?.slots;
+            for (const [name, data] of Object.entries(element.slots ?? {})) {
+              const oldData = oldSlots?.[name];
+              if (oldData?._component && oldData.template === data.template) {
+                data._component = oldData._component;
+              }
+            }
             this.elements[id] = element;
           }
 

--- a/nicegui/static/nicegui.js
+++ b/nicegui/static/nicegui.js
@@ -310,10 +310,10 @@ function renderRecursively(elements, id, propsContext) {
         // Cache the component definition on the slot so its identity is stable across renders.
         // Otherwise a fresh object literal makes Vue treat each render as a new component type,
         // unmounting and remounting the slot's DOM (losing local state) and recompiling the template.
-        data._component ??= {
+        data._component ??= Vue.markRaw({
           props: { props: { type: Object, default: {} } },
           template: data.template,
-        };
+        });
         rendered.push(
           Vue.h(data._component, {
             props: props,

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -541,3 +541,20 @@ def test_even_special_elements_have_an_html_id(screen: Screen):
     screen.open('/')
     screen.click('Check IDs')
     screen.should_contain('All IDs found')
+
+
+def test_template_slot_survives_rerender(screen: Screen):
+    @ui.page('/')
+    def page():
+        element = ui.element()
+        element.add_slot('default', '<input placeholder="type here">')
+        ui.button('Update', on_click=lambda: element.classes('bg-red-100'))
+
+    screen.open('/')
+    element = screen.selenium.find_element(By.XPATH, '//input[@placeholder="type here"]')
+    element.send_keys('hello')
+    assert element.get_attribute('value') == 'hello'
+
+    screen.click('Update')  # #6284: an unrelated re-render must not discard the slot's DOM
+    screen.wait(0.5)
+    assert element.get_attribute('value') == 'hello'

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -78,6 +78,23 @@ def test_multi_select(screen: Screen):
     screen.should_contain("['Bob']")
 
 
+def test_remove_chip_with_custom_slot(screen: Screen):
+    @ui.page('/')
+    def page():
+        s = ui.select(['Apple', 'Banana', 'Cherry'],
+                      multiple=True, value=['Apple', 'Banana', 'Cherry'], with_input=True).props('use-chips')
+        s.add_slot('selected-item',
+                   '<q-chip removable @remove="props.removeAtIndex(props.index)">{{ props.opt.label }}</q-chip>')
+        ui.label().bind_text_from(s, 'value', backward=str)
+
+    screen.open('/')
+    screen.should_contain("['Apple', 'Banana', 'Cherry']")
+
+    # #6284: focusing the field on the first click must not remount the chip and swallow the click
+    screen.find_by_css('.q-chip__icon--remove').click()
+    screen.should_contain("['Banana', 'Cherry']")
+
+
 def test_changing_options(screen: Screen):
     @ui.page('/')
     def page():


### PR DESCRIPTION
*Filed by Claude Code on SaadZahem's behalf*

### Motivation

Fixes #6284.

A removable chip in a `ui.select` with a custom `selected-item` slot swallowed the first click on its "x" — you had to click twice. More generally, **any** template slot lost its entire local DOM and component state whenever the surrounding element re-rendered for an unrelated reason. For example, typed text disappears here when the button is pressed:

```python
element = ui.element()
element.add_slot('default', '<input placeholder="type here">')
ui.button('update', on_click=lambda: element.classes('bg-red-100'))
```

**Mechanism:** In `renderRecursively` the slot render function passed a fresh object literal as the component definition to `Vue.h()` on every invocation. Vue identifies a vnode's component by the identity of its `type`, so each render looked like a different component: Vue unmounted the old slot subtree and mounted a new one, throwing away its DOM/component state and recompiling the template. For the chip, the first click makes Quasar add its focus classes and re-render the field, which destroys and recreates the chip's DOM node while the mouse button is held down; on `mouseup` the browser can't find the original node, so no `click` is synthesized and `@remove` never fires.

### Implementation

Give each slot template a stable component identity so Vue patches the slot in place instead of remounting it:

- Cache the component definition on the slot entry itself (`data._component ??= {...}`) rather than in a module-level map, tying its lifetime to the element (no monotonic leak with dynamically generated templates).
- Because a server update replaces the whole element object (`this.elements[id] = element`) — and with it the `slots` object — the cache is also carried over from the previous element during `update`, but only while the template string is unchanged. If the template changes, a new component is built and the old one is dropped.

Together these fix both the client-side re-render case (chip focus) and the server-update case (typed input surviving `.classes()`).

Two trade-offs worth noting: attaching the cache to the element (as suggested) means two elements sharing an identical template string no longer share a compiled component — each keeps its own — which trades a small amount of duplicate compilation for the leak-free lifetime. And when an element's event listeners change, `update` deletes and re-creates it, so the carry-over doesn't apply and the slot remounts by design in that path.

Note on the [related question](https://github.com/zauberzeug/nicegui/issues/6284) about slot closures: the slot functions are recreated on every `renderRecursively` call, but that doesn't cause remounts — Vue diffs the vnodes the closure returns by type, and stabilizing the component type is what's needed. So no change there.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated:
  - `test_remove_chip_with_custom_slot` — the original symptom: a single click on a removable chip's "x" removes the option.
  - `test_template_slot_survives_rerender` — a slot's typed input survives an unrelated re-render.

  Both were confirmed to fail on `main` and pass with this change.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
