### PR TITLE
Fix missing tab storage creation in the On Air handshake

### DIFF
--- a/nicegui/air.py
+++ b/nicegui/air.py
@@ -29,6 +29,23 @@ class Stream:
     response: httpx.Response
 
 
+async def _handle_handshake(data: dict[str, Any]) -> bool:
+    """Process an On Air handshake, including tab-storage creation."""
+    if client := Client.instances.get(data['client_id']):
+        if not client.accept_handshake(data['sid'], data['tab_id'], data['environ']):
+            return False
+        client.environ = data['environ']
+        if data.get('old_tab_id'):
+            core.app.storage.copy_tab(data['old_tab_id'], data['tab_id'])
+        client.tab_id = data['tab_id']
+        client.on_air = True
+        client.handle_handshake(data['sid'], data['document_id'], data.get('next_message_id'))
+        assert client.tab_id is not None
+        await core.app.storage._create_tab_storage(client.tab_id)  # pylint: disable=protected-access
+        return True
+    return False
+
+
 class Air:
 
     def __init__(self, token: str) -> None:
@@ -135,19 +152,7 @@ class Air:
         def _handleerror(data: dict[str, Any]) -> None:
             print('Error:', data['message'], flush=True)
 
-        @relay.on('handshake')
-        def _handle_handshake(data: dict[str, Any]) -> bool:
-            if client := Client.instances.get(data['client_id']):
-                if not client.accept_handshake(data['sid'], data['tab_id'], data['environ']):
-                    return False
-                client.environ = data['environ']
-                if data.get('old_tab_id'):
-                    core.app.storage.copy_tab(data['old_tab_id'], data['tab_id'])
-                client.tab_id = data['tab_id']
-                client.on_air = True
-                client.handle_handshake(data['sid'], data['document_id'], data.get('next_message_id'))
-                return True
-            return False
+        relay.on('handshake', _handle_handshake)
 
         @relay.on('client_disconnect')
         def _handle_client_disconnect(data: dict[str, Any]) -> None:

--- a/tests/test_air.py
+++ b/tests/test_air.py
@@ -1,6 +1,31 @@
 import socketio
 
+from nicegui import Client, app, ui
+from nicegui.air import _handle_handshake
+from nicegui.testing import User
+
 
 def test_engineio_state_contract() -> None:
     assert socketio.AsyncClient().eio.state == 'disconnected', \
         'Air.connect() detects a stale Socket.IO connection via this Engine.IO state'
+
+
+async def test_air_handshake_creates_tab_storage(user: User) -> None:
+    @ui.page('/')
+    def index():
+        pass
+
+    template = await user.open('/')
+    client = Client(template.page, request=template.request)
+
+    assert await _handle_handshake({
+        'client_id': client.id,
+        'sid': 'air-sid',
+        'tab_id': 'air-tab',
+        'environ': {'QUERY_STRING': f'client_id={client.id}'},
+        'document_id': 'air-doc',
+    })
+
+    with client:
+        app.storage.tab['x'] = 1
+        assert app.storage.tab['x'] == 1


### PR DESCRIPTION
### Motivation

Fixes https://github.com/zauberzeug/nicegui/issues/6310.

On Air's handshake never called `Storage._create_tab_storage`, unlike the local Socket.IO handler. A first visit therefore left `_tabs` empty, and `app.storage.tab` raised `AssertionError: tab storage for <tab_id> should be created before accessing it`.

### Implementation

Lift the On Air handshake into a module-level async `_handle_handshake` and, after `handle_handshake`, await `_create_tab_storage` the same way `_on_handshake` does. `copy_tab` still runs first; `_create_tab_storage` is a no-op when the tab already exists.

The handler is async because `_create_tab_storage` is async (Redis-backed tabs need `initialize()`). python-socketio's `AsyncClient` already uses async handlers for the other relay events.

A `User` test drives the handshake without a relay and asserts that `app.storage.tab` can be written afterwards.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary.
- [x] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.
