### PR TITLE
Fix on_change documentation for ui.slider and ui.range

### DIFF
--- a/nicegui/elements/range.py
+++ b/nicegui/elements/range.py
@@ -22,7 +22,8 @@ class Range(ValueElement[dict[str, float] | None], DisableableElement):
         :param max: upper bound of the range
         :param step: step size
         :param value: initial value to set min and max position of the range (default: ``min`` to ``max``)
-        :param on_change: callback which is invoked when the user releases the range
+        :param on_change: callback to execute when the value changes, including while dragging
+            (to react only when the range is released, use ``.on('change', ...)`` instead)
         """
         super().__init__(tag='q-range', value=value or {'min': min, 'max': max},
                          on_value_change=on_change, throttle=0.05)

--- a/nicegui/elements/slider.py
+++ b/nicegui/elements/slider.py
@@ -22,7 +22,8 @@ class Slider(ValueElement[float | None], DisableableElement):
         :param max: upper bound of the slider
         :param step: step size
         :param value: initial value to set position of the slider
-        :param on_change: callback which is invoked when the user releases the slider
+        :param on_change: callback to execute when the value changes, including while dragging
+            (to react only when the slider is released, use ``.on('change', ...)`` instead)
         """
         super().__init__(tag='q-slider', value=value, on_value_change=on_change, throttle=0.05)
         self._props['min'] = min


### PR DESCRIPTION
*Opened by Claude Code on evnchn's behalf.*

### Motivation

Reported in #6291: `ui.range(on_change=...)` fires while the user drags, but the docstring promises it fires on release.

The docstring is the stale artifact, not the behaviour. `Slider` and `Range` pass `on_change` to `ValueElement`, which subscribes to Quasar's `update:model-value` — the continuous stream, throttled to 50 ms. Nothing has ever listened for `change`.

`ui.splitter` carries the same sentence and is **left untouched**: I measured `ui.splitter(on_change=...)` firing only after release, so its wording appears accurate. That is one scenario, not an exhaustive claim about QSplitter — happy to look further if you think it warrants it.

### Implementation

Two docstring lines, no behaviour change. The new wording follows the phrasing `ui.knob` already uses — equally drag-driven, and documented as "callback to execute when the value changes" — and points at `.on('change', ...)` for the release-only case the old wording implied.

<details>
<summary><b>Measurements</b> — real mouse drag, counting callbacks that arrive <i>before</i> mouse-up</summary>

Playwright drove `mousedown` → 20 × `mousemove` over ~800 ms → `mouseup`, with `on_change=` and `.on('change', ...)` both registered on the same element:

| element | `on_change` during drag (button still down) | `on_change` total incl. release | `change` events |
|---|---|---|---|
| `ui.slider` | 20 | 20 | 1 (on release) |
| `ui.range` | 21 | 21 | 1 (on release) |
| `ui.splitter` | **0** | 1 | 0 (QSplitter has no `change`) |

Timestamps confirm the 50 ms throttle:

```
1786892362.477 slider 52
1786892362.527 slider 54
1786892362.576 slider 56
...
1786892363.428 slider 90
```

The splitter row is why this PR only touches two files.

</details>

<details>
<summary><b>Why not change <code>on_change</code> instead</b></summary>

Considered and rejected — it would be a silent breaking change:

- `on_change=` and the public `.on_value_change()` append to the **same** `_change_handlers` list on `ValueElement`. Making the constructor argument release-only would split the two on the same object.
- `website/components/about_section.py` uses `ui.slider(..., on_change=lambda e: output.set_text(f'{e.value:.0f}%'))` for live feedback on the homepage, beside `ui.input(on_change=...)` and `ui.checkbox(on_change=...)`.
- The documentation site already documents the continuous behaviour as intended — the slider page's "Throttle events with leading and trailing options" demo says *"the value change event of a slider is throttled to 0.05 seconds"*.

A separate PR adding a first-class `on_release` is staged on the fork; this one is deliberately just the docs correction so it can merge on its own.

</details>

<details>
<summary><b>Verification</b></summary>

- `ruff` / `mypy` / `pylint` (10.00) clean on both changed files.
- Booted the real documentation site and confirmed the reference table renders the new wording and no longer contains *"invoked when the user releases the slider"*.
- Simulated `website/documentation/reference.py` lines 26–32 to confirm the wrapped `:param` continuation line survives docs rendering (it appends indented continuation lines to the previous parameter).

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary. — documentation-only change, no behaviour to test.
- [x] Documentation has been added/updated.
- [x] No breaking changes to the public API.
