### PR TITLE
Fix button.clicked() stacking a new click listener on every await

### DIFF
--- a/nicegui/elements/button.py
+++ b/nicegui/elements/button.py
@@ -35,6 +35,7 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
         :param icon: the name of an icon to be displayed on the button (default: `None`)
         """
         super().__init__(tag='q-btn', text=text, background_color=color, icon=icon)
+        self._clicked_waiters_bound = False
 
         if on_click:
             self.on_click(on_click)
@@ -60,6 +61,16 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
     def _text_to_model_text(self, text: str) -> None:
         self._props['label'] = text
 
+    def _wake_clicked_waiters(self) -> None:
+        for event in self._waiting_tasks.values():
+            event.set()
+
+    def _ensure_clicked_waiter_listener(self) -> None:
+        if self._clicked_waiters_bound:
+            return
+        self._clicked_waiters_bound = True
+        self.on('click', self._wake_clicked_waiters, [])
+
     async def clicked(self) -> None:
         """Wait until the button is clicked.
 
@@ -68,6 +79,6 @@ class Button(IconElement, TextElement, DisableableElement, BackgroundColorElemen
         """
         event = asyncio.Event()
         with self._cancel_when_deleted(event):
-            self.on('click', event.set, [])
+            self._ensure_clicked_waiter_listener()
             await self.client.connected()
             await event.wait()

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -206,3 +206,21 @@ async def test_click_that_deletes_the_button_is_still_delivered(user: User):
     user.find('Click me').click()
     await asyncio.sleep(0.1)  # let the async on_click handler delete the button
     assert results == ['clicked'], 'a real click must not be swallowed by the deletion it triggers'
+
+
+async def test_clicked_can_be_awaited_repeatedly(user: User):
+    """Each click should complete one iteration of an await-clicked loop."""
+    clicks = []
+
+    @ui.page('/')
+    async def page():
+        button = ui.button('Click me')
+        while True:
+            await button.clicked()
+            clicks.append('clicked')
+
+    await user.open('/')
+    for _ in range(3):
+        user.find('Click me').click()
+        await asyncio.sleep(0.1)
+    assert clicks == ['clicked', 'clicked', 'clicked']

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -224,3 +224,5 @@ async def test_clicked_can_be_awaited_repeatedly(user: User):
         user.find('Click me').click()
         await asyncio.sleep(0.1)
     assert clicks == ['clicked', 'clicked', 'clicked']
+    button = next(iter(user.find('Click me').elements))
+    assert len(button._event_listeners) == 1, 'clicked() must reuse one listener'  # pylint: disable=protected-access


### PR DESCRIPTION
### Motivation

Fixes https://github.com/zauberzeug/nicegui/issues/6312.

`Button.clicked()` registered a new `click` listener on every await. In the documented `while True: await button.clicked()` loop that grows without bound: each physical click dispatched N times, and every registration after the first render rebuilt the button DOM.

### Implementation

Register a single click listener on first use and wake every waiter already tracked by `CancelableWaitElement._waiting_tasks`. Later `clicked()` calls only add an `asyncio.Event` to that registry, so they do not call `Element.on()` again.

Existing cancellation tests still apply: deleting the button or client still cancels waiters via the mixin. A new `User` test clicks the same button three times in the await loop.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary.
- [x] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.
