### PR TITLE
Add  and make the choice elements generic in their option type

### DIFF
--- a/nicegui/binding.py
+++ b/nicegui/binding.py
@@ -8,9 +8,10 @@ import weakref
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal
 
-from typing_extensions import dataclass_transform
+# NOTE: typing_extensions.TypeVar is needed because typing.TypeVar does not support defaults before Python 3.13
+from typing_extensions import TypeVar, dataclass_transform
 
 from . import core
 from .logging import log
@@ -34,6 +35,8 @@ _binding_keys_by_object: defaultdict[int, set[BindingKey]] = defaultdict(set)
 
 TC = TypeVar('TC', bound=type)
 T = TypeVar('T')
+# NOTE: the default keeps a bare BindableProperty() usable without a type annotation
+BindableT = TypeVar('BindableT', default=Any)
 
 _MISSING = object()
 
@@ -266,7 +269,7 @@ def _path_contains_dict(obj: Any, name: tuple[str, ...]) -> bool:
     return False
 
 
-class BindableProperty:
+class BindableProperty(Generic[BindableT]):
 
     def __init__(self, on_change: Callable[..., Any] | None = None) -> None:
         self._change_handler = on_change
@@ -274,10 +277,10 @@ class BindableProperty:
     def __set_name__(self, _, name: str) -> None:
         self.name = name  # pylint: disable=attribute-defined-outside-init
 
-    def __get__(self, owner: Any, _=None) -> Any:
+    def __get__(self, owner: Any, _=None) -> BindableT:
         return getattr(owner, '___' + self.name)
 
-    def __set__(self, owner: Any, value: Any) -> None:
+    def __set__(self, owner: Any, value: BindableT) -> None:
         has_attr = hasattr(owner, '___' + self.name)
         if not has_attr:
             _make_copyable(type(owner))

--- a/nicegui/elements/choice_element.py
+++ b/nicegui/elements/choice_element.py
@@ -1,22 +1,46 @@
-from typing import Any
+import dataclasses
+from collections.abc import Callable, Mapping
+from typing import Any, Generic, TypeVar, cast
 
 from typing_extensions import Self
 
-from ..events import Handler, ValueChangeEventArguments
+from ..events import Handler, ValueChangeEventArguments, ValueT
 from .mixins.value_element import ValueElement
 
+RESERVED_OPTION_KEYS = ('value', 'label')
 
-class ChoiceElement(ValueElement[Any]):
+OptionT = TypeVar('OptionT')
+
+
+def _option_fields(option: Any) -> dict[str, Any]:
+    """Return the extra client-side properties of a rich option.
+
+    Options which are dataclasses or mappings expose their fields to the client,
+    so slots can access them as ``props.opt.<key>``.
+    Scalar options (and anything else) contribute nothing.
+    """
+    if isinstance(option, Mapping):
+        fields = dict(option)
+    elif dataclasses.is_dataclass(option) and not isinstance(option, type):
+        fields = dataclasses.asdict(option)
+    else:
+        return {}
+    return {key: value for key, value in fields.items() if key not in RESERVED_OPTION_KEYS}
+
+
+class ChoiceElement(ValueElement[ValueT], Generic[OptionT, ValueT]):
 
     def __init__(self, *,
                  tag: str | None = None,
-                 options: list | dict,
-                 value: Any,
-                 on_change: Handler[ValueChangeEventArguments[Any]] | None = None,
+                 options: list[OptionT] | dict[OptionT, Any],
+                 value: ValueT,
+                 on_change: Handler[ValueChangeEventArguments[ValueT]] | None = None,
+                 option_label: Callable[[OptionT], Any] | None = None,
                  ) -> None:
-        self.options = options
-        self._values: list[str] = []
-        self._labels: list[str] = []
+        self.options: list[OptionT] | dict[OptionT, Any] = options
+        self.option_label = option_label
+        self._values: list[OptionT] = []
+        self._labels: list[Any] = []
         self._update_values_and_labels()
         if not isinstance(value, list) and value is not None and value not in self._values:
             raise ValueError(f'Invalid value: {value}')
@@ -39,14 +63,25 @@ class ChoiceElement(ValueElement[Any]):
 
     def _update_values_and_labels(self) -> None:
         self._values = self.options if isinstance(self.options, list) else list(self.options.keys())
-        self._labels = self.options if isinstance(self.options, list) else list(self.options.values())
+        if self.option_label is not None:
+            self._labels = [self.option_label(value) for value in self._values]
+        else:
+            self._labels = self.options if isinstance(self.options, list) else list(self.options.values())
+
+    def _option_dict(self, index: int) -> dict[str, Any]:
+        """Build the option as sent to the client.
+
+        NOTE: "value" and "label" are written last so a rich option's own fields can never shadow them.
+        """
+        return {**_option_fields(self._values[index]), 'value': index, 'label': self._labels[index]}
 
     def _update_options(self) -> None:
         before_value = self.value
-        self._props['options'] = [{'value': index, 'label': option} for index, option in enumerate(self._labels)]
+        self._props['options'] = [self._option_dict(index) for index in range(len(self._values))]
         self._props[self.VALUE_PROP] = self._value_to_model_value(before_value)
         if not isinstance(before_value, list):  # no need to update value in case of multi-select
-            self.value = before_value if before_value in self._values else None
+            # NOTE: every subclass admits None as a value in the non-multi-select case, but ValueT can't express that
+            self.value = before_value if before_value in self._values else cast(ValueT, None)
 
     def update(self) -> None:
         with self._props.suspend_updates():
@@ -54,7 +89,7 @@ class ChoiceElement(ValueElement[Any]):
             self._update_options()
         super().update()
 
-    def set_options(self, options: list | dict, *, value: Any = ...) -> Self:
+    def set_options(self, options: list[OptionT] | dict[OptionT, Any], *, value: Any = ...) -> Self:
         """Set the options of this choice element.
 
         :param options: The new options.

--- a/nicegui/elements/mixins/value_element.py
+++ b/nicegui/elements/mixins/value_element.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Generic, cast
+from typing import Any, Generic, cast
 
 from typing_extensions import Self
 
@@ -22,11 +22,8 @@ class ValueElement(Element, Generic[ValueT]):
     - ``None``: The value is updated automatically by the Vue element.
     '''
 
-    value = BindableProperty(
+    value: BindableProperty[ValueT] = BindableProperty(
         on_change=lambda sender, value: cast(Self, sender)._handle_value_change(value))  # pylint: disable=protected-access
-
-    if TYPE_CHECKING:
-        value: ValueT  # type: ignore[assignment,no-redef]  # BindableProperty descriptor can't propagate generic type
 
     def __init__(self, *,
                  value: ValueT,

--- a/nicegui/elements/radio.py
+++ b/nicegui/elements/radio.py
@@ -1,18 +1,20 @@
-from typing import Any
+from collections.abc import Callable
+from typing import Any, Generic
 
 from ..defaults import DEFAULT_PROPS, resolve_defaults
 from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
-from .choice_element import ChoiceElement
+from .choice_element import ChoiceElement, OptionT
 from .mixins.disableable_element import DisableableElement
 
 
-class Radio(ChoiceElement, DisableableElement):
+class Radio(ChoiceElement[OptionT, 'OptionT | None'], DisableableElement, Generic[OptionT]):
 
     @resolve_defaults
     def __init__(self,
-                 options: list | dict, *,
-                 value: Any = DEFAULT_PROPS['model-value'] | None,
-                 on_change: Handler[ValueChangeEventArguments[Any]] | None = None,
+                 options: list[OptionT] | dict[OptionT, Any], *,
+                 value: OptionT | None = DEFAULT_PROPS['model-value'] | None,
+                 on_change: Handler[ValueChangeEventArguments[OptionT | None]] | None = None,
+                 option_label: Callable[[OptionT], Any] | None = None,
                  ) -> None:
         """Radio Selection
 
@@ -24,10 +26,12 @@ class Radio(ChoiceElement, DisableableElement):
         :param options: a list ['value1', ...] or dictionary `{'value1':'label1', ...}` specifying the options
         :param value: the initial value
         :param on_change: callback to execute when selection changes
+        :param option_label: a callback mapping an option to the label shown for it (default: None, i.e. the option itself)
         """
-        super().__init__(tag='q-option-group', options=options, value=value, on_change=on_change)
+        super().__init__(tag='q-option-group', options=options, value=value, on_change=on_change,
+                         option_label=option_label)
 
-    def _event_args_to_value(self, e: GenericEventArguments) -> Any:
+    def _event_args_to_value(self, e: GenericEventArguments) -> OptionT | None:
         return self._values[e.args]
 
     def _value_to_model_value(self, value: Any) -> Any:

--- a/nicegui/elements/select.py
+++ b/nicegui/elements/select.py
@@ -1,30 +1,79 @@
 from collections.abc import Callable, Generator, Iterable, Iterator
 from contextlib import suppress
 from copy import deepcopy
-from typing import Any, Literal
+from typing import Any, Generic, Literal, cast, overload
 
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
-from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
-from .choice_element import ChoiceElement
+from ..events import GenericEventArguments, Handler, ValueChangeEventArguments, ValueT
+from .choice_element import ChoiceElement, OptionT
 from .mixins.disableable_element import DisableableElement
 from .mixins.label_element import LabelElement
 from .mixins.validation_element import ValidationDict, ValidationElement, ValidationFunction
 
+NewValueMode = Literal['add', 'add-unique', 'toggle']
 
-class Select(LabelElement, ValidationElement[Any], ChoiceElement, DisableableElement, component='select.js'):
+
+class Select(LabelElement, ValidationElement[ValueT], ChoiceElement[OptionT, ValueT], DisableableElement,
+             Generic[OptionT, ValueT], component='select.js'):
+
+    @overload
+    def __init__(self: 'Select[OptionT, list[OptionT]]',
+                 options: list[OptionT] | dict[OptionT, Any], *,
+                 label: str | None = ...,
+                 value: OptionT | list[OptionT] | None = ...,
+                 on_change: Handler[ValueChangeEventArguments[list[OptionT]]] | None = ...,
+                 with_input: bool = ...,
+                 new_value_mode: NewValueMode | None = ...,
+                 multiple: Literal[True],
+                 clearable: bool = ...,
+                 validation: ValidationFunction | ValidationDict | None = ...,
+                 key_generator: Callable[[Any], Any] | Iterator[Any] | None = ...,
+                 option_label: Callable[[OptionT], Any] | None = ...,
+                 ) -> None: ...
+
+    @overload
+    def __init__(self: 'Select[OptionT, OptionT | None]',
+                 options: list[OptionT] | dict[OptionT, Any], *,
+                 label: str | None = ...,
+                 value: OptionT | None = ...,
+                 on_change: Handler[ValueChangeEventArguments[OptionT | None]] | None = ...,
+                 with_input: bool = ...,
+                 new_value_mode: NewValueMode | None = ...,
+                 multiple: Literal[False] = ...,
+                 clearable: bool = ...,
+                 validation: ValidationFunction | ValidationDict | None = ...,
+                 key_generator: Callable[[Any], Any] | Iterator[Any] | None = ...,
+                 option_label: Callable[[OptionT], Any] | None = ...,
+                 ) -> None: ...
+
+    @overload
+    def __init__(self: 'Select[OptionT, Any]',
+                 options: list[OptionT] | dict[OptionT, Any], *,
+                 label: str | None = ...,
+                 value: OptionT | list[OptionT] | None = ...,
+                 on_change: Handler[ValueChangeEventArguments[Any]] | None = ...,
+                 with_input: bool = ...,
+                 new_value_mode: NewValueMode | None = ...,
+                 multiple: bool = ...,
+                 clearable: bool = ...,
+                 validation: ValidationFunction | ValidationDict | None = ...,
+                 key_generator: Callable[[Any], Any] | Iterator[Any] | None = ...,
+                 option_label: Callable[[OptionT], Any] | None = ...,
+                 ) -> None: ...
 
     @resolve_defaults
     def __init__(self,
-                 options: list | dict, *,
+                 options: list[OptionT] | dict[OptionT, Any], *,
                  label: str | None = DEFAULT_PROP | None,
                  value: Any = DEFAULT_PROPS['model-value'] | None,
                  on_change: Handler[ValueChangeEventArguments[Any]] | None = None,
                  with_input: bool = False,
-                 new_value_mode: Literal['add', 'add-unique', 'toggle'] | None = DEFAULT_PROP | None,
+                 new_value_mode: NewValueMode | None = DEFAULT_PROP | None,
                  multiple: bool = DEFAULT_PROP | False,
                  clearable: bool = DEFAULT_PROP | False,
                  validation: ValidationFunction | ValidationDict | None = None,
                  key_generator: Callable[[Any], Any] | Iterator[Any] | None = None,
+                 option_label: Callable[[OptionT], Any] | None = None,
                  ) -> None:
         """Dropdown Selection
 
@@ -45,6 +94,17 @@ class Select(LabelElement, ValidationElement[Any], ChoiceElement, DisableableEle
         Alternatively, you can pass a callable that returns an optional error message.
         To disable the automatic validation on every value change, you can use the `without_auto_validation` method.
 
+        Options are not limited to scalars: a list may hold dataclasses or dictionaries,
+        in which case `value` is the selected option itself.
+        Pass `option_label` to say how such an option should be labelled.
+        A rich option's own fields are sent to the client and are available as ``props.opt.<key>`` in slots,
+        except for the reserved keys "value" and "label".
+
+        The element is generic in its option type, so type checkers infer the argument of `option_label`
+        as well as the type of `value` from the options:
+        ``ui.select(people, option_label=lambda person: person.name).value`` is a ``Person | None``,
+        and a ``list[Person]`` when `multiple` is True.
+
         :param options: a list ['value1', ...] or dictionary `{'value1':'label1', ...}` specifying the options
         :param label: the label to display above the selection
         :param value: the initial value
@@ -55,6 +115,7 @@ class Select(LabelElement, ValidationElement[Any], ChoiceElement, DisableableEle
         :param clearable: whether to add a button to clear the selection
         :param validation: dictionary of validation rules or a callable that returns an optional error message (default: None for no validation)
         :param key_generator: a callback or iterator to generate a dictionary key for new values
+        :param option_label: a callback mapping an option to the label shown for it (default: None, i.e. the option itself)
         """
         self.multiple = multiple
         if multiple:
@@ -64,7 +125,8 @@ class Select(LabelElement, ValidationElement[Any], ChoiceElement, DisableableEle
                 value = [value]
             else:
                 value = value[:]  # avoid modifying the original list which could be the list of options (#3014)
-        super().__init__(label=label, options=options, value=value, on_change=on_change, validation=validation)
+        super().__init__(label=label, options=options, value=value, on_change=on_change, validation=validation,
+                         option_label=option_label)
         if isinstance(key_generator, Generator):
             next(key_generator)  # prime the key generator, prepare it to receive the first value
         self.key_generator = key_generator
@@ -126,13 +188,11 @@ class Select(LabelElement, ValidationElement[Any], ChoiceElement, DisableableEle
             result = []
             for item in value or []:
                 with suppress(ValueError):
-                    index = self._values.index(item)
-                    result.append({'value': index, 'label': self._labels[index]})
+                    result.append(self._option_dict(self._values.index(item)))
             return result
         else:
             try:
-                index = self._values.index(value)
-                return {'value': index, 'label': self._labels[index]}
+                return self._option_dict(self._values.index(value))
             except ValueError:
                 return None
 
@@ -147,33 +207,35 @@ class Select(LabelElement, ValidationElement[Any], ChoiceElement, DisableableEle
 
     def _handle_new_value(self, value: str) -> Any:
         mode = self._props['new-value-mode']
-        if isinstance(self.options, list):
+        # NOTE: new values entered by the user are strings, so they widen the option type beyond OptionT
+        options = cast('list[Any] | dict[Any, Any]', self.options)
+        if isinstance(options, list):
             if mode == 'add':
-                self.options.append(value)
+                options.append(value)
             elif mode == 'add-unique':
-                if value not in self.options:
-                    self.options.append(value)
+                if value not in options:
+                    options.append(value)
             elif mode == 'toggle':
-                if value in self.options:
-                    self.options.remove(value)
+                if value in options:
+                    options.remove(value)
                 else:
-                    self.options.append(value)
+                    options.append(value)
             # self._labels and self._values are updated via self.options since they share the same references
             return value
         else:
             key = value
             if mode == 'add':
                 key = self._generate_key(value)
-                self.options[key] = value
+                options[key] = value
             elif mode == 'add-unique':
-                if value not in self.options.values():
+                if value not in options.values():
                     key = self._generate_key(value)
-                    self.options[key] = value
+                    options[key] = value
             elif mode == 'toggle':
-                if value in self.options:
-                    self.options.pop(value)
+                if value in options:
+                    options.pop(value)
                 else:
                     key = self._generate_key(value)
-                    self.options.update({key: value})
+                    options.update({key: value})
             self._update_values_and_labels()
             return key

--- a/nicegui/elements/toggle.py
+++ b/nicegui/elements/toggle.py
@@ -1,19 +1,21 @@
-from typing import Any
+from collections.abc import Callable
+from typing import Any, Generic
 
 from ..defaults import DEFAULT_PROP, DEFAULT_PROPS, resolve_defaults
 from ..events import GenericEventArguments, Handler, ValueChangeEventArguments
-from .choice_element import ChoiceElement
+from .choice_element import ChoiceElement, OptionT
 from .mixins.disableable_element import DisableableElement
 
 
-class Toggle(ChoiceElement, DisableableElement):
+class Toggle(ChoiceElement[OptionT, 'OptionT | None'], DisableableElement, Generic[OptionT]):
 
     @resolve_defaults
     def __init__(self,
-                 options: list | dict, *,
-                 value: Any = DEFAULT_PROPS['model-value'] | None,
-                 on_change: Handler[ValueChangeEventArguments[Any]] | None = None,
+                 options: list[OptionT] | dict[OptionT, Any], *,
+                 value: OptionT | None = DEFAULT_PROPS['model-value'] | None,
+                 on_change: Handler[ValueChangeEventArguments[OptionT | None]] | None = None,
                  clearable: bool = DEFAULT_PROP | False,
+                 option_label: Callable[[OptionT], Any] | None = None,
                  ) -> None:
         """Toggle
 
@@ -26,11 +28,13 @@ class Toggle(ChoiceElement, DisableableElement):
         :param value: the initial value
         :param on_change: callback to execute when selection changes
         :param clearable: whether the toggle can be cleared by clicking the selected option
+        :param option_label: a callback mapping an option to the label shown for it (default: None, i.e. the option itself)
         """
-        super().__init__(tag='q-btn-toggle', options=options, value=value, on_change=on_change)
+        super().__init__(tag='q-btn-toggle', options=options, value=value, on_change=on_change,
+                         option_label=option_label)
         self._props.set_bool('clearable', clearable)
 
-    def _event_args_to_value(self, e: GenericEventArguments) -> Any:
+    def _event_args_to_value(self, e: GenericEventArguments) -> OptionT | None:
         return self._values[e.args] if e.args is not None else None
 
     def _value_to_model_value(self, value: Any) -> Any:

--- a/nicegui/events.py
+++ b/nicegui/events.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Iterator
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias, cast
+
+# NOTE: typing_extensions.TypeVar is needed because typing.TypeVar does not support defaults before Python 3.13
+from typing_extensions import TypeVar
 
 from . import background_tasks, core, helpers
 from .slot import Slot
@@ -142,7 +145,8 @@ class MultiUploadEventArguments(UiEventArguments):
     files: list[FileUpload]
 
 
-ValueT = TypeVar('ValueT')
+# NOTE: the default lets multi-parameter generics like Select[Person] be written without spelling out the value type
+ValueT = TypeVar('ValueT', default=Any)
 
 
 @dataclass(kw_only=True, slots=True)

--- a/nicegui/testing/user_interaction.py
+++ b/nicegui/testing/user_interaction.py
@@ -42,7 +42,7 @@ class UserInteraction(Generic[T]):
                 if isinstance(element, ui.input) and event == 'keydown.tab':
                     autocomplete: list[str] = element.props['_autocomplete']
                     for option in autocomplete:
-                        if option.startswith(element.value):
+                        if option.startswith(element.value or ''):  # an empty input matches the first option
                             element.value = option
                             break
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "typing-extensions>=4.0.0",
+    "typing-extensions>=4.4.0",  # TypeVar defaults (PEP 696), used by ValueT
     "markdown2>=2.4.7,!=2.4.11",
     "Pygments>=2.20.0,<3.0.0",  # https://github.com/zauberzeug/nicegui/security/dependabot/174
     "starlette>=1.3.1",  # https://github.com/zauberzeug/nicegui/security/dependabot/317

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import pytest
 from selenium.webdriver import Keys
 
@@ -326,3 +328,100 @@ def test_popup_scroll_behavior(screen: Screen):
     screen.type(Keys.ESCAPE)
     screen.wait(0.2)
     assert screen.selenium.execute_script('return window.scrollY') == position
+
+
+@dataclass
+class Person:
+    name: str
+    icon: str
+
+
+async def test_dataclass_options(user: User):
+    people = [Person('Alice', 'a'), Person('Bob', 'b')]
+    select = None
+
+    @ui.page('/')
+    def page():
+        nonlocal select
+        select = ui.select(people, value=people[0], option_label=lambda person: person.name)
+
+    await user.open('/')
+    assert select.value == Person('Alice', 'a'), 'the value is the selected option itself'
+    assert select.props['options'] == [
+        {'name': 'Alice', 'icon': 'a', 'value': 0, 'label': 'Alice'},
+        {'name': 'Bob', 'icon': 'b', 'value': 1, 'label': 'Bob'},
+    ], "a dataclass option's fields are sent to the client"
+    assert select.props['model-value'] == {'name': 'Alice', 'icon': 'a', 'value': 0, 'label': 'Alice'}
+
+
+async def test_dict_options_expose_their_fields(user: User):
+    options = [{'name': 'Alice', 'icon': 'a'}, {'name': 'Bob', 'icon': 'b'}]
+    select = None
+
+    @ui.page('/')
+    def page():
+        nonlocal select
+        select = ui.select(options, value=options[1], option_label=lambda option: option['name'])
+
+    await user.open('/')
+    assert select.value == {'name': 'Bob', 'icon': 'b'}
+    assert select.props['options'] == [
+        {'name': 'Alice', 'icon': 'a', 'value': 0, 'label': 'Alice'},
+        {'name': 'Bob', 'icon': 'b', 'value': 1, 'label': 'Bob'},
+    ]
+
+
+async def test_rich_options_cannot_shadow_reserved_keys(user: User):
+    options = [{'value': 'shadowed', 'label': 'shadowed', 'icon': 'a'}]
+    select = None
+
+    @ui.page('/')
+    def page():
+        nonlocal select
+        select = ui.select(options, option_label=lambda option: option['icon'])
+
+    await user.open('/')
+    assert select.props['options'] == [{'icon': 'a', 'value': 0, 'label': 'a'}]
+
+
+async def test_option_label_with_scalar_options(user: User):
+    select = None
+
+    @ui.page('/')
+    def page():
+        nonlocal select
+        select = ui.select([1, 2, 3], value=2, option_label=lambda number: f'#{number}')
+
+    await user.open('/')
+    assert select.value == 2, 'the value stays the scalar, only the label changes'
+    assert select.props['options'] == [
+        {'value': 0, 'label': '#1'},
+        {'value': 1, 'label': '#2'},
+        {'value': 2, 'label': '#3'},
+    ]
+
+
+async def test_scalar_options_are_unchanged(user: User):
+    select = None
+
+    @ui.page('/')
+    def page():
+        nonlocal select
+        select = ui.select(['A', 'B'])
+
+    await user.open('/')
+    assert select.props['options'] == [{'value': 0, 'label': 'A'}, {'value': 1, 'label': 'B'}]
+
+
+async def test_rich_options_survive_set_options(user: User):
+    select = None
+
+    @ui.page('/')
+    def page():
+        nonlocal select
+        select = ui.select([Person('Alice', 'a')], option_label=lambda person: person.name)
+
+    await user.open('/')
+    select.set_options([Person('Bob', 'b')], value=Person('Bob', 'b'))
+    assert select.props['options'] == [{'name': 'Bob', 'icon': 'b', 'value': 0, 'label': 'Bob'}]
+    assert select.value == Person('Bob', 'b')

--- a/uv.lock
+++ b/uv.lock
@@ -2254,7 +2254,7 @@ requires-dist = [
     { name = "redis", marker = "extra == 'redis'", specifier = ">=4.0.0" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "tinycss2", specifier = ">=1.4.0,<2" },
-    { name = "typing-extensions", specifier = ">=4.0.0" },
+    { name = "typing-extensions", specifier = ">=4.4.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.22.0" },
     { name = "watchfiles", specifier = ">=0.18.1" },
 ]

--- a/website/documentation/content/select_documentation.py
+++ b/website/documentation/content/select_documentation.py
@@ -50,4 +50,47 @@ def update_selection():
         ui.button('1, 2, 3', on_click=lambda: select.set_options([1, 2, 3], value=1))
 
 
+@doc.demo('Rich options', '''
+    Options are not limited to scalars.
+    A list may hold dataclasses or dictionaries, and then `value` is the selected option itself.
+    Use `option_label` to say how an option should be labelled.
+
+    A rich option's own fields are sent to the client,
+    so slots can access them as `props.opt.<key>`.
+    The keys "value" and "label" are reserved.
+
+    The element is generic in its option type,
+    so a type checker knows that `person` is a `Person` and that `select.value` is a `Person | None`
+    (a `list[Person]` if `multiple` is True).
+''')
+def rich_options():
+    from dataclasses import dataclass
+
+    @dataclass
+    class Person:
+        name: str
+        icon: str
+        team: str
+
+    people = [
+        Person('Alice', 'engineering', 'Engineering'),
+        Person('Bob', 'palette', 'Design'),
+        Person('Carol', 'query_stats', 'Data Science'),
+    ]
+    select = ui.select(people, value=people[0], option_label=lambda person: person.name) \
+        .classes('w-64')
+    select.add_slot('option', '''
+        <q-item v-bind="props.itemProps">
+            <q-item-section avatar>
+                <q-icon :name="props.opt.icon" />
+            </q-item-section>
+            <q-item-section>
+                <q-item-label>{{ props.opt.label }}</q-item-label>
+                <q-item-label caption>{{ props.opt.team }}</q-item-label>
+            </q-item-section>
+        </q-item>
+    ''')
+    ui.label().bind_text_from(select, 'value', lambda person: f'Selected: {person.name}')
+
+
 doc.reference(ui.select)


### PR DESCRIPTION
> [!NOTE]
> This is my second attempt at making choice elements generic and typed better. The original PR, which failed to add the desired features and broke backwards compatibility, is https://github.com/zauberzeug/nicegui/pull/5322.

### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->

<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->

<!-- Include any important technical decisions or trade-offs made. -->

### Progress

- [ ] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [ ] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [ ] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [ ] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary. <!--Remove the option that does not apply.-->
- [ ] Documentation has been added/updated or is not necessary. <!--Remove the option that does not apply.-->
- [ ] No breaking changes to the public API or migration steps are described above. <!--Remove the option that does not apply.-->
