### PR TITLE
Fix `page.py`: don't propagate CancelledError from late `task.result()` (#6296)

### DIFF
--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -204,7 +204,7 @@ class page:
                 if not task_wait_for_connection.done():
                     task_wait_for_connection.cancel()
                 if task.done():
-                    result = task.result()
+                    result = None if task.cancelled() else task.result()
                 else:
                     result = None
                     task.add_done_callback(check_for_late_return_value)

--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -204,7 +204,12 @@ class page:
                 if not task_wait_for_connection.done():
                     task_wait_for_connection.cancel()
                 if task.done():
-                    result = None if task.cancelled() else task.result()
+                    if task.cancelled():
+                        log.warning(f'Page building for {client.page.path} was cancelled; '
+                                    'serving the elements created so far')
+                        result = None
+                    else:
+                        result = task.result()
                 else:
                     result = None
                     task.add_done_callback(check_for_late_return_value)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -205,16 +205,17 @@ def test_ui_page_http_exception_404_keeps_html(screen: Screen):
         'ui.page raising HTTPException(404) should render the HTML error page for browsers'
 
 
-async def test_normal_response_when_async_page_is_cancelled(screen: Screen):
+def test_normal_response_when_async_page_is_cancelled(screen: Screen):
     @ui.page('/')
     async def page():
-        task = asyncio.current_task()
-        task.cancel()
+        asyncio.current_task().cancel()
         ui.label('The end')
 
     screen.start_server()
     response = httpx.get(f'http://localhost:{Screen.PORT}/')
-    assert response.status_code == 200
+    assert response.status_code == 200, 'page cancelling its own task should still return a normal response'
+    assert 'The end' in response.text, 'elements created before the cancellation takes effect should be served'
+    screen.assert_py_logger('WARNING', re.compile('Page building for / was cancelled'))
 
 
 def test_page_with_args(screen: Screen):

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -205,6 +205,18 @@ def test_ui_page_http_exception_404_keeps_html(screen: Screen):
         'ui.page raising HTTPException(404) should render the HTML error page for browsers'
 
 
+async def test_normal_response_when_async_page_is_cancelled(screen: Screen):
+    @ui.page('/')
+    async def page():
+        task = asyncio.current_task()
+        task.cancel()
+        ui.label('The end')
+
+    screen.start_server()
+    response = httpx.get(f'http://localhost:{Screen.PORT}/')
+    assert response.status_code == 200
+
+
 def test_page_with_args(screen: Screen):
     @ui.page('/page/{id_}')
     def page(id_: int):


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->

<!-- Please provide relevant links to corresponding issues and feature requests. -->

Fixes #6296
Related to #6271 and #6294

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->

<!-- Include any important technical decisions or trade-offs made. -->


```diff
diff --git a/nicegui/page.py b/nicegui/page.py
index 2ced4129..09305075 100644
--- a/nicegui/page.py
+++ b/nicegui/page.py
@@ -204,7 +204,7 @@ class page:
                 if not task_wait_for_connection.done():
                     task_wait_for_connection.cancel()
                 if task.done():
-                    result = task.result()
+                    result = None if task.cancelled() else task.result()
                 else:
                     result = None
                     task.add_done_callback(check_for_late_return_value)
```

One pytest was added to `test_page.py`.
It asserts that the response status code from a cancelled async page is 200.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary. <!--Remove the option that does not apply.-->
- [x] Documentation has been added/updated or is not necessary. <!--Remove the option that does not apply.-->
- [x] No breaking changes to the public API or migration steps are described above. <!--Remove the option that does not apply.-->
