### PR TITLE
Fix nicegui_reset_globals not clearing Slot.stacks

### DIFF
--- a/nicegui/testing/general.py
+++ b/nicegui/testing/general.py
@@ -8,6 +8,7 @@ from starlette.routing import Route
 from .. import app, binding, core, dependencies, event, run, ui
 from ..client import Client
 from ..helpers import warnings
+from ..slot import Slot
 
 
 def prepare_simulation() -> None:
@@ -55,6 +56,7 @@ def nicegui_reset_globals():
 
     dependencies.importmap_overrides.clear()
     Client.instances.clear()
+    Slot.stacks.clear()
     Client.page_routes.clear()
     Client.shared_head_html = ''
     Client.shared_body_html = ''

--- a/tests/test_reset_globals.py
+++ b/tests/test_reset_globals.py
@@ -1,0 +1,21 @@
+import pytest
+
+from nicegui import Event, ui
+from nicegui.slot import Slot
+from nicegui.testing.general import nicegui_reset_globals
+
+
+@pytest.mark.filterwarnings('ignore:coroutine .Outbox.loop. was never awaited:RuntimeWarning')
+def test_reset_globals_clears_dangling_script_mode_slot() -> None:
+    """Bare UI outside a page leaves Slot.stacks[0]; reset must drop it.
+
+    Otherwise a later Event.subscribe() with no active task hits a deleted parent (#6314).
+    """
+    with ui.card():
+        ui.label('hello')
+    assert Slot.stacks.get(0)
+
+    with nicegui_reset_globals():
+        pass
+
+    Event().subscribe(lambda: None)

--- a/tests/test_reset_globals.py
+++ b/tests/test_reset_globals.py
@@ -2,20 +2,19 @@ import pytest
 
 from nicegui import Event, ui
 from nicegui.slot import Slot
-from nicegui.testing.general import nicegui_reset_globals
+from nicegui.testing import general
 
 
 @pytest.mark.filterwarnings('ignore:coroutine .Outbox.loop. was never awaited:RuntimeWarning')
-def test_reset_globals_clears_dangling_script_mode_slot() -> None:
+def test_reset_globals_clears_dangling_script_mode_slot(nicegui_reset_globals) -> None:
     """Bare UI outside a page leaves Slot.stacks[0]; reset must drop it.
 
     Otherwise a later Event.subscribe() with no active task hits a deleted parent (#6314).
     """
-    with ui.card():
-        ui.label('hello')
+    ui.card()
     assert Slot.stacks.get(0)
 
-    with nicegui_reset_globals():
+    with general.nicegui_reset_globals():
         pass
 
     Event().subscribe(lambda: None)


### PR DESCRIPTION
### Motivation

Fixes https://github.com/zauberzeug/nicegui/issues/6314.

A bare `ui.card()` (or any element) built outside a page enters script mode and pushes a slot onto `Slot.stacks[0]` with no matching pop. `nicegui_reset_globals()` already dropped `Client.instances`, so the parent was gone, but the stack entry stayed. A later `Event.subscribe()` with no active asyncio task then hit `RuntimeError: The parent element this slot belongs to has been deleted.`

### Implementation

Clear `Slot.stacks` next to `Client.instances` in `nicegui_reset_globals()`. A regression test builds a bare card, runs reset, then `Event.subscribe()`.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete. (Otherwise, open a [draft PR](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/).)
- [x] This PR does not address a security issue. (Security fixes must be coordinated via the [security advisory](https://github.com/zauberzeug/nicegui/security/advisories/new) process before opening a PR.)
- [x] Pytests have been added/updated, or the **Implementation** section explains why they are not necessary.
- [x] Documentation has been added/updated or is not necessary.
- [x] No breaking changes to the public API or migration steps are described above.