### PR TITLE
Fix awaited ui.run_javascript leaking task when client is deleted

### DIFF
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -257,7 +257,10 @@ class Client:
         return self.page.resolve_title() if self.title is None else self.title
 
     async def connected(self, timeout: float | None = None) -> None:
-        """Block execution until the client is connected.
+        """Block execution until the client is connected or deleted.
+
+        Because this method also returns when the client is deleted,
+        the caller must recheck using `client.is_deleted`.
 
         :param timeout: timeout in seconds (default: ``None``)
         """

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -303,9 +303,6 @@ class Client:
         async def send_and_wait():
             self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id}, target_id)
             await self.connected()
-            if self.is_deleted:
-                asyncio.current_task().cancel()
-                await asyncio.sleep(0)  # let cancellation take effect
             return await JavaScriptRequest(request_id, timeout=timeout)
 
         return AwaitableResponse(send_and_forget, send_and_wait)

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -261,7 +261,7 @@ class Client:
 
         :param timeout: timeout in seconds (default: ``None``)
         """
-        if self.has_socket_connection:
+        if self.has_socket_connection or self.is_deleted:
             return
         self._waiting_for_connection.set()
         self._connected.clear()
@@ -303,6 +303,8 @@ class Client:
         async def send_and_wait():
             self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id}, target_id)
             await self.connected()
+            if self.is_deleted:
+                return None
             return await JavaScriptRequest(request_id, timeout=timeout)
 
         return AwaitableResponse(send_and_forget, send_and_wait)

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -307,7 +307,7 @@ class Client:
             self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id}, target_id)
             await self.connected()
             if self.is_deleted:
-                asyncio.current_task().cancel()
+                cast(asyncio.Task, asyncio.current_task()).cancel()
                 await asyncio.sleep(0)  # let cancellation take effect
             return await JavaScriptRequest(request_id, timeout=timeout)
 

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -257,10 +257,7 @@ class Client:
         return self.page.resolve_title() if self.title is None else self.title
 
     async def connected(self, timeout: float | None = None) -> None:
-        """Block execution until the client is connected or deleted.
-
-        Because this method also returns when the client is deleted,
-        the caller must recheck using `client.is_deleted`.
+        """Block execution until the client is connected.
 
         :param timeout: timeout in seconds (default: ``None``)
         """

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -303,6 +303,9 @@ class Client:
         async def send_and_wait():
             self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id}, target_id)
             await self.connected()
+            if self.is_deleted:
+                asyncio.current_task().cancel()
+                await asyncio.sleep(0)  # let cancellation take effect
             return await JavaScriptRequest(request_id, timeout=timeout)
 
         return AwaitableResponse(send_and_forget, send_and_wait)

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -307,7 +307,7 @@ class Client:
             self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id}, target_id)
             await self.connected()
             if self.is_deleted:
-                cast(asyncio.Task, asyncio.current_task()).cancel()
+                asyncio.current_task().cancel()
                 await asyncio.sleep(0)  # let cancellation take effect
             return await JavaScriptRequest(request_id, timeout=timeout)
 

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -260,6 +260,7 @@ class Client:
         """Block execution until the client is connected.
 
         :param timeout: timeout in seconds (default: ``None``)
+        :raises ClientConnectionTimeout: if ``timeout`` elapses first
         """
         if self.has_socket_connection or self.is_deleted:
             return

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -290,10 +290,14 @@ class Client:
         Internally, ``await client.connected()`` is called before the JavaScript code is executed (*since version 3.0.0*).
         This might delay the execution of the JavaScript code and is not covered by the ``timeout`` parameter.
 
+        *Updated in version 3.17.0: Awaiting the response resolves with ``None`` when the client has been deleted,
+        e.g. because the browser tab was closed.*
+
         :param code: JavaScript code to run
         :param timeout: timeout in seconds (default: 1.0)
 
-        :return: AwaitableResponse that can be awaited to get the result of the JavaScript code
+        :return: AwaitableResponse that can be awaited to get the result of the JavaScript code,
+            or ``None`` if the client has been deleted
         """
         request_id = str(uuid.uuid4())
         target_id = self._temporary_socket_id or self.id

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -303,9 +303,13 @@ class Client:
         target_id = self._temporary_socket_id or self.id
 
         def send_and_forget():
+            if self.is_deleted:
+                return
             self.outbox.enqueue_message('run_javascript', {'code': code}, target_id)
 
         async def send_and_wait():
+            if self.is_deleted:
+                return None
             self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id}, target_id)
             await self.connected()
             if self.is_deleted:

--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -302,12 +302,12 @@ class Client:
         request_id = str(uuid.uuid4())
         target_id = self._temporary_socket_id or self.id
 
-        def send_and_forget():
+        def send_and_forget() -> None:
             if self.is_deleted:
                 return
             self.outbox.enqueue_message('run_javascript', {'code': code}, target_id)
 
-        async def send_and_wait():
+        async def send_and_wait() -> Any:
             if self.is_deleted:
                 return None
             self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id}, target_id)

--- a/nicegui/functions/javascript.py
+++ b/nicegui/functions/javascript.py
@@ -16,9 +16,13 @@ def run_javascript(code: str, *, timeout: float = 1.0) -> AwaitableResponse:
     Internally, ``await client.connected()`` is called before the JavaScript code is executed (*since version 3.0.0*).
     This might delay the execution of the JavaScript code and is not covered by the ``timeout`` parameter.
 
+    *Updated in version 3.17.0: Awaiting the response resolves with ``None`` when the client has been deleted,
+    e.g. because the browser tab was closed.*
+
     :param code: JavaScript code to run
     :param timeout: timeout in seconds (default: 1.0)
 
-    :return: AwaitableResponse that can be awaited to get the result of the JavaScript code
+    :return: AwaitableResponse that can be awaited to get the result of the JavaScript code,
+        or ``None`` if the client has been deleted
     """
     return context.client.run_javascript(code, timeout=timeout)

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -1,5 +1,8 @@
-from nicegui import ui
-from nicegui.testing import Screen
+import asyncio
+
+from nicegui import background_tasks, ui
+from nicegui.client import Client
+from nicegui.testing import Screen, User
 
 
 def test_run_javascript_on_button_press(screen: Screen):
@@ -93,3 +96,37 @@ def test_simultaneous_async_javascript(screen: Screen):
     screen.click('runB')
     screen.should_contain('A: 1')
     screen.should_contain('B: 2')
+
+
+async def test_awaited_run_javascript_resolves_when_client_is_deleted_while_waiting(user: User):
+    results = []
+
+    @ui.page('/')
+    async def page():
+        results.append(await ui.run_javascript('window.innerWidth'))
+
+    await user.http_client.get('/')  # request the page without ever opening the websocket
+    await asyncio.sleep(0)
+    Client.prune_instances(client_age_threshold=0)  # delete the client, waking up connected()
+    await asyncio.sleep(1.5)  # longer than run_javascript's default 1.0 s timeout
+    assert results == [None]
+
+
+async def test_awaited_run_javascript_resolves_when_client_is_already_deleted(user: User):
+    results = []
+
+    @ui.page('/')
+    async def page():
+        client = ui.context.client
+
+        async def later() -> None:
+            await asyncio.sleep(0.3)  # resume long after the client is gone
+            results.append(await client.run_javascript('window.innerWidth'))
+
+        background_tasks.create(later())
+
+    await user.http_client.get('/')  # request the page without ever opening the websocket
+    await asyncio.sleep(0)
+    Client.prune_instances(client_age_threshold=0)
+    await asyncio.sleep(1.5)
+    assert results == [None]

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -1,7 +1,6 @@
 import asyncio
 
-from nicegui import background_tasks, ui
-from nicegui.client import Client
+from nicegui import Client, ui
 from nicegui.testing import Screen, User
 
 
@@ -98,35 +97,23 @@ def test_simultaneous_async_javascript(screen: Screen):
     screen.should_contain('B: 2')
 
 
-async def test_awaited_run_javascript_resolves_when_client_is_deleted_while_waiting(user: User):
+async def test_awaited_run_javascript_resolves_when_client_is_deleted(user: User):
+    """The task awaiting run_javascript must not time out or wait forever when the client is deleted, e.g. after a disconnect."""
+    clients: list[Client] = []
     results = []
 
     @ui.page('/')
     async def page():
+        clients.append(ui.context.client)
         results.append(await ui.run_javascript('window.innerWidth'))
 
     await user.http_client.get('/')  # request the page without ever opening the websocket
     await asyncio.sleep(0)
+    assert not results
+
     Client.prune_instances(client_age_threshold=0)  # delete the client, waking up connected()
-    await asyncio.sleep(1.5)  # longer than run_javascript's default 1.0 s timeout
-    assert results == [None]
+    await asyncio.sleep(0.1)  # let the page function resume
+    assert results == [None]  # the page function resumed with None instead of timing out
 
-
-async def test_awaited_run_javascript_resolves_when_client_is_already_deleted(user: User):
-    results = []
-
-    @ui.page('/')
-    async def page():
-        client = ui.context.client
-
-        async def later() -> None:
-            await asyncio.sleep(0.3)  # resume long after the client is gone
-            results.append(await client.run_javascript('window.innerWidth'))
-
-        background_tasks.create(later())
-
-    await user.http_client.get('/')  # request the page without ever opening the websocket
-    await asyncio.sleep(0)
-    Client.prune_instances(client_age_threshold=0)
-    await asyncio.sleep(1.5)
-    assert results == [None]
+    # calling on a deleted client resolves immediately
+    assert await clients[0].run_javascript('window.innerWidth') is None

--- a/tests/test_speculative_loading.py
+++ b/tests/test_speculative_loading.py
@@ -117,9 +117,11 @@ def test_prefetch_connects_after_navigation(screen: Screen, event_log: EventLog)
     screen.click('answer')
     event_log.wait_for('connect: /answer')
     event_log.wait_for('answer: 42')
-    # if the client was deleted, shouldn't the answer be None?
-    assert event_log.items == ['answer: called', 'connect: /', 'answer: called', 'connect: /answer', 'answer: 42'], \
-        'answer() should re-evaluate after prefetch client was pruned'
+    assert event_log.items == [
+        'answer: called', 'connect: /',
+        'answer: None',
+        'answer: called', 'connect: /answer', 'answer: 42',
+    ], 'answer() should re-evaluate after prefetch client was pruned'
     screen.should_contain('all done')
 
 

--- a/tests/test_speculative_loading.py
+++ b/tests/test_speculative_loading.py
@@ -117,6 +117,7 @@ def test_prefetch_connects_after_navigation(screen: Screen, event_log: EventLog)
     screen.click('answer')
     event_log.wait_for('connect: /answer')
     event_log.wait_for('answer: 42')
+    # if the client was deleted, shouldn't the answer be None?
     assert event_log.items == ['answer: called', 'connect: /', 'answer: called', 'connect: /answer', 'answer: 42'], \
         'answer() should re-evaluate after prefetch client was pruned'
     screen.should_contain('all done')


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->

<!-- Please provide relevant links to corresponding issues and feature requests. -->

Fixes #6278

A lot of issues are related to this one.
This PR also updates the docstring of `client.connected`

### Implementation

PS (placed higher for importance): @evnchn pointed this out
> ⚠️ One residual worth naming in the PR body rather than hiding behind the green: after the fix the woken builder continues past the None into ui.label('all done') on a deleted client, so check_existence() logs "Client has been deleted but is still being used. This is most likely a bug in your application code." Nothing fails on a WARNING, so the updated assertion passes with it still firing. Whether to also stop the builder is a maintainer call.

<!-- What is the concept behind the implementation? How does it work? -->

<!-- Include any important technical decisions or trade-offs made. -->

#### The fix

Based on the info that `client.connected` returns when the client is connected
_but also when it's deleted_ (I have added this to its docstring),
I added a guard after it that checks whether the client is deleted.
This guard cancels the calling async task since they can't do much without a client.

```diff
diff --git a/nicegui/client.py b/nicegui/client.py
index 8886c135..97ae82a0 100644
--- a/nicegui/client.py
+++ b/nicegui/client.py
@@ -303,6 +303,9 @@ class Client:
         async def send_and_wait():
             self.outbox.enqueue_message('run_javascript', {'code': code, 'request_id': request_id}, target_id)
             await self.connected()
+            if self.is_deleted:
+                return None
             return await JavaScriptRequest(request_id, timeout=timeout)
 
         return AwaitableResponse(send_and_forget, send_and_wait)
```

The guard at the beginning of `client.connected` got extended:
```py
        if self.has_socket_connection or self.is_deleted:
            return
```

#### Testing

I tested using this modified MRE (at first)

```py
import asyncio

from nicegui import app, ui
from nicegui.client import Client


@ui.page('/')
async def page():
    width = await ui.run_javascript('window.innerWidth')
    ui.label(f'{width}px')


@app.on_startup
async def prune_faster() -> None:
    while True:
        await asyncio.sleep(0.5)
        Client.prune_instances(client_age_threshold=2)


ui.run(show=False)
```

I added 2 tests:
1. test if client disconnected in the middle of `await ui.run_javascript()`
2. test if client disconnected before `await ui.run_javascript()`

#### Documentation

A bit of documentation was added to `client.connected` method mentioning that it raises `ClientConnectionTimeout`.
I've noted the use of double backticks in the docstring.

<details><summary>

#### One suggestion (out of scope)

</summary>

I recommend making `client.connected` return a boolean.
`True` when connected, `False` otherwise.
In that case, the user can use it like this:

```py
    if not await ui.context.client.connected():
        return
```

Otherwise, the user is instructed to check for whether the client is deleted after calling
`client.connected`, which looks like this:

```py
    await ui.context.client.connected()
    if ui.context.client.is_deleted:
        return
```

It's not just about writing less code, it's about having a function communicate its purpose clearly.
By having the function returning `True` or `False`, the user can guess that True is when things go right,
and `False` is for when things go otherwise.

That was my suggestion. It's up to the maintainers to decide how to shape the public API.

</details>

### Progress

- [x] The PR title is a short phrase starting with the verb "Fix"
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests are not necessary.
- [x] Documentation was added to `client.connected` advising the user to guard it.
- [x] No breaking changes to the public API or migration steps are described above.
