### PR TITLE
Fix leakage of tasks awaiting initialization of some elements

### DIFF
--- a/nicegui/elements/leaflet/leaflet.py
+++ b/nicegui/elements/leaflet/leaflet.py
@@ -51,6 +51,7 @@ class Leaflet(Element, component='leaflet.js', esm={'nicegui-leaflet': 'dist'}, 
         self.layers: list[Layer] = []
         self.is_initialized = False
         self._initialized_event = asyncio.Event()
+        self._initialized_tasks: set[asyncio.Task] = set()
 
         # read-write public API
         self.center = center
@@ -102,8 +103,19 @@ class Leaflet(Element, component='leaflet.js', esm={'nicegui-leaflet': 'dist'}, 
 
     async def initialized(self) -> None:
         """Wait until the map is initialized."""
-        await self.client.connected()
-        await self._initialized_event.wait()
+        if self.is_initialized:
+            return
+        task = asyncio.current_task()
+        assert task is not None
+        if self.is_deleted:
+            task.cancel()
+            await asyncio.sleep(0)
+        self._initialized_tasks.add(task)
+        try:
+            await self.client.connected()
+            await self._initialized_event.wait()
+        finally:
+            self._initialized_tasks.discard(task)
 
     def _handle_move_or_zoom_end(self, e: GenericEventArguments) -> None:
         self._send_update_on_value_change = False
@@ -171,6 +183,8 @@ class Leaflet(Element, component='leaflet.js', esm={'nicegui-leaflet': 'dist'}, 
 
     def _handle_delete(self) -> None:
         binding.remove(self.layers)
+        for task in self._initialized_tasks:
+            task.cancel()
         super()._handle_delete()
 
     def _to_dict(self):

--- a/nicegui/elements/leaflet/leaflet.py
+++ b/nicegui/elements/leaflet/leaflet.py
@@ -7,12 +7,12 @@ from typing_extensions import Self
 from ... import binding
 from ...awaitable_response import AwaitableResponse, NullResponse
 from ...defaults import DEFAULT_PROP, resolve_defaults
-from ...element import Element
 from ...events import GenericEventArguments
+from ..mixins.cancelable_wait_element import CancelableWaitElement
 from .leaflet_layer import Layer
 
 
-class Leaflet(Element, component='leaflet.js', esm={'nicegui-leaflet': 'dist'}, default_classes='nicegui-leaflet'):
+class Leaflet(CancelableWaitElement, component='leaflet.js', esm={'nicegui-leaflet': 'dist'}, default_classes='nicegui-leaflet'):
     # pylint: disable=import-outside-toplevel
     from .leaflet_layers import GenericLayer as generic_layer
     from .leaflet_layers import ImageOverlay as image_overlay
@@ -51,7 +51,6 @@ class Leaflet(Element, component='leaflet.js', esm={'nicegui-leaflet': 'dist'}, 
         self.layers: list[Layer] = []
         self.is_initialized = False
         self._initialized_event = asyncio.Event()
-        self._initialized_tasks: set[asyncio.Task] = set()
 
         # read-write public API
         self.center = center
@@ -105,18 +104,11 @@ class Leaflet(Element, component='leaflet.js', esm={'nicegui-leaflet': 'dist'}, 
         """Wait until the map is initialized.
 
         *Updated in version 3.17.0: Awaiting leaflet initialization cancels the calling task
-        when the leaflet element is deleted, e.g. because the client disconnected.*
+        when the leaflet is deleted, e.g. because the client disconnected.*
         """
-        task = cast(asyncio.Task, asyncio.current_task())
-        if self.is_deleted:
-            task.cancel()
-            await asyncio.sleep(0)
-        self._initialized_tasks.add(task)
-        try:
+        with self._cancel_when_deleted(self._initialized_event):
             await self.client.connected()
             await self._initialized_event.wait()
-        finally:
-            self._initialized_tasks.discard(task)
 
     def _handle_move_or_zoom_end(self, e: GenericEventArguments) -> None:
         self._send_update_on_value_change = False
@@ -184,8 +176,6 @@ class Leaflet(Element, component='leaflet.js', esm={'nicegui-leaflet': 'dist'}, 
 
     def _handle_delete(self) -> None:
         binding.remove(self.layers)
-        for task in self._initialized_tasks:
-            task.cancel()
         super()._handle_delete()
 
     def _to_dict(self):

--- a/nicegui/elements/leaflet/leaflet.py
+++ b/nicegui/elements/leaflet/leaflet.py
@@ -103,8 +103,8 @@ class Leaflet(CancelableWaitElement, component='leaflet.js', esm={'nicegui-leafl
     async def initialized(self) -> None:
         """Wait until the map is initialized.
 
-        *Updated in version 3.17.0: Awaiting leaflet initialization cancels the calling task
-        when the leaflet is deleted, e.g. because the client disconnected.*
+        *Updated in version 3.17.0: Awaiting map initialization cancels the awaiting task
+        when the map is deleted, e.g. because the client disconnected.*
         """
         with self._cancel_when_deleted(self._initialized_event):
             await self.client.connected()

--- a/nicegui/elements/leaflet/leaflet.py
+++ b/nicegui/elements/leaflet/leaflet.py
@@ -102,11 +102,12 @@ class Leaflet(Element, component='leaflet.js', esm={'nicegui-leaflet': 'dist'}, 
             self.run_method('add_layer', layer.to_dict(), layer.id)
 
     async def initialized(self) -> None:
-        """Wait until the map is initialized."""
-        if self.is_initialized:
-            return
-        task = asyncio.current_task()
-        assert task is not None
+        """Wait until the map is initialized.
+
+        *Updated in version 3.17.0: Awaiting leaflet initialization cancels the calling task
+        when the leaflet element is deleted, e.g. because the client disconnected.*
+        """
+        task = cast(asyncio.Task, asyncio.current_task())
         if self.is_deleted:
             task.cancel()
             await asyncio.sleep(0)

--- a/nicegui/elements/scene/scene.py
+++ b/nicegui/elements/scene/scene.py
@@ -2,7 +2,7 @@ import asyncio
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from typing_extensions import Self
 
@@ -214,9 +214,12 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
         return super().run_method(name, *args, timeout=timeout)
 
     async def initialized(self) -> None:
-        """Wait until the scene is initialized."""
-        task = asyncio.current_task()
-        assert task is not None
+        """Wait until the scene is initialized.
+
+        *Updated in version 3.17.0: Awaiting scene initialization cancels the calling task
+        when the scene element is deleted, e.g. because the client disconnected.*
+        """
+        task = cast(asyncio.Task, asyncio.current_task())
         if self.is_deleted:
             task.cancel()
             await asyncio.sleep(0)

--- a/nicegui/elements/scene/scene.py
+++ b/nicegui/elements/scene/scene.py
@@ -215,7 +215,7 @@ class Scene(CancelableWaitElement, component='scene.js', esm={'nicegui-scene': '
     async def initialized(self) -> None:
         """Wait until the scene is initialized.
 
-        *Updated in version 3.17.0: Awaiting scene initialization cancels the calling task
+        *Updated in version 3.17.0: Awaiting scene initialization cancels the awaiting task
         when the scene is deleted, e.g. because the client disconnected.*
         """
         with self._cancel_when_deleted(self._initialized_event):

--- a/nicegui/elements/scene/scene.py
+++ b/nicegui/elements/scene/scene.py
@@ -113,6 +113,7 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
         self.stack: list[Object3D | SceneObject] = [SceneObject()]
         self._batched_calls: list[list[Any]] | None = None
         self._initialized_event = asyncio.Event()
+        self._initialized_tasks: set[asyncio.Task] = set()
         self._click_handlers = [on_click] if on_click else []
         self._props['click-events'] = click_events[:]
         self._drag_start_handlers = [on_drag_start] if on_drag_start else []
@@ -214,8 +215,17 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
 
     async def initialized(self) -> None:
         """Wait until the scene is initialized."""
-        await self.client.connected()
-        await self._initialized_event.wait()
+        task = asyncio.current_task()
+        assert task is not None
+        if self.is_deleted:
+            task.cancel()
+            await asyncio.sleep(0)
+        self._initialized_tasks.add(task)
+        try:
+            await self.client.connected()
+            await self._initialized_event.wait()
+        finally:
+            self._initialized_tasks.discard(task)
 
     def _handle_click(self, e: GenericEventArguments) -> None:
         arguments = SceneClickEventArguments(
@@ -306,6 +316,8 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
 
     def _handle_delete(self) -> None:
         binding.remove(list(self.objects.values()))
+        for task in self._initialized_tasks:
+            task.cancel()
         super()._handle_delete()
 
     def delete_objects(self, predicate: Callable[[Object3D], bool] = lambda _: True) -> None:

--- a/nicegui/elements/scene/scene.py
+++ b/nicegui/elements/scene/scene.py
@@ -2,14 +2,13 @@ import asyncio
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from typing_extensions import Self
 
 from ... import binding
 from ...awaitable_response import AwaitableResponse, NullResponse
 from ...defaults import DEFAULT_PROP, resolve_defaults
-from ...element import Element
 from ...events import (
     GenericEventArguments,
     Handler,
@@ -18,6 +17,7 @@ from ...events import (
     SceneDragEventArguments,
     handle_event,
 )
+from ..mixins.cancelable_wait_element import CancelableWaitElement
 from .scene_object3d import Object3D
 
 
@@ -41,7 +41,7 @@ class SceneObject:
     id: str = 'scene'
 
 
-class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, default_classes='nicegui-scene'):
+class Scene(CancelableWaitElement, component='scene.js', esm={'nicegui-scene': 'dist'}, default_classes='nicegui-scene'):
     # pylint: disable=import-outside-toplevel
     from .objects.axes_helper import AxesHelper as axes_helper
     from .objects.box import Box as box
@@ -113,7 +113,6 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
         self.stack: list[Object3D | SceneObject] = [SceneObject()]
         self._batched_calls: list[list[Any]] | None = None
         self._initialized_event = asyncio.Event()
-        self._initialized_tasks: set[asyncio.Task] = set()
         self._click_handlers = [on_click] if on_click else []
         self._props['click-events'] = click_events[:]
         self._drag_start_handlers = [on_drag_start] if on_drag_start else []
@@ -217,18 +216,11 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
         """Wait until the scene is initialized.
 
         *Updated in version 3.17.0: Awaiting scene initialization cancels the calling task
-        when the scene element is deleted, e.g. because the client disconnected.*
+        when the scene is deleted, e.g. because the client disconnected.*
         """
-        task = cast(asyncio.Task, asyncio.current_task())
-        if self.is_deleted:
-            task.cancel()
-            await asyncio.sleep(0)
-        self._initialized_tasks.add(task)
-        try:
+        with self._cancel_when_deleted(self._initialized_event):
             await self.client.connected()
             await self._initialized_event.wait()
-        finally:
-            self._initialized_tasks.discard(task)
 
     def _handle_click(self, e: GenericEventArguments) -> None:
         arguments = SceneClickEventArguments(
@@ -319,8 +311,6 @@ class Scene(Element, component='scene.js', esm={'nicegui-scene': 'dist'}, defaul
 
     def _handle_delete(self) -> None:
         binding.remove(list(self.objects.values()))
-        for task in self._initialized_tasks:
-            task.cancel()
         super()._handle_delete()
 
     def delete_objects(self, predicate: Callable[[Object3D], bool] = lambda _: True) -> None:

--- a/nicegui/elements/scene/scene_view.py
+++ b/nicegui/elements/scene/scene_view.py
@@ -1,10 +1,8 @@
 import asyncio
-from typing import cast
 
 from typing_extensions import Self
 
 from ...defaults import DEFAULT_PROP, resolve_defaults
-from ...element import Element
 from ...events import (
     ClickEventArguments,
     GenericEventArguments,
@@ -13,10 +11,11 @@ from ...events import (
     SceneClickHit,
     handle_event,
 )
+from ..mixins.cancelable_wait_element import CancelableWaitElement
 from .scene import Scene, SceneCamera
 
 
-class SceneView(Element, component='scene_view.js', default_classes='nicegui-scene-view'):
+class SceneView(CancelableWaitElement, component='scene_view.js', default_classes='nicegui-scene-view'):
     # NOTE: The ESM is already registered in scene.py.
 
     @resolve_defaults
@@ -56,7 +55,6 @@ class SceneView(Element, component='scene_view.js', default_classes='nicegui-sce
         self._props['camera-type'] = self.camera.type
         self._props['camera-params'] = self.camera.params
         self._initialized_event = asyncio.Event()
-        self._initialized_tasks: set[asyncio.Task] = set()
         self._click_handlers = [on_click] if on_click else []
         self.on('init', self._handle_init)
         self.on('click3d', self._handle_click)
@@ -80,23 +78,11 @@ class SceneView(Element, component='scene_view.js', default_classes='nicegui-sce
         """Wait until the scene is initialized.
 
         *Updated in version 3.17.0: Awaiting scene_view initialization cancels the calling task
-        when the scene_view element is deleted, e.g. because the client disconnected.*
+        when the scene_view is deleted, e.g. because the client disconnected.*
         """
-        task = cast(asyncio.Task, asyncio.current_task())
-        if self.is_deleted:
-            task.cancel()
-            await asyncio.sleep(0)
-        self._initialized_tasks.add(task)
-        try:
+        with self._cancel_when_deleted(self._initialized_event):
             await self.client.connected()
             await self._initialized_event.wait()
-        finally:
-            self._initialized_tasks.discard(task)
-
-    def _handle_delete(self) -> None:
-        for task in self._initialized_tasks:
-            task.cancel()
-        super()._handle_delete()
 
     def _handle_click(self, e: GenericEventArguments) -> None:
         arguments = SceneClickEventArguments(

--- a/nicegui/elements/scene/scene_view.py
+++ b/nicegui/elements/scene/scene_view.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import cast
 
 from typing_extensions import Self
 
@@ -76,9 +77,12 @@ class SceneView(Element, component='scene_view.js', default_classes='nicegui-sce
         self.run_method('init')
 
     async def initialized(self) -> None:
-        """Wait until the scene is initialized."""
-        task = asyncio.current_task()
-        assert task is not None
+        """Wait until the scene is initialized.
+
+        *Updated in version 3.17.0: Awaiting scene_view initialization cancels the calling task
+        when the scene_view element is deleted, e.g. because the client disconnected.*
+        """
+        task = cast(asyncio.Task, asyncio.current_task())
         if self.is_deleted:
             task.cancel()
             await asyncio.sleep(0)

--- a/nicegui/elements/scene/scene_view.py
+++ b/nicegui/elements/scene/scene_view.py
@@ -77,8 +77,8 @@ class SceneView(CancelableWaitElement, component='scene_view.js', default_classe
     async def initialized(self) -> None:
         """Wait until the scene is initialized.
 
-        *Updated in version 3.17.0: Awaiting scene_view initialization cancels the calling task
-        when the scene_view is deleted, e.g. because the client disconnected.*
+        *Updated in version 3.17.0: Awaiting scene view initialization cancels the awaiting task
+        when the scene view is deleted, e.g. because the client disconnected.*
         """
         with self._cancel_when_deleted(self._initialized_event):
             await self.client.connected()

--- a/nicegui/elements/scene/scene_view.py
+++ b/nicegui/elements/scene/scene_view.py
@@ -55,6 +55,7 @@ class SceneView(Element, component='scene_view.js', default_classes='nicegui-sce
         self._props['camera-type'] = self.camera.type
         self._props['camera-params'] = self.camera.params
         self._initialized_event = asyncio.Event()
+        self._initialized_tasks: set[asyncio.Task] = set()
         self._click_handlers = [on_click] if on_click else []
         self.on('init', self._handle_init)
         self.on('click3d', self._handle_click)
@@ -76,8 +77,22 @@ class SceneView(Element, component='scene_view.js', default_classes='nicegui-sce
 
     async def initialized(self) -> None:
         """Wait until the scene is initialized."""
-        await self.client.connected()
-        await self._initialized_event.wait()
+        task = asyncio.current_task()
+        assert task is not None
+        if self.is_deleted:
+            task.cancel()
+            await asyncio.sleep(0)
+        self._initialized_tasks.add(task)
+        try:
+            await self.client.connected()
+            await self._initialized_event.wait()
+        finally:
+            self._initialized_tasks.discard(task)
+
+    def _handle_delete(self) -> None:
+        for task in self._initialized_tasks:
+            task.cancel()
+        super()._handle_delete()
 
     def _handle_click(self, e: GenericEventArguments) -> None:
         arguments = SceneClickEventArguments(

--- a/tests/test_leaflet.py
+++ b/tests/test_leaflet.py
@@ -1,10 +1,11 @@
+import asyncio
 import base64
 import time
 
 from fastapi import Response
 
 from nicegui import app, ui
-from nicegui.testing import Screen
+from nicegui.testing import Screen, User
 
 
 def test_leaflet(screen: Screen):
@@ -57,6 +58,25 @@ def test_await_initialized_twice(screen: Screen):
     screen.open('/')
     screen.should_contain('Leaflet initialized')
     assert not screen.caplog.records
+
+
+async def test_await_initialized_cancel_task(user: User):
+    initialized = asyncio.Event()
+    task: list[asyncio.Task] = []
+
+    @ui.page('/')
+    async def page():
+        task.append(asyncio.current_task())
+        m = ui.leaflet()
+        await m.initialized()
+        initialized.set()
+
+    client = await user.open('/')
+    await asyncio.sleep(0.1)
+    client.delete()
+    await asyncio.sleep(0.1)
+    assert not initialized.is_set(), 'code after leaflet.initialized() ran'
+    assert task[0].cancelled(), 'the waiting task should be cancelled, not left pending or resolved'
 
 
 def test_leaflet_unhide(screen: Screen):

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -1,3 +1,4 @@
+import asyncio
 import gc
 import weakref
 from typing import Literal
@@ -12,6 +13,25 @@ from nicegui.events import GenericEventArguments
 from nicegui.testing import Screen, User
 
 from .test_helpers import TEST_DIR
+
+
+async def test_await_initialized_cancel_task(user: User):
+    initialized = asyncio.Event()
+    task: list[asyncio.Task] = []
+
+    @ui.page('/')
+    async def page():
+        task.append(asyncio.current_task())
+        m = ui.scene()
+        await m.initialized()
+        initialized.set()
+
+    client = await user.open('/')
+    await asyncio.sleep(0.1)
+    client.delete()
+    await asyncio.sleep(0.1)
+    assert not initialized.is_set(), 'code after scene.initialized() ran'
+    assert task[0].cancelled(), 'the waiting task should be cancelled, not left pending or resolved'
 
 
 def test_moving_sphere_with_timer(screen: Screen):

--- a/tests/test_scene_view.py
+++ b/tests/test_scene_view.py
@@ -1,9 +1,29 @@
+import asyncio
 import numpy as np
 
 from nicegui import app, ui
-from nicegui.testing import Screen
+from nicegui.testing import Screen, User
 
 from .test_helpers import TEST_DIR
+
+
+async def test_await_initialized_cancel_task(user: User):
+    initialized = asyncio.Event()
+    task: list[asyncio.Task] = []
+
+    @ui.page('/')
+    async def page():
+        task.append(asyncio.current_task())
+        m = ui.scene_view(ui.scene())
+        await m.initialized()
+        initialized.set()
+
+    client = await user.open('/')
+    await asyncio.sleep(0.1)
+    client.delete()
+    await asyncio.sleep(0.1)
+    assert not initialized.is_set(), 'code after scene_view.initialized() ran'
+    assert task[0].cancelled(), 'the waiting task should be cancelled, not left pending or resolved'
 
 
 def test_create_dynamically(screen: Screen):

--- a/tests/test_scene_view.py
+++ b/tests/test_scene_view.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import numpy as np
 
 from nicegui import app, ui


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->

<!-- Please provide relevant links to corresponding issues and feature requests. -->

Follow up to #6271
Fixes #6277

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->

<!-- Include any important technical decisions or trade-offs made. -->

`ui.scene`, `ui.scene_view` and `ui.leaflet` now inherit the `CancelableWaitElement` mixin from #6271 instead of `Element`, and each `initialized()` body is wrapped in `with self._cancel_when_deleted(self._initialized_event):`.

The mixin does both halves:
1. On deletion, it cancels every task awaiting this element (`_handle_delete`).
2. Its entry check raises `CancelledError` immediately when the element is *already* deleted — before `await self.client.connected()`, which would otherwise park forever on a deleted client.

So all three elements now behave exactly like `ui.button`'s `clicked()`.


### Progress

- [x] The PR title is a short phrase starting with the verb "Fix"
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.

