### PR TITLE
Add replace parameter to Element.on and ui.button.on_click

### DIFF
--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -386,8 +386,8 @@ class Element(Visibility):
         :param leading_events: whether to trigger the event handler immediately upon the first event occurrence (default: ``True``)
         :param trailing_events: whether to trigger the event handler after the last event occurrence (default: ``True``)
         :param js_handler: JavaScript function that is handling the event on the client (default: "(...args) => emit(...args)")
-        :param replace: whether to replace the event or append to existing events
-        :param key : an identifier key to distinct between internally and externally generated elements
+        :param replace: whether to replace a listener with the same ``type`` and ``key`` instead of adding another one (default: ``False``)
+        :param key: object identifying this listener, so that it can be replaced later (default: ``None``)
         """
         if handler or js_handler:
             event_type = helpers.event_type_to_camel_case(type)

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -357,7 +357,8 @@ class Element(Visibility):
            leading_events: bool = True,
            trailing_events: bool = True,
            js_handler: str = '(...args) => emit(...args)',
-           replace: bool = False
+           replace: bool = False,
+           key: Any = None
            ) -> Self:
         """Subscribe to an event.
 
@@ -386,6 +387,7 @@ class Element(Visibility):
         :param trailing_events: whether to trigger the event handler after the last event occurrence (default: ``True``)
         :param js_handler: JavaScript function that is handling the event on the client (default: "(...args) => emit(...args)")
         :param replace: whether to replace the event or append to existing events
+        :param key : an identifier key to distinct between internally and externally generated elements
         """
         if handler or js_handler:
             event_type = helpers.event_type_to_camel_case(type)
@@ -399,11 +401,20 @@ class Element(Visibility):
                 leading_events=leading_events,
                 trailing_events=trailing_events,
                 request=storage.request_contextvar.get(),
+                key=key
             )
-            if replace:
-                self._event_listeners = {
-                    id_: l for id_, l in self._event_listeners.items() if l.type != event_type
-                }
+            if replace and key is not None:
+                existing = next((listener for listener in self._event_listeners.values()
+                                 if listener.type == event_type and listener.key == key), None)
+                if existing is not None:
+                    old_dict = {**existing.to_dict(), 'listener_id': ''}
+                    new_dict = {**listener.to_dict(), 'listener_id': ''}
+                    existing.handler = handler
+                    existing.request = listener.request
+                    if old_dict == new_dict:
+                        return self
+                    del self._event_listeners[existing.id]
+
             self._event_listeners[listener.id] = listener
             self.update()
         return self

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -404,16 +404,15 @@ class Element(Visibility):
                 key=key
             )
             if replace and key is not None:
-                existing = next((listener for listener in self._event_listeners.values()
-                                 if listener.type == event_type and listener.key == key), None)
-                if existing is not None:
-                    old_dict = {**existing.to_dict(), 'listener_id': ''}
-                    new_dict = {**listener.to_dict(), 'listener_id': ''}
-                    existing.handler = handler
-                    existing.request = listener.request
-                    if old_dict == new_dict:
-                        return self
-                    del self._event_listeners[existing.id]
+                previous = [old for old in self._event_listeners.values()
+                            if old.type == event_type and old.key == key]
+                new_dict = {**listener.to_dict(), 'listener_id': ''}
+                if len(previous) == 1 and {**previous[0].to_dict(), 'listener_id': ''} == new_dict:
+                    previous[0].handler = handler
+                    previous[0].request = listener.request
+                    return self
+                for old in previous:
+                    del self._event_listeners[old.id]
 
             self._event_listeners[listener.id] = listener
             self.update()

--- a/nicegui/element.py
+++ b/nicegui/element.py
@@ -357,6 +357,7 @@ class Element(Visibility):
            leading_events: bool = True,
            trailing_events: bool = True,
            js_handler: str = '(...args) => emit(...args)',
+           replace: bool = False
            ) -> Self:
         """Subscribe to an event.
 
@@ -384,11 +385,13 @@ class Element(Visibility):
         :param leading_events: whether to trigger the event handler immediately upon the first event occurrence (default: ``True``)
         :param trailing_events: whether to trigger the event handler after the last event occurrence (default: ``True``)
         :param js_handler: JavaScript function that is handling the event on the client (default: "(...args) => emit(...args)")
+        :param replace: whether to replace the event or append to existing events
         """
         if handler or js_handler:
+            event_type = helpers.event_type_to_camel_case(type)
             listener = EventListener(
                 element_id=self.id,
-                type=helpers.event_type_to_camel_case(type),
+                type=event_type,
                 args=[args] if args and isinstance(args[0], str) else args,  # type: ignore
                 handler=handler,
                 js_handler=None if js_handler == '(...args) => emit(...args)' else js_handler,
@@ -397,6 +400,10 @@ class Element(Visibility):
                 trailing_events=trailing_events,
                 request=storage.request_contextvar.get(),
             )
+            if replace:
+                self._event_listeners = {
+                    id_: l for id_, l in self._event_listeners.items() if l.type != event_type
+                }
             self._event_listeners[listener.id] = listener
             self.update()
         return self

--- a/nicegui/elements/button.py
+++ b/nicegui/elements/button.py
@@ -38,9 +38,15 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
         if on_click:
             self.on_click(on_click)
 
-    def on_click(self, callback: Handler[ClickEventArguments]) -> Self:
-        """Add a callback to be invoked when the button is clicked."""
-        self.on('click', lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [])
+    def on_click(self, callback: Handler[ClickEventArguments], replace: bool = False) -> Self:
+        """Add a callback to be invoked when the button is clicked.
+
+        :param callback: callback to be invoked when the button is clicked
+        :param replace: replace existing callback with a new one rather than appending
+        """
+        self.on('click',
+                lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [],
+                replace=replace)
         return self
 
     def _render_markdown(self) -> str:

--- a/nicegui/elements/button.py
+++ b/nicegui/elements/button.py
@@ -39,7 +39,7 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
         if on_click:
             self.on_click(on_click)
 
-    def on_click(self, callback: Handler[ClickEventArguments], replace: bool = False) -> Self:
+    def on_click(self, callback: Handler[ClickEventArguments], *, replace: bool = False) -> Self:
         """Add a callback to be invoked when the button is clicked.
 
         :param callback: callback to be invoked when the button is clicked

--- a/nicegui/elements/button.py
+++ b/nicegui/elements/button.py
@@ -11,6 +11,7 @@ from .mixins.text_element import TextElement
 
 
 class Button(IconElement, TextElement, DisableableElement, BackgroundColorElement):
+    _ON_CLICK_KEY = object()
 
     @resolve_defaults
     def __init__(self,
@@ -46,7 +47,7 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
         """
         self.on('click',
                 lambda _: handle_event(callback, ClickEventArguments(sender=self, client=self.client)), [],
-                replace=replace)
+                replace=replace, key=self._ON_CLICK_KEY)
         return self
 
     def _render_markdown(self) -> str:

--- a/nicegui/event_listener.py
+++ b/nicegui/event_listener.py
@@ -18,6 +18,7 @@ class EventListener:
     leading_events: bool
     trailing_events: bool
     request: Request | None
+    key: Any = None
 
     def __post_init__(self) -> None:
         self.id = str(uuid.uuid4())


### PR DESCRIPTION
### Motivation

Discussion [#3440](https://github.com/zauberzeug/nicegui/discussions/3440) ("Removing an existing handler") asks how to swap out a handler that is already registered on an element.

Today `Element.on()` — and therefore `ui.button.on_click()` — always *appends*: each call stores a new `EventListener` under a fresh id, so the previously registered handler keeps firing alongside the new one. There is no public way to replace a handler, which can lead to unintended behavior when the same event is bound a second time.

### Implementation

`Element.on()` gets an opt-in `replace: bool = False` parameter. When it is `True`, listeners of the *same* event type are dropped before the new listener is registered:

```py
if replace:
    self._event_listeners = {
        id_: l for id_, l in self._event_listeners.items() if l.type != event_type
    }
self._event_listeners[listener.id] = listener
```

Filtering on `l.type` keeps listeners for other event types untouched — an element with both a click and a hover handler only loses its click handler when `on('click', ..., replace=True)` is called.

`ui.button.on_click()` forwards the parameter, so the common case reads:

```py
button = ui.button('Click me', on_click=first_handler)
...
button.on_click(second_handler, replace=True)  # first_handler no longer fires
```

The default is `False`, so existing behavior is unchanged and nothing else needs to be touched.

Open points:

- Only `ui.button.on_click()` forwards `replace` so far. The same forwarding could be added to the `on_*` convenience methods of other elements; this PR covers the case I needed.
- No pytests yet — happy to add one if you tell me where it fits best.
- No documentation page was changed; the new parameter is described in the `Element.on()` and `on_click()` docstrings.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [ ] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary.
- [ ] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.
