### PR TITLE
Fix `ui.codemirror` and `ui.editor` losing their HTML id (breaks tooltips)

### DIFF
--- a/nicegui/elements/codemirror/codemirror.js
+++ b/nicegui/elements/codemirror/codemirror.js
@@ -48,7 +48,7 @@ const { setEffect: setTooltipsEffect, field: tooltipField } = defineRemappableRa
 
 export default {
   template: `
-    <div :id="id"></div>
+    <div></div>
   `,
   props: {
     value: String,
@@ -62,7 +62,6 @@ export default {
     keymap: Array,
     lineTooltips: Object,
     lineTooltipHtml: Boolean,
-    id: String,
   },
   watch: {
     language(newLanguage) {
@@ -98,7 +97,7 @@ export default {
   },
   beforeUnmount() {
     if (this.editor) {
-      const element = mounted_app.elements[this.$props.id.slice(1)];
+      const element = mounted_app.elements[this.$el.id.slice(1)];
       if (element) {
         element.props.value = this.editor.state.doc.toString();
         // A client-side remount (e.g. a v-if container) re-applies these props against the restored

--- a/nicegui/elements/codemirror/codemirror.js
+++ b/nicegui/elements/codemirror/codemirror.js
@@ -48,7 +48,7 @@ const { setEffect: setTooltipsEffect, field: tooltipField } = defineRemappableRa
 
 export default {
   template: `
-    <div></div>
+    <div :id="id"></div>
   `,
   props: {
     value: String,

--- a/nicegui/elements/editor.js
+++ b/nicegui/elements/editor.js
@@ -1,6 +1,6 @@
 export default {
   template: `
-    <q-editor ref="qRef" :id="id" v-model="inputValue">
+    <q-editor ref="qRef" v-model="inputValue">
       <template v-for="(_, slot) in $slots" v-slot:[slot]="slotProps">
         <slot :name="slot" v-bind="slotProps || {}" />
       </template>
@@ -8,7 +8,6 @@ export default {
   `,
   props: {
     value: String,
-    id: String,
   },
   data() {
     return {
@@ -17,7 +16,7 @@ export default {
     };
   },
   beforeUnmount() {
-    const element = mounted_app.elements[this.$props.id.slice(1)];
+    const element = mounted_app.elements[this.$el.id.slice(1)];
     if (element) element.props.value = this.inputValue;
   },
   watch: {

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -526,6 +526,7 @@ def test_even_special_elements_have_an_html_id(screen: Screen):
             ui.toggle([]),
             ui.radio([]),
             ui.upload(),
+            ui.codemirror(),
         ]
         with ui.tabs() as tabs:
             elements += [ui.tab('One')]


### PR DESCRIPTION
### Motivation

Fixes #6315: `ui.codemirror(...).tooltip(...)` does nothing and the console logs `Anchor: target "#c4" not found`.

`renderRecursively` passes `id: "c" + id` to every component and relies on Vue attribute fallthrough to put it on the root element. `codemirror.js` declares `id: String` in `props` (added in 9d60c9a so `beforeUnmount` can look the element up), so Vue consumes it as a prop and the root `<div>` renders without an `id`.

### Implementation

The prop exists only for the `beforeUnmount` lookup, and it is the prop declaration itself that cancels the fallthrough. So instead of re-binding `:id="id"` in the template, drop the prop and read the id from `this.$el`, as `scene.js` already does. Vue runs `beforeUnmount` before it unmounts the subtree, so `this.$el` is still the connected root element there.

`editor.js` had the same prop and compensated with an explicit `:id="id"` binding. It gets the same treatment, so no component is left that has to remember to re-bind the id. `input.js` also declares the prop, but its template has two root nodes and its DOM id comes from the Python-side `for` prop, so it stays as is.

Test: `ui.codemirror()` added to `test_even_special_elements_have_an_html_id`. It fails on main (`assert False` on `document.getElementById("c4") !== null`) and passes with the fix. The existing `test_anchors_survive_client_side_remount` covers the `beforeUnmount` path for codemirror; a throwaway remount test for `ui.editor` (tab panels with `keep_alive=False`) passed as well.

<details>
<summary>Symptom-level check (not shipped)</summary>

The reporter's actual symptom, verified with a throwaway test — fails without the fix on the console assertion, passes with it:

```python
ui.codemirror('return').tooltip('hello')
...
assert not any('Anchor: target' in m for m in logs), logs
ActionChains(screen.selenium).move_to_element(
    screen.selenium.find_element(By.CLASS_NAME, 'cm-editor')).perform()
screen.should_contain('hello')
```

Left out because it duplicates the symptom; `html_id` resolving to a real node is the contract `tooltip()`, `ui.query` and `ui.teleport` all share.

CodeMirror mounts with `parent: this.$el`, so the anchored root div stays the root.
</details>

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.
