### PR TITLE
Fix CodeMirror line anchors and tooltips set together with a new value

### DIFF
--- a/nicegui/elements/codemirror/codemirror.js
+++ b/nicegui/elements/codemirror/codemirror.js
@@ -76,14 +76,14 @@ export default {
     lineWrapping(newLineWrapping) {
       this.setLineWrapping(newLineWrapping);
     },
-    lineAnchors(newAnchors) {
-      this.applyLineAnchors(newAnchors);
+    lineAnchors() {
+      this._anchorsPending = true; // applied from setEditorValueFromProps
     },
     keymap() {
       this.setKeymap();
     },
-    lineTooltips(newTooltips) {
-      this.setLineTooltips(newTooltips);
+    lineTooltips() {
+      this._tooltipsPending = true; // applied from setEditorValueFromProps
     },
   },
   data() {
@@ -163,6 +163,16 @@ export default {
     },
     setEditorValueFromProps() {
       this.setEditorValue(this.value);
+      // Vue runs the prop watchers before nicegui.js calls this update method, so anchors and
+      // tooltips sent together with a new value would otherwise be applied to the old document.
+      if (this._anchorsPending) {
+        this._anchorsPending = false;
+        this.applyLineAnchors(this.lineAnchors);
+      }
+      if (this._tooltipsPending) {
+        this._tooltipsPending = false;
+        this.setLineTooltips(this.lineTooltips);
+      }
     },
     setEditorValue(value) {
       if (!this.editor) return;

--- a/tests/test_codemirror.py
+++ b/tests/test_codemirror.py
@@ -151,6 +151,21 @@ def test_line_tooltip_stick_to_text(screen: Screen):
     screen.should_contain('tooltip')
 
 
+def test_line_tooltip_declared_for_a_value_sent_in_the_same_update(screen: Screen):
+    editor: ui.codemirror = None  # type: ignore[assignment]
+
+    @ui.page('/')
+    def page():
+        nonlocal editor
+        editor = ui.codemirror('abc').classes('w-24')
+
+    screen.open('/')
+    editor.value = 'abc\ndef'
+    editor.line_tooltips = {2: 'tooltip'}
+    ActionChains(screen.selenium).move_to_element(screen.find('def')).perform()
+    screen.should_contain('tooltip')
+
+
 def test_line_tooltip_plain_text_default(screen: Screen):
     @ui.page('/')
     def page():

--- a/tests/test_codemirror_line_anchors.py
+++ b/tests/test_codemirror_line_anchors.py
@@ -221,6 +221,22 @@ def test_anchors_survive_client_side_remount(screen: Screen):
     assert editor.line_anchors == {'mid': 4}, f'anchors should survive a client-side remount, got {editor.line_anchors}'
 
 
+def test_anchors_declared_for_a_value_sent_in_the_same_update(screen: Screen):
+    """Anchors assigned in the same handler as a new value address that value, not the previous one."""
+    editor: ui.codemirror = None  # type: ignore[assignment]
+
+    @ui.page('/')
+    def page():
+        nonlocal editor
+        editor = ui.codemirror('a\nb\nc')
+
+    screen.open('/')
+    _wait_for_editor(screen)
+    editor.value = '\n'.join(f'line {i}' for i in range(1, 11))
+    editor.line_anchors = {'end': 10}
+    screen.wait_for(lambda: editor.line_anchors == {'end': 10})
+
+
 def test_on_anchor_change_handler(screen: Screen):
     """on_anchor_change fires with the current positions on every change."""
     editor: ui.codemirror = None  # type: ignore[assignment]


### PR DESCRIPTION
### Motivation

Fixes #6335: `editor.value = long_text; editor.line_anchors = {'end': 50}` in one handler logged the anchor as out of range and dropped it, because the anchor was checked against the document before the new value had been applied. Tooltips behaved the same way. Decorations had the same ordering and were fixed in #5991 with the pattern used here.

### Implementation

Vue runs the prop watchers before nicegui.js calls the element's `update_method`, so the `lineAnchors` and `lineTooltips` watchers now only set a flag, and `setEditorValueFromProps` applies them after the value has landed. Since nicegui.js calls that method after every update message, anchors and tooltips without a value change are applied exactly as before, just a tick later. Two Screen tests cover the same-handler case, one per feature; both fail without the fix.

This will conflict trivially with #5991, which adds the same flag for decorations in the same two places.

### Progress

- [x] The PR title is a short phrase starting with a verb like "Add ...", "Fix ...", "Update ...", "Remove ...", etc.
- [x] The implementation is complete.
- [x] This PR does not address a security issue.
- [x] Pytests have been added/updated.
- [x] Documentation is not necessary.
- [x] No breaking changes to the public API.

[※](https://zauberzeug.github.io/colophon/#m=claude-fable-5-1&t=Fix%20and%20tests%20by%20the%20model%2C%20following%20the%20pattern%20agreed%20for%20decorations%20in%20%235991%3B%20wording%20from%20the%20model.&a=claude-code "claude-fable-5-1: Fix and tests by the model, following the pattern agreed for decorations in #5991; wording from the model.")
