### PR TITLE
Fix sortable containers created in callbacks or dialogs

### DIFF
--- a/nicegui/elements/sortable/__init__.py
+++ b/nicegui/elements/sortable/__init__.py
@@ -1,3 +1,9 @@
-from .sortable import Sortable
+from typing import TYPE_CHECKING
 
+from ...dependencies import setup_esm_package
+
+__getattr__, __dir__ = setup_esm_package(__file__, __name__, 'nicegui-sortable', {'Sortable': '.sortable'})
 __all__ = ['Sortable']
+
+if TYPE_CHECKING:
+    from .sortable import Sortable

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -1,6 +1,5 @@
 import builtins
 import importlib
-import importlib.util
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -450,8 +449,7 @@ def __getattr__(name: str) -> object:
 
 
 # Eagerly import element packages with 'dist' dirs so their __init__.py registers ESM modules in the importmap.
-for _module_path in {mp for mp, _ in _LAZY_IMPORTS.values()}:
-    _spec = importlib.util.find_spec(_module_path, package='nicegui')
-    if _spec and _spec.submodule_search_locations and (Path(_spec.submodule_search_locations[0]) / 'dist').is_dir():
-        importlib.import_module(_module_path, package='nicegui')
-del _module_path, _spec  # pylint: disable=undefined-loop-variable
+# We scan the file system rather than `_LAZY_IMPORTS`, because some packages (e.g. sortable) have no `ui` name.
+for _dist in sorted(Path(__file__).parent.glob('elements/*/dist')):
+    importlib.import_module(f'.elements.{_dist.parent.name}', package='nicegui')
+del _dist  # pylint: disable=undefined-loop-variable

--- a/nicegui/ui.py
+++ b/nicegui/ui.py
@@ -452,4 +452,3 @@ def __getattr__(name: str) -> object:
 # We scan the file system rather than `_LAZY_IMPORTS`, because some packages (e.g. sortable) have no `ui` name.
 for _dist in sorted(Path(__file__).parent.glob('elements/*/dist')):
     importlib.import_module(f'.elements.{_dist.parent.name}', package='nicegui')
-del _dist  # pylint: disable=undefined-loop-variable

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -40,12 +40,11 @@ def test_module_access_does_not_import_others():
 def test_esm_modules_registered_on_import():
     result = subprocess.run(['python3', '-c', dedent('''\
         from pathlib import Path
-        import nicegui
         from nicegui import ui
         from nicegui.dependencies import esm_modules
-        packages = {p.parent.name for p in Path(nicegui.__file__).parent.glob('elements/*/dist')}
+        packages = {p.parent.name for p in Path(ui.__file__).parent.glob('elements/*/dist')}
         registered = {m.path.parent.name for m in esm_modules.values()}
         missing = packages - registered
-        raise SystemExit(f'ESM modules not registered on import: {sorted(missing)}' if missing else 0)
+        assert not missing, f'ESM modules not registered on import: {sorted(missing)}'
     ''')], capture_output=True, text=True, timeout=30, check=False)
     assert result.returncode == 0, result.stderr

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -35,3 +35,17 @@ def test_module_access_does_not_import_others():
         sys.exit('button' in sys.modules.keys())
     ''')], capture_output=True, text=True, timeout=30, check=False)
     assert result.returncode == 0, 'button should not be imported when accessing label'
+
+
+def test_esm_modules_registered_on_import():
+    result = subprocess.run(['python3', '-c', dedent('''\
+        from pathlib import Path
+        import nicegui
+        from nicegui import ui
+        from nicegui.dependencies import esm_modules
+        packages = {p.parent.name for p in Path(nicegui.__file__).parent.glob('elements/*/dist')}
+        registered = {m.path.parent.name for m in esm_modules.values()}
+        missing = packages - registered
+        raise SystemExit(f'ESM modules not registered on import: {sorted(missing)}' if missing else 0)
+    ''')], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
### Motivation

Sortable containers did not work when created in an event callback or inside a dialog (#6318). The browser console showed `TypeError: Failed to resolve module specifier 'nicegui-sortable'`, and the only workaround was to create a dummy sortable container at startup.

As @evnchn analyzed in the issue, this is an import-map problem, not a timing problem: the sortable package registered its ESM module only when `make_sortable()` first imported the `Sortable` class. The eager-import loop at the end of `nicegui/ui.py` was meant to register all ESM packages at startup, but it iterated over `_LAZY_IMPORTS`, and sortable is not listed there because it has no `ui.*` name (it is only reachable via `make_sortable()`). So any page rendered before the first `make_sortable()` call had no `nicegui-sortable` entry in its import map.

Fixes #6318

### Implementation

- The eager-import loop in `nicegui/ui.py` now scans the file system for `elements/*/dist` directories instead of `_LAZY_IMPORTS`, so every ESM package is registered at import time regardless of whether it has a `ui` name. This also removes the need for `importlib.util` and for the `del` of loop variables, which would have raised NameError on an empty glob.
- `nicegui/elements/sortable/__init__.py` now uses `setup_esm_package` like the other ten ESM packages, so importing the package registers the module without importing the class.
- A new test in `tests/test_lazy_imports.py` imports `nicegui.ui` in a fresh subprocess and asserts that every dist package is registered. A Screen test would not be reliable here: the ESM registry is process-global, so an in-process test would pass on an unfixed tree whenever an earlier test already called `make_sortable()`. The new test fails with the fix reverted and passes with it.

Verified manually with the MRE from the issue: after clicking the button, the freshly created container is draggable and the console shows no errors.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

[※](https://zauberzeug.github.io/colophon/#m=claude-fable-5-1&t=Diagnosis%20from%20the%20issue%20discussion%2C%20fix%2C%20test%20and%20wording%20by%20the%20model.&a=claude-code "claude-fable-5-1: Diagnosis from the issue discussion, fix, test and wording by the model.")

