### PR TITLE
Make more launch methods work: `python -c`, stdin and zipapp

### DIFF
--- a/nicegui/ui_run.py
+++ b/nicegui/ui_run.py
@@ -222,7 +222,7 @@ def run(root: Callable | None = None, *,
         return
 
     is_repl = bool(getattr(sys, 'ps1', sys.flags.interactive))
-    if reload and is_repl:
+    if reload and (is_repl or not helpers.is_file(getattr(sys.modules.get('__main__'), '__file__', None))):
         log.warning('disabling auto-reloading because it is only supported when running from a file')
         core.app.config.reload = reload = False
 


### PR DESCRIPTION
### Motivation

Three launch methods crash with the misleading main-guard error, then hang. One line makes all three serve.

| launch method | before | after |
|---|---|---|
| `python -c "import app; ui.run()"` | `RuntimeError`, hangs | serves (warning) |
| `python - < app.py` | `FileNotFoundError`, hangs | serves (warning) |
| `python app.pyz` (zipapp) | `RuntimeError`, hangs | serves (warning) |
| `python app.py` | works | unchanged |
| `python -m pkg` | #6068's error | unchanged |

`spawn` rebuilds the child's `__main__` from `__spec__.name` or `__file__`. When it can use neither, `ui.run()` never runs there, so `_startup()` blames a nonexistent main guard — the cause #6066 hit.

**Relation to #6068**: this is not the salvager that PR rejected. It just does what #6068's error already tells the user to do by hand. Draft because that trade is yours — fold below.

<details>
<summary>The #6068 trade, and the alternative I will write instead if you prefer it</summary>

#6068's shipped message offers exactly one remedy:

```
Auto-reload is not supported when running a package with `python -m`.
Pass `reload=False` to ui.run() to start the server.
```

This patch applies that remedy automatically for three launch methods where it is the only outcome available, exactly as `ui.run()` already does in a REPL. The rejected salvager was a different thing: it re-ran the user's package in the spawn child via `runpy.run_module`, bypassing CPython policy and running user code on `import nicegui`. None of its three rejection reasons applies here.

The open question is consistency. If auto-downgrading is right for these three, `python -m pkg` telling the user to do it by hand is hard to defend — the constraint and the remedy are identical. Either extend this warning to `-m` and drop #6068's error, or give these three targeted errors instead and keep them all broken. Say which and I will write it; I have no stake beyond consistency.

</details>

<details>
<summary>Per-case evidence</summary>

**`python -c`** — no `__spec__`, no `__file__`, so `get_preparation_data` emits neither key:

```console
$ python -c "
import sys, multiprocessing.spawn as spawn
main = sys.modules['__main__']
print('__file__ =', getattr(main, '__file__', '<ABSENT>'))
print('__spec__ =', main.__spec__)
data = spawn.get_preparation_data('probe')
print('init_main_from_name:', data.get('init_main_from_name', '<ABSENT>'))
print('init_main_from_path:', data.get('init_main_from_path', '<ABSENT>'))"
__file__ = <ABSENT>
__spec__ = None
init_main_from_name: <ABSENT>
init_main_from_path: <ABSENT>
```

**stdin** — `__main__.__file__` is the literal string `<stdin>`, which the child resolves against the cwd:

```
FileNotFoundError: [Errno 2] No such file or directory: '/private/tmp/<stdin>'
```

**zipapp** — `__spec__.name` is exactly `__main__`, so spawn takes the by-name branch and `_fixup_main_from_name` returns early under the same policy #6068 quotes. `__file__` points inside the archive (`/tmp/app.pyz/__main__.py`).

`app.py` is the whole repro: `from nicegui import ui` plus one `@ui.page('/')` function. Verified on `main` at `4cdf8edd`, Python 3.14.2, macOS 26 arm64. Also reproduces on `nicegui==3.16.0`.

</details>

### Implementation

`ui.run()` already disables reload for the REPL, which cannot re-run its `__main__` either. `is_repl` misses these three:

```python
 is_repl = bool(getattr(sys, 'ps1', sys.flags.interactive))
-if reload and is_repl:
+if reload and (is_repl or not helpers.is_file(getattr(sys.modules.get('__main__'), '__file__', None))):
     log.warning('disabling auto-reloading because it is only supported when running from a file')
     core.app.config.reload = reload = False
```

Both details matter: the short-circuit keeps `reload=False` from evaluating it, and `.get` avoids a `KeyError` during teardown. CI caught a revision that got both wrong.

**No pytest**: one real interpreter per case and a 90 s red path, to guard one `if` branch; CONTRIBUTING permits that with a reason. **#5939 is not fixed.** Both folded.

<details>
<summary>Why <code>is_file(__file__)</code> and not spawn's own two-branch predicate</summary>

Accepting `__spec__.name` as sufficient would be wrong: the zipapp case has one and is still broken, for the `_fixup_main_from_name` reason above. The remaining `__spec__`-only cases (`python -m mod`, `python -m pkg`) all carry a real `__file__`, so `is_file` leaves them alone. One clause, not two.

</details>

<details>
<summary>Why #5939 (console-script entry point) is out of reach</summary>

Its `__main__.__file__` is the installed shim — a real file that spawn *can* re-run, so the predicate correctly declines to fire. It breaks for a different reason: the installer-generated shim guards on `if __name__ == "__main__":` only, so re-run as `__mp_main__` it never calls `main()`. That guard is in generated code the user does not own, which is why it looks unfixable from inside NiceGUI. Verified still broken on this branch.

</details>

<details>
<summary>The pytest I wrote, and its results</summary>

```python
import os
import socket
import subprocess
import sys
import zipapp
from pathlib import Path
from textwrap import dedent

import pytest

APP = dedent('''\
    from nicegui import app, ui

    @ui.page('/')
    def index():
        ui.label('hello')

    app.on_startup(app.shutdown)
    ui.run(port={port}, show=False, reload=True)
''')


def app_source() -> str:
    """Return an app which shuts itself down again, on a port nothing else is listening on."""
    with socket.socket() as sock:
        sock.bind(('', 0))
        return APP.format(port=sock.getsockname()[1])


def assert_starts_up(*args: str, stdin: str | None = None) -> None:
    """Run the given Python entry point and check it serves instead of raising a misleading main-guard error."""
    env = {key: value for key, value in os.environ.items() if key != 'PYTEST_CURRENT_TEST'}
    try:
        result = subprocess.run([sys.executable, *args], input=stdin, capture_output=True, text=True,
                                timeout=30, check=False, env=env)
    except subprocess.TimeoutExpired as error:
        pytest.fail(f'the server never started up:\n{error.stderr}')
    assert 'You must call ui.run()' not in result.stderr, result.stderr
    assert result.returncode == 0, result.stderr


def test_dash_c_entrypoint_disables_reload():
    """`python -c` leaves __main__ without a __file__, so the reload subprocess can not re-run it."""
    assert_starts_up('-c', app_source())


def test_stdin_entrypoint_disables_reload():
    """A script on stdin sets __main__.__file__ to "<stdin>", which the reload subprocess can not re-run."""
    assert_starts_up('-', stdin=app_source())


def test_zipapp_entrypoint_disables_reload(tmp_path: Path):
    """A zipapp does set __main__.__spec__, but its __file__ points inside the archive and can not be re-run."""
    (tmp_path / 'src').mkdir()
    (tmp_path / 'src' / '__main__.py').write_text(app_source())
    zipapp.create_archive(tmp_path / 'src', tmp_path / 'app.pyz')
    assert_starts_up(str(tmp_path / 'app.pyz'))
```

Fix reverted — all three red, each for its own reason rather than one shared timeout:

```
FAILED test_dash_c_entrypoint_disables_reload   -> "You must call ui.run() to start the server"
FAILED test_stdin_entrypoint_disables_reload    -> FileNotFoundError: '<cwd>/<stdin>'
FAILED test_zipapp_entrypoint_disables_reload   -> "You must call ui.run() to start the server"
3 failed in 90.19s
```

Restored: `3 passed in 0.98s`, no skips under `-rs`.

</details>

<details>
<summary>Verification</summary>

Every row of the table was run by hand against the patched tree and curled. `python app.py` keeps auto-reload with no warning; `python -m mypkg` still reaches #6068's error.

`uv run pre-commit run --all-files` passed, `mypy ./nicegui` clean over 264 files, `pylint ./nicegui` 10.00/10, CI green on run `32586510263`.

The earlier revision went red as `8 failed, 1037 passed, 8 errors`, every failure a late browser test raising `KeyError: '__main__'` inside the `ui.run()` thread of `nicegui/testing/screen.py` — the lookup was evaluated eagerly above the `if`, and the subscript form raises once the interpreter starts finalizing:

```console
$ python -c "
import sys
from nicegui import helpers
del sys.modules['__main__']
try:
    helpers.is_file(getattr(sys.modules['__main__'], '__file__', None))
except KeyError as e:
    print('subscript raises KeyError:', e)
print('.get returns:', helpers.is_file(getattr(sys.modules.get('__main__'), '__file__', None)))"
subscript raises KeyError: '__main__'
.get returns: False
```

</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [ ] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).) — code complete and CI green; draft until the **#6068** question is settled
- [x] This PR does not address a security issue.
- [x] The **Implementation** section explains why pytests are not necessary.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
