### PR TITLE
Fix queued lazy tasks losing their `await_on_shutdown` protection

### DIFF
--- a/nicegui/background_tasks.py
+++ b/nicegui/background_tasks.py
@@ -9,7 +9,7 @@ from .logging import log
 
 running_tasks: set[asyncio.Task] = set()
 lazy_tasks_running: dict[str, asyncio.Task] = {}
-lazy_coroutines_waiting: dict[str, Coroutine[Any, Any, Any]] = {}
+lazy_coroutines_waiting: dict[str, Awaitable[Any]] = {}
 _await_tasks_on_shutdown: set[asyncio.Task] = set()
 
 
@@ -79,9 +79,11 @@ def create_lazy(awaitable: Awaitable[Any] | None = None, *,
     """
     awaitable = _resolve_awaitable(awaitable, coroutine, function_name='create_lazy')
     if name in lazy_tasks_running:
-        if name in lazy_coroutines_waiting:
-            lazy_coroutines_waiting[name].close()
-        lazy_coroutines_waiting[name] = _ensure_coroutine(awaitable)
+        waiting = lazy_coroutines_waiting.get(name)
+        if asyncio.iscoroutine(waiting):
+            waiting.close()
+        # NOTE: store the original awaitable so an _AwaitOnShutdown marker survives requeueing in finalize()
+        lazy_coroutines_waiting[name] = awaitable
         return
 
     def finalize(_) -> None:
@@ -174,5 +176,6 @@ async def teardown() -> None:
                           ', '.join(t.get_name() for t in tasks if not t.done()))
             except Exception:
                 log.exception('Error while cancelling tasks')
-    for coro in lazy_coroutines_waiting.values():
-        coro.close()
+    for awaitable in lazy_coroutines_waiting.values():
+        if asyncio.iscoroutine(awaitable):
+            awaitable.close()

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -99,6 +99,27 @@ async def test_inner_async_function_is_awaited_on_shutdown(user: User, create: C
     assert events == ['inner ran']
 
 
+async def test_queued_lazy_task_is_awaited_on_shutdown(user: User):
+    events: list[str] = []
+
+    @background_tasks.await_on_shutdown
+    async def work(value: str) -> None:
+        try:
+            await asyncio.sleep(0.1)
+            events.append(value)
+        except asyncio.CancelledError:
+            events.append(f'{value} cancelled')
+
+    @ui.page('/')
+    def page():
+        background_tasks.create_lazy(work('first'), name='work')
+        background_tasks.create_lazy(work('second'), name='work')  # queued while "first" is still busy
+
+    await user.open('/')
+    await background_tasks.teardown()
+    assert events == ['first', 'second']
+
+
 def test_create_tasks(screen: Screen) -> None:
     events: list[str] = []
 


### PR DESCRIPTION
### Motivation

`@background_tasks.await_on_shutdown` promises that tasks created from a tagged function are not cancelled during shutdown. That promise silently breaks for *requeued* lazy tasks: `create_lazy` stores waiting awaitables as `_ensure_coroutine(...)`, which wraps the `_AwaitOnShutdown` marker in a plain coroutine, so when `finalize` resubmits the queued task, the `isinstance` check in `create` no longer matches and `teardown()` cancels it like any ordinary task.

Minimal example, paste and run on current `main`:

```python
import asyncio

from nicegui import app, background_tasks, ui


@background_tasks.await_on_shutdown
async def save(value: str) -> None:
    await asyncio.sleep(1.0)  # simulate a slow write
    print('saved:', value)


async def demo():
    background_tasks.create_lazy(save('old'), name='save')
    await asyncio.sleep(0)  # let the first save start
    background_tasks.create_lazy(save('new'), name='save')  # queued while the first is still busy

app.on_startup(demo)
app.timer(0.3, app.shutdown, once=True)  # shut down while the first save is still running

ui.run(reload=False, show=False)
```

Expected: `saved: old` and `saved: new`. Actual on `main`: only `saved: old` — the queued `save('new')` is cancelled despite `await_on_shutdown` (deterministic; with this PR both lines appear).

For storage this means: a mutation that lands while a backup is already in flight gets its follow-up backup queued — and at shutdown that queued backup, the one carrying the newest state, is cancelled instead of awaited, silently dropping the latest change. Found while reviewing #6263; independent of that fix and present since the decorator was introduced in 2.16.0.

### Implementation

`lazy_coroutines_waiting` now stores the original awaitable instead of a prepared coroutine, so the `_AwaitOnShutdown` marker survives requeueing. Discarding a superseded waiting entry closes it only if it actually is a coroutine — a never-started `_AwaitOnShutdown` has not created one yet, so there is nothing to close (which matches the previous behavior: closing the wrapper never reached the inner awaitable either). Note that the registry's value type widens from `Coroutine` to `Awaitable`; it is internal bookkeeping that nothing outside the module reads, and for plain coroutines — the common case — the stored object is the same as before.

The new test asserts the user-visible contract — a queued `await_on_shutdown` task still runs to completion through `teardown()` — and fails deterministically on the old code.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

[※](https://zauberzeug.github.io/colophon/#m=claude-fable-5&t=Bug%20found%20by%20the%20model%20while%20reviewing%20PR%206263%3B%20analysis%2C%20fix%2C%20and%20test%20by%20the%20model.&a=claude-code "claude-fable-5: Bug found by the model while reviewing PR 6263; analysis, fix, and test by the model.")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
