### PR TITLE
Fix stale sub pages 404 after an awaited builder

### DIFF
--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -54,6 +54,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         self._active_tasks: set[asyncio.Task] = set()
         self._404_enabled = show_404
         self._404_elements: list[Element] = []
+        self._error_rendered = False
         self.has_404 = False
         if parent_sub_pages_element is not None and parent_sub_pages_element.has_404:
             parent_sub_pages_element._retract_404()
@@ -82,6 +83,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
     def _show(self) -> None:
         """Display the page matching the current URL path."""
         self._rendered_path = ''
+        self._error_rendered = False
         match = self._find_matching_path()
         has_nested_sub_pages = any(isinstance(el, SubPages) for el in self.descendants())
         # if path and query params are the same, only update fragment without re-rendering
@@ -115,6 +117,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         except Exception as e:
             self.clear()  # clear partial content created before the exception
             self._render_error(e)
+            self._error_rendered = True
             self.client.handle_exception(e)
             return True
 
@@ -155,7 +158,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
             if not element.is_deleted:
                 element.delete()
         self._404_elements.clear()
-        if self.has_404 and self._404_enabled:
+        if self.has_404 and self._404_enabled and not self._error_rendered:  # a rendered error tells more than a 404
             if not self._active_tasks:  # a builder which is still running keeps the content it has already created
                 self.clear()
             index = len(self.default_slot.children)
@@ -165,7 +168,9 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
 
     def _retract_404(self) -> None:
         """Withdraw a 404 because a nested sub pages element has appeared to consume the remaining path."""
-        self._set_match(self._find_matching_path())
+        match = self._find_matching_path()
+        if match is not None:  # a 404 which is due to no route matching at all stands
+            self._set_match(match)
 
     def _has_unconsumed_path(self, match: RouteMatch) -> bool:
         """Check if the match leaves a remaining path which no nested sub pages element can consume."""

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -164,7 +164,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
             index = len(self.default_slot.children)
             with self:
                 self._render_404()
-            self._404_elements = self.default_slot.children[index:]
+            self._404_elements = self.default_slot.children[index:]  # the elements to delete when the 404 is retracted
 
     def _retract_404(self) -> None:
         """Withdraw a 404 because a nested sub pages element has appeared to consume the remaining path."""

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -96,7 +96,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
             not self._required_query_params_changed(match)
         ):
             # Even though our matched path is the same, the remaining path might still require us to handle 404 (if we are the last sub pages element)
-            if self._has_unconsumed_path(match):
+            if match.remaining_path and not has_nested_sub_pages:
                 self._set_match(None)
             else:
                 self._handle_scrolling(match, behavior='smooth')
@@ -154,10 +154,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
     def _set_match(self, match: RouteMatch | None) -> None:
         self._match = match
         self.has_404 = match is None
-        for element in self._404_elements:
-            if not element.is_deleted:
-                element.delete()
-        self._404_elements.clear()
+        self._404_elements = []
         if self.has_404 and self._404_enabled and not self._error_rendered:  # a rendered error tells more than a 404
             if not self._active_tasks:  # a builder which is still running keeps the content it has already created
                 self.clear()
@@ -170,6 +167,9 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         """Withdraw a 404 because a nested sub pages element has appeared to consume the remaining path."""
         match = self._find_matching_path()
         if match is not None:  # a 404 which is due to no route matching at all stands
+            for element in self._404_elements:
+                if not element.is_deleted:
+                    element.delete()
             self._set_match(match)
 
     def _has_unconsumed_path(self, match: RouteMatch) -> bool:

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -53,7 +53,10 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         self._match: RouteMatch | None = None
         self._active_tasks: set[asyncio.Task] = set()
         self._404_enabled = show_404
+        self._404_elements: list[Element] = []
         self.has_404 = False
+        if parent_sub_pages_element is not None and parent_sub_pages_element.has_404:
+            parent_sub_pages_element._retract_404()
         self._show()
 
     def add(self, path: str, page: Callable) -> Self:
@@ -91,7 +94,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
             not self._required_query_params_changed(match)
         ):
             # Even though our matched path is the same, the remaining path might still require us to handle 404 (if we are the last sub pages element)
-            if match.remaining_path and not has_nested_sub_pages:
+            if self._has_unconsumed_path(match):
                 self._set_match(None)
             else:
                 self._handle_scrolling(match, behavior='smooth')
@@ -99,7 +102,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         else:
             self._cancel_active_tasks()
             with self.clear():
-                if match is not None and self._render_page(match):
+                if match is not None and self._render_page(match) and not self._has_unconsumed_path(match):
                     self._set_match(match)
                 else:
                     self._set_match(None)
@@ -148,9 +151,25 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
     def _set_match(self, match: RouteMatch | None) -> None:
         self._match = match
         self.has_404 = match is None
+        for element in self._404_elements:
+            if not element.is_deleted:
+                element.delete()
+        self._404_elements.clear()
         if self.has_404 and self._404_enabled:
-            with self.clear():
+            if not self._active_tasks:  # a builder which is still running keeps the content it has already created
+                self.clear()
+            index = len(self.default_slot.children)
+            with self:
                 self._render_404()
+            self._404_elements = self.default_slot.children[index:]
+
+    def _retract_404(self) -> None:
+        """Withdraw a 404 because a nested sub pages element has appeared to consume the remaining path."""
+        self._set_match(self._find_matching_path())
+
+    def _has_unconsumed_path(self, match: RouteMatch) -> bool:
+        """Check if the match leaves a remaining path which no nested sub pages element can consume."""
+        return bool(match.remaining_path) and not any(isinstance(el, SubPages) for el in self.descendants())
 
     def _reset_match(self) -> None:
         self._match = None

--- a/nicegui/sub_pages_router.py
+++ b/nicegui/sub_pages_router.py
@@ -124,8 +124,7 @@ class SubPagesRouter:
         for sub_pages in sub_pages_elements:
             if (
                 sub_pages._match is not None and  # pylint: disable=protected-access
-                sub_pages._match.remaining_path and  # pylint: disable=protected-access
-                not any(isinstance(el, SubPages) for el in sub_pages.descendants())
+                sub_pages._has_unconsumed_path(sub_pages._match)  # pylint: disable=protected-access
             ):
                 sub_pages._set_match(None)  # pylint: disable=protected-access
         return not has_any_unresolved_path(client, with_404_enabled_only=True)

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -1058,6 +1058,28 @@ def test_param_coercion_error_on_client_side_navigation(screen: Screen):
     screen.assert_py_logger('ERROR', msg)
 
 
+def test_error_is_not_replaced_by_404_when_the_path_is_not_fully_consumed(screen: Screen):
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index():
+        ui.link('Go to deep link', '/other/deep')
+        ui.sub_pages({'/': main, '/other': broken})
+
+    def main():
+        ui.label('main page')
+
+    def broken():
+        raise Exception('test exception')  # pylint: disable=broad-exception-raised
+
+    screen.open('/')
+    screen.should_contain('main page')
+
+    msg = 'sub page /other/deep produced an error'
+    screen.click('Go to deep link')
+    screen.should_contain(f'500: {msg}')
+    screen.assert_py_logger('ERROR', msg)
+
+
 def test_disabling_404(screen: Screen):
     @ui.page('/')
     @ui.page('/{_:path}')
@@ -1246,6 +1268,17 @@ def test_unknown_path_still_shows_404_when_routes_are_added_after_an_await(scree
     screen.wait(1.0)  # the late add() must not turn the 404 into a fallback match
     screen.should_contain('404: sub page /other/zzz not found')
     screen.should_not_contain('sub main page')
+
+
+def test_nested_sub_pages_survives_a_parent_without_a_matching_route(screen: Screen):
+    @ui.page('/')
+    def index():
+        with ui.sub_pages({'/other': lambda: ui.label('other page')}):
+            ui.sub_pages({'/': lambda: ui.label('nested main page')})
+
+    screen.allowed_js_errors.append('/ - Failed to load resource')
+    screen.open('/')
+    screen.should_contain('nested main page')
 
 
 def test_http_404_with_root_function_and_sub_pages(screen: Screen):

--- a/tests/test_sub_pages.py
+++ b/tests/test_sub_pages.py
@@ -1204,6 +1204,50 @@ def test_http_404_on_initial_request_with_async_sub_page_builder(screen: Screen)
     screen.should_contain('404: sub page /bad_path not found')
 
 
+def test_404_is_retracted_when_nested_sub_pages_are_created_after_an_await(screen: Screen):
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index():
+        ui.sub_pages({'/': main, '/other': other})
+
+    def main():
+        ui.label('main page')
+
+    async def other():
+        ui.label('other page')
+        await asyncio.sleep(0.5)
+        ui.sub_pages({'/': lambda: ui.label('sub main page'), '/a': lambda: ui.label('sub A page')})
+
+    screen.allowed_js_errors.append('/other/a - Failed to load resource')
+    screen.open('/other/a')
+    screen.should_contain('sub A page')
+    screen.should_contain('other page')
+    screen.should_not_contain('not found')
+
+
+def test_unknown_path_still_shows_404_when_routes_are_added_after_an_await(screen: Screen):
+    @ui.page('/')
+    @ui.page('/{_:path}')
+    def index():
+        ui.sub_pages({'/': main, '/other': other})
+
+    def main():
+        ui.label('main page')
+
+    async def other():
+        ui.label('other page')
+        sub = ui.sub_pages({'/': lambda: ui.label('sub main page')})
+        await asyncio.sleep(0.5)
+        sub.add('/a', lambda: ui.label('sub A page'))
+
+    screen.allowed_js_errors.append('/other/zzz - Failed to load resource')
+    screen.open('/other/zzz')
+    screen.should_contain('404: sub page /other/zzz not found')
+    screen.wait(1.0)  # the late add() must not turn the 404 into a fallback match
+    screen.should_contain('404: sub page /other/zzz not found')
+    screen.should_not_contain('sub main page')
+
+
 def test_http_404_with_root_function_and_sub_pages(screen: Screen):
     def root():
         ui.sub_pages({'/': lambda: ui.label('Home')})


### PR DESCRIPTION
Reported in https://github.com/zauberzeug/nicegui/discussions/6298

### Motivation

`ui.sub_pages` decides "was the whole path consumed?" once, in `SubPagesRouter._can_resolve_full_path`, giving an async sub-page builder exactly one event-loop tick to register nested `ui.sub_pages`. The verdict is then never revisited, while the still-suspended builder keeps rendering into the same element. Three user-visible consequences, all measured on `main`:

- Opening `/other/a` directly, where `other()` awaits before creating the nested `ui.sub_pages`, leaves `404: sub page /other/a not found` sitting in the DOM next to the `sub A page` that did resolve a moment later.
- `_set_match(None)` renders the 404 inside `with self.clear():`, so content the builder had already produced is destroyed and the builder then appends into a cleared container.
- If the nested routes arrive later via `add()`, an unknown path such as `/other/zzz` quietly renders the nested `/` page instead, even though the response for it was a 404.

The practical guidance for users is unchanged and unaffected by this PR: register nested routes before the builder suspends. Worth noting that the boundary is the first *suspension*, not the first `await` — `await asyncio.sleep(0)` already misses the window, while awaiting a coroutine that never yields still works.

### Implementation

The rule "matched, but has an unconsumed remaining path and no nested `SubPages`" already existed inline in two places and was applied on only one of `_show`'s two branches. It is now one helper, `SubPages._has_unconsumed_path`, applied on both branches and called by the router.

- `_set_match` no longer calls `clear()` while a builder is in flight; it tracks the elements `_render_404()` produced so they can be removed individually when the verdict changes.
- A nested `SubPages` created inside a parent that has already been marked 404 calls the parent's new `_retract_404()`. That no-ops when the parent has no matching route at all — without the guard it deletes the very element that is mid-`__init__`.
- An element that rendered a `500: ... produced an error` keeps it; the 404 no longer replaces it.

Three things a reviewer should know rather than discover:

1. `SubPages.__init__` now mutates its parent (`_retract_404`). That is a new child-to-parent coupling and is the design call worth challenging first.
2. `has_404` is now `True` while a 500 is rendered. `has_404` feeds `has_any_unresolved_path`, which `nicegui/testing/user_navigate.py` uses to choose full-reload versus client-side navigation. Narrow, cross-file, and not covered by a test.
3. **Out of scope by decision:** the initial HTTP status for a valid deep link is still `404`. Making it correct would mean awaiting sub-page builders past `response_timeout` in `page.py`, which is a maintainer design call, not a bug fix. This is why the new tests carry `screen.allowed_js_errors.append('... Failed to load resource')` — the response really is a 404, and only the rendering is being fixed.

What this branch is really doing, stated plainly: it **decouples DOM correctness from the tick**. After it, only the HTTP status code still depends on the one-tick guess; the rendered tree self-corrects whenever a nested `SubPages` appears, however late it arrives.

The router keeps its post-`sleep(0)` fixup loop rather than deleting it. Element *creation* after a stale match is covered by `_retract_404`, but element *deletion* has no symmetric hook, and neither of two independent traces could rule that case out. It is now unverified defensive code sharing one definition of the rule, rather than a second copy of it.

<details>
<summary>Measurements behind the Motivation section</summary>

NiceGUI `3.15.0.post12.dev0+3bb58aee`. Direct load of `/other/a`; status via `curl`, body text via Playwright 3 s after load.

| Variant | HTTP | Body text |
|---|---|---|
| `await asyncio.sleep(1)`, then nested `ui.sub_pages` | 404 | `404: sub page /other/a not found` <br> `sub A page` |
| `await asyncio.sleep(0)` before the nested `ui.sub_pages` | 404 | same |
| `await noop()` where `noop` never suspends | 200 | `sub page` <br> `sub A page` |
| nested `ui.sub_pages` created before the `await` | 200 | `sub page` <br> `sub A page` |
| `show_404=False` on the outer, await kept | 200 | `sub page` <br> `sub A page` |

Late `add()`, element created before the `await` and routes added after:

| Path | HTTP | Body text |
|---|---|---|
| `/other/a` | 404 | `sub page` <br> `sub A page` |
| `/other/zzz` | 404 | `sub page` <br> `sub main page` |

</details>

<details>
<summary>Tests</summary>

Four tests, all asserting observable text only.

Two were committed before any production change and were seen to fail:

- `test_404_is_retracted_when_nested_sub_pages_are_created_after_an_await` — failed with `Could not find "other page"`, the parent content destroyed by `clear()`.
- `test_unknown_path_still_shows_404_when_routes_are_added_after_an_await` — failed with `Could not find "404: sub page /other/zzz not found"` after the late `add()` replaced it with the fallback match.

Two came out of review:

- `test_nested_sub_pages_survives_a_parent_without_a_matching_route` — guards the `_retract_404` no-op. Passes on `main` and fails on the intermediate commit `6529c1c3` with `An element has been deleted but is still being used`; it exists because that intermediate commit was a real regression against `main`.
- `test_error_is_not_replaced_by_404_when_the_path_is_not_fully_consumed` — fails on `main` too, because it guards a deliberate improvement rather than a restoration.

`tests/test_sub_pages.py`: 58 passed in 72.65s at `061df1e2`, verified independently of the implementing agent. `test_sub_pages_with_url_fragments` flaked three times during this work on a scroll timing race; it is unreachable from every path this PR changes (no remaining path, no nesting), and it flakes on the unmodified tree at the same rate.

</details>

Opened as a draft: the branch has had three independent reviews and a full local suite run, but not yet a second-lineage review or a green CI run here. I will undraft once CI passes.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary. <!-- no public API change; the ordering requirement is user-facing but belongs in the sub_pages docs as a separate change -->
- [x] No breaking changes to the public API.
