### PR TITLE
Add on_release to ui.slider and ui.range

### DIFF
--- a/nicegui/elements/mixins/releasable_element.py
+++ b/nicegui/elements/mixins/releasable_element.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+from typing_extensions import Self
+
+from ...events import GenericEventArguments, Handler, ValueChangeEventArguments, ValueT, handle_event
+from .value_element import ValueElement
+
+
+class ReleasableElement(ValueElement[ValueT]):
+
+    def __init__(self, *,
+                 on_release: Handler[ValueChangeEventArguments[ValueT]] | None = None,
+                 **kwargs: Any,
+                 ) -> None:
+        super().__init__(**kwargs)
+        self._release_handlers: list[Handler[ValueChangeEventArguments[ValueT]]] = []
+        self._released_value = self.value
+        if on_release:
+            self.on_release(on_release)
+
+    def on_release(self, callback: Handler[ValueChangeEventArguments[ValueT]]) -> Self:
+        """Add a callback to be invoked when the user finishes an interaction.
+
+        In contrast to ``on_value_change``, this is not called while dragging, but once the element is released.
+        Clicking the track and pressing an arrow key also finish an interaction and invoke the callback.
+        The event's ``previous_value`` is the value at the previous release, ignoring programmatic changes.
+        """
+        if not self._release_handlers:
+            self.on('change', self._handle_release, [None])
+        self._release_handlers.append(callback)
+        return self
+
+    def _handle_release(self, e: GenericEventArguments) -> None:
+        previous_value = self._released_value
+        self._released_value = self._event_args_to_value(e)
+        args = ValueChangeEventArguments(sender=self, client=self.client,
+                                         value=self._released_value, previous_value=previous_value)
+        for handler in self._release_handlers:
+            handle_event(handler, args)

--- a/nicegui/elements/range.py
+++ b/nicegui/elements/range.py
@@ -22,7 +22,8 @@ class Range(ValueElement[dict[str, float] | None], DisableableElement):
         :param max: upper bound of the range
         :param step: step size
         :param value: initial value to set min and max position of the range (default: ``min`` to ``max``)
-        :param on_change: callback which is invoked when the user releases the range
+        :param on_change: callback to execute when the value changes, including while dragging
+            (to react only when the range is released, use ``.on('change', ...)`` instead)
         """
         super().__init__(tag='q-range', value=value or {'min': min, 'max': max},
                          on_value_change=on_change, throttle=0.05)

--- a/nicegui/elements/range.py
+++ b/nicegui/elements/range.py
@@ -1,10 +1,10 @@
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
-from .mixins.value_element import ValueElement
+from .mixins.releasable_element import ReleasableElement
 
 
-class Range(ValueElement[dict[str, float] | None], DisableableElement):
+class Range(ReleasableElement[dict[str, float] | None], DisableableElement):
 
     @resolve_defaults
     def __init__(self, *,
@@ -13,6 +13,7 @@ class Range(ValueElement[dict[str, float] | None], DisableableElement):
                  step: float = DEFAULT_PROP | 1.0,
                  value: dict[str, float] | None = DEFAULT_PROPS['model-value'] | None,
                  on_change: Handler[ValueChangeEventArguments[dict[str, float] | None]] | None = None,
+                 on_release: Handler[ValueChangeEventArguments[dict[str, float] | None]] | None = None,
                  ) -> None:
         """Range
 
@@ -23,10 +24,10 @@ class Range(ValueElement[dict[str, float] | None], DisableableElement):
         :param step: step size
         :param value: initial value to set min and max position of the range (default: ``min`` to ``max``)
         :param on_change: callback to execute when the value changes, including while dragging
-            (to react only when the range is released, use ``.on('change', ...)`` instead)
+        :param on_release: callback to execute when the user releases the range (*added in version 3.17.0*)
         """
         super().__init__(tag='q-range', value=value or {'min': min, 'max': max},
-                         on_value_change=on_change, throttle=0.05)
+                         on_value_change=on_change, throttle=0.05, on_release=on_release)
         self._props['min'] = min
         self._props['max'] = max
         self._props['step'] = step

--- a/nicegui/elements/slider.py
+++ b/nicegui/elements/slider.py
@@ -1,10 +1,10 @@
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..events import Handler, ValueChangeEventArguments
 from .mixins.disableable_element import DisableableElement
-from .mixins.value_element import ValueElement
+from .mixins.releasable_element import ReleasableElement
 
 
-class Slider(ValueElement[float | None], DisableableElement):
+class Slider(ReleasableElement[float | None], DisableableElement):
 
     @resolve_defaults
     def __init__(self, *,
@@ -13,6 +13,7 @@ class Slider(ValueElement[float | None], DisableableElement):
                  step: float = DEFAULT_PROP | 1.0,
                  value: float | None = DEFAULT_PROPS['model-value'] | None,
                  on_change: Handler[ValueChangeEventArguments[float | None]] | None = None,
+                 on_release: Handler[ValueChangeEventArguments[float | None]] | None = None,
                  ) -> None:
         """Slider
 
@@ -23,9 +24,10 @@ class Slider(ValueElement[float | None], DisableableElement):
         :param step: step size
         :param value: initial value to set position of the slider
         :param on_change: callback to execute when the value changes, including while dragging
-            (to react only when the slider is released, use ``.on('change', ...)`` instead)
+        :param on_release: callback to execute when the user releases the slider (*added in version 3.17.0*)
         """
-        super().__init__(tag='q-slider', value=value, on_value_change=on_change, throttle=0.05)
+        super().__init__(tag='q-slider', value=value, on_value_change=on_change, throttle=0.05,
+                         on_release=on_release)
         self._props['min'] = min
         self._props['max'] = max
         self._props['step'] = step

--- a/nicegui/elements/slider.py
+++ b/nicegui/elements/slider.py
@@ -22,7 +22,8 @@ class Slider(ValueElement[float | None], DisableableElement):
         :param max: upper bound of the slider
         :param step: step size
         :param value: initial value to set position of the slider
-        :param on_change: callback which is invoked when the user releases the slider
+        :param on_change: callback to execute when the value changes, including while dragging
+            (to react only when the slider is released, use ``.on('change', ...)`` instead)
         """
         super().__init__(tag='q-slider', value=value, on_value_change=on_change, throttle=0.05)
         self._props['min'] = min

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.action_chains import ActionChains
+
 from nicegui import ui
 from nicegui.testing import Screen
 
@@ -20,3 +22,32 @@ def test_range_no_value(screen: Screen):
 
     screen.open('/')
     screen.should_contain('min: 0, max: 100')
+
+
+def test_range_on_release_waits_for_the_release(screen: Screen):
+    r = None
+
+    @ui.page('/')
+    def page():
+        nonlocal r
+        r = ui.range(min=0, max=100, value={'min': 20, 'max': 80},
+                     on_change=lambda e: changed.set_text(f'changed {e.value["max"]}'),
+                     on_release=lambda e: released.set_text(f'released {e.value["max"]}'))
+        changed = ui.label('changed -')
+        released = ui.label('released -')
+
+    screen.open('/')
+    range_ = screen.find_element(r)
+
+    ActionChains(screen.selenium) \
+        .move_to_element_with_offset(range_, range_.size['width'] * 3 // 10, 0) \
+        .click_and_hold() \
+        .move_by_offset(30, 0) \
+        .pause(0.5) \
+        .perform()
+    screen.should_not_contain('changed -')  # on_change fires while dragging
+    screen.should_contain('released -')  # on_release does not
+
+    ActionChains(screen.selenium).release().perform()
+    screen.should_not_contain('released -')
+    screen.should_contain(f'released {r.value["max"]}')

--- a/tests/test_slider.py
+++ b/tests/test_slider.py
@@ -1,0 +1,33 @@
+from selenium.webdriver.common.action_chains import ActionChains
+
+from nicegui import ui
+from nicegui.testing import Screen
+
+
+def test_slider_on_release_waits_for_the_release(screen: Screen):
+    s = None
+
+    @ui.page('/')
+    def page():
+        nonlocal s
+        s = ui.slider(min=0, max=100, value=50,
+                      on_change=lambda e: changed.set_text(f'changed {e.value}'),
+                      on_release=lambda e: released.set_text(f'released {e.value}'))
+        changed = ui.label('changed -')
+        released = ui.label('released -')
+
+    screen.open('/')
+    slider = screen.find_element(s)
+
+    ActionChains(screen.selenium) \
+        .move_to_element(slider) \
+        .click_and_hold() \
+        .move_by_offset(40, 0) \
+        .pause(0.5) \
+        .perform()
+    screen.should_not_contain('changed -')  # on_change fires while dragging
+    screen.should_contain('released -')  # on_release does not
+
+    ActionChains(screen.selenium).release().perform()
+    screen.should_not_contain('released -')
+    screen.should_contain(f'released {s.value}')

--- a/website/documentation/content/slider_documentation.py
+++ b/website/documentation/content/slider_documentation.py
@@ -37,6 +37,17 @@ def throttle_events_with_leading_and_trailing_options():
             throttle=1.0, leading_events=False)
 
 
+@doc.demo('Only react once the slider is released', '''
+    The `on_change` callback is invoked continuously while the slider moves.
+    If the callback is expensive - a database query, say - use `on_release` instead,
+    which is invoked once the user finishes the interaction.
+
+    *Added in version 3.17.0*
+''')
+def only_react_once_the_slider_is_released():
+    ui.slider(min=0, max=100, value=50, on_release=lambda e: ui.notify(f'released at {e.value}'))
+
+
 @doc.demo('Disable slider', '''
     You can disable a slider with the `disable()` method.
     This will prevent the user from moving the slider.


### PR DESCRIPTION
*Opened by Claude Code on evnchn's behalf. Draft — stacked on #6292, and there are open questions below I would like your call on.*

### Motivation

Follow-up to #6291. **Stacked on #6292** — this branch carries that docstring commit too, so it will rebase down to a single commit once #6292 merges. Only the second commit is new.

`ui.slider` and `ui.range` promised, for years, a callback that fires "when the user releases". They never had a first-class parameter for it — only `.on('change', ...)` as an escape hatch. #6292 argues the docstring was the stale artifact, and I still think that is right. But the reporter came to `on_change` *because* of that sentence, so the demand behind it is real, and correcting the wording alone deletes the promise rather than keeping it.

This provides it. `on_change` is untouched — still the value-change stream, still identical in meaning to `.on_value_change()`.

```python
ui.slider(min=0, max=100, value=50, on_release=lambda e: expensive_query(e.value))
```

It also closes the request from issue 1074, where "lazy input" was answered with the `.on('change', ...)` workaround rather than an API.

### Implementation

`on_release` wraps Quasar's native `change` event, in a new `ReleasableElement` mixin shared by `Slider` and `Range`.

**The listener registers lazily**, on the first `on_release` callback — so elements that never use it add no listener to their payload and no round-trip per interaction. Verified against `Element.on()` and `_to_dict()`, not assumed.

**`previous_value` means "the value at the previous release"**, seeded from the initial value. Programmatic `set_value()` and binding pushes do not advance it. Stated in the `on_release()` docstring rather than papered over.

### Three things I would like your call on

1. **The version annotation says 3.17.0** — please correct if that is not the right next release.
2. **`ReleasableElement` now appears in the inheritance list on the `ui.slider` and `ui.range` documentation pages**, and `on_release` renders as inherited rather than native. Accurate, but it is a new name in the public docs — say the word if you would rather it were folded elsewhere or named differently.
3. **`ui.range` gets no usage demo**, only the reference entry; the slider demo covers the concept. Happy to add one if you would rather have symmetry, though the issue was filed against `ui.range`, so there is an argument for it.

<details>
<summary><b>Why <code>ui.knob</code> is deliberately excluded</b> — measured, and it contradicts what the source suggests</summary>

`QKnob`'s source has the same `updateValue(change)` shape as `QSlider`, which suggests it should get `on_release` too. Measured behaviour disagrees — `ui.knob` emits `change` **continuously** during a drag, paired 1:1 with `on_change`:

```
knob on_change = 0.15   knob change = 0.15
knob on_change = 0.18   knob change = 0.18
knob on_change = 0.20   knob change = 0.20      (15 more)
```

`on_release` on a knob would therefore be a misleading alias for continuous change. Excluded on that basis. If you know why the two components differ here, I would be glad to hear it — I could not account for it from the source alone.

</details>

<details>
<summary><b>When Quasar's <code>change</code> actually fires</b> — it is not literally "release"</summary>

| interaction | `change` events | when |
|---|---|---|
| drag → release | 1 | at release |
| single click on the track | 1 | immediately |
| 3 × ArrowRight while focused | **3** | one per keypress |
| Tab / blur | 0 | — |

So it is "committed value change" rather than "release" — the right behaviour for a lazy callback, since each keypress is a deliberate commit, but broader than the name. The method docstring spells this out. If you prefer a different name, this is the moment.

</details>

<details>
<summary><b>A staleness scare that turned out to be my test rig</b> — recorded so nobody re-walks it</summary>

While validating, `change` appeared to carry the value from where the drag *started* — 0/6 correct at an 8–16 ms gap between the last `mousemove` and `mouseup`. That nearly bought a client-side value cache into this PR.

It was the harness. The drag fired **one** synthetic `mousemove`, which Quasar reads as a click rather than a drag — which is exactly why the "stale" value was always the mousedown position. Varying the number of pointer moves:

| pointermoves in the drag | 0 ms gap | 8 ms | 16 ms | 33 ms | 50 ms |
|---|---|---|---|---|---|
| 1 (teleport) | 1/6 | 0/6 | 1/6 | 5/6 | 6/6 |
| 5 | 5/6 | 6/6 | 6/6 | 6/6 | 6/6 |
| 20 | **6/6** | 6/6 | 6/6 | 6/6 | 6/6 |
| 50 | **6/6** | 6/6 | 6/6 | 6/6 | 6/6 |

Any realistic drag emits dozens of moves and `change` is correct every time, on Chromium, Firefox and WebKit alike. **No workaround is present in this PR**, and `.on('change', ...)` remains sound advice on current releases.

</details>

<details>
<summary><b>Verification</b></summary>

- **The new tests were seen to fail.** Rewiring the mixin's listener from `change` to `update:model-value` fails both on `AssertionError: Could not find "released -"` — i.e. the callback fired during the drag. Restored, green again. Re-run after the mixin extraction, not only before it.
- `test_slider.py`, `test_range.py`, `test_defaults.py`, `test_binding.py`, `test_events.py` → **41 passed, 0 skipped** (`-rs`, since a platform-conditional skip beside an event-timing change would look green and prove nothing).
- `ruff` / `mypy` / `pylint` (10.00) clean, including the new mixin.
- Booted the documentation site and confirmed the new demo renders and the inheritance lists are correct on both pages.

The duplication between `Slider` and `Range` was flagged by a review pass and extracted into the mixin afterwards; an earlier reviewer had accepted the duplication, and I went with extraction. Reviewed by Codex, which returned APPROVE with no blockers on the final shape.

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. Opened as a draft because of the three open questions above, not because of missing work.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation has been added/updated.
- [x] No breaking changes to the public API. `on_change` is untouched; `on_release` is purely additive.
