### PR TITLE
Fix half-built SubPages remaining registered after a bad route

### DIFF
--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -41,11 +41,12 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         :param show_404: whether to show a 404 error message if the full path could not be consumed
             (can be useful for dynamically created nested sub pages) (default: ``True``)
         """
+        routes = routes or {}
+        for path in routes:
+            self._validate_route(path)
         super().__init__()
         self._router = context.client.sub_pages_router
-        self._routes = routes or {}
-        for path in self._routes:
-            self._validate_route(path)
+        self._routes = routes
         parent_sub_pages_element = next((el for el in self.ancestors() if isinstance(el, SubPages)), None)
         self._rendered_path = ''
         self._root_path = parent_sub_pages_element._rendered_path if parent_sub_pages_element else root_path

--- a/nicegui/elements/sub_pages.py
+++ b/nicegui/elements/sub_pages.py
@@ -43,7 +43,7 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
         """
         routes = routes or {}
         for path in routes:
-            self._validate_route(path)
+            SubPages._validate_route(path)  # NOTE: must not touch self, the element is not registered yet
         super().__init__()
         self._router = context.client.sub_pages_router
         self._routes = routes
@@ -199,7 +199,8 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
 
     @staticmethod
     def _validate_route(path: str) -> None:
-        for parameter in re.findall(r'\{(.*?)\}', path):
+        parameters = re.findall(r'\{(.*?)\}', path)
+        for parameter in parameters:
             if not parameter.isidentifier():
                 raise ValueError(
                     f'Invalid route "{path}": the parameter "{{{parameter}}}" is not supported. '
@@ -208,6 +209,8 @@ class SubPages(Element, component='sub_pages.js', default_classes='nicegui-sub-p
                     'For wildcard routing, use show_404=False and read PageArguments.remaining_path '
                     '(see https://nicegui.io/documentation/sub_pages).'
                 )
+        if len(set(parameters)) != len(parameters):
+            raise ValueError(f'Invalid route "{path}": parameter names must be unique.')
 
     @staticmethod
     def _match_path(pattern: str, path: str) -> dict[str, str] | None:

--- a/tests/test_sub_pages_match_path.py
+++ b/tests/test_sub_pages_match_path.py
@@ -176,6 +176,13 @@ def test_validate_route_rejects_unsupported_patterns():
             ui.sub_pages._validate_route(pattern)
 
 
+def test_validate_route_rejects_duplicate_parameter_names():
+    """Repeated parameter names would raise re.error when matched, so they are rejected at registration time."""
+    for pattern in ['/{a}/{a}', '/{id}/x/{id}']:
+        with pytest.raises(ValueError, match='must be unique'):
+            ui.sub_pages._validate_route(pattern)
+
+
 def test_adjacent_parameters():
     """Test patterns with parameters that are adjacent (no static separators)."""
     # This is an edge case - adjacent parameters without separators

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -1181,6 +1181,22 @@ async def test_scope_searches_whole_page(user: User,
         await user.should_not_see('in content')
 
 
+async def test_invalid_sub_pages_route_does_not_break_page(user: User) -> None:
+    @ui.page('/')
+    def page():
+        ui.label('before')
+        try:
+            ui.sub_pages({'/{x:path}': lambda: None})
+        except ValueError:
+            ui.label('caught')
+        ui.label('after')
+
+    await user.open('/')
+    await user.should_see('before')
+    await user.should_see('caught')
+    await user.should_see('after')
+
+
 async def test_switching_between_sub_pages(user: User) -> None:
     calls = {'index': 0, 'a': 0, 'b': 0, 'other': 0}
 

--- a/tests/test_user_simulation.py
+++ b/tests/test_user_simulation.py
@@ -1184,17 +1184,14 @@ async def test_scope_searches_whole_page(user: User,
 async def test_invalid_sub_pages_route_does_not_break_page(user: User) -> None:
     @ui.page('/')
     def page():
-        ui.label('before')
         try:
             ui.sub_pages({'/{x:path}': lambda: None})
         except ValueError:
             ui.label('caught')
-        ui.label('after')
 
     await user.open('/')
-    await user.should_see('before')
     await user.should_see('caught')
-    await user.should_see('after')
+    user.client.delete()
 
 
 async def test_switching_between_sub_pages(user: User) -> None:


### PR DESCRIPTION
### Motivation

Fixes #6313. `ui.sub_pages` rejects Starlette-style converters like `{x:path}` with a `ValueError`, but that check ran after `Element.__init__` had already put the instance in `client.elements`. Catching the error left a half-built object behind, so the page request and later `Client.delete()` failed with `AttributeError: 'SubPages' object has no attribute '_active_tasks'` (and then `_match`).

### Implementation

Validate every route pattern before `super().__init__()`. `_validate_route` is a staticmethod and does not need the element to exist yet, so a bad pattern never gets registered.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights-product-news-introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary.
- [x] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.
